### PR TITLE
[bd-thfal] Fix test_compute_sort_no_stats for PR #77 tiebreaker

### DIFF
--- a/backend/tests/unit/test_compute_sort_endpoint.py
+++ b/backend/tests/unit/test_compute_sort_endpoint.py
@@ -242,9 +242,9 @@ async def test_compute_sort_no_stats(async_client, mock_settings):
     assert response.status_code == 200
     data = response.json()
     assert len(data["results"]) == 1
-    # No stats -> original order preserved
-    assert data["results"][0]["sorted_stream_ids"] == [999, 998]
-    assert data["results"][0]["changed"] is False
+    # No stats -> deterministic order by stream_id tiebreaker (bd-thfal / PR #77)
+    assert data["results"][0]["sorted_stream_ids"] == [998, 999]
+    assert data["results"][0]["changed"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- PR #77 (stevencoutts) added a `stream_id` tiebreaker in `smart_sort_streams` so no-stats sorting is deterministic. `test_compute_sort_no_stats` still asserted the old non-deterministic contract ("preserve input order"), so post-merge CI on `dev` went red.
- Test updated to assert the new deterministic order: `[998, 999]` with `changed=True` (was `[999, 998]` / `False`).

## Test plan
- [x] `pytest tests/unit/test_compute_sort_endpoint.py::test_compute_sort_no_stats` passes locally
- [x] Full backend suite passes locally (2448/2448)
- [ ] Tests workflow runs green on this PR branch (validates that the commit currently red on `dev` turns green with this change)

## Links
- Triage bead: `enhancedchannelmanager-thfal`
- Upstream change: PR #77 — commit `8532f097` "Fix smart sort always reporting 'already in order'"

Single-file, test-only change. No runtime behavior touched.