### PR TITLE
Fix ffmpeg protocol whitelist in scheduled probe path (closes bd-v3xfl)

### DIFF
--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -27,6 +27,13 @@ logger = logging.getLogger(__name__)
 DEFAULT_PROBE_TIMEOUT = 30  # seconds
 BITRATE_SAMPLE_DURATION = 8  # seconds to sample stream for bitrate measurement
 
+# Restrict ffprobe/ffmpeg to safe network protocols only — blocks file://, data://,
+# concat:, subfile:, etc. URLs fed to these invocations come from Dispatcharr stream
+# rows, which an attacker who can write a stream URL could otherwise weaponise for
+# local-file exfiltration or DoS on the ECM host. Matches the whitelist used in
+# backend/ffmpeg_builder/probe.py and backend/routers/stream_preview.py.
+FFPROBE_PROTOCOL_WHITELIST = "http,https,tcp,udp,rtp,rtmp,pipe"
+
 # Per-account ramp-up configuration
 RAMP_INITIAL_LIMIT = 1         # Start each account at 1 concurrent probe
 RAMP_INCREMENT = 1             # Increase allowed concurrency by 1 after each successful window
@@ -906,6 +913,7 @@ class StreamProber:
             "ffprobe",
             "-v",
             "error",  # Show errors in stderr (was "quiet" which suppressed everything)
+            "-protocol_whitelist", FFPROBE_PROTOCOL_WHITELIST,
             "-print_format",
             "json",
             "-show_format",
@@ -1039,6 +1047,7 @@ class StreamProber:
         """
         cmd = [
             "ffmpeg",
+            "-protocol_whitelist", FFPROBE_PROTOCOL_WHITELIST,
             "-user_agent", "VLC/3.0.20 LibVLC/3.0.20",
             # Network stall guard (microseconds). If the upstream stops
             # delivering data for this long, ffmpeg bails on its own rather

--- a/backend/tests/unit/test_stream_prober_protocol_whitelist.py
+++ b/backend/tests/unit/test_stream_prober_protocol_whitelist.py
@@ -1,0 +1,111 @@
+"""Regression tests for the ffmpeg/ffprobe protocol whitelist in stream_prober.
+
+Background: ppe28.1 added -protocol_whitelist to ffmpeg_builder/probe.py and
+routers/stream_preview.py but missed the scheduled probing path in
+backend/stream_prober.py (_run_ffprobe and _detect_black_screen). Bead v3xfl
+closed that gap. These tests exist so that any future refactor of those cmd
+arrays that drops the whitelist fails loudly in CI — the string-level assertion
+is intentional. Do not "soften" these assertions without re-doing the threat
+model: the whitelist is the control that stops file://, concat:, subfile:,
+data:, etc. from being dereferenced against the ECM host.
+"""
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from stream_prober import FFPROBE_PROTOCOL_WHITELIST, StreamProber
+
+
+EXPECTED_WHITELIST = "http,https,tcp,udp,rtp,rtmp,pipe"
+
+
+def _make_prober(**kwargs) -> StreamProber:
+    """Build a StreamProber with test-friendly defaults."""
+    mock_client = MagicMock()
+    defaults = {
+        "probe_timeout": 1,
+        "black_screen_detection_enabled": True,
+        "black_screen_sample_duration": 1,
+    }
+    defaults.update(kwargs)
+    return StreamProber(client=mock_client, **defaults)
+
+
+def _make_mock_process(stdout: bytes = b"{}", stderr: bytes = b"", returncode: int = 0):
+    """Build an awaitable mock subprocess for asyncio.create_subprocess_exec."""
+    mock_process = AsyncMock()
+
+    async def mock_communicate():
+        return (stdout, stderr)
+
+    mock_process.communicate = mock_communicate
+    mock_process.kill = Mock()
+    mock_process.wait = AsyncMock()
+    mock_process.returncode = returncode
+    return mock_process
+
+
+def test_protocol_whitelist_constant_matches_canonical_value():
+    """The constant must match the value used in probe.py and stream_preview.py.
+
+    Consistency is the point — divergent whitelists across sites create confusion
+    and increase the odds someone "fixes" one and forgets the others.
+    """
+    assert FFPROBE_PROTOCOL_WHITELIST == EXPECTED_WHITELIST
+
+
+@pytest.mark.asyncio
+async def test_run_ffprobe_includes_protocol_whitelist():
+    """_run_ffprobe must pass -protocol_whitelist to ffprobe.
+
+    Without this flag an attacker who can write a stream URL into Dispatcharr
+    can coerce the scheduled prober into dereferencing file://, concat:,
+    subfile:, data:, etc. on the ECM host.
+    """
+    prober = _make_prober()
+    captured_cmd = []
+
+    async def fake_create_subprocess_exec(*args, **_kwargs):
+        captured_cmd.extend(args)
+        return _make_mock_process(stdout=b'{"streams": [], "format": {}}')
+
+    with patch(
+        "stream_prober.asyncio.create_subprocess_exec",
+        side_effect=fake_create_subprocess_exec,
+    ):
+        await prober._run_ffprobe("http://example.test/stream.ts")
+
+    assert captured_cmd[0] == "ffprobe"
+    assert "-protocol_whitelist" in captured_cmd, (
+        f"-protocol_whitelist missing from ffprobe cmd: {captured_cmd}"
+    )
+    idx = captured_cmd.index("-protocol_whitelist")
+    assert captured_cmd[idx + 1] == EXPECTED_WHITELIST
+
+
+@pytest.mark.asyncio
+async def test_detect_black_screen_includes_protocol_whitelist():
+    """_detect_black_screen must pass -protocol_whitelist to ffmpeg.
+
+    Same threat model as _run_ffprobe — the black-screen scan runs ffmpeg
+    against URLs from Dispatcharr and must not dereference unsafe protocols.
+    """
+    prober = _make_prober()
+    captured_cmd = []
+
+    async def fake_create_subprocess_exec(*args, **_kwargs):
+        captured_cmd.extend(args)
+        return _make_mock_process(stderr=b"lavfi.signalstats.YAVG=50.0\n")
+
+    with patch(
+        "stream_prober.asyncio.create_subprocess_exec",
+        side_effect=fake_create_subprocess_exec,
+    ):
+        await prober._detect_black_screen("http://example.test/stream.ts")
+
+    assert captured_cmd[0] == "ffmpeg"
+    assert "-protocol_whitelist" in captured_cmd, (
+        f"-protocol_whitelist missing from ffmpeg cmd: {captured_cmd}"
+    )
+    idx = captured_cmd.index("-protocol_whitelist")
+    assert captured_cmd[idx + 1] == EXPECTED_WHITELIST


### PR DESCRIPTION
## Summary

Scoped follow-up to `ppe28.1`. That bead added `-protocol_whitelist` to `backend/ffmpeg_builder/probe.py` and `backend/routers/stream_preview.py` but missed the scheduled probing path in `backend/stream_prober.py`.

`_run_ffprobe` and `_detect_black_screen` were invoking `ffprobe`/`ffmpeg` against URLs sourced from Dispatcharr stream rows without `-protocol_whitelist`. That is the hottest path in the system (runs continuously per stream-probe schedule) and accepts attacker-influenceable URLs, so `file://`, `concat:`, `subfile:`, `data:`, etc. could be coerced into local-file exfiltration or DoS against the ECM host. Flagged by the Security Engineer during `/onboard` on 2026-04-19.

## Changes

- New module constant `FFPROBE_PROTOCOL_WHITELIST = "http,https,tcp,udp,rtp,rtmp,pipe"` in `backend/stream_prober.py` (matches the string used in the existing fix sites, intentionally identical — divergence would create confusion and reintroduce the "ppe28.1 missed one" failure mode).
- Added `-protocol_whitelist` to the `ffprobe` cmd in `_run_ffprobe`.
- Added `-protocol_whitelist` to the `ffmpeg` cmd in `_detect_black_screen`.
- Added `backend/tests/unit/test_stream_prober_protocol_whitelist.py` with three sanity tests that will fail loudly if someone accidentally drops the whitelist in the future.

## Defensive pass

Audited every `"ffmpeg"` / `"ffprobe"` subprocess invocation in `backend/*.py` to make sure no other site was missed:

| Site | Status |
|---|---|
| `backend/stream_prober.py:_run_ffprobe` | **Fixed in this PR.** |
| `backend/stream_prober.py:_detect_black_screen` | **Fixed in this PR.** |
| `backend/stream_prober.py:check_ffprobe_available` | Safe. `shutil.which` availability check — not a subprocess, no URL. |
| `backend/routers/stream_preview.py` (4 sites) | Already has `-protocol_whitelist` (ppe28.1). |
| `backend/ffmpeg_builder/probe.py:probe_source` | Already has `-protocol_whitelist` (ppe28.1). |
| `backend/ffmpeg_builder/probe.py:_run_ffmpeg_query` | Safe. Self-introspection only (`-version`, `-encoders`, `-decoders`, `-formats`, `-filters`) — no URL input. |
| `backend/ffmpeg_builder/command_generator.py` | Out of scope. Builds user-authored recipes for the authed-admin ffmpeg-builder UI (different trust model — users intentionally construct arbitrary ffmpeg commands including non-network inputs). |
| `backend/ffmpeg_builder/execution.py` | Docstring reference only, not an invocation. |

No additional vulnerable sites found. The two listed above were the only remaining gaps.

## Test plan

- [x] `cd backend && pytest tests/unit/test_stream_prober_protocol_whitelist.py -v` — 3 passed.
- [x] `cd backend && pytest tests/unit/` — 1310 passed, no regressions.
- [ ] CI green on this PR.

Closes `bd-v3xfl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)