### PR TITLE
Wire tests + typecheck into CI (closes bd-t8xw3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,15 +5,13 @@ on:
     branches:
       - main
       - dev
-      # Scratch validation branch for bead enhancedchannelmanager-t8xw3.
-      # Remove this line before merging back to dev.
-      - ci/test-t8xw3
     paths-ignore:
       - '.beads/**'
       - '**.md'
   pull_request:
     branches:
       - main
+      - dev
     paths-ignore:
       - '.beads/**'
       - '**.md'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,8 @@ jobs:
           # elsewhere are grandfathered and tracked via companion bead
           # enhancedchannelmanager-zjge5. New violations on changed files
           # block the PR via --max-warnings 0.
-          git fetch --no-tags --depth=0 origin "${{ github.base_ref }}"
+          # Checkout step uses fetch-depth: 0, so origin/<base_ref> is already
+          # available — no extra fetch required.
           BASE_REF="origin/${{ github.base_ref }}"
           CHANGED=$(git diff --name-only --diff-filter=ACMR "${BASE_REF}...HEAD" \
             | grep -E '^frontend/.*\.(ts|tsx|js|mjs|cjs)$' \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,13 +273,20 @@ jobs:
           # Broader state needed by individual specs (orphaned groups, M3U
           # accounts, etc.) is out of scope here and is tracked in bead
           # enhancedchannelmanager-2lw25.
-          curl -sSf -X POST http://localhost:6100/api/auth/setup \
+          # Use -w so we get the HTTP code even on failure; include response
+          # body in diagnostics so future regressions are easy to diagnose.
+          HTTP_CODE=$(curl -sS -o /tmp/setup-response.json -w '%{http_code}' \
+            -X POST http://localhost:6100/api/auth/setup \
             -H 'Content-Type: application/json' \
-            -d "{\"username\":\"${E2E_TEST_USERNAME}\",\"email\":\"e2e@test.local\",\"password\":\"${E2E_TEST_PASSWORD}\"}" \
-            -o /tmp/setup-response.json
-          echo "Setup response:"
+            -d "{\"username\":\"${E2E_TEST_USERNAME}\",\"email\":\"e2e@example.com\",\"password\":\"${E2E_TEST_PASSWORD}\"}")
+          echo "Setup HTTP code: ${HTTP_CODE}"
+          echo "Setup response body:"
           cat /tmp/setup-response.json
           echo
+          if [ "${HTTP_CODE}" != "201" ] && [ "${HTTP_CODE}" != "200" ]; then
+            echo "Setup call failed with HTTP ${HTTP_CODE}"
+            exit 1
+          fi
 
       - name: Install root dependencies (Playwright)
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,13 @@ jobs:
           RATE_LIMIT_ENABLED: '0'
           ECM_CI_DB_PATH: /tmp/ecm-test.db
         run: |
-          python -m pytest -m "not slow" --tb=short --no-header -p no:warnings
+          # tests/e2e/ hits a running ECM container at localhost:6100.
+          # That path is exercised by the separate `e2e` job (Playwright +
+          # docker build). Skip it here so the backend unit+integration
+          # suite can run without a live service.
+          python -m pytest \
+            --ignore=tests/e2e \
+            -m "not slow" --tb=short --no-header -p no:warnings
 
   # ─── Frontend lint / typecheck / unit tests ───────────────────────────
   frontend:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,281 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      # Scratch validation branch for bead enhancedchannelmanager-t8xw3.
+      # Remove this line before merging back to dev.
+      - ci/test-t8xw3
+    paths-ignore:
+      - '.beads/**'
+      - '**.md'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '.beads/**'
+      - '**.md'
+  schedule:
+    # Nightly E2E on dev — 07:00 UTC. The job itself short-circuits if no new
+    # commits have landed on dev since the last successful run.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+jobs:
+  # ─── Backend tests ────────────────────────────────────────────────────
+  backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio httpx
+
+      - name: Prepare CI SQLite database
+        working-directory: backend
+        run: |
+          mkdir -p /tmp/ecm_test_config
+          rm -f /tmp/ecm-test.db
+          # Materialize an empty SQLite file — tests that opt into the
+          # `ci_seed_db` fixture load their own tmp DBs; this file exists so
+          # smoke checks (e.g. DB driver import, write permissions) work.
+          python -c "import sqlite3; sqlite3.connect('/tmp/ecm-test.db').close()"
+
+      - name: Run pytest
+        working-directory: backend
+        env:
+          CONFIG_DIR: /tmp/ecm_test_config
+          RATE_LIMIT_ENABLED: '0'
+          ECM_CI_DB_PATH: /tmp/ecm-test.db
+        run: |
+          python -m pytest -m "not slow" --tb=short --no-header -p no:warnings
+
+  # ─── Frontend lint / typecheck / unit tests ───────────────────────────
+  frontend:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Need full history so we can diff against origin/main in PR mode.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Lint changed files (PR mode — blocking)
+        if: github.event_name == 'pull_request'
+        run: |
+          # Enforce lint only on files touched by this PR. Existing errors
+          # elsewhere are grandfathered and tracked via companion bead
+          # enhancedchannelmanager-zjge5. New violations on changed files
+          # block the PR via --max-warnings 0.
+          git fetch --no-tags --depth=0 origin "${{ github.base_ref }}"
+          BASE_REF="origin/${{ github.base_ref }}"
+          CHANGED=$(git diff --name-only --diff-filter=ACMR "${BASE_REF}...HEAD" \
+            | grep -E '^frontend/.*\.(ts|tsx|js|mjs|cjs)$' \
+            | grep -v '^frontend/node_modules/' \
+            | sed 's|^frontend/||' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No lintable frontend files changed in this PR."
+            exit 0
+          fi
+          echo "Linting changed files:"
+          echo "$CHANGED"
+          cd frontend
+          echo "$CHANGED" | xargs npx eslint --report-unused-disable-directives --max-warnings 0
+
+      - name: Full lint (push mode — informational only)
+        if: github.event_name != 'pull_request'
+        working-directory: frontend
+        continue-on-error: true
+        run: |
+          echo "Full-repo lint — NON-BLOCKING. Tracking baseline via bead enhancedchannelmanager-zjge5."
+          npm run lint
+
+      - name: Typecheck
+        working-directory: frontend
+        run: npm run typecheck
+
+      - name: Unit tests
+        working-directory: frontend
+        run: npm test
+
+      - name: Coverage report (informational only)
+        working-directory: frontend
+        continue-on-error: true
+        run: |
+          echo "Coverage report — NON-BLOCKING. Threshold enforcement tracked in bead enhancedchannelmanager-nmlxi."
+          npm run test:coverage
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # ─── E2E tests ────────────────────────────────────────────────────────
+  e2e-should-run:
+    name: E2E — Skip-if-no-new-commits guard
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    outputs:
+      run: ${{ steps.guard.outputs.run }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Check for new commits on dev since last successful run
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CURRENT_SHA="$(git rev-parse HEAD)"
+          echo "Current dev HEAD: ${CURRENT_SHA}"
+          # Find the most recent successful scheduled run of this workflow.
+          LAST_SHA=$(gh run list --workflow test.yml --branch dev \
+            --event schedule --status success --limit 1 \
+            --json headSha --jq '.[0].headSha // empty')
+          if [ -z "$LAST_SHA" ]; then
+            echo "No previous successful scheduled run — will run."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Last successful scheduled run SHA: ${LAST_SHA}"
+          if [ "$LAST_SHA" = "$CURRENT_SHA" ]; then
+            echo "No new commits since last successful run — skipping."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New commits detected — will run."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: [e2e-should-run]
+    # PR to main: always run. Nightly cron on dev: run only when guard says so.
+    # workflow_dispatch: always run. Push to dev/main: skip (handled by build pipeline).
+    if: >-
+      always() &&
+      (
+        (github.event_name == 'pull_request' && github.base_ref == 'main') ||
+        (github.event_name == 'schedule' && needs.e2e-should-run.outputs.run == 'true') ||
+        github.event_name == 'workflow_dispatch'
+      )
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(jq -r '.version' frontend/package.json)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Build ECM image locally
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          tags: ecm:e2e-test
+          platforms: linux/amd64
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            ECM_VERSION=${{ steps.version.outputs.version }}
+            RELEASE_CHANNEL=ci
+          cache-from: type=gha,scope=amd64
+
+      - name: Start ECM container
+        run: |
+          docker run -d --name ecm-e2e -p 6100:6100 \
+            -e DISPATCHARR_URL=http://localhost:9999 \
+            ecm:e2e-test
+
+          echo "Waiting for application to become healthy..."
+          READY=false
+          for i in {1..30}; do
+            if curl -sf http://localhost:6100/api/health > /dev/null 2>&1; then
+              echo "Application is ready."
+              READY=true
+              break
+            fi
+            echo "Waiting... ($i/30)"
+            sleep 2
+          done
+
+          if [ "$READY" = "false" ]; then
+            echo "Application failed to start within 60 seconds."
+            docker logs ecm-e2e
+            exit 1
+          fi
+
+      - name: Install root dependencies (Playwright)
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        env:
+          E2E_BASE_URL: http://localhost:6100
+          CI: '1'
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Stop container and collect logs
+        if: always()
+        run: |
+          docker logs ecm-e2e || true
+          docker stop ecm-e2e || true
+          docker rm ecm-e2e || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,6 @@ on:
     paths-ignore:
       - '.beads/**'
       - '**.md'
-  schedule:
-    # Nightly E2E on dev — 07:00 UTC. The job itself short-circuits if no new
-    # commits have landed on dev since the last successful run.
-    - cron: '0 7 * * *'
   workflow_dispatch:
 
 jobs:
@@ -28,7 +24,6 @@ jobs:
   backend:
     name: Backend Tests
     runs-on: ubuntu-latest
-    if: github.event_name != 'schedule'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -64,10 +59,10 @@ jobs:
           RATE_LIMIT_ENABLED: '0'
           ECM_CI_DB_PATH: /tmp/ecm-test.db
         run: |
-          # tests/e2e/ hits a running ECM container at localhost:6100.
-          # That path is exercised by the separate `e2e` job (Playwright +
-          # docker build). Skip it here so the backend unit+integration
-          # suite can run without a live service.
+          # tests/e2e/ hits a running ECM container at localhost:6100 and is
+          # only meaningful against a live service. E2E coverage as a CI gate
+          # is deferred to bead enhancedchannelmanager-2lw25; skip it here so
+          # the backend unit+integration suite can run without a live service.
           python -m pytest \
             --ignore=tests/e2e \
             -m "not slow" --tb=short --no-header -p no:warnings
@@ -76,7 +71,6 @@ jobs:
   frontend:
     name: Frontend Tests
     runs-on: ubuntu-latest
-    if: github.event_name != 'schedule'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -148,172 +142,3 @@ jobs:
           path: frontend/coverage/
           if-no-files-found: ignore
           retention-days: 14
-
-  # ─── E2E tests ────────────────────────────────────────────────────────
-  e2e-should-run:
-    name: E2E — Skip-if-no-new-commits guard
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
-    outputs:
-      run: ${{ steps.guard.outputs.run }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          ref: dev
-          fetch-depth: 0
-
-      - name: Check for new commits on dev since last successful run
-        id: guard
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          CURRENT_SHA="$(git rev-parse HEAD)"
-          echo "Current dev HEAD: ${CURRENT_SHA}"
-          # Find the most recent successful scheduled run of this workflow.
-          LAST_SHA=$(gh run list --workflow test.yml --branch dev \
-            --event schedule --status success --limit 1 \
-            --json headSha --jq '.[0].headSha // empty')
-          if [ -z "$LAST_SHA" ]; then
-            echo "No previous successful scheduled run — will run."
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Last successful scheduled run SHA: ${LAST_SHA}"
-          if [ "$LAST_SHA" = "$CURRENT_SHA" ]; then
-            echo "No new commits since last successful run — skipping."
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "New commits detected — will run."
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          fi
-
-  e2e:
-    name: E2E Tests
-    runs-on: ubuntu-latest
-    needs: [e2e-should-run]
-    # PR to main: always run. Nightly cron on dev: run only when guard says so.
-    # workflow_dispatch: always run. Push to dev/main: skip (handled by build pipeline).
-    if: >-
-      always() &&
-      (
-        (github.event_name == 'pull_request' && github.base_ref == 'main') ||
-        (github.event_name == 'schedule' && needs.e2e-should-run.outputs.run == 'true') ||
-        github.event_name == 'workflow_dispatch'
-      )
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Extract version
-        id: version
-        run: |
-          VERSION=$(jq -r '.version' frontend/package.json)
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Build ECM image locally
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          load: true
-          tags: ecm:e2e-test
-          platforms: linux/amd64
-          build-args: |
-            GIT_COMMIT=${{ github.sha }}
-            ECM_VERSION=${{ steps.version.outputs.version }}
-            RELEASE_CHANNEL=ci
-          cache-from: type=gha,scope=amd64
-
-      - name: Start ECM container
-        run: |
-          docker run -d --name ecm-e2e -p 6100:6100 \
-            -e DISPATCHARR_URL=http://localhost:9999 \
-            ecm:e2e-test
-
-          echo "Waiting for application to become healthy..."
-          READY=false
-          for i in {1..30}; do
-            if curl -sf http://localhost:6100/api/health > /dev/null 2>&1; then
-              echo "Application is ready."
-              READY=true
-              break
-            fi
-            echo "Waiting... ($i/30)"
-            sleep 2
-          done
-
-          if [ "$READY" = "false" ]; then
-            echo "Application failed to start within 60 seconds."
-            docker logs ecm-e2e
-            exit 1
-          fi
-
-      - name: Seed E2E test admin user
-        env:
-          E2E_TEST_USERNAME: e2etester
-          # Password must pass validate_password: >=8 chars, not contain the
-          # username, not a common/breached password. 'Ch4nn3lM4nager!' fits.
-          E2E_TEST_PASSWORD: 'Ch4nn3lM4nager!'
-        run: |
-          # The Playwright suite expects an admin user matching testCredentials
-          # in e2e/fixtures/test-data.ts (overridable via E2E_TEST_USERNAME /
-          # E2E_TEST_PASSWORD env vars). On a fresh container, /api/auth/setup
-          # is required (and only succeeds) before any user exists. Calling it
-          # here creates the first admin so the login fixture can sign in.
-          # Broader state needed by individual specs (orphaned groups, M3U
-          # accounts, etc.) is out of scope here and is tracked in bead
-          # enhancedchannelmanager-2lw25.
-          # Use -w so we get the HTTP code even on failure; include response
-          # body in diagnostics so future regressions are easy to diagnose.
-          HTTP_CODE=$(curl -sS -o /tmp/setup-response.json -w '%{http_code}' \
-            -X POST http://localhost:6100/api/auth/setup \
-            -H 'Content-Type: application/json' \
-            -d "{\"username\":\"${E2E_TEST_USERNAME}\",\"email\":\"e2e@example.com\",\"password\":\"${E2E_TEST_PASSWORD}\"}")
-          echo "Setup HTTP code: ${HTTP_CODE}"
-          echo "Setup response body:"
-          cat /tmp/setup-response.json
-          echo
-          if [ "${HTTP_CODE}" != "201" ] && [ "${HTTP_CODE}" != "200" ]; then
-            echo "Setup call failed with HTTP ${HTTP_CODE}"
-            exit 1
-          fi
-
-      - name: Install root dependencies (Playwright)
-        run: npm ci
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-
-      - name: Run Playwright tests
-        env:
-          E2E_BASE_URL: http://localhost:6100
-          E2E_TEST_USERNAME: e2etester
-          E2E_TEST_PASSWORD: 'Ch4nn3lM4nager!'
-          CI: '1'
-        run: npx playwright test
-
-      - name: Upload Playwright report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: playwright-report/
-          if-no-files-found: ignore
-          retention-days: 14
-
-      - name: Stop container and collect logs
-        if: always()
-        run: |
-          docker logs ecm-e2e || true
-          docker stop ecm-e2e || true
-          docker rm ecm-e2e || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,6 +258,29 @@ jobs:
             exit 1
           fi
 
+      - name: Seed E2E test admin user
+        env:
+          E2E_TEST_USERNAME: e2etester
+          # Password must pass validate_password: >=8 chars, not contain the
+          # username, not a common/breached password. 'Ch4nn3lM4nager!' fits.
+          E2E_TEST_PASSWORD: 'Ch4nn3lM4nager!'
+        run: |
+          # The Playwright suite expects an admin user matching testCredentials
+          # in e2e/fixtures/test-data.ts (overridable via E2E_TEST_USERNAME /
+          # E2E_TEST_PASSWORD env vars). On a fresh container, /api/auth/setup
+          # is required (and only succeeds) before any user exists. Calling it
+          # here creates the first admin so the login fixture can sign in.
+          # Broader state needed by individual specs (orphaned groups, M3U
+          # accounts, etc.) is out of scope here and is tracked in bead
+          # enhancedchannelmanager-2lw25.
+          curl -sSf -X POST http://localhost:6100/api/auth/setup \
+            -H 'Content-Type: application/json' \
+            -d "{\"username\":\"${E2E_TEST_USERNAME}\",\"email\":\"e2e@test.local\",\"password\":\"${E2E_TEST_PASSWORD}\"}" \
+            -o /tmp/setup-response.json
+          echo "Setup response:"
+          cat /tmp/setup-response.json
+          echo
+
       - name: Install root dependencies (Playwright)
         run: npm ci
 
@@ -267,6 +290,8 @@ jobs:
       - name: Run Playwright tests
         env:
           E2E_BASE_URL: http://localhost:6100
+          E2E_TEST_USERNAME: e2etester
+          E2E_TEST_PASSWORD: 'Ch4nn3lM4nager!'
           CI: '1'
         run: npx playwright test
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -166,6 +166,56 @@ def sample_alert_method(test_session):
     return alert_method
 
 
+@pytest.fixture(scope="function")
+def ci_seed_db(tmp_path):
+    """
+    Opt-in CI fixture that materializes a tmp SQLite database seeded from
+    `tests/fixtures/ci_seed.sql`.
+
+    Yields a tuple of `(engine, session)`. The underlying database file lives
+    at `tmp_path / "ecm-test.db"` so the filesystem interaction is exercised
+    (matching the CI layout where pytest runs against a tmp SQLite rather
+    than an in-memory DB). The in-memory `test_engine`/`test_session`
+    fixtures remain the default for speed.
+
+    Usage:
+        def test_read_seeded_row(ci_seed_db):
+            engine, session = ci_seed_db
+            ...
+    """
+    db_path = tmp_path / "ecm-test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+    database.Base.metadata.create_all(bind=engine)
+
+    seed_path = Path(__file__).parent / "fixtures" / "ci_seed.sql"
+    seed_sql = seed_path.read_text()
+    with engine.begin() as conn:
+        for statement in seed_sql.split(";"):
+            stripped = statement.strip()
+            if not stripped or stripped.upper() in {"BEGIN TRANSACTION", "COMMIT"}:
+                continue
+            conn.exec_driver_sql(stripped)
+
+    TestSessionLocal = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=engine,
+        expire_on_commit=False,
+    )
+    session = TestSessionLocal()
+    try:
+        yield engine, session
+    finally:
+        session.close()
+        database.Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
 # Pytest-asyncio configuration
 @pytest.fixture(scope="session")
 def event_loop_policy():

--- a/backend/tests/fixtures/ci_seed.sql
+++ b/backend/tests/fixtures/ci_seed.sql
@@ -1,0 +1,36 @@
+-- CI seed data for the ECM backend test suite.
+--
+-- This file is loaded by the `ci_seed_db` pytest fixture in conftest.py to
+-- populate a SQLite database with deterministic reference rows. It is an
+-- OPT-IN fixture — tests that use it must request it explicitly. The default
+-- in-memory `test_engine` / `test_session` fixtures remain unchanged.
+--
+-- Keep the inserts minimal and rely on column defaults where practical so
+-- schema drift does not silently break the seed. When adding new rows, use
+-- primary keys >= 1000 to avoid colliding with rows created inside tests.
+
+BEGIN TRANSACTION;
+
+-- Representative task configuration (disabled so no scheduler will pick it up).
+INSERT INTO scheduled_tasks (id, task_id, task_name, description, enabled,
+                             schedule_type, send_alerts, alert_on_success,
+                             alert_on_warning, alert_on_error, alert_on_info,
+                             send_to_email, send_to_discord, send_to_telegram,
+                             show_notifications, created_at, updated_at)
+VALUES (1001, 'ci_seed_task', 'CI Seed Task', 'Deterministic seed row', 0,
+        'manual', 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        '2026-01-01 00:00:00', '2026-01-01 00:00:00');
+
+-- Representative journal entry for read-path tests that need one row.
+INSERT INTO journal_entries (id, timestamp, category, action_type, entity_id,
+                             entity_name, description, user_initiated)
+VALUES (1001, '2026-01-01 00:00:00', 'channel', 'create', 1001,
+        'CI Seed Channel', 'Seed row for CI tests.', 1);
+
+-- Representative unread notification.
+INSERT INTO notifications (id, type, title, message, read, source, created_at)
+VALUES (1001, 'info', 'CI Seed Notification',
+        'Seed row for CI tests.', 0, 'system',
+        '2026-01-01 00:00:00');
+
+COMMIT;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "enhanced-channel-manager",
-  "version": "0.16.0-0034",
+  "version": "0.16.0-0040",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "enhanced-channel-manager",
-      "version": "0.16.0-0034",
+      "version": "0.16.0-0040",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/sortable": "8.0.0",
@@ -1085,6 +1085,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -1107,6 +1124,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.39.2",
@@ -2535,23 +2559,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3542,6 +3549,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
@@ -3564,6 +3588,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "10.4.0",
@@ -3675,6 +3706,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -3698,23 +3736,6 @@
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.0",
@@ -4583,13 +4604,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -5374,16 +5388,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -6071,6 +6075,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-parse": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:ci": "vitest run --coverage --reporter=verbose",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@dnd-kit/core": "6.3.1",
@@ -43,7 +44,6 @@
     "vitest": "4.1.4"
   },
   "overrides": {
-    "minimatch": ">=10.2.1",
-    "ajv": ">=8.18.0"
+    "minimatch": ">=10.2.1"
   }
 }


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/test.yml` with two parallel CI jobs: `backend` (pytest unit+integration) and `frontend` (ESLint, typecheck, Vitest, coverage artifact).
- Removes the broken `ajv` override from `frontend/package.json` that was preventing lint from running at all, and adds a `typecheck` script so CI can enforce TS typing.
- Enforces changed-files-only ESLint on PRs (blocking, `--max-warnings 0`) while running full-repo lint on `push` as non-blocking informational output — grandfathers existing violations, blocks new ones.
- Backend job excludes `backend/tests/e2e/` (those specs require a live ECM container at `localhost:6100` and are unsuitable for CI without orchestration).
- No E2E job in this PR — deferring live-service E2E coverage to a dedicated follow-up so this PR can land cleanly.

## Follow-ups

Companion beads tracking the intentional gaps left open by this PR:

- `enhancedchannelmanager-zjge5` — Clean up the ESLint baseline (grandfathered violations on unchanged files).
- `enhancedchannelmanager-8w33i` — Configure branch protection to require the new `Backend Tests` and `Frontend Tests` checks.
- `enhancedchannelmanager-nmlxi` — Define and enforce frontend coverage thresholds (currently informational-only).
- `enhancedchannelmanager-2lw25` — Stand up E2E infrastructure (container + seeded data) so the Playwright/live-service suites can run in CI.

## Test plan

- [x] Backend job green on `ci/test-t8xw3` (latest: run 24645673056, success in 2m17s)
- [x] Frontend job green on `ci/test-t8xw3` (same run)
- [x] Scratch-branch push trigger removed from `test.yml` before PR (verified: push of scrub commit `2d49b1da` did not trigger a CI run on `ci/test-t8xw3`, as intended)
- [ ] CI runs against this PR targeting `dev` and both jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)