### PR TITLE
[bd-8w33i] docs: document main branch protection config

### DIFF
--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -82,3 +82,16 @@ Create beads for anything that needs follow-up.
    ```
 5. Create GitHub release: `gh release create vX.Y.Z --target main --title "vX.Y.Z" --notes-file /tmp/release-notes.md`
 6. **Root checkout MUST stay on dev** — never leave it on main
+
+## Branch Protection on Main
+
+`main` is protected (configured via bead `enhancedchannelmanager-8w33i`). Enforced rules:
+
+- **Required status checks** (strict, branch must be up-to-date): `Backend Tests`, `Frontend Tests` — both jobs defined in `.github/workflows/test.yml`.
+- **Force-pushes blocked** and **deletions blocked**.
+- **Required conversation resolution** on PRs.
+- **Admins are NOT enforced** — the PO can push hotfixes directly if a check outage would otherwise block a release. Use sparingly.
+- **PR reviews are NOT required** — solo-maintainer workaround; add a review requirement when contributor count grows.
+- **Linear history not required** and **signed commits not required** — matches current merge-commit-tolerant workflow.
+
+To inspect or adjust: `gh api /repos/MotWakorb/enhancedchannelmanager/branches/main/protection`. Full config lives only in the GitHub API (no IaC yet).


### PR DESCRIPTION
## Summary
- Documents the branch protection rules now enforced on `main` (configured via `gh api` for bead `enhancedchannelmanager-8w33i`)
- Records both the active gates (required `Backend Tests` / `Frontend Tests`, force-push + deletion blocks, conversation resolution) and the deliberate opt-outs (admin enforcement, PR reviews, linear history, signed commits) so they don't drift into "wait, was that intentional?" territory
- Points the next maintainer at the `gh api .../branches/main/protection` endpoint as the source of truth until we move branch protection into IaC

## Test plan
- [x] Verified `gh api /repos/MotWakorb/enhancedchannelmanager/branches/main/protection` returns the documented config (contexts, enforce_admins=false, allow_force_pushes=false, allow_deletions=false, required_conversation_resolution=true, required_linear_history=false, required_signatures=false, strict=true)
- [ ] Docs-only change — no runtime tests needed

Closes bead `enhancedchannelmanager-8w33i` once merged.

Generated with Claude Code.