### PR TITLE
Apply probe_batch_size after skip-recently-probed filter

### DIFF
--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -1741,6 +1741,12 @@ class StreamProber:
             streams_to_probe.sort(key=lambda s: stream_to_channel_number.get(s["id"], 999999))
             logger.info("[STREAM-PROBE] Sorted %s streams by channel number", len(streams_to_probe))
 
+            # Apply batch size limit after filtering out recently probed streams
+            # This ensures the batch only contains streams that will actually be probed
+            if self.probe_batch_size > 0 and len(streams_to_probe) > self.probe_batch_size:
+                logger.info("[STREAM-PROBE] Limiting batch to %s streams (from %s eligible)", self.probe_batch_size, len(streams_to_probe))
+                streams_to_probe = streams_to_probe[:self.probe_batch_size]
+
             self._probe_progress_total = len(streams_to_probe)
             self._probe_progress_status = "probing"
 


### PR DESCRIPTION
probe_batch_size was stored and plumbed through settings/task config but never actually used to limit the stream list. The batch was assembled from all eligible streams, so every run probed everything regardless of the configured batch size.

Now the limit is applied after the recently-probed filter and channel-number sort. This means a batch of N will contain N streams that actually need probing, rather than N arbitrary streams where some get skipped immediately.

Proof it's not working:

<img width="648" height="246" alt="2026-02-21 at 15 31 22@2x" src="https://github.com/user-attachments/assets/bc58bb36-d7f7-4518-9968-b095399db2bf" />

<img width="706" height="332" alt="2026-02-21 at 15 31 17@2x" src="https://github.com/user-attachments/assets/a4036996-590b-441d-bd90-8f0e1b574c2f" />
