### PR TITLE
[bd-w0iyw] Add /api/health/ready with DB + Dispatcharr + ffprobe checks

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -185,6 +185,8 @@ async def security_headers_middleware(request: Request, call_next):
 AUTH_EXEMPT_PATHS = {
     # Health check (Docker, load balancers)
     "/api/health",
+    # Rich readiness check (load balancers, orchestrators)
+    "/api/health/ready",
     # Auth flow (must be public by definition)
     "/api/auth/login",
     "/api/auth/refresh",
@@ -277,7 +279,7 @@ async def request_timing_middleware(request: Request, call_next):
     method = request.method
 
     # Skip static files and health checks for timing logs
-    skip_timing = path.startswith("/assets") or path == "/api/health"
+    skip_timing = path.startswith("/assets") or path == "/api/health" or path == "/api/health/ready"
 
     # Process the request
     response = await call_next(request)

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -1,21 +1,170 @@
 """
 Health & cache router — health check and cache management endpoints.
 
-Extracted from main.py (Phase 2 of v0.13.0 backend refactor).
-"""
-import os
-from typing import Optional
+Two health endpoints with distinct purposes:
 
-from fastapi import APIRouter
+- ``/api/health``: cheap liveness probe. Returns 200 with version metadata.
+  Called every 30s by the Dockerfile HEALTHCHECK, so it must stay fast and
+  must NOT depend on external subsystems (DB, Dispatcharr, ffprobe). If this
+  endpoint returns non-200, the container is considered unhealthy — we don't
+  want a transient Dispatcharr outage to mark the whole app as down.
+
+- ``/api/health/ready``: rich readiness probe. Verifies the app can actually
+  do work by checking DB connectivity, Dispatcharr reachability (cached 30s
+  to avoid hammering), and ffprobe availability. Returns 200 when all
+  subsystems are healthy, 503 when any required subsystem is degraded
+  (standard readiness convention).
+
+Extracted from main.py (Phase 2 of v0.13.0 backend refactor). Rich readiness
+added per bead enhancedchannelmanager-w0iyw (SRE operability improvement).
+"""
+import asyncio
+import logging
+import os
+import shutil
+import time
+from typing import Any, Optional
+
+from fastapi import APIRouter, Response
+from sqlalchemy import text
 
 from cache import get_cache
+from config import get_settings
+from database import get_session
+from dispatcharr_client import get_client
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Health"])
 
 
+# ============================================================================
+# Readiness-check helpers
+# ============================================================================
+# Cache the Dispatcharr reachability result to avoid hammering Dispatcharr
+# when /api/health/ready is polled rapidly (e.g., by a load balancer). A
+# simple module-level dict is sufficient — the cache lives as long as the
+# process and has a single key. A full cache library would be overkill.
+_DISPATCHARR_CACHE_TTL_SECONDS = 30.0
+_DISPATCHARR_PING_TIMEOUT_SECONDS = 3.0
+_dispatcharr_cache: dict = {"expires_at": 0.0, "result": None}
+
+# Track last-known readiness state so we only log transitions, not every poll.
+_last_ready_state: Optional[bool] = None
+
+
+async def _check_database() -> dict:
+    """Run a cheap ``SELECT 1`` to confirm the DB is reachable.
+
+    Returns a dict with ``status`` ("ok" or "fail") and a ``detail`` string.
+    Never raises — failures are captured as a "fail" result.
+    """
+    try:
+        db = get_session()
+        try:
+            db.execute(text("SELECT 1"))
+        finally:
+            db.close()
+        return {"status": "ok", "detail": "SELECT 1 succeeded"}
+    except Exception as e:
+        logger.warning("[HEALTH] Database readiness check failed: %s", e)
+        return {"status": "fail", "detail": f"{type(e).__name__}: {e}"}
+
+
+async def _ping_dispatcharr() -> dict:
+    """Attempt to reach Dispatcharr with a short timeout.
+
+    Only verifies the URL is reachable (TCP + HTTP response). Does NOT
+    authenticate — we don't want a transient auth problem to mark readiness
+    as failed, and authenticating on every readiness poll would defeat the
+    purpose of a cheap probe.
+
+    Uses the Dispatcharr client's underlying httpx client so we inherit the
+    configured connection limits. Returns a dict with ``status``, ``detail``,
+    and ``cached_until`` fields.
+    """
+    settings = get_settings()
+    if not settings.url:
+        return {"status": "skipped", "detail": "not configured"}
+
+    try:
+        client = get_client()
+        # Hit the base URL — any response (including 4xx) means Dispatcharr
+        # is up and responding, which is all readiness needs to confirm.
+        response = await asyncio.wait_for(
+            client._client.get(client.base_url),
+            timeout=_DISPATCHARR_PING_TIMEOUT_SECONDS,
+        )
+        return {
+            "status": "ok",
+            "detail": f"reachable (HTTP {response.status_code})",
+        }
+    except asyncio.TimeoutError:
+        return {
+            "status": "fail",
+            "detail": f"timeout after {_DISPATCHARR_PING_TIMEOUT_SECONDS}s",
+        }
+    except Exception as e:
+        return {"status": "fail", "detail": f"{type(e).__name__}: {e}"}
+
+
+async def _check_dispatcharr() -> dict:
+    """Ping Dispatcharr, caching the result for 30s.
+
+    The readiness endpoint may be polled rapidly (load balancer, k8s probe),
+    and pinging Dispatcharr on every call would add avoidable load to the
+    downstream service. Caching for 30s gives us a fresh-enough signal
+    without creating a thundering herd.
+    """
+    now = time.monotonic()
+    cached = _dispatcharr_cache.get("result")
+    expires_at = _dispatcharr_cache.get("expires_at", 0.0)
+    if cached is not None and now < expires_at:
+        # Echo the cached result with a wall-clock hint for observers.
+        return {**cached, "cached_until": _dispatcharr_cache.get("cached_until_iso", "")}
+
+    result = await _ping_dispatcharr()
+    expires_at = now + _DISPATCHARR_CACHE_TTL_SECONDS
+    # Use wall-clock time for the "cached_until" field so callers can read it
+    # meaningfully. Monotonic time is used internally for the TTL check.
+    import datetime
+    cached_until_iso = (
+        datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(seconds=_DISPATCHARR_CACHE_TTL_SECONDS)
+    ).isoformat()
+
+    _dispatcharr_cache["result"] = result
+    _dispatcharr_cache["expires_at"] = expires_at
+    _dispatcharr_cache["cached_until_iso"] = cached_until_iso
+    return {**result, "cached_until": cached_until_iso}
+
+
+def _check_ffprobe() -> dict:
+    """Check whether ffprobe is available on PATH."""
+    ffprobe_path = shutil.which("ffprobe")
+    if ffprobe_path:
+        return {"status": "ok", "detail": ffprobe_path}
+    return {"status": "fail", "detail": "ffprobe not found on PATH"}
+
+
+def _reset_dispatcharr_cache() -> None:
+    """Reset the Dispatcharr readiness cache. Intended for tests."""
+    _dispatcharr_cache["expires_at"] = 0.0
+    _dispatcharr_cache["result"] = None
+    _dispatcharr_cache["cached_until_iso"] = ""
+
+
+# ============================================================================
+# Endpoints
+# ============================================================================
 @router.get("/api/health")
 async def health_check():
-    """Health check endpoint returning version and connection status."""
+    """Cheap liveness check — no subsystem probing.
+
+    The Dockerfile HEALTHCHECK calls this every 30s; it must stay fast and
+    must not fail for transient downstream issues. For rich subsystem
+    verification, callers should hit ``/api/health/ready`` instead.
+    """
     version = os.environ.get("ECM_VERSION", "unknown")
     release_channel = os.environ.get("RELEASE_CHANNEL", "latest")
     git_commit = os.environ.get("GIT_COMMIT", "unknown")
@@ -29,6 +178,63 @@ async def health_check():
     }
 
 
+@router.get("/api/health/ready")
+async def readiness_check(response: Response) -> dict:
+    """Rich readiness check — verifies DB, Dispatcharr, and ffprobe.
+
+    Returns 200 when every required subsystem is "ok" (or Dispatcharr is
+    "skipped" because no URL is configured — first-run state). Returns 503
+    when any required subsystem fails, so load balancers and orchestrators
+    can route traffic accordingly.
+
+    The Dispatcharr ping is cached for 30s to avoid hammering the downstream
+    service when readiness is polled rapidly.
+    """
+    global _last_ready_state
+
+    db_result = await _check_database()
+    dispatcharr_result = await _check_dispatcharr()
+    ffprobe_result = _check_ffprobe()
+
+    checks = {
+        "database": db_result,
+        "dispatcharr": dispatcharr_result,
+        "ffprobe": ffprobe_result,
+    }
+
+    # "skipped" counts as acceptable — no Dispatcharr configured yet is a
+    # valid first-run state, not a failure.
+    is_ready = all(
+        check["status"] in ("ok", "skipped") for check in checks.values()
+    )
+
+    # Log transitions only, not every poll, to keep log volume sane.
+    if _last_ready_state is not None and _last_ready_state != is_ready:
+        if is_ready:
+            logger.info("[HEALTH] Readiness transitioned fail -> ok")
+        else:
+            failing = [
+                f"{name}={check['status']} ({check['detail']})"
+                for name, check in checks.items()
+                if check["status"] == "fail"
+            ]
+            logger.info("[HEALTH] Readiness transitioned ok -> fail: %s", "; ".join(failing))
+    _last_ready_state = is_ready
+
+    payload: dict[str, Any] = {
+        "status": "ready" if is_ready else "not_ready",
+        "checks": checks,
+    }
+
+    if not is_ready:
+        response.status_code = 503
+
+    return payload
+
+
+# ============================================================================
+# Cache management endpoints (unchanged)
+# ============================================================================
 @router.post("/api/cache/invalidate", tags=["Cache"])
 async def invalidate_cache(prefix: Optional[str] = None):
     """Invalidate cached data. If prefix is provided, only invalidate matching keys."""

--- a/backend/tests/routers/test_health.py
+++ b/backend/tests/routers/test_health.py
@@ -1,11 +1,15 @@
 """
 Unit tests for health and cache endpoints.
 
-Tests: GET /api/health, POST /api/cache/invalidate, GET /api/cache/stats
-Mocks: get_cache() to isolate from real cache state.
+Tests: GET /api/health, GET /api/health/ready, POST /api/cache/invalidate,
+GET /api/cache/stats
+Mocks: get_cache() to isolate from real cache state; subsystem probes for
+readiness are mocked at the router module level.
 """
+import asyncio
+
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
 class TestHealthCheck:
@@ -111,3 +115,152 @@ class TestCacheInvalidate:
             assert "3" in data["message"]
             assert "streams" in data["message"]
             mock_cache.invalidate_prefix.assert_called_once_with("streams")
+
+
+# ============================================================================
+# Readiness tests — GET /api/health/ready
+# ============================================================================
+@pytest.fixture(autouse=True)
+def _reset_readiness_state():
+    """Reset the readiness module globals between tests to prevent bleed-through.
+
+    The Dispatcharr cache is module-level state that persists across tests,
+    and the ``_last_ready_state`` tracker similarly survives. Both need to be
+    pristine for each test or ordering becomes load-bearing.
+    """
+    from routers import health as health_module
+    health_module._reset_dispatcharr_cache()
+    health_module._last_ready_state = None
+    yield
+    health_module._reset_dispatcharr_cache()
+    health_module._last_ready_state = None
+
+
+def _mk_dispatcharr_client_mock(*, response_status: int = 200, raise_exc=None):
+    """Build a mock that mirrors the DispatcharrClient's inner httpx client.
+
+    The readiness probe calls ``client._client.get(base_url)``, so we need a
+    mock with a ``base_url`` attribute and an async ``_client.get``.
+    """
+    mock_client = MagicMock()
+    mock_client.base_url = "http://dispatcharr.example:9191"
+    inner = MagicMock()
+    if raise_exc is not None:
+        inner.get = AsyncMock(side_effect=raise_exc)
+    else:
+        mock_response = MagicMock()
+        mock_response.status_code = response_status
+        inner.get = AsyncMock(return_value=mock_response)
+    mock_client._client = inner
+    return mock_client
+
+
+class TestReadiness:
+    """Tests for GET /api/health/ready endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_ready_returns_200_when_all_ok(self, async_client):
+        """Ready endpoint returns 200 with status=ready when all subsystems OK."""
+        mock_settings = MagicMock()
+        mock_settings.url = "http://dispatcharr.example:9191"
+        mock_client = _mk_dispatcharr_client_mock(response_status=200)
+
+        with patch("routers.health.get_settings", return_value=mock_settings), \
+             patch("routers.health.get_client", return_value=mock_client), \
+             patch("routers.health.shutil.which", return_value="/usr/bin/ffprobe"):
+            response = await async_client.get("/api/health/ready")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ready"
+        assert data["checks"]["database"]["status"] == "ok"
+        assert data["checks"]["dispatcharr"]["status"] == "ok"
+        assert data["checks"]["ffprobe"]["status"] == "ok"
+        assert data["checks"]["ffprobe"]["detail"] == "/usr/bin/ffprobe"
+
+    @pytest.mark.asyncio
+    async def test_ready_returns_503_when_db_fails(self, async_client):
+        """Ready endpoint returns 503 when the DB check fails."""
+        mock_settings = MagicMock()
+        mock_settings.url = ""  # dispatcharr skipped
+        mock_session = MagicMock()
+        mock_session.execute.side_effect = RuntimeError("database is locked")
+
+        with patch("routers.health.get_session", return_value=mock_session), \
+             patch("routers.health.get_settings", return_value=mock_settings), \
+             patch("routers.health.shutil.which", return_value="/usr/bin/ffprobe"):
+            response = await async_client.get("/api/health/ready")
+
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "not_ready"
+        assert data["checks"]["database"]["status"] == "fail"
+        assert "database is locked" in data["checks"]["database"]["detail"]
+
+    @pytest.mark.asyncio
+    async def test_ready_returns_503_when_dispatcharr_times_out(self, async_client):
+        """Ready endpoint returns 503 when Dispatcharr ping times out."""
+        mock_settings = MagicMock()
+        mock_settings.url = "http://dispatcharr.example:9191"
+        mock_client = _mk_dispatcharr_client_mock(
+            raise_exc=asyncio.TimeoutError("timed out"),
+        )
+
+        with patch("routers.health.get_settings", return_value=mock_settings), \
+             patch("routers.health.get_client", return_value=mock_client), \
+             patch("routers.health.shutil.which", return_value="/usr/bin/ffprobe"):
+            response = await async_client.get("/api/health/ready")
+
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "not_ready"
+        assert data["checks"]["dispatcharr"]["status"] == "fail"
+        assert "timeout" in data["checks"]["dispatcharr"]["detail"]
+
+    @pytest.mark.asyncio
+    async def test_ready_skips_dispatcharr_when_not_configured(self, async_client):
+        """When no Dispatcharr URL is set, dispatcharr status is 'skipped' and overall is ready."""
+        mock_settings = MagicMock()
+        mock_settings.url = ""
+
+        with patch("routers.health.get_settings", return_value=mock_settings), \
+             patch("routers.health.shutil.which", return_value="/usr/bin/ffprobe"):
+            response = await async_client.get("/api/health/ready")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ready"
+        assert data["checks"]["dispatcharr"]["status"] == "skipped"
+        assert data["checks"]["dispatcharr"]["detail"] == "not configured"
+
+    @pytest.mark.asyncio
+    async def test_ready_returns_503_when_ffprobe_missing(self, async_client):
+        """Ready endpoint returns 503 when ffprobe is not on PATH."""
+        mock_settings = MagicMock()
+        mock_settings.url = ""
+
+        with patch("routers.health.get_settings", return_value=mock_settings), \
+             patch("routers.health.shutil.which", return_value=None):
+            response = await async_client.get("/api/health/ready")
+
+        assert response.status_code == 503
+        data = response.json()
+        assert data["checks"]["ffprobe"]["status"] == "fail"
+
+    @pytest.mark.asyncio
+    async def test_dispatcharr_check_is_cached(self, async_client):
+        """Two rapid readiness calls should only ping Dispatcharr once (30s cache)."""
+        mock_settings = MagicMock()
+        mock_settings.url = "http://dispatcharr.example:9191"
+        mock_client = _mk_dispatcharr_client_mock(response_status=200)
+
+        with patch("routers.health.get_settings", return_value=mock_settings), \
+             patch("routers.health.get_client", return_value=mock_client), \
+             patch("routers.health.shutil.which", return_value="/usr/bin/ffprobe"):
+            r1 = await async_client.get("/api/health/ready")
+            r2 = await async_client.get("/api/health/ready")
+
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        # Only the first call should have actually pinged Dispatcharr.
+        assert mock_client._client.get.await_count == 1


### PR DESCRIPTION
## Summary

Adds a rich readiness endpoint alongside the existing cheap liveness probe, so operators can actually see whether required subsystems are healthy instead of just \`{\"status\": \"healthy\"}\` baked-in at deploy time.

### Endpoints

- \`GET /api/health\` — **unchanged**. Cheap liveness probe. The Dockerfile HEALTHCHECK calls this every 30s; it must stay fast and must NOT depend on external subsystems. A transient Dispatcharr outage must not mark the whole container as unhealthy.
- \`GET /api/health/ready\` — **new**. Rich readiness probe.
  - \`database\`: \`SELECT 1\` via \`get_session()\`.
  - \`dispatcharr\`: short-timeout HTTP ping (3s). Cached for 30s to avoid hammering the downstream service when readiness is polled rapidly (e.g., by a load balancer). When no URL is configured (first-run state), status is \`skipped\` — not \`fail\`.
  - \`ffprobe\`: \`shutil.which(\"ffprobe\")\`.
  - Returns 200 when all subsystems are \`ok\` (or Dispatcharr is \`skipped\`), 503 when any required subsystem fails — standard readiness convention.

### Why two endpoints?

Liveness and readiness have different semantics and different cadences. The Dockerfile HEALTHCHECK runs every 30s; if we folded subsystem checks into \`/api/health\` we'd generate 120 Dispatcharr pings an hour per container, and any transient Dispatcharr hiccup would trigger container restarts. Readiness is a separate probe that callers can poll on their own cadence.

### Sample payload (200)

\`\`\`json
{
  \"status\": \"ready\",
  \"checks\": {
    \"database\": {\"status\": \"ok\", \"detail\": \"SELECT 1 succeeded\"},
    \"dispatcharr\": {
      \"status\": \"ok\",
      \"detail\": \"reachable (HTTP 200)\",
      \"cached_until\": \"2026-04-20T03:27:46.176769+00:00\"
    },
    \"ffprobe\": {\"status\": \"ok\", \"detail\": \"/usr/bin/ffprobe\"}
  }
}
\`\`\`

### Caching strategy

Module-level dict with \`{expires_at, result, cached_until_iso}\`. TTL 30s, using monotonic clock for the expiry check and wall-clock for the observable \`cached_until\` field. No cache library needed — a single key with a fixed TTL doesn't warrant one.

### Notes

- Also exempts \`/api/health/ready\` from the auth middleware (same as \`/api/health\`) and from request-timing logs.
- Readiness transitions (ok→fail, fail→ok) are logged at INFO. Individual polls are not logged.
- \`/api/health\` schema is unchanged — existing callers (Dockerfile HEALTHCHECK, CI smoke tests, existing unit/e2e tests asserting \`status == \"healthy\"\`) are preserved.

## Test plan

- [x] \`backend/tests/routers/test_health.py\` — 6 new tests pass (all ok, DB fail, Dispatcharr timeout, Dispatcharr skipped, ffprobe missing, cache hits only once across two rapid calls)
- [x] Full unit suite (1307 tests) passes
- [x] Router + integration suites (938 tests) pass
- [ ] CI green on this PR

## Out of scope (separate beads)

- Prometheus \`/metrics\` endpoint
- Task-liveness / background-job health checks
- Dispatcharr auth verification (readiness only confirms reachability)

Closes bead enhancedchannelmanager-w0iyw.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>