### PR TITLE
Add merge channels feature

### DIFF
--- a/backend/routers/channels.py
+++ b/backend/routers/channels.py
@@ -61,6 +61,17 @@ class AssignNumbersRequest(BaseModel):
     starting_number: Optional[float] = None
 
 
+class MergeChannelsRequest(BaseModel):
+    source_channel_ids: list[int]
+    target_name: str
+    target_channel_number: Optional[float] = None
+    target_channel_group_id: Optional[int] = None
+    target_logo_id: Optional[int] = None
+    target_tvg_id: Optional[str] = None
+    target_epg_data_id: Optional[int] = None
+    target_stream_profile_id: Optional[int] = None
+
+
 class ClearAutoCreatedRequest(BaseModel):
     group_ids: list[int]
 
@@ -1587,6 +1598,109 @@ async def update_channel(channel_id: int, data: dict):
         return result
     except Exception as e:
         logger.exception("[CHANNELS] Failed to update channel %s: %s", channel_id, e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.post("/merge")
+async def merge_channels(request: "MergeChannelsRequest"):
+    """Merge multiple channels into a single new channel.
+
+    Creates a new channel with the specified metadata, moves all streams
+    from the source channels into it (preserving order, deduplicating),
+    then deletes the source channels.
+    """
+    logger.debug("[CHANNELS] POST /channels/merge - sources=%s target_name=%s",
+                 request.source_channel_ids, request.target_name)
+
+    if len(request.source_channel_ids) < 2:
+        raise HTTPException(status_code=400, detail="At least 2 source channels are required")
+
+    client = get_client()
+    new_channel = None
+    try:
+        # 1. Fetch all source channels and collect their streams (ordered, deduplicated)
+        source_channels = []
+        all_streams: list[int] = []
+        seen_streams: set[int] = set()
+        for cid in request.source_channel_ids:
+            channel = await client.get_channel(cid)
+            source_channels.append(channel)
+            for sid in channel.get("streams", []):
+                if sid not in seen_streams:
+                    all_streams.append(sid)
+                    seen_streams.add(sid)
+
+        source_names = [ch.get("name", "Unknown") for ch in source_channels]
+
+        # 2. Create the new merged channel
+        create_data = {"name": request.target_name}
+        if request.target_channel_number is not None:
+            create_data["channel_number"] = request.target_channel_number
+        if request.target_channel_group_id is not None:
+            create_data["channel_group_id"] = request.target_channel_group_id
+        if request.target_logo_id is not None:
+            create_data["logo_id"] = request.target_logo_id
+        if request.target_tvg_id is not None:
+            create_data["tvg_id"] = request.target_tvg_id
+
+        new_channel = await client.create_channel(create_data)
+        new_channel_id = new_channel["id"]
+        logger.info("[CHANNELS] Created merged channel id=%s name=%s", new_channel_id, request.target_name)
+
+        # 3. Assign streams to the new channel
+        if all_streams:
+            await client.update_channel(new_channel_id, {"streams": all_streams})
+            logger.info("[CHANNELS] Assigned %d streams to merged channel %s", len(all_streams), new_channel_id)
+
+        # 4. Update EPG data if specified
+        update_data = {}
+        if request.target_epg_data_id is not None:
+            update_data["epg_data_id"] = request.target_epg_data_id
+        if request.target_stream_profile_id is not None:
+            update_data["stream_profile_id"] = request.target_stream_profile_id
+        if update_data:
+            await client.update_channel(new_channel_id, update_data)
+
+        # 5. Delete source channels
+        deleted_ids = []
+        for cid in request.source_channel_ids:
+            try:
+                await client.delete_channel(cid)
+                deleted_ids.append(cid)
+                logger.debug("[CHANNELS] Deleted source channel %s during merge", cid)
+            except Exception as del_err:
+                logger.warning("[CHANNELS] Failed to delete source channel %s during merge: %s", cid, del_err)
+
+        # 6. Fetch the final state of the merged channel
+        result = await client.get_channel(new_channel_id)
+
+        # Log to journal
+        journal.log_entry(
+            category="channel",
+            action_type="merge",
+            entity_id=new_channel_id,
+            entity_name=request.target_name,
+            description=f"Merged {len(source_channels)} channels into '{request.target_name}'",
+            before_value={"source_channels": [{"id": ch.get("id"), "name": ch.get("name")} for ch in source_channels]},
+            after_value={"merged_channel_id": new_channel_id, "stream_count": len(all_streams), "deleted_source_ids": deleted_ids},
+        )
+
+        logger.info("[CHANNELS] Merge complete: %d channels -> '%s' (id=%s, %d streams)",
+                     len(source_channels), request.target_name, new_channel_id, len(all_streams))
+
+        return result
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        # Rollback: delete the new channel if it was created
+        if new_channel:
+            try:
+                await client.delete_channel(new_channel["id"])
+                logger.info("[CHANNELS] Rolled back merged channel %s after error", new_channel["id"])
+            except Exception:
+                logger.warning("[CHANNELS] Failed to rollback merged channel %s", new_channel["id"])
+        logger.exception("[CHANNELS] Channel merge failed: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/frontend/src/components/ChannelsPane.tsx
+++ b/frontend/src/components/ChannelsPane.tsx
@@ -45,6 +45,7 @@ import { ChannelListItem } from './ChannelListItem';
 import { StreamListItem } from './StreamListItem';
 import { PreviewStreamModal } from './PreviewStreamModal';
 import { CSVImportModal } from './CSVImportModal';
+import { MergeChannelsModal } from './MergeChannelsModal';
 import { exportChannelsToCSV, downloadCSVTemplate } from '../services/api';
 import './ChannelsPane.css';
 import './ModalBase.css';
@@ -1450,6 +1451,10 @@ export function ChannelsPane({
 
   // CSV import modal state
   const csvImportModal = useModal();
+
+  // Merge channels modal state
+  const mergeModal = useModal();
+  const [mergeChannelIds, setMergeChannelIds] = useState<number[]>([]);
 
   // Context menu management
   const {
@@ -7190,6 +7195,15 @@ export function ChannelsPane({
             <div className="context-menu-item" onClick={handleCreateGroupAndMove}>
               Create new group and move
             </div>
+            {contextMenu.metadata.channelIds.length >= 2 && (
+              <div className="context-menu-item" onClick={() => {
+                setMergeChannelIds(contextMenu.metadata.channelIds);
+                mergeModal.open();
+                hideContextMenu();
+              }}>
+                Merge channels ({contextMenu.metadata.channelIds.length})
+              </div>
+            )}
           </div>
         )}
 
@@ -7219,6 +7233,44 @@ export function ChannelsPane({
             }
           }}
         />
+
+        {/* Merge Channels Modal */}
+        {mergeModal.isOpen && mergeChannelIds.length >= 2 && (
+          <MergeChannelsModal
+            channels={channels.filter((c) => mergeChannelIds.includes(c.id))}
+            logos={logos}
+            epgData={epgData.map((e) => ({
+              id: e.id,
+              tvg_id: e.tvg_id,
+              name: e.name,
+              icon_url: e.icon_url,
+              epg_source: e.epg_source,
+            }))}
+            epgSources={epgSources.map((s) => ({
+              id: s.id,
+              name: s.name,
+              source_type: s.source_type,
+            }))}
+            channelGroups={channelGroups}
+            streamProfiles={streamProfiles}
+            streams={allStreams.map((s) => ({
+              id: s.id,
+              name: s.name,
+              m3u_account: s.m3u_account,
+            }))}
+            onClose={() => {
+              mergeModal.close();
+              setMergeChannelIds([]);
+            }}
+            onMerged={() => {
+              mergeModal.close();
+              setMergeChannelIds([]);
+              onClearChannelSelection?.();
+              onChannelsChange?.();
+              onChannelGroupsChange?.();
+            }}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/MergeChannelsModal.css
+++ b/frontend/src/components/MergeChannelsModal.css
@@ -1,0 +1,90 @@
+/* MergeChannelsModal — only merge-specific styles; layout from ModalBase.css */
+
+/* Short input for channel number */
+.merge-channels-modal .merge-input-short {
+  max-width: 120px;
+}
+
+/* Source channels list */
+.merge-source-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--bg-tertiary, #1a1a2e);
+  border: 1px solid var(--border-color, #3a3a5a);
+  border-radius: var(--radius-lg);
+  padding: 8px;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.merge-source-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary, #252540);
+}
+
+.merge-source-name {
+  font-size: 0.85rem;
+  color: var(--text-primary, #fff);
+}
+
+.merge-source-streams {
+  font-size: 0.8rem;
+  color: var(--text-secondary, #888);
+}
+
+/* Radio group container (EPG, Logo pickers) */
+.merge-radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--bg-tertiary, #1a1a2e);
+  border: 1px solid var(--border-color, #3a3a5a);
+  border-radius: var(--radius-lg);
+  padding: 8px;
+}
+
+/* Logo preview thumbnail in radio options */
+.merge-logo-preview {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  border-radius: var(--radius-sm);
+}
+
+/* Streams preview */
+.merge-streams-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--bg-tertiary, #1a1a2e);
+  border: 1px solid var(--border-color, #3a3a5a);
+  border-radius: var(--radius-lg);
+  padding: 8px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.merge-stream-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 6px;
+  font-size: 0.85rem;
+  color: var(--text-primary, #fff);
+}
+
+.merge-stream-icon {
+  font-size: 16px;
+  color: var(--text-secondary, #888);
+}
+
+.merge-stream-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/frontend/src/components/MergeChannelsModal.tsx
+++ b/frontend/src/components/MergeChannelsModal.tsx
@@ -1,0 +1,320 @@
+import { useState, useMemo } from 'react';
+import type { Channel, Logo, MergeChannelsRequest } from '../types';
+import { CustomSelect, type SelectOption } from './CustomSelect';
+import { ModalOverlay } from './ModalOverlay';
+import * as api from '../services/api';
+import './ModalBase.css';
+import './MergeChannelsModal.css';
+
+export interface MergeChannelsModalProps {
+  channels: Channel[];
+  logos: Logo[];
+  epgData: { id: number; tvg_id: string; name: string; icon_url: string | null; epg_source: number }[];
+  epgSources: { id: number; name: string; source_type?: string }[];
+  channelGroups: { id: number; name: string }[];
+  streamProfiles: { id: number; name: string; is_active: boolean }[];
+  streams: { id: number; name: string; m3u_account?: number | null }[];
+  onClose: () => void;
+  onMerged: () => void;
+}
+
+export function MergeChannelsModal({
+  channels,
+  logos,
+  epgData,
+  epgSources,
+  channelGroups,
+  streamProfiles,
+  streams,
+  onClose,
+  onMerged,
+}: MergeChannelsModalProps) {
+  // Default values from the first selected channel
+  const first = channels[0];
+
+  const [name, setName] = useState(first.name);
+  const [channelNumber, setChannelNumber] = useState<string>(
+    String(
+      Math.min(
+        ...channels
+          .map((c) => c.channel_number)
+          .filter((n): n is number => n !== null)
+      ) || ''
+    )
+  );
+  const [groupId, setGroupId] = useState<number | null>(first.channel_group_id);
+  const [logoId, setLogoId] = useState<number | null>(first.logo_id);
+  const [epgDataId, setEpgDataId] = useState<number | null>(first.epg_data_id);
+  const [tvgId] = useState<string>(first.tvg_id || '');
+  const [streamProfileId, setStreamProfileId] = useState<number | null>(first.stream_profile_id);
+  const [merging, setMerging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Collect all unique streams from selected channels (preserving order)
+  const mergedStreams = useMemo(() => {
+    const seen = new Set<number>();
+    const result: number[] = [];
+    for (const ch of channels) {
+      for (const sid of ch.streams) {
+        if (!seen.has(sid)) {
+          seen.add(sid);
+          result.push(sid);
+        }
+      }
+    }
+    return result;
+  }, [channels]);
+
+  // Build EPG options from the selected channels' EPG data
+  const epgOptions = useMemo(() => {
+    const seen = new Set<number>();
+    const options: { id: number; name: string; sourceName: string }[] = [];
+    for (const ch of channels) {
+      if (ch.epg_data_id && !seen.has(ch.epg_data_id)) {
+        seen.add(ch.epg_data_id);
+        const epg = epgData.find((e) => e.id === ch.epg_data_id);
+        if (epg) {
+          const source = epgSources.find((s) => s.id === epg.epg_source);
+          options.push({
+            id: epg.id,
+            name: epg.name,
+            sourceName: source?.name || 'Unknown',
+          });
+        }
+      }
+    }
+    return options;
+  }, [channels, epgData, epgSources]);
+
+  // Build logo options from the selected channels
+  const logoOptions = useMemo(() => {
+    const seen = new Set<number>();
+    const options: Logo[] = [];
+    for (const ch of channels) {
+      if (ch.logo_id && !seen.has(ch.logo_id)) {
+        seen.add(ch.logo_id);
+        const logo = logos.find((l) => l.id === ch.logo_id);
+        if (logo) options.push(logo);
+      }
+    }
+    return options;
+  }, [channels, logos]);
+
+  // Group options for CustomSelect
+  const groupOptions: SelectOption[] = [
+    { value: '', label: 'Uncategorized' },
+    ...channelGroups.map((g) => ({ value: String(g.id), label: g.name })),
+  ];
+
+  // Stream profile options
+  const profileOptions: SelectOption[] = [
+    { value: '', label: 'Default' },
+    ...streamProfiles
+      .filter((p) => p.is_active)
+      .map((p) => ({ value: String(p.id), label: p.name })),
+  ];
+
+  const handleMerge = async () => {
+    setMerging(true);
+    setError(null);
+    try {
+      const parsedNumber = parseFloat(channelNumber);
+      const request: MergeChannelsRequest = {
+        source_channel_ids: channels.map((c) => c.id),
+        target_name: name.trim(),
+        target_channel_number: !isNaN(parsedNumber) ? parsedNumber : null,
+        target_channel_group_id: groupId,
+        target_logo_id: logoId,
+        target_tvg_id: tvgId || null,
+        target_epg_data_id: epgDataId,
+        target_stream_profile_id: streamProfileId,
+      };
+      await api.mergeChannels(request);
+      onMerged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Merge failed');
+    } finally {
+      setMerging(false);
+    }
+  };
+
+  return (
+    <ModalOverlay onClose={onClose}>
+      <div className="modal-container modal-lg merge-channels-modal">
+        <div className="modal-header">
+          <h2>Merge {channels.length} Channels</h2>
+          <button className="modal-close-btn" onClick={onClose} title="Close">
+            <span className="material-icons">close</span>
+          </button>
+        </div>
+
+        <div className="modal-body">
+          {error && (
+            <div className="modal-error-banner">
+              <span className="material-icons">error</span>
+              {error}
+            </div>
+          )}
+
+          {/* Source channels list */}
+          <div className="modal-form-group">
+            <label>Merging channels:</label>
+            <div className="merge-source-list">
+              {channels.map((ch) => (
+                <div key={ch.id} className="merge-source-item">
+                  <span className="merge-source-name">{ch.name}</span>
+                  <span className="merge-source-streams">
+                    {ch.streams.length} stream{ch.streams.length !== 1 ? 's' : ''}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Channel name */}
+          <div className="modal-form-group">
+            <label>Channel Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Enter channel name..."
+            />
+          </div>
+
+          {/* Channel number */}
+          <div className="modal-form-group">
+            <label>Channel Number</label>
+            <input
+              type="text"
+              className="merge-input-short"
+              value={channelNumber}
+              onChange={(e) => setChannelNumber(e.target.value)}
+              placeholder="123"
+            />
+          </div>
+
+          {/* Group selector */}
+          <div className="modal-form-group">
+            <label>Channel Group</label>
+            <CustomSelect
+              options={groupOptions}
+              value={groupId != null ? String(groupId) : ''}
+              onChange={(val) => setGroupId(val ? parseInt(val) : null)}
+              searchable
+              searchPlaceholder="Search groups..."
+            />
+          </div>
+
+          {/* EPG selection */}
+          {epgOptions.length > 0 && (
+            <div className="modal-form-group">
+              <label>EPG Data</label>
+              <div className="merge-radio-group">
+                <label className="modal-checkbox-row">
+                  <input
+                    type="radio"
+                    name="epg"
+                    checked={epgDataId === null}
+                    onChange={() => setEpgDataId(null)}
+                  />
+                  None
+                </label>
+                {epgOptions.map((epg) => (
+                  <label key={epg.id} className="modal-checkbox-row">
+                    <input
+                      type="radio"
+                      name="epg"
+                      checked={epgDataId === epg.id}
+                      onChange={() => setEpgDataId(epg.id)}
+                    />
+                    {epg.name}
+                    <span className="form-hint">({epg.sourceName})</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Logo selection */}
+          {logoOptions.length > 0 && (
+            <div className="modal-form-group">
+              <label>Logo</label>
+              <div className="merge-radio-group">
+                <label className="modal-checkbox-row">
+                  <input
+                    type="radio"
+                    name="logo"
+                    checked={logoId === null}
+                    onChange={() => setLogoId(null)}
+                  />
+                  None
+                </label>
+                {logoOptions.map((logo) => (
+                  <label key={logo.id} className="modal-checkbox-row">
+                    <input
+                      type="radio"
+                      name="logo"
+                      checked={logoId === logo.id}
+                      onChange={() => setLogoId(logo.id)}
+                    />
+                    <img
+                      src={logo.url}
+                      alt={logo.name}
+                      className="merge-logo-preview"
+                      onError={(e) => {
+                        (e.target as HTMLImageElement).style.display = 'none';
+                      }}
+                    />
+                    {logo.name}
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Stream profile */}
+          <div className="modal-form-group">
+            <label>Stream Profile</label>
+            <CustomSelect
+              options={profileOptions}
+              value={streamProfileId != null ? String(streamProfileId) : ''}
+              onChange={(val) => setStreamProfileId(val ? parseInt(val) : null)}
+            />
+          </div>
+
+          {/* Merged streams preview */}
+          <div className="modal-form-group">
+            <label>Merged Streams ({mergedStreams.length})</label>
+            <div className="merge-streams-preview">
+              {mergedStreams.map((sid) => {
+                const stream = streams.find((s) => s.id === sid);
+                return (
+                  <div key={sid} className="merge-stream-item">
+                    <span className="material-icons merge-stream-icon">play_circle</span>
+                    <span className="merge-stream-name">
+                      {stream?.name || `Stream #${sid}`}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <div className="modal-footer">
+          <button className="modal-btn modal-btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="modal-btn modal-btn-primary"
+            onClick={handleMerge}
+            disabled={merging || !name.trim()}
+          >
+            {merging ? 'Merging...' : `Merge ${channels.length} Channels`}
+          </button>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,6 +2,7 @@ import type {
   Channel,
   ChannelGroup,
   ChannelProfile,
+  MergeChannelsRequest,
   Stream,
   StreamGroupInfo,
   M3UAccount,
@@ -225,6 +226,13 @@ export async function createChannel(data: {
   return fetchJson(`${API_BASE}/channels`, {
     method: 'POST',
     body: JSON.stringify(data),
+  });
+}
+
+export async function mergeChannels(request: MergeChannelsRequest): Promise<Channel> {
+  return fetchJson(`${API_BASE}/channels/merge`, {
+    method: 'POST',
+    body: JSON.stringify(request),
   });
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -17,6 +17,17 @@ export interface Channel {
   _stagedLogoUrl?: string;
 }
 
+export interface MergeChannelsRequest {
+  source_channel_ids: number[];
+  target_name: string;
+  target_channel_number?: number | null;
+  target_channel_group_id?: number | null;
+  target_logo_id?: number | null;
+  target_tvg_id?: string | null;
+  target_epg_data_id?: number | null;
+  target_stream_profile_id?: number | null;
+}
+
 export type EPGSourceType = 'xmltv' | 'schedules_direct' | 'dummy';
 export type EPGSourceStatus = 'idle' | 'fetching' | 'parsing' | 'error' | 'success' | 'disabled';
 


### PR DESCRIPTION
## Summary
- **Backend**: `POST /api/channels/merge` endpoint that creates a merged channel, moves all streams (deduplicated, order-preserved) from source channels, deletes sources, with rollback on failure
- **Frontend**: `MergeChannelsModal` with channel name, number, group, EPG, logo, and stream profile pickers plus merged streams preview
- **UX**: "Merge channels (N)" context menu item appears when 2+ channels are multi-selected in edit mode

## Test plan
- [ ] Multi-select 2+ channels in Channel Manager (Ctrl+click)
- [ ] Right-click → verify "Merge channels (N)" appears
- [ ] Open modal → verify source channels listed with stream counts
- [ ] Set name, number, group, EPG, logo, stream profile
- [ ] Click merge → verify new channel created with all streams
- [ ] Verify source channels deleted
- [ ] Verify modal follows ModalBase.css styling standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)