### PR TITLE
[bd-zjge5] ESLint session 2: 63 errors -> 17 (46 fixes)

### DIFF
--- a/frontend/src/components/ChannelsPane.tsx
+++ b/frontend/src/components/ChannelsPane.tsx
@@ -13,6 +13,7 @@ import {
   DragStartEvent,
   useDroppable,
 } from '@dnd-kit/core';
+import type { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
 import {
   arrayMove,
   SortableContext,
@@ -755,7 +756,11 @@ interface DroppableGroupHeaderProps {
   onSelectAll?: () => void;
   onStreamDropOnGroup?: (groupId: number | 'ungrouped', streamIds: number[]) => void;
   onContextMenu?: (e: React.MouseEvent) => void;
-  dragHandleProps?: any;
+  // Drag handle props: `{ ...attributes, ...listeners }` from @dnd-kit/sortable's
+  // useSortable(). `attributes` is ARIA/a11y metadata (strings/booleans) and `listeners`
+  // is a map of DOM event handlers. dnd-kit's SyntheticListenerMap (Record<string, Function>)
+  // doesn't compose cleanly with DraggableAttributes, so we widen to the spread shape.
+  dragHandleProps?: DraggableAttributes | (DraggableAttributes & NonNullable<DraggableSyntheticListeners>);
   onProbeGroup?: () => void;
   isProbing?: boolean;
   onSortStreamsByQuality?: () => void;
@@ -3130,7 +3135,7 @@ export function ChannelsPane({
   const stripCountryPrefix = useCallback((channelName: string): string => {
     // Match country code (2-3 uppercase letters) followed by separator and the rest
     // Supports: "US | Name", "UK: Name", "CA - Name", "USA | Name", etc.
-    const match = channelName.match(/^[A-Z]{2,3}\s*[|:\-]\s*(.+)$/);
+    const match = channelName.match(/^[A-Z]{2,3}\s*[|:-]\s*(.+)$/);
     if (match) {
       return match[1].trim();
     }
@@ -4643,12 +4648,13 @@ export function ChannelsPane({
           handleCrossGroupMoveConfirm(false, crossGroupMoveData.suggestedChannelNumber, renumberSourceGroup);
         }
         break;
-      case 'custom':
+      case 'custom': {
         const customNum = parseInt(customStartingNumber, 10);
         if (!isNaN(customNum) && customNum >= 1) {
           handleCrossGroupMoveConfirm(false, customNum, renumberSourceGroup);
         }
         break;
+      }
     }
   };
 
@@ -4779,7 +4785,7 @@ export function ChannelsPane({
       const newNumber = startingNumber + index;
       if (channel.channel_number !== newNumber) {
         // Apply auto-rename if enabled in dialog
-        let updates: Partial<Channel> = { channel_number: newNumber };
+        const updates: Partial<Channel> = { channel_number: newNumber };
         if (sortRenumberUpdateNames && channel.channel_number !== null) {
           const newName = computeAutoRename(channel.name, channel.channel_number, newNumber);
           if (newName && newName !== channel.name) {
@@ -5004,7 +5010,7 @@ export function ChannelsPane({
       sortedConflicts.forEach((channel, index) => {
         // New number = endNum + 1 + (position from the end of conflicts)
         const newNumber = endNum + 1 + (sortedConflicts.length - 1 - index);
-        let updates: Partial<Channel> = { channel_number: newNumber };
+        const updates: Partial<Channel> = { channel_number: newNumber };
 
         // Apply auto-rename if enabled in the dialog
         if (massRenumberUpdateNames && channel.channel_number !== null) {
@@ -5025,7 +5031,7 @@ export function ChannelsPane({
     massRenumberChannels.forEach((channel, index) => {
       const newNumber = startNum + index;
       if (channel.channel_number !== newNumber) {
-        let updates: Partial<Channel> = { channel_number: newNumber };
+        const updates: Partial<Channel> = { channel_number: newNumber };
 
         // Apply auto-rename if enabled in the dialog
         if (massRenumberUpdateNames && channel.channel_number !== null) {

--- a/frontend/src/components/DummyEPGChannelPicker.tsx
+++ b/frontend/src/components/DummyEPGChannelPicker.tsx
@@ -4,6 +4,7 @@ import * as api from '../services/api';
 import { ModalOverlay } from './ModalOverlay';
 import { CustomSelect } from './CustomSelect';
 import { useNotifications } from '../contexts/NotificationContext';
+import { logger } from '../utils/logger';
 import './ModalBase.css';
 import './DummyEPGChannelPicker.css';
 
@@ -43,6 +44,7 @@ export const DummyEPGChannelPicker = memo(function DummyEPGChannelPicker({
       setGroups(groupData);
       setAssignments(assignmentData);
     } catch (err) {
+      logger.error('DummyEPGChannelPicker: failed to load channel data', err);
       notifications.error('Failed to load channel data', 'Channel Picker');
     } finally {
       setLoading(false);
@@ -83,6 +85,7 @@ export const DummyEPGChannelPicker = memo(function DummyEPGChannelPicker({
       await loadData();
       onChanged();
     } catch (err) {
+      logger.error('DummyEPGChannelPicker: failed to assign channels', err);
       notifications.error('Failed to assign channels', 'Channel Picker');
     } finally {
       setAdding(false);
@@ -95,6 +98,7 @@ export const DummyEPGChannelPicker = memo(function DummyEPGChannelPicker({
       setAssignments(prev => prev.filter(a => a.channel_id !== channelId));
       onChanged();
     } catch (err) {
+      logger.error('DummyEPGChannelPicker: failed to remove channel', err);
       notifications.error('Failed to remove channel', 'Channel Picker');
     }
   }, [profileId, onChanged]);
@@ -107,6 +111,7 @@ export const DummyEPGChannelPicker = memo(function DummyEPGChannelPicker({
       await loadData();
       onChanged();
     } catch (err) {
+      logger.error('DummyEPGChannelPicker: failed to add channels from group', err);
       notifications.error('Failed to add channels from group', 'Channel Picker');
     } finally {
       setAdding(false);

--- a/frontend/src/components/DummyEPGManagerSection.tsx
+++ b/frontend/src/components/DummyEPGManagerSection.tsx
@@ -7,6 +7,7 @@ import { ImportDummyEPGModal } from './ImportDummyEPGModal';
 import { ModalOverlay } from './ModalOverlay';
 import { useNotifications } from '../contexts/NotificationContext';
 import { useModal } from '../hooks/useModal';
+import { logger } from '../utils/logger';
 import './DummyEPGManagerSection.css';
 import './ModalBase.css';
 
@@ -69,6 +70,7 @@ export const DummyEPGManagerSection = memo(function DummyEPGManagerSection({ onS
       const data = await api.getDummyEPGProfiles();
       setProfiles(data);
     } catch (err) {
+      logger.error('DummyEPGManagerSection: failed to load profiles', err);
       notifications.error('Failed to load Dummy EPG profiles', 'Dummy EPG');
     } finally {
       setLoading(false);
@@ -90,6 +92,7 @@ export const DummyEPGManagerSection = memo(function DummyEPGManagerSection({ onS
       setEditingProfile(full);
       setProfileModalOpen(true);
     } catch (err) {
+      logger.error('DummyEPGManagerSection: failed to load profile details', err);
       notifications.error('Failed to load profile details', 'Dummy EPG');
     }
   };
@@ -109,6 +112,7 @@ export const DummyEPGManagerSection = memo(function DummyEPGManagerSection({ onS
       setProfileToDelete(null);
       onSourcesChanged?.();
     } catch (err) {
+      logger.error('DummyEPGManagerSection: failed to delete profile', err);
       notifications.error('Failed to delete profile', 'Dummy EPG');
     } finally {
       setDeleting(false);
@@ -127,6 +131,7 @@ export const DummyEPGManagerSection = memo(function DummyEPGManagerSection({ onS
         p.id === profile.id ? { ...p, enabled: !p.enabled } : p
       ));
     } catch (err) {
+      logger.error('DummyEPGManagerSection: failed to update profile', err);
       notifications.error('Failed to update profile', 'Dummy EPG');
     }
   };
@@ -138,6 +143,7 @@ export const DummyEPGManagerSection = memo(function DummyEPGManagerSection({ onS
       notifications.success('XMLTV regenerated successfully', 'Dummy EPG');
       await loadProfiles();
     } catch (err) {
+      logger.error('DummyEPGManagerSection: failed to regenerate XMLTV', err);
       notifications.error('Failed to regenerate XMLTV', 'Dummy EPG');
     } finally {
       setRegenerating(false);
@@ -212,6 +218,7 @@ export const DummyEPGManagerSection = memo(function DummyEPGManagerSection({ onS
       notifications.success(`"${profile.name}" added to Dispatcharr`, 'Dummy EPG');
       onSourcesChanged?.();
     } catch (err) {
+      logger.error('DummyEPGManagerSection: failed to add profile to Dispatcharr', err);
       notifications.error(`Failed to add "${profile.name}" to Dispatcharr`, 'Dummy EPG');
     } finally {
       setAddingToDispatcharr(null);

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -109,6 +109,7 @@ export const SettingsModal = memo(function SettingsModal({ isOpen, onClose, onSa
         notifications.error(result.message, 'Connection Failed');
       }
     } catch (err) {
+      logger.error('SettingsModal: connection test failed', err);
       setConnectionVerified(false);
     } finally {
       setTesting(false);

--- a/frontend/src/components/autoCreation/AutoCreationTab.tsx
+++ b/frontend/src/components/autoCreation/AutoCreationTab.tsx
@@ -46,7 +46,7 @@ function getActionCategory(action: ActionLogEntry): string | null {
     return 'removed';
   } else if (action.type === 'set_stream_priority') {
     return 'updated';
-  } else if ((action as any).action === 'excluded' || desc.includes('excluded:')) {
+  } else if ((action as ActionLogEntry & { action?: string }).action === 'excluded' || desc.includes('excluded:')) {
     return 'excluded';
   } else if (['assign_logo', 'assign_tvg_id', 'assign_epg', 'assign_profile', 'set_channel_number'].includes(action.type)) {
     return 'assigned';

--- a/frontend/src/components/ffmpegBuilder/InputSourceConfig.tsx
+++ b/frontend/src/components/ffmpegBuilder/InputSourceConfig.tsx
@@ -190,7 +190,8 @@ export function InputSourceConfig({ value, onChange }: InputSourceConfigProps) {
 
   const handleHWAccelChange = (api: string) => {
     if (api === 'none') {
-      const { hwaccel, ...rest } = input;
+      // Strip hwaccel from input by destructuring it out; the binding is intentionally unused.
+      const { hwaccel: _hwaccel, ...rest } = input;
       emit(rest as InputSource);
     } else {
       const hwaccel: HWAccelConfig = { api: api as HWAccelAPI };

--- a/frontend/src/components/status/AlertConfigurationPanel.tsx
+++ b/frontend/src/components/status/AlertConfigurationPanel.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect, useMemo } from 'react';
 import type { ServiceAlertRule, ServiceWithStatus } from '../../types';
 import * as api from '../../services/api';
 import { CustomSelect } from '../CustomSelect';
+import { logger } from '../../utils/logger';
 import './AlertConfigurationPanel.css';
 
 export interface AlertConfigurationPanelProps {
@@ -80,6 +81,7 @@ export function AlertConfigurationPanel({ onRefresh: _onRefresh }: AlertConfigur
         }
         setNotificationMethods(methods);
       } catch (err) {
+        logger.error('AlertConfigurationPanel: failed to load alert configuration', err);
         setError('Failed to load alert configuration');
       } finally {
         setLoading(false);
@@ -96,6 +98,7 @@ export function AlertConfigurationPanel({ onRefresh: _onRefresh }: AlertConfigur
         r.id === ruleId ? { ...r, enabled: !enabled } : r
       ));
     } catch (err) {
+      logger.error('AlertConfigurationPanel: failed to update rule', err);
       setError('Failed to update rule');
     }
   };
@@ -108,6 +111,7 @@ export function AlertConfigurationPanel({ onRefresh: _onRefresh }: AlertConfigur
       await api.deleteServiceAlertRule(ruleId);
       setRules(prev => prev.filter(r => r.id !== ruleId));
     } catch (err) {
+      logger.error('AlertConfigurationPanel: failed to delete rule', err);
       setError('Failed to delete rule');
     }
   };
@@ -145,6 +149,7 @@ export function AlertConfigurationPanel({ onRefresh: _onRefresh }: AlertConfigur
         notify_method_ids: [],
       });
     } catch (err) {
+      logger.error('AlertConfigurationPanel: failed to create rule', err);
       setError('Failed to create rule');
     } finally {
       setSaving(false);

--- a/frontend/src/components/status/ServiceControlPanel.tsx
+++ b/frontend/src/components/status/ServiceControlPanel.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import type { ServiceWithStatus } from '../../types';
 import { StatusIndicator } from './StatusIndicator';
 import * as api from '../../services/api';
+import { logger } from '../../utils/logger';
 import './ServiceControlPanel.css';
 
 export interface ServiceControlPanelProps {
@@ -36,6 +37,7 @@ export function ServiceControlPanel({
       }
       onRefresh?.();
     } catch (err) {
+      logger.error('ServiceControlPanel: failed to toggle service enabled state', err);
       setError(`Failed to ${currentlyEnabled ? 'disable' : 'enable'} service`);
     } finally {
       setLoading(prev => ({ ...prev, [serviceId]: false }));
@@ -51,6 +53,7 @@ export function ServiceControlPanel({
       await api.restartService(serviceId);
       onRefresh?.();
     } catch (err) {
+      logger.error('ServiceControlPanel: failed to restart service', err);
       setError('Failed to restart service');
     } finally {
       setLoading(prev => ({ ...prev, [`restart-${serviceId}`]: false }));
@@ -65,6 +68,7 @@ export function ServiceControlPanel({
     try {
       await api.triggerHealthCheck(serviceId);
     } catch (err) {
+      logger.error('ServiceControlPanel: failed to trigger health check', err);
       setError('Failed to trigger health check');
     } finally {
       setLoading(prev => ({ ...prev, [`check-${serviceId}`]: false }));

--- a/frontend/src/components/tabs/EPGManagerTab.tsx
+++ b/frontend/src/components/tabs/EPGManagerTab.tsx
@@ -481,6 +481,7 @@ export function EPGManagerTab({ onSourcesChange, hideEpgUrls = false }: EPGManag
         );
         await loadSources();
       } catch (err) {
+        logger.error('EPGManagerTab: failed to update priorities', err);
         notifications.error('Failed to update priorities', 'EPG Manager');
         await loadSources();
       }
@@ -499,6 +500,7 @@ export function EPGManagerTab({ onSourcesChange, hideEpgUrls = false }: EPGManag
       setEditingSource(fullSource);
       setModalOpen(true);
     } catch (err) {
+      logger.error('EPGManagerTab: failed to load EPG source details', err);
       notifications.error('Failed to load EPG source details', 'EPG Manager');
     }
   };
@@ -513,6 +515,7 @@ export function EPGManagerTab({ onSourcesChange, hideEpgUrls = false }: EPGManag
       await loadSources();
       onSourcesChange?.();
     } catch (err) {
+      logger.error('EPGManagerTab: failed to delete EPG source', err);
       notifications.error('Failed to delete EPG source', 'EPG Manager');
     }
   };
@@ -537,6 +540,7 @@ export function EPGManagerTab({ onSourcesChange, hideEpgUrls = false }: EPGManag
       // Stop polling after 5 minutes max
       setTimeout(() => clearInterval(pollInterval), 300000);
     } catch (err) {
+      logger.error('EPGManagerTab: failed to refresh EPG source', err);
       notifications.error('Failed to refresh EPG source', 'EPG Manager');
     }
   };
@@ -546,6 +550,7 @@ export function EPGManagerTab({ onSourcesChange, hideEpgUrls = false }: EPGManag
       await api.updateEPGSource(source.id, { is_active: !source.is_active });
       await loadSources();
     } catch (err) {
+      logger.error('EPGManagerTab: failed to update EPG source active state', err);
       notifications.error('Failed to update EPG source', 'EPG Manager');
     }
   };
@@ -573,6 +578,7 @@ export function EPGManagerTab({ onSourcesChange, hideEpgUrls = false }: EPGManag
       setEditingDummySource(fullSource);
       setDummyModalOpen(true);
     } catch (err) {
+      logger.error('EPGManagerTab: failed to load dummy EPG source details', err);
       notifications.error('Failed to load EPG source details', 'EPG Manager');
     }
   };
@@ -587,6 +593,7 @@ export function EPGManagerTab({ onSourcesChange, hideEpgUrls = false }: EPGManag
       await loadSources();
       onSourcesChange?.();
     } catch (err) {
+      logger.error('EPGManagerTab: failed to delete dummy EPG source', err);
       notifications.error('Failed to delete dummy EPG source', 'EPG Manager');
     }
   };
@@ -596,6 +603,7 @@ export function EPGManagerTab({ onSourcesChange, hideEpgUrls = false }: EPGManag
       await api.updateEPGSource(source.id, { is_active: !source.is_active });
       await loadSources();
     } catch (err) {
+      logger.error('EPGManagerTab: failed to toggle dummy EPG source active state', err);
       notifications.error('Failed to update dummy EPG source', 'EPG Manager');
     }
   };

--- a/frontend/src/components/tabs/M3UManagerTab.tsx
+++ b/frontend/src/components/tabs/M3UManagerTab.tsx
@@ -420,6 +420,7 @@ export function M3UManagerTab({
       await loadData();
       onAccountsChange?.();  // Notify parent to reload providers
     } catch (err) {
+      logger.error('M3UManagerTab: failed to delete M3U account', err);
       notifications.error('Failed to delete M3U account', 'M3U Manager');
     }
   };
@@ -443,6 +444,7 @@ export function M3UManagerTab({
         a.id === account.id ? { ...a, status: 'fetching' } : a
       ));
     } catch (err) {
+      logger.error('M3UManagerTab: failed to refresh M3U account', err);
       notifications.error('Failed to refresh M3U account', 'M3U Manager');
     }
   };
@@ -452,6 +454,7 @@ export function M3UManagerTab({
       await api.patchM3UAccount(account.id, { is_active: !account.is_active });
       await loadData();
     } catch (err) {
+      logger.error('M3UManagerTab: failed to toggle M3U account active state', err);
       notifications.error('Failed to update M3U account', 'M3U Manager');
     }
   };
@@ -488,6 +491,7 @@ export function M3UManagerTab({
         a.is_active && a.name.toLowerCase() !== 'custom' ? { ...a, status: 'fetching' } : a
       ));
     } catch (err) {
+      logger.error('M3UManagerTab: failed to refresh all M3U accounts', err);
       notifications.error('Failed to refresh M3U accounts', 'M3U Manager');
     }
   };
@@ -576,6 +580,7 @@ export function M3UManagerTab({
       });
       setLinkedM3UAccounts(linkGroups);
     } catch (err) {
+      logger.error('M3UManagerTab: failed to save linked accounts', err);
       notifications.error('Failed to save linked accounts', 'M3U Manager');
     }
   };

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -629,7 +629,7 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
           setProbeProgress(progress);
           setProbingAll(true);
         }
-      } catch (err) {
+      } catch {
         // Silently ignore errors - this is background polling
       }
     };
@@ -827,6 +827,7 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
         notifications.error('Failed to reset statistics', 'Reset Statistics');
       }
     } catch (err) {
+      logger.error('SettingsTab: failed to reset statistics', err);
       notifications.error('Failed to reset statistics', 'Reset Statistics');
     } finally {
       setResettingStats(false);
@@ -1180,6 +1181,7 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
         notifications.error(result.message || 'Failed to restart services', 'Restart Failed');
       }
     } catch (err) {
+      logger.error('SettingsTab: failed to restart services', err);
       notifications.error('Failed to restart services', 'Restart Failed');
     } finally {
       setRestarting(false);
@@ -2371,6 +2373,7 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
         notifications.error(result.message, 'SMTP Test');
       }
     } catch (err) {
+      logger.error('SettingsTab: failed to test SMTP connection', err);
       notifications.error('Failed to test SMTP connection', 'SMTP Test');
     } finally {
       setSmtpTesting(false);
@@ -2429,6 +2432,7 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
         notifications.error(result.message, 'Telegram Test');
       }
     } catch (err) {
+      logger.error('SettingsTab: failed to test Telegram bot', err);
       notifications.error('Failed to test Telegram bot', 'Telegram Test');
     } finally {
       setTelegramTesting(false);

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -80,7 +80,6 @@ class IntersectionObserverMock {
   readonly root: Element | null = null
   readonly rootMargin: string = ''
   readonly thresholds: ReadonlyArray<number> = []
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(_callback: IntersectionObserverCallback) {}
 
   observe = vi.fn()

--- a/frontend/src/types/autoCreation.ts
+++ b/frontend/src/types/autoCreation.ts
@@ -242,7 +242,7 @@ export interface CreateRuleData {
 /**
  * Data for updating an existing rule.
  */
-export interface UpdateRuleData extends Partial<CreateRuleData> {}
+export type UpdateRuleData = Partial<CreateRuleData>;
 
 // =============================================================================
 // Execution


### PR DESCRIPTION
## Summary

Session 2 of bead `zjge5`. Drops the frontend ESLint baseline from **63 errors + 89 warnings** (152 problems) to **17 errors + 89 warnings** (106 problems) — 46 error reductions, zero new warnings.

## Chunks in this PR

**1. Unused caught-error errors (36 fixes).** Every `catch (err)` that previously discarded the error before firing only a user-facing notification now calls `logger.error('<context>', err)` first, so backend failures surface in the browser console alongside the toast. Across:
- `DummyEPGChannelPicker.tsx`, `DummyEPGManagerSection.tsx`, `SettingsModal.tsx`
- `status/AlertConfigurationPanel.tsx`, `status/ServiceControlPanel.tsx`
- `tabs/EPGManagerTab.tsx`, `tabs/M3UManagerTab.tsx`, `tabs/SettingsTab.tsx`

One site (`SettingsTab.tsx:632`, a background poller) dropped the unused binding via `catch {}` since the rule genuinely doesn't care — documented in the comment.

**2. ChannelsPane cluster (5 fixes).** `no-useless-escape`, `no-case-declarations`, three `prefer-const` on `updates` objects that are mutated but never reassigned. Plus replaced `dragHandleProps?: any` with the real `@dnd-kit/core` types.

**3. Small scattered fixes (5).**
- `AutoCreationTab.tsx` — narrowed `(action as any).action` to an intersection documenting the backend-extension field.
- `ffmpegBuilder/InputSourceConfig.tsx` — renamed destructured `hwaccel` to `_hwaccel` (intentionally unused — it's being stripped).
- `test/setup.ts` — removed an unused `eslint-disable-next-line` (the `_callback` parameter already satisfied the rule).
- `types/autoCreation.ts` — converted empty-extends interface `UpdateRuleData` to type alias.

## What's left (session 3)

All 17 remaining errors are react-compiler diagnostics or a single `rules-of-hooks` violation — each needs real refactoring work, deferred to a future session:
- 13× `Calling setState synchronously within an effect can trigger cascading renders`
- 3× `Compilation Skipped: Existing memoization could not be preserved`
- 1× `Cannot access refs during render`
- 1× `useMemo` called conditionally

Warnings (89) are untouched — mostly `react-hooks/exhaustive-deps` and `react-refresh/only-export-components`, also deeper work.

## Test plan

- [x] `npm run lint` — 17 errors, 89 warnings (down from 63/89)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 1118/1118 pass

Not flipping t8xw3's lint workflow to full-blocking yet — baseline is still above zero.