### PR TITLE
fix: correct stream stats pushed to Dispatcharr in _push_stats_to_dispatcharr

### DIFF
--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -1131,9 +1131,13 @@ class StreamProber:
             if ecm_stats.get("audio_codec") is not None:
                 mapped["audio_codec"] = ecm_stats["audio_codec"]
             if ecm_stats.get("audio_channels") is not None:
-                mapped["audio_channels"] = ecm_stats["audio_channels"]
+                _channel_names = {1: "mono", 2: "stereo", 6: "5.1", 8: "7.1"}
+                raw_ch = ecm_stats["audio_channels"]
+                mapped["audio_channels"] = (
+                    _channel_names.get(raw_ch, str(raw_ch)) if isinstance(raw_ch, int) else raw_ch
+                )
             if ecm_stats.get("video_bitrate") is not None:
-                mapped["video_bitrate"] = ecm_stats["video_bitrate"]
+                mapped["ffmpeg_output_bitrate"] = round(ecm_stats["video_bitrate"] / 1000, 1)
             if ecm_stats.get("fps") is not None:
                 mapped["source_fps"] = ecm_stats["fps"]
             if ecm_stats.get("stream_type") is not None:

--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -1126,6 +1126,12 @@ class StreamProber:
             mapped: dict = {}
             if ecm_stats.get("resolution") is not None:
                 mapped["resolution"] = ecm_stats["resolution"]
+                try:
+                    w, h = ecm_stats["resolution"].split("x")
+                    mapped["width"] = int(w)
+                    mapped["height"] = int(h)
+                except (ValueError, AttributeError):
+                    pass
             if ecm_stats.get("video_codec") is not None:
                 mapped["video_codec"] = ecm_stats["video_codec"]
             if ecm_stats.get("audio_codec") is not None:
@@ -1139,7 +1145,10 @@ class StreamProber:
             if ecm_stats.get("video_bitrate") is not None:
                 mapped["ffmpeg_output_bitrate"] = round(ecm_stats["video_bitrate"] / 1000, 1)
             if ecm_stats.get("fps") is not None:
-                mapped["source_fps"] = ecm_stats["fps"]
+                try:
+                    mapped["source_fps"] = float(ecm_stats["fps"])
+                except (ValueError, TypeError):
+                    pass
             if ecm_stats.get("stream_type") is not None:
                 mapped["stream_type"] = ecm_stats["stream_type"]
 

--- a/backend/tests/unit/test_stream_prober_push.py
+++ b/backend/tests/unit/test_stream_prober_push.py
@@ -92,11 +92,13 @@ async def test_push_merges_with_existing_stats_and_maps_fps():
     assert merged["pixel_format"] == "yuv420p"
     # ECM overwrote the stale codec
     assert merged["video_codec"] == "h264"
-    # fps -> source_fps mapping
-    assert merged["source_fps"] == "29.97"
+    # fps -> source_fps mapping (float, not string)
+    assert merged["source_fps"] == 29.97
     assert "fps" not in merged
     # Other ECM fields present
     assert merged["resolution"] == "1920x1080"
+    assert merged["width"] == 1920
+    assert merged["height"] == 1080
     assert merged["audio_codec"] == "aac"
     assert merged["audio_channels"] == "stereo"
     assert merged["ffmpeg_output_bitrate"] == 5000.0

--- a/backend/tests/unit/test_stream_prober_push.py
+++ b/backend/tests/unit/test_stream_prober_push.py
@@ -98,8 +98,8 @@ async def test_push_merges_with_existing_stats_and_maps_fps():
     # Other ECM fields present
     assert merged["resolution"] == "1920x1080"
     assert merged["audio_codec"] == "aac"
-    assert merged["audio_channels"] == 2
-    assert merged["video_bitrate"] == 5000000
+    assert merged["audio_channels"] == "stereo"
+    assert merged["ffmpeg_output_bitrate"] == 5000.0
     # Timestamp written
     assert "stream_stats_updated_at" in sent_payload
 


### PR DESCRIPTION
## Summary

Commit 19e76a2 introduced `_push_stats_to_dispatcharr`, which reflects ECM probe results back to Dispatcharr via `PATCH /api/channels/streams/{id}/`. Several fields in the payload were incorrect:

- **Wrong field name** — bitrate was written to `video_bitrate` instead of `ffmpeg_output_bitrate`.
- **Wrong bitrate unit** — the measured bitrate (in bit/s) was sent as-is; Dispatcharr expects kbit/s with one decimal place (e.g. `1234.5`).
- **Audio channels not normalized** — ffprobe returns a raw integer (e.g. `2`); Dispatcharr stores named strings (`"stereo"`, `"5.1"`, etc.). The integer was forwarded without conversion.
- **`source_fps` sent as string** — ECM stores fps as a string column; the value was forwarded without casting, so Dispatcharr received `"29.97"` instead of `29.97`.
- **`width`/`height` not included** — resolution was sent as a combined string only, without the separate integer fields Dispatcharr expects alongside it.

## Approach

- `video_bitrate` key renamed to `ffmpeg_output_bitrate` in the mapped payload.
- Bitrate divided by 1000 and rounded to one decimal before sending.
- Audio channel integers normalized to named strings using the `{1: "mono", 2: "stereo", 6: "5.1", 8: "7.1"}` map, with a `str()` fallback for other counts — consistent with how `VLCLogParser.parse_audio_stream` in `apps/proxy/ts_proxy/services/log_parsers.py` already handles this.
- `fps` cast to `float` before being written to `source_fps`.
- `resolution` string split on `"x"` to derive `width` and `height` as separate integers, matching what `FFmpegLogParser` and `VLCLogParser` both produce.

All affected assertions in `tests/unit/test_stream_prober_push.py` have been updated to match.