### PR TITLE
[bd-sw883] Smart sort: apply primary criteria within failed-rank buckets (#73)

### DIFF
--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -167,6 +167,61 @@ def smart_sort_streams(
         else:
             logger.debug("[STREAM-PROBE-SORT]   Stream %s: NO STATS AVAILABLE", stream_id)
 
+    def compute_criteria_values(stat, stream_id: int) -> list:
+        """Compute sort-key values for active_criteria in priority order.
+
+        Used for both successful streams (primary ordering) and deprioritized
+        streams (within-bucket tiebreaker — bd-sw883 / issue #73). For a
+        deprioritized stream where ``stat`` is None (no probe row at all),
+        only m3u_priority can be computed; all other criteria are 0.
+        """
+        values = []
+        for criterion in active_criteria:
+            if criterion == "resolution":
+                resolution_value = 0
+                if stat and stat.resolution:
+                    try:
+                        parts = stat.resolution.split('x')
+                        if len(parts) == 2:
+                            resolution_value = int(parts[1])  # height only
+                    except (ValueError, IndexError) as e:
+                        logger.debug("[STREAM-PROBE] Suppressed resolution parse error: %s", e)
+                values.append(-resolution_value)
+
+            elif criterion == "bitrate":
+                bitrate_value = 0
+                if stat:
+                    bitrate_value = stat.video_bitrate or stat.bitrate or 0
+                values.append(-bitrate_value)
+
+            elif criterion == "framerate":
+                framerate_value = 0
+                if stat and stat.fps:
+                    try:
+                        framerate_value = float(stat.fps)
+                    except (ValueError, TypeError) as e:
+                        logger.debug("[STREAM-PROBE] Suppressed fps parse error: %s", e)
+                values.append(-framerate_value)
+
+            elif criterion == "m3u_priority":
+                # m3u_priority does NOT require a successful probe — it comes
+                # from the m3u account map, so it's always meaningful.
+                m3u_priority_value = 0
+                m3u_account_id = stream_m3u_map.get(stream_id)
+                if m3u_account_id is not None:
+                    m3u_priority_value = m3u_account_priorities.get(str(m3u_account_id), 0)
+                values.append(-m3u_priority_value)
+
+            elif criterion == "audio_channels":
+                audio_channels_value = stat.audio_channels if stat and stat.audio_channels else 0
+                values.append(-audio_channels_value)
+
+            elif criterion == "video_codec":
+                codec_value = get_codec_rank(stat.video_codec) if stat else 0
+                values.append(-codec_value)
+
+        return values
+
     def get_sort_value(stream_id: int) -> tuple:
         stat = stats_map.get(stream_id)
         stream_name = stat.stream_name if stat else f"Stream {stream_id}"
@@ -176,19 +231,22 @@ def smart_sort_streams(
             if not stat or stat.probe_status in ('failed', 'timeout', 'pending'):
                 rank = failed_rank.get('failed', 0)
                 logger.debug("[STREAM-PROBE-SORT]   %s: DEPRIORITIZED (status=%s, rank=%s)", stream_name, stat.probe_status if stat else 'no_stats', rank)
-                return (1, rank) + tuple(0 for _ in active_criteria)
+                # bd-sw883: apply primary criteria within the failed bucket too.
+                return (1, rank) + tuple(compute_criteria_values(stat, stream_id))
 
         # Deprioritize black screen streams (probe succeeded but content is black)
         if deprioritize_failed_streams and deprioritize_black_screen and stat and getattr(stat, 'is_black_screen', False) is True:
             rank = failed_rank.get('black_screen', 1)
             logger.debug("[STREAM-PROBE-SORT]   %s: DEPRIORITIZED (black screen, rank=%s)", stream_name, rank)
-            return (1, rank) + tuple(0 for _ in active_criteria)
+            # bd-sw883: apply primary criteria within the black_screen bucket too.
+            return (1, rank) + tuple(compute_criteria_values(stat, stream_id))
 
         # Deprioritize low FPS streams (probe succeeded but FPS < 20)
         if deprioritize_failed_streams and deprioritize_low_fps and stat and getattr(stat, 'is_low_fps', False) is True:
             rank = failed_rank.get('low_fps', 2)
             logger.debug("[STREAM-PROBE-SORT]   %s: DEPRIORITIZED (low fps, rank=%s)", stream_name, rank)
-            return (1, rank) + tuple(0 for _ in active_criteria)
+            # bd-sw883: apply primary criteria within the low_fps bucket too.
+            return (1, rank) + tuple(compute_criteria_values(stat, stream_id))
 
         if not stat or stat.probe_status != 'success':
             logger.debug("[STREAM-PROBE-SORT]   %s: No successful probe data", stream_name)

--- a/backend/tests/unit/test_sort_criteria.py
+++ b/backend/tests/unit/test_sort_criteria.py
@@ -602,7 +602,13 @@ class TestStandaloneSortFunction:
         assert result == [1, 2]
 
     def test_standalone_failed_still_sorted_by_m3u(self):
-        """Both-failed streams still get M3U priority ordering."""
+        """Both-failed streams still get M3U priority ordering within their bucket.
+
+        bd-sw883 / issue #73: within a deprioritized bucket the primary criteria
+        (here m3u_priority) must still apply. Stream 2 is on m3u account 1
+        (priority 100); stream 1 is on m3u account 2 (priority 50) — so stream 2
+        leads the bucket.
+        """
         result = run_standalone_sort(
             [1, 2],
             {
@@ -613,11 +619,10 @@ class TestStandaloneSortFunction:
             stream_sort_priority=["m3u_priority"],
             stream_sort_enabled={"m3u_priority": True},
             m3u_account_priorities={"1": 100, "2": 50},
-            # With deprioritize enabled, both failed get (1, 0) so order is stable
             deprioritize_failed_streams=True,
         )
-        # Both deprioritized to bottom with same tuple, so original order preserved
-        assert result == [1, 2]
+        # Both deprioritized, but m3u_priority ordering is applied within the bucket
+        assert result == [2, 1]
 
 
 class TestExtractM3uAccountId:
@@ -743,3 +748,184 @@ class TestPerCategoryDeprioritization:
         # Low FPS sorts by quality (1080), ok by quality (720), black screen at bottom
         assert result[0] == 2  # Low FPS 1080 first
         assert result[-1] == 1  # Black screen last
+
+
+class TestWithinBucketPrimaryCriteria:
+    """Regression tests for bd-sw883 / GitHub #73.
+
+    Primary sort criteria (resolution, framerate, etc.) must be applied
+    WITHIN each failed-rank bucket — not just at the bucket-boundary level.
+    Previously streams inside the same bucket (e.g. all black_screen at rank=0,
+    or all status=failed at rank=2) were tied on the composite sort key and
+    therefore kept insertion order regardless of configured criteria.
+    """
+
+    def _bs_stats(self, stream_id, resolution, fps):
+        """Build a success-probed black-screen stream stats (lands in rank=0)."""
+        stats = create_mock_stats(
+            stream_id,
+            resolution=resolution,
+            fps=fps,
+            probe_status="success",
+        )
+        stats.is_black_screen = True
+        stats.is_low_fps = False
+        return stats
+
+    def _failed_stats(self, stream_id, resolution, fps):
+        """Build a status=failed stream stats (lands in rank=2).
+
+        Failed probes don't have meaningful resolution/fps on disk, but we
+        attach them here so the test can assert sort-key ordering logic —
+        reporter's log shows these fields ARE populated from the prior
+        successful probe when a later probe fails.
+        """
+        stats = create_mock_stats(
+            stream_id,
+            resolution=resolution,
+            fps=fps,
+            probe_status="failed",
+        )
+        stats.is_black_screen = False
+        stats.is_low_fps = False
+        return stats
+
+    # -- Black screen bucket (rank=0) --
+
+    def test_black_screen_bucket_sorted_by_resolution_desc(self):
+        """Within the black_screen bucket, higher resolution sorts first."""
+        result = smart_sort_streams(
+            [1, 2, 3],
+            {
+                1: self._bs_stats(1, resolution="1024x576", fps="25"),
+                2: self._bs_stats(2, resolution="1920x1080", fps="25"),
+                3: self._bs_stats(3, resolution="1024x576", fps="25"),
+            },
+            stream_sort_priority=["resolution", "framerate", "m3u_priority", "bitrate", "audio_channels", "video_codec"],
+            stream_sort_enabled={
+                "resolution": True, "framerate": True, "m3u_priority": True,
+                "bitrate": True, "audio_channels": True, "video_codec": True,
+            },
+            deprioritize_failed_streams=True,
+            deprioritize_black_screen=True,
+            failed_stream_sort_order=["black_screen", "low_fps", "failed"],
+        )
+        # All three are rank=0 black_screen. Primary criterion is resolution desc:
+        # the 1920x1080 stream (id=2) must lead the bucket.
+        assert result[0] == 2, (
+            f"Expected 1920x1080 stream (id=2) at #1 in black_screen bucket, "
+            f"got ordering {result}"
+        )
+
+    # -- Status=failed bucket (rank=2) --
+
+    def test_failed_bucket_sorted_by_resolution_then_framerate(self):
+        """Within the status=failed bucket, resolution desc then framerate desc apply.
+
+        Reporter's exact scenario: 1280x720@25 was landing ahead of 1920x1080@50
+        inside the failed bucket because the within-bucket tiebreaker was a
+        tuple of zeros across all primary criteria.
+        """
+        result = smart_sort_streams(
+            [10, 20, 30, 40],
+            {
+                10: self._failed_stats(10, resolution="1280x720", fps="25"),
+                20: self._failed_stats(20, resolution="1920x1080", fps="50"),
+                30: self._failed_stats(30, resolution="1280x720", fps="25"),
+                40: self._failed_stats(40, resolution="1920x1080", fps="50"),
+            },
+            stream_sort_priority=["resolution", "framerate", "m3u_priority", "bitrate", "audio_channels", "video_codec"],
+            stream_sort_enabled={
+                "resolution": True, "framerate": True, "m3u_priority": True,
+                "bitrate": True, "audio_channels": True, "video_codec": True,
+            },
+            deprioritize_failed_streams=True,
+            failed_stream_sort_order=["black_screen", "low_fps", "failed"],
+        )
+        # Expected within-bucket order: both 1920x1080@50 streams first (by
+        # insertion order 20, 40), then both 1280x720@25 streams (10, 30).
+        assert result[:2] == [20, 40], (
+            f"Expected 1920x1080@50 streams (20, 40) to lead the failed bucket, "
+            f"got {result}"
+        )
+        assert result[2:] == [10, 30], (
+            f"Expected 1280x720@25 streams (10, 30) at the tail of the failed bucket, "
+            f"got {result}"
+        )
+
+    # -- Cross-bucket invariant MUST NOT break --
+
+    def test_cross_bucket_ordering_preserved(self):
+        """Cross-bucket ordering: rank=0 (black_screen) still precedes rank=2 (failed).
+
+        This is the invariant we must not regress while fixing within-bucket sort.
+        Pick values so primary-criteria alone would invert the order: the
+        rank=2 stream has HIGHER resolution than the rank=0 stream, yet
+        the rank=0 bucket must still sort above rank=2.
+        """
+        result = smart_sort_streams(
+            [1, 2],
+            {
+                # rank=0 (black_screen) but lower-resolution content
+                1: self._bs_stats(1, resolution="1024x576", fps="25"),
+                # rank=2 (failed) but higher-resolution content
+                2: self._failed_stats(2, resolution="1920x1080", fps="50"),
+            },
+            stream_sort_priority=["resolution", "framerate"],
+            stream_sort_enabled={"resolution": True, "framerate": True},
+            deprioritize_failed_streams=True,
+            deprioritize_black_screen=True,
+            failed_stream_sort_order=["black_screen", "low_fps", "failed"],
+        )
+        # rank=0 (id=1) must precede rank=2 (id=2) regardless of quality inversion
+        assert result == [1, 2], (
+            f"Cross-bucket invariant broken: expected rank=0 before rank=2 "
+            f"but got {result}"
+        )
+
+    # -- Full ferteque-like scenario --
+
+    def test_ferteque_channel_scenario(self):
+        """Condensed reproduction of the reporter's channel-591424 case.
+
+        3 black_screen streams and 4 failed streams. Expected:
+        - Black_screen bucket leads.
+        - Within black_screen, the 1920x1080 stream leads (was landing #2 in prod).
+        - Within failed, the 1920x1080@50 streams lead (were landing #8 in prod).
+        """
+        stats_map = {
+            # Black-screen bucket — from reporter's log
+            101: self._bs_stats(101, resolution="1024x576", fps="25"),    # D.LaLiga2
+            102: self._bs_stats(102, resolution="1920x1080", fps="25"),   # UHD
+            103: self._bs_stats(103, resolution="1024x576", fps="25"),    # SD
+            # Failed bucket — condensed
+            201: self._failed_stats(201, resolution="1280x720", fps="25"),   # HD
+            202: self._failed_stats(202, resolution="1920x1080", fps="50"),  # HD 1080
+            203: self._failed_stats(203, resolution="1920x1080", fps="25"),  # S.LaLiga2
+        }
+        result = smart_sort_streams(
+            [101, 102, 103, 201, 202, 203],
+            stats_map,
+            stream_sort_priority=["resolution", "framerate", "m3u_priority", "bitrate", "audio_channels", "video_codec"],
+            stream_sort_enabled={
+                "resolution": True, "framerate": True, "m3u_priority": True,
+                "bitrate": True, "audio_channels": True, "video_codec": True,
+            },
+            deprioritize_failed_streams=True,
+            deprioritize_black_screen=True,
+            failed_stream_sort_order=["black_screen", "low_fps", "failed"],
+        )
+        # Bucket boundaries: first 3 are rank=0, last 3 are rank=2
+        bs_bucket = result[:3]
+        failed_bucket = result[3:]
+        # Within black_screen bucket — 1920x1080 (id=102) leads
+        assert bs_bucket[0] == 102, (
+            f"Expected 1920x1080 black_screen stream (102) to lead bucket, "
+            f"got black_screen bucket order {bs_bucket}"
+        )
+        # Within failed bucket — 1920x1080@50 (id=202) leads,
+        # then 1920x1080@25 (id=203), then 1280x720@25 (id=201) at the tail
+        assert failed_bucket == [202, 203, 201], (
+            f"Expected failed bucket ordered by resolution desc then framerate desc "
+            f"— [202, 203, 201] — got {failed_bucket}"
+        )


### PR DESCRIPTION
## Summary
- **Bug:** within each failed-rank bucket (black_screen, low_fps, failed), Smart Sort ignored the user's configured primary criteria (resolution, framerate, m3u_priority, bitrate, audio_channels, video_codec). Streams landed in insertion order inside each bucket. Bucket boundaries themselves were correct.
- **Hypothesis (confirmed):** `smart_sort_streams()` returned `(1, rank) + (0,) * len(active_criteria)` for deprioritized streams, collapsing the within-bucket tiebreaker to a tuple of zeros. Python's stable sort then preserved insertion order inside each bucket.
- **Fix:** extract a `compute_criteria_values()` helper that builds the same criteria-value tuple used for successful streams, and reuse it on the three deprioritized paths. The helper is tolerant of `stat is None` (only `m3u_priority` is computable in that case). Bucket boundaries (`rank` precedes criteria) are untouched.

Scope stays inside the reporter's `[STREAM-PROBE-SORT]` code path per the sprint's bugfix-only rule. `auto_creation_engine._smart_sort_streams` has the same pattern and is tracked separately as **bd-bqpq0**.

Linked:
- Bead: `enhancedchannelmanager-sw883`
- Issue: https://github.com/MotWakorb/enhancedchannelmanager/issues/73
- Follow-up (out of scope here): `enhancedchannelmanager-bqpq0`

## Test plan
- [x] New `TestWithinBucketPrimaryCriteria` class (4 tests) — RED before fix, GREEN after:
  - black_screen bucket sorted by resolution desc
  - failed bucket sorted by resolution desc then framerate desc
  - cross-bucket invariant (rank 0 still before rank 2) — stays GREEN throughout
  - condensed `channel-591424` reproduction (3 BS + 3 failed streams, asserts full ordering)
- [x] `test_standalone_failed_still_sorted_by_m3u` updated to reflect the corrected semantics (it previously codified the bug).
- [x] `tests/unit/test_sort_criteria.py` — 44/44 passing
- [x] Full backend suite — **2445 passed in 49.43s**, no regressions
- [x] Container smoke: `docker cp` the fixed `stream_prober.py` to `ecm-ecm-1`, restart, run the condensed ferteque scenario through `smart_sort_streams()` inline — returns `[102, 101, 103, 202, 203, 201]` (1920x1080 leads each bucket) as expected.
- [ ] Reporter (@ferteque) verification on the dev container once merged

## Root cause (one sentence)
The composite sort key for deprioritized streams was `(1, rank, 0, 0, ...)`, so every stream inside the same failed-rank bucket collided on the key and Python's stable sort silently preserved insertion order instead of applying the configured primary criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)