### PR TITLE
[bd-zjge5] Replace any[] with unknown[] in logger.ts

### DIFF
--- a/frontend/src/utils/logger.ts
+++ b/frontend/src/utils/logger.ts
@@ -37,9 +37,19 @@ class Logger {
   }
 
   /**
-   * Format a log message with timestamp and level
+   * Format a log message with timestamp and level.
+   *
+   * `args` is typed as `unknown[]` because callers pass arbitrary structured
+   * payloads (errors, objects, primitives) that are forwarded verbatim to
+   * `console.*`. We never introspect them here — we just prepend the formatted
+   * prefix and hand them through — so `unknown` is the correct contract: we
+   * accept anything and make no assumptions.
    */
-  private formatMessage(level: LogLevel, message: string, ...args: any[]): [string, ...any[]] {
+  private formatMessage(
+    level: LogLevel,
+    message: string,
+    ...args: unknown[]
+  ): [string, ...unknown[]] {
     const timestamp = new Date().toISOString();
     const formattedMessage = `[${timestamp}] [${level}] ${message}`;
     return [formattedMessage, ...args];
@@ -48,7 +58,7 @@ class Logger {
   /**
    * Log a debug message
    */
-  debug(message: string, ...args: any[]): void {
+  debug(message: string, ...args: unknown[]): void {
     if (this.shouldLog('DEBUG')) {
       console.log(...this.formatMessage('DEBUG', message, ...args));
     }
@@ -57,7 +67,7 @@ class Logger {
   /**
    * Log an info message
    */
-  info(message: string, ...args: any[]): void {
+  info(message: string, ...args: unknown[]): void {
     if (this.shouldLog('INFO')) {
       console.log(...this.formatMessage('INFO', message, ...args));
     }
@@ -66,7 +76,7 @@ class Logger {
   /**
    * Log a warning message
    */
-  warn(message: string, ...args: any[]): void {
+  warn(message: string, ...args: unknown[]): void {
     if (this.shouldLog('WARN')) {
       console.warn(...this.formatMessage('WARN', message, ...args));
     }
@@ -75,7 +85,7 @@ class Logger {
   /**
    * Log an error message
    */
-  error(message: string, ...args: any[]): void {
+  error(message: string, ...args: unknown[]): void {
     if (this.shouldLog('ERROR')) {
       console.error(...this.formatMessage('ERROR', message, ...args));
     }
@@ -84,7 +94,7 @@ class Logger {
   /**
    * Log an error with stack trace
    */
-  exception(message: string, error: Error, ...args: any[]): void {
+  exception(message: string, error: Error, ...args: unknown[]): void {
     if (this.shouldLog('ERROR')) {
       console.error(...this.formatMessage('ERROR', message, ...args));
       console.error('Stack trace:', error.stack);


### PR DESCRIPTION
## Summary

First chunk of bead `enhancedchannelmanager-zjge5` (drive frontend ESLint baseline toward zero).

- Replace `...args: any[]` with `...args: unknown[]` on all 6 `Logger` methods + `formatMessage` helper in `frontend/src/utils/logger.ts`.
- `args` is forwarded verbatim to `console.*` and never introspected — `unknown[]` is the correct contract (accept anything, make no assumptions). Added a comment on `formatMessage` explaining the choice.
- Fixes 7 of 70 baseline `@typescript-eslint/no-explicit-any` errors; no `eslint-disable` escape hatches.

## Scope

Intentionally narrow — one file, one rule. This is session 1 of 1-3 expected sessions on zjge5; subsequent PRs will tackle the remaining `no-explicit-any` (ChannelsPane, AutoCreationTab, AnnotationCanvas, ECMIntegration, AnnotationPopover), then the unused-caught-err / eslint-disable-directive / empty-interface pile. The final session will flip the t8xw3 lint strategy to blocking once the count hits zero.

## Lint delta

| | Before | After |
|-|-|-|
| errors | 70 | 63 |
| warnings | 89 | 89 |
| total | 159 | 152 |

## Test plan

- [x] `npm run lint` — confirmed 70→63 errors (exactly -7 matching the 7 `no-explicit-any` fixes)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 1118/1118 passing (including 17 existing `logger.test.ts` cases, which exercise argument forwarding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)