### PR TITLE
Fix stream sorting by provider m3u priority value

### DIFF
--- a/backend/auto_creation_engine.py
+++ b/backend/auto_creation_engine.py
@@ -702,13 +702,16 @@ class AutoCreationEngine:
 
                 channel_name = channel.get("name", f"Channel #{channel_id}")
 
-                # Build smart sort key function
-                sorted_streams = _smart_sort_streams(
+                # Respect rule.stream_sort_field (Provider Order, Quality, etc.).
+                # Previously this always used global smart-sort settings, so "Provider Order (M3U)"
+                # only changed the log label and did not reorder by M3U account priority.
+                sorted_streams = _reorder_streams_for_rule(
                     current_streams,
+                    rule,
                     self._stream_stats_cache,
                     stream_m3u_map,
                     channel_name,
-                    settings
+                    settings,
                 )
 
                 # Skip if order didn't change
@@ -723,7 +726,7 @@ class AutoCreationEngine:
                         "rule_id": rule.id,
                         "rule_name": rule.name,
                         "action": f"Would reorder {len(sorted_streams)} streams in '{channel_name}' "
-                                  f"by smart sort ({rule.stream_sort_field})",
+                                  f"by {_stream_sort_rule_label(rule.stream_sort_field)}",
                         "would_create": False,
                         "would_modify": True
                     })
@@ -745,7 +748,8 @@ class AutoCreationEngine:
                                 elif stats.get("probe_status") in ("failed", "timeout"):
                                     deprioritized.append({"id": sid, "name": stats.get("stream_name", f"Stream {sid}"), "reason": stats.get("probe_status")})
 
-                        desc_parts = [f"Reordered {len(sorted_streams)} streams in '{channel_name}' by smart sort ({rule.stream_sort_field})"]
+                        mode_label = _stream_sort_rule_label(rule.stream_sort_field)
+                        desc_parts = [f"Reordered {len(sorted_streams)} streams in '{channel_name}' by {mode_label}"]
                         if deprioritized:
                             reasons = {}
                             for d in deprioritized:
@@ -2252,6 +2256,163 @@ def _smart_sort_streams(
         logger.info("[AUTO-CREATE-ENGINE]   #%s: %s (id=%s, res=%s)", idx+1, sname, sid, res)
 
     return sorted_ids
+
+
+def _stream_sort_rule_label(stream_sort_field: str | None) -> str:
+    """Human-readable label for execution logs."""
+    f = (stream_sort_field or "").strip()
+    return {
+        "smart_sort": "smart sort (from Settings)",
+        "provider_order": "provider order (M3U account priority)",
+        "quality": "quality (resolution)",
+        "stream_name": "stream name",
+        "stream_name_natural": "stream name (natural)",
+    }.get(f, f"stream sort ({f})" if f else "stream sort")
+
+
+def _sort_streams_by_m3u_account_priority(
+    stream_ids: list[int],
+    stream_m3u_map: dict,
+    settings,
+    order: str,
+    channel_name: str,
+) -> list[int]:
+    """Order streams by ECM Settings → M3U account priority values (higher = preferred).
+
+    Does not require probe stats. *order*: "desc" = highest priority first (recommended),
+    "asc" = lowest priority first.
+    """
+    pri_map = getattr(settings, "m3u_account_priorities", None) or {}
+
+    def sort_key(sid: int):
+        aid = stream_m3u_map.get(sid)
+        pri = pri_map.get(str(aid), 0) if aid is not None else 0
+        if order == "desc":
+            return (-pri, sid)
+        return (pri, sid)
+
+    sorted_ids = sorted(stream_ids, key=sort_key)
+    logger.info(
+        "[AUTO-CREATE-ENGINE] Channel '%s': provider order (%s) by M3U priority -> %s",
+        channel_name, order, sorted_ids,
+    )
+    return sorted_ids
+
+
+def _resolution_height_from_stats(stats: dict | None) -> int:
+    if not stats or not stats.get("resolution"):
+        return 0
+    try:
+        parts = stats["resolution"].split("x")
+        if len(parts) == 2:
+            return int(parts[1])
+    except (ValueError, IndexError) as e:
+        logger.debug("[AUTO-CREATE-ENGINE] Suppressed resolution parse error: %s", e)
+    return 0
+
+
+def _sort_streams_by_resolution_height(
+    stream_ids: list[int],
+    stats_cache: dict,
+    order: str,
+    channel_name: str,
+) -> list[int]:
+    """Sort by probed resolution height; missing stats count as 0."""
+
+    def sort_key(sid: int):
+        h = _resolution_height_from_stats(stats_cache.get(sid))
+        if order == "desc":
+            return (-h, sid)
+        return (h, sid)
+
+    sorted_ids = sorted(stream_ids, key=sort_key)
+    logger.info(
+        "[AUTO-CREATE-ENGINE] Channel '%s': quality sort (%s) -> %s",
+        channel_name, order, sorted_ids,
+    )
+    return sorted_ids
+
+
+def _stream_name_for_sort(sid: int, stats_cache: dict) -> str:
+    st = stats_cache.get(sid)
+    if st and st.get("stream_name"):
+        return st["stream_name"]
+    return f"Stream {sid}"
+
+
+def _sort_streams_by_stream_name(
+    stream_ids: list[int],
+    stats_cache: dict,
+    order: str,
+    channel_name: str,
+    natural: bool,
+) -> list[int]:
+    if natural:
+        temp = sorted(
+            stream_ids,
+            key=lambda sid: (_natural_sort_key(_stream_name_for_sort(sid, stats_cache)), sid),
+        )
+    else:
+        temp = sorted(
+            stream_ids,
+            key=lambda sid: (_stream_name_for_sort(sid, stats_cache).lower(), sid),
+        )
+    if order == "desc":
+        temp = list(reversed(temp))
+    logger.info(
+        "[AUTO-CREATE-ENGINE] Channel '%s': stream name sort (%s, natural=%s) -> %s",
+        channel_name, order, natural, temp,
+    )
+    return temp
+
+
+def _reorder_streams_for_rule(
+    stream_ids: list[int],
+    rule,
+    stats_cache: dict,
+    stream_m3u_map: dict,
+    channel_name: str,
+    settings,
+) -> list[int]:
+    """Dispatch stream reordering based on rule.stream_sort_field."""
+    field = (getattr(rule, "stream_sort_field", None) or "").strip()
+    order = (getattr(rule, "stream_sort_order", None) or "asc").lower()
+    if order not in ("asc", "desc"):
+        order = "asc"
+
+    if not field or field == "smart_sort":
+        return _smart_sort_streams(
+            stream_ids, stats_cache, stream_m3u_map, channel_name, settings
+        )
+
+    if field == "provider_order":
+        return _sort_streams_by_m3u_account_priority(
+            stream_ids, stream_m3u_map, settings, order, channel_name
+        )
+
+    if field == "quality":
+        return _sort_streams_by_resolution_height(
+            stream_ids, stats_cache, order, channel_name
+        )
+
+    if field == "stream_name":
+        return _sort_streams_by_stream_name(
+            stream_ids, stats_cache, order, channel_name, natural=False
+        )
+
+    if field == "stream_name_natural":
+        return _sort_streams_by_stream_name(
+            stream_ids, stats_cache, order, channel_name, natural=True
+        )
+
+    logger.warning(
+        "[AUTO-CREATE-ENGINE] Channel '%s': unknown stream_sort_field=%r, "
+        "falling back to smart sort",
+        channel_name, field,
+    )
+    return _smart_sort_streams(
+        stream_ids, stats_cache, stream_m3u_map, channel_name, settings
+    )
 
 
 def _natural_sort_key(s: str) -> list:

--- a/backend/routers/stream_stats.py
+++ b/backend/routers/stream_stats.py
@@ -284,6 +284,11 @@ async def compute_sort(request: ComputeSortRequest):
     # Sort each channel
     results = []
     for ch in request.channels:
+        # M3U priority does not require probe stats; respect priorities even if stats are missing.
+        deprioritize_failed = settings.deprioritize_failed_streams
+        if request.mode == "m3u_priority":
+            deprioritize_failed = False
+
         sorted_ids = smart_sort_streams(
             stream_ids=ch.stream_ids,
             stats_map=stats_map,
@@ -291,7 +296,7 @@ async def compute_sort(request: ComputeSortRequest):
             stream_sort_priority=sort_priority,
             stream_sort_enabled=sort_enabled,
             m3u_account_priorities=settings.m3u_account_priorities,
-            deprioritize_failed_streams=settings.deprioritize_failed_streams,
+            deprioritize_failed_streams=deprioritize_failed,
             deprioritize_black_screen=getattr(settings, 'deprioritize_black_screen', True),
             deprioritize_low_fps=getattr(settings, 'deprioritize_low_fps', True),
             failed_stream_sort_order=getattr(settings, 'failed_stream_sort_order', None),

--- a/backend/routers/stream_stats.py
+++ b/backend/routers/stream_stats.py
@@ -272,7 +272,12 @@ async def compute_sort(request: ComputeSortRequest):
             elapsed_ms = (time.time() - start_fetch) * 1000
             logger.debug("[STREAM-STATS-SORT] Fetched %s streams for M3U priority in %.1fms", len(streams_data), elapsed_ms)
             for s in streams_data:
-                stream_m3u_map[s["id"]] = extract_m3u_account_id(s.get("m3u_account"))
+                # Dispatcharr has historically returned either "id" or "stream_id" as the identifier.
+                # Be tolerant so M3U priority sorting doesn't silently no-op.
+                stream_id = s.get("id", s.get("stream_id"))
+                if stream_id is None:
+                    continue
+                stream_m3u_map[int(stream_id)] = extract_m3u_account_id(s.get("m3u_account"))
         except Exception as e:
             logger.warning("[STREAM-STATS-SORT] Failed to fetch M3U data: %s", e)
 

--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -147,6 +147,12 @@ def smart_sort_streams(
     ]
 
     safe_name = str(channel_name).replace('\n', '').replace('\r', '')
+    if not active_criteria:
+        logger.warning(
+            "[STREAM-PROBE-SORT] Channel '%s': no criteria enabled in Settings → Smart Sort; "
+            "sorting will only use stream id as a tiebreaker",
+            safe_name,
+        )
     logger.info("[STREAM-PROBE-SORT] Channel '%s': Sorting %s streams", safe_name, len(stream_ids))
     logger.info("[STREAM-PROBE-SORT] Sort config: priority=%s, enabled=%s", stream_sort_priority, stream_sort_enabled)
     logger.info("[STREAM-PROBE-SORT] Active criteria (in order): %s", active_criteria)
@@ -232,21 +238,21 @@ def smart_sort_streams(
                 rank = failed_rank.get('failed', 0)
                 logger.debug("[STREAM-PROBE-SORT]   %s: DEPRIORITIZED (status=%s, rank=%s)", stream_name, stat.probe_status if stat else 'no_stats', rank)
                 # bd-sw883: apply primary criteria within the failed bucket too.
-                return (1, rank) + tuple(compute_criteria_values(stat, stream_id))
+                return (1, rank) + tuple(compute_criteria_values(stat, stream_id)) + (stream_id,)
 
         # Deprioritize black screen streams (probe succeeded but content is black)
         if deprioritize_failed_streams and deprioritize_black_screen and stat and getattr(stat, 'is_black_screen', False) is True:
             rank = failed_rank.get('black_screen', 1)
             logger.debug("[STREAM-PROBE-SORT]   %s: DEPRIORITIZED (black screen, rank=%s)", stream_name, rank)
             # bd-sw883: apply primary criteria within the black_screen bucket too.
-            return (1, rank) + tuple(compute_criteria_values(stat, stream_id))
+            return (1, rank) + tuple(compute_criteria_values(stat, stream_id)) + (stream_id,)
 
         # Deprioritize low FPS streams (probe succeeded but FPS < 20)
         if deprioritize_failed_streams and deprioritize_low_fps and stat and getattr(stat, 'is_low_fps', False) is True:
             rank = failed_rank.get('low_fps', 2)
             logger.debug("[STREAM-PROBE-SORT]   %s: DEPRIORITIZED (low fps, rank=%s)", stream_name, rank)
             # bd-sw883: apply primary criteria within the low_fps bucket too.
-            return (1, rank) + tuple(compute_criteria_values(stat, stream_id))
+            return (1, rank) + tuple(compute_criteria_values(stat, stream_id)) + (stream_id,)
 
         if not stat or stat.probe_status != 'success':
             logger.debug("[STREAM-PROBE-SORT]   %s: No successful probe data", stream_name)
@@ -261,7 +267,7 @@ def smart_sort_streams(
                     sort_values.append(-m3u_priority_value)
                 else:
                     sort_values.append(0)
-            return tuple(sort_values)
+            return tuple(sort_values) + (stream_id,)
 
         # Build sort values based on active criteria in priority order
         sort_values = [0, 0]  # First element: 0 = successful stream, second: sub-rank (unused for good streams)
@@ -322,7 +328,7 @@ def smart_sort_streams(
                     "(res=%s, br=%s, fps=%s, m3u=%s, audio_ch=%s, codec=%s)",
                     stream_name, tuple(sort_values),
                     stat.resolution, stat.bitrate, stat.fps, m3u_account_id, stat.audio_channels, stat.video_codec)
-        return tuple(sort_values)
+        return tuple(sort_values) + (stream_id,)
 
     # Sort stream IDs by their stats
     sorted_ids = sorted(stream_ids, key=get_sort_value)

--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -1837,9 +1837,24 @@ class StreamProber:
                     streams_data = await self.client.get_streams_by_ids(stream_ids)
                     # Log raw stream data for debugging
                     for s in streams_data:
-                        logger.debug("[STREAM-PROBE-SORT] Channel %s: Stream %s ('%s') has raw m3u_account=%r", channel_id, s['id'], s.get('name', 'Unknown'), s.get('m3u_account'))
+                        stream_id = s.get("id", s.get("stream_id"))
+                        logger.debug(
+                            "[STREAM-PROBE-SORT] Channel %s: Stream %s ('%s') has raw m3u_account=%r",
+                            channel_id,
+                            stream_id,
+                            s.get("name", "Unknown"),
+                            s.get("m3u_account"),
+                        )
                     # Extract M3U account IDs (handles both direct ID and nested object formats)
-                    stream_m3u_map = {s["id"]: self._extract_m3u_account_id(s.get("m3u_account")) for s in streams_data}
+                    # Dispatcharr may return either "id" or "stream_id" depending on version/endpoint.
+                    stream_m3u_map = {}
+                    for s in streams_data:
+                        stream_id = s.get("id", s.get("stream_id"))
+                        if stream_id is None:
+                            continue
+                        stream_m3u_map[int(stream_id)] = self._extract_m3u_account_id(
+                            s.get("m3u_account")
+                        )
                     logger.debug("[STREAM-PROBE-SORT] Channel %s: Built M3U map for %s streams: %s", channel_id, len(stream_m3u_map), stream_m3u_map)
 
                     # Fetch stream stats for this channel's streams (uses get_session and StreamStats imported at top of file)

--- a/backend/tests/unit/test_auto_creation_engine.py
+++ b/backend/tests/unit/test_auto_creation_engine.py
@@ -13,6 +13,8 @@ from auto_creation_engine import (
     set_auto_creation_engine,
     init_auto_creation_engine,
     _sort_key,
+    _sort_streams_by_m3u_account_priority,
+    _reorder_streams_for_rule,
 )
 from auto_creation_evaluator import StreamContext
 from auto_creation_evaluator import StreamContext
@@ -880,6 +882,42 @@ class TestAutoCreationEngineIntegration:
         assert result["streams_matched"] == 1  # Only ESPN2 matches
         assert len(result["dry_run_results"]) == 1
         assert "ESPN2" in result["dry_run_results"][0]["stream_name"]
+
+
+class TestStreamReorderByRule:
+    """Tests for Pass 3.5 reorder respecting rule.stream_sort_field."""
+
+    def test_m3u_account_priority_desc(self):
+        """Higher M3U priority value sorts first when order is desc."""
+        settings = MagicMock()
+        settings.m3u_account_priorities = {"1": 10, "2": 6}
+        stream_m3u_map = {100: 2, 101: 1}
+        out = _sort_streams_by_m3u_account_priority(
+            [100, 101], stream_m3u_map, settings, "desc", "Test"
+        )
+        assert out == [101, 100]
+
+    def test_m3u_account_priority_asc(self):
+        """Lower M3U priority value sorts first when order is asc."""
+        settings = MagicMock()
+        settings.m3u_account_priorities = {"1": 10, "2": 6}
+        stream_m3u_map = {100: 2, 101: 1}
+        out = _sort_streams_by_m3u_account_priority(
+            [100, 101], stream_m3u_map, settings, "asc", "Test"
+        )
+        assert out == [100, 101]
+
+    def test_reorder_streams_for_rule_uses_provider_order(self):
+        rule = MagicMock()
+        rule.stream_sort_field = "provider_order"
+        rule.stream_sort_order = "desc"
+        settings = MagicMock()
+        settings.m3u_account_priorities = {"1": 10, "2": 6}
+        stream_m3u_map = {100: 2, 101: 1}
+        out = _reorder_streams_for_rule(
+            [100, 101], rule, {}, stream_m3u_map, "Ch", settings
+        )
+        assert out == [101, 100]
 
 
 class TestSortKey:

--- a/frontend/src/components/ChannelsPane.tsx
+++ b/frontend/src/components/ChannelsPane.tsx
@@ -2749,6 +2749,10 @@ export function ChannelsPane({
       const result = response.results[0];
       if (!result || !result.changed) {
         logger.info(`[SmartSort] No change needed - streams already in sorted order`);
+        notifications.info(
+          'No reorder needed: stream order already matches this sort (or all streams tie on the same metrics). Enable more criteria in Settings → Smart Sort, or probe streams for quality data.',
+          'Sort Complete'
+        );
         return;
       }
 
@@ -2832,7 +2836,10 @@ export function ChannelsPane({
       if (changesCount > 0) {
         notifications.success(`Sorted ${changesCount} of ${channelsToProcess.length} channel${channelsToProcess.length !== 1 ? 's' : ''} by ${SORT_MODE_LABELS[mode]}`, 'Sort Complete');
       } else {
-        notifications.info(`Streams already in ${SORT_MODE_LABELS[mode]} order`, 'Sort Complete');
+        notifications.info(
+          `No channels reordered: order already matches ${SORT_MODE_LABELS[mode]} (or all streams tie). Check Settings → Smart Sort, or probe streams.`,
+          'Sort Complete'
+        );
       }
       logger.info(`Bulk sort by ${SORT_MODE_LABELS[mode]}: ${changesCount} of ${channelsToProcess.length} channels reordered`);
     } catch (err) {

--- a/frontend/src/components/autoCreation/RuleBuilder.tsx
+++ b/frontend/src/components/autoCreation/RuleBuilder.tsx
@@ -485,6 +485,11 @@ export function RuleBuilder({
                 </p>
               </div>
             )}
+            {streamSortField === 'provider_order' && (
+              <p className="form-hint">
+                Uses priority values from M3U Manager (Save Priorities). Choose Descending so the highest priority number is first; Ascending puts the lowest priority first.
+              </p>
+            )}
           </div>
 
           <div className="form-field">


### PR DESCRIPTION
When trying to sort by provider m3u priority value, streams were not sorted. This appears to fix it.