### PR TITLE
  feat: make HTTP and HTTPS ports fully configurable via environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,13 +62,15 @@ RUN mkdir -p /config /config/tls /config/uploads/logos \
 
 # Environment
 ENV CONFIG_DIR=/config
+ENV ECM_PORT=6100
+ENV ECM_HTTPS_PORT=6143
 
-# Expose ports (HTTP on 6100, HTTPS on 6143 when TLS enabled)
-EXPOSE 6100 6143
+# Expose ports (HTTP on ECM_PORT, HTTPS on ECM_HTTPS_PORT when TLS enabled)
+EXPOSE $ECM_PORT $ECM_HTTPS_PORT
 
 # Add healthcheck
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:6100/api/health')" || exit 1
+  CMD python -c "import urllib.request, os; port = os.environ.get('ECM_PORT', '6100'); urllib.request.urlopen(f'http://localhost:{port}/api/health')" || exit 1
 
 # Entrypoint fixes volume permissions then drops to non-root user via gosu
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -925,17 +925,20 @@ services:
   ecm:
     image: ghcr.io/motwakorb/enhancedchannelmanager:latest
     ports:
-      - "6100:6100"   # HTTP (always available)
-      - "6143:6143"   # HTTPS (when TLS is enabled)
+      - "6100:6100"   # HTTP (configurable via ECM_PORT)
+      - "6143:6143"   # HTTPS (configurable via ECM_HTTPS_PORT)
     volumes:
       - ./config:/config
+    environment:
+      - ECM_PORT=6100
+      - ECM_HTTPS_PORT=6143
 ```
 
 The Dispatcharr URL can be configured through the Settings modal in the UI, which persists to the config volume.
 
 **Port Configuration:**
-- **Port 6100** - HTTP interface (always available as fallback)
-- **Port 6143** - HTTPS interface (when TLS is configured in Settings → TLS Certificates)
+- **ECM_PORT** (default: 6100) - HTTP interface (always available as fallback)
+- **ECM_HTTPS_PORT** (default: 6143) - HTTPS interface (when TLS is configured in Settings → TLS Certificates)
 
 ### Development
 

--- a/backend/auth/routes.py
+++ b/backend/auth/routes.py
@@ -48,7 +48,7 @@ def send_password_reset_email(to_email: str, reset_token: str, base_url: str) ->
     Args:
         to_email: Recipient email address.
         reset_token: The raw reset token to include in the link.
-        base_url: The base URL of the application (e.g., http://localhost:6100).
+        base_url: The base URL of the application (e.g., http://localhost:6100 by default).
 
     Returns:
         True if email was sent successfully, False otherwise.

--- a/backend/tls/settings.py
+++ b/backend/tls/settings.py
@@ -67,7 +67,7 @@ class TLSSettings(BaseModel):
     last_renewal_error: Optional[str] = None
 
     # HTTPS port for TLS connections (HTTP always stays on 6100 as fallback)
-    https_port: int = 6143
+    https_port: int = int(os.environ.get("ECM_HTTPS_PORT", 6143))
 
     @field_validator("domain")
     @classmethod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,14 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "6100:6100"
+      - "${ECM_PORT:-6100}:${ECM_PORT:-6100}"
+      - "${ECM_HTTPS_PORT:-6143}:${ECM_HTTPS_PORT:-6143}"
     volumes:
       - ecm-config:/config
     environment:
       - CONFIG_DIR=/config
+      - ECM_PORT=${ECM_PORT:-6100}
+      - ECM_HTTPS_PORT=${ECM_HTTPS_PORT:-6143}
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -180,8 +180,8 @@ graph TB
 ## Request Flow
 
 ```
-Browser → Frontend (React SPA on :6100/static/)
-       → HTTP/JSON → FastAPI (:6100/api/*)
+Browser → Frontend (React SPA on :6100/static/ by default)
+       → HTTP/JSON → FastAPI (:6100/api/* by default)
                     → CORS middleware → Auth check → Router endpoint
                     → DispatcharrClient → Dispatcharr API (upstream)
                     → SQLAlchemy ORM → SQLite (/config/journal.db)

--- a/frontend/src/components/settings/TLSSettingsSection.tsx
+++ b/frontend/src/components/settings/TLSSettingsSection.tsx
@@ -350,7 +350,7 @@ export function TLSSettingsSection({ isAdmin }: Props) {
           <span className={`tls-status-badge ${status.enabled && status.has_certificate ? 'encrypted' : 'unencrypted'}`}>
             {status.enabled && status.has_certificate ? `Encrypted (port ${status.https_port})` : 'UNENCRYPTED'}
           </span>
-          <span className="tls-status-fallback">HTTP fallback on port 6100</span>
+          <span className="tls-status-fallback">HTTP fallback available</span>
         </div>
       )}
 
@@ -425,7 +425,7 @@ export function TLSSettingsSection({ isAdmin }: Props) {
                     min={1}
                     max={65535}
                   />
-                  <span className="form-hint">HTTPS will listen on this port (default: 6143). HTTP always stays on 6100 as fallback.</span>
+                  <span className="form-hint">HTTPS will listen on this port (default: 6143). HTTP stays on its configured port (default: 6100) as fallback.</span>
                 </div>
 
                 <div className="form-group">
@@ -696,7 +696,7 @@ export function TLSSettingsSection({ isAdmin }: Props) {
         </h4>
         <ul>
           <li>
-            <strong>Dual-Port Setup:</strong> HTTP always runs on port 6100 as a fallback.
+            <strong>Dual-Port Setup:</strong> HTTP always runs on its configured port (default 6100) as a fallback.
             HTTPS runs on the configured port (default 6143) when TLS is enabled.
           </li>
           <li>
@@ -713,7 +713,7 @@ export function TLSSettingsSection({ isAdmin }: Props) {
           </li>
           <li>
             After enabling TLS, ECM will restart. Access via HTTPS on port {httpsPort},
-            or HTTP on port 6100 as fallback.
+            or HTTP on its configured port as fallback.
           </li>
         </ul>
       </div>


### PR DESCRIPTION
  This merge request introduces full configurability for the application's network ports, removing hardcoded defaults and providing better support for varied deployment environments.

ECM_PORT (default: 6100) for the primary HTTP interface.
ECM_HTTPS_PORT (default: 6143) for HTTPS traffic when TLS is enabled.