### PR TITLE
[bd-yopgt] Scaffold CHANGELOG.md (Keep a Changelog) + PR template + shipping link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+# Pull Request
+
+## Summary
+<!-- What changed and why. 1-3 bullets. Link the bead ID. -->
+
+## Test plan
+<!-- Bulleted checklist of how this was verified. -->
+
+## Checklist
+- [ ] Bead linked in the commit message (`[bd-xxxxx]`).
+- [ ] Tests updated or added (backend `pytest`, frontend `vitest`).
+- [ ] `CHANGELOG.md` updated under `[Unreleased]` (Added / Changed / Deprecated / Removed / Fixed / Security). See [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Skip only for docs-only, test-only, or CI-only changes — note the reason.
+- [ ] Docs updated if behaviour or interfaces changed (`docs/`, runbooks, ADRs).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,114 @@
 # Changelog
 
-Release notes for Enhanced Channel Manager live on GitHub Releases:
+All notable changes to Enhanced Channel Manager are documented in this file.
 
-https://github.com/MotWakorb/enhancedchannelmanager/releases
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Historical entries prior to this change are preserved in git history.
+## [Unreleased]
+
+### Added
+- Structured JSON logging on stdout with `trace_id` correlation middleware (honors inbound `X-Request-ID`, generates UUIDv4 otherwise, echoes in response header). `bind_context()` helper for attaching structured fields to long-running tasks (`bd-ak1db`, PR #80).
+- Prometheus `/metrics` endpoint exposing `ecm_http_requests_total`, `ecm_http_request_duration_seconds`, `ecm_health_ready_ok`, and `ecm_health_ready_check_duration_seconds`. HTTP middleware labels by matched FastAPI route pattern so cardinality stays bounded. `/metrics` is unauthenticated by design (Prometheus scrapers have no session context) — hardening via reverse-proxy allowlist or bearer-token scrape credential is a separate future bead (`bd-ak1db`, PR #80).
+- Alembic schema migration system with baseline revision `0001` capturing the current SQLAlchemy metadata (36 tables). `alembic upgrade head` wired into app startup; legacy pre-Alembic DBs are `stamp`ed rather than re-DDLed (`bd-c5wf5`, PR #81).
+- `GET /api/health/schema` public endpoint returning `current_revision`, `head_revision`, `up_to_date`, `foreign_keys_enabled`, and `journal_mode` — required by DBAS restore/sync to gate backup imports on schema version (`bd-c5wf5`, PR #81).
+- `docs/database_migrations.md` authoring conventions (`bd-c5wf5`, PR #81).
+- `docs/runbooks/` scaffold with template and v0.16.0 hard-rollback exemplar (`bd-bwly4`).
+
+### Changed
+- `docs/backend_architecture.md` expanded with an Observability section covering logging schema, metric naming conventions, cardinality rules, `bind_context` usage, and the process for adding new metrics (`bd-ak1db`, PR #80).
+
+## [0.16.0] — Yanked 2026-04-20
+
+**This release was rolled back** before any external consumer pulled the tag. The GitHub Release, git tag, and GHCR image for `0.16.0` were deleted; `:latest` was retagged back to the `v0.15.2` multi-arch index. Rollback executed per `bd-vgm4l`; see `docs/runbooks/v0.16.0-rollback.md` for the procedure. The PO chose rollback over a forward hotfix because open P0/P1 bugs needed to clear before a release could ship. Work originally tagged `0.16.0` will re-ship in a later version once blockers are cleared.
+
+## [0.15.2] — 2026-04-16
+
+### Security
+- Upgraded `vite` out of the vulnerable 7.0.0–7.3.1 range, resolving three high-severity advisories affecting the frontend dev tooling:
+  - [GHSA-4w7w-66w2-5vf9](https://github.com/advisories/GHSA-4w7w-66w2-5vf9) — path traversal in optimized-deps `.map` handling.
+  - [GHSA-v2wj-q39q-566r](https://github.com/advisories/GHSA-v2wj-q39q-566r) — `server.fs.deny` bypass with queries.
+  - [GHSA-p9ff-h696-f583](https://github.com/advisories/GHSA-p9ff-h696-f583) — arbitrary file read via dev server WebSocket.
+- No runtime code changes; only the frontend build tooling is affected. Dev server users should upgrade promptly.
+
+## [0.15.1] — 2026-03-31
+
+### Added
+- Login rate limiting — 5 attempts per minute per IP via slowapi on both local and Dispatcharr login endpoints.
+- Security headers: `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`.
+- Client IP in login-failure logs (includes `X-Forwarded-For` for forensics).
+
+### Changed
+- **Password policy now follows NIST 800-63B** — dropped composition rules (uppercase/lowercase/number), replaced the 33-word list with the 10k common-passwords list, uniform 8-character minimum for all users including admin-created.
+- CORS tightened — explicit method and header allow-lists instead of wildcards.
+
+### Fixed
+- EPG matching: channel names with a number prefix (e.g. `535 | ESPN`) were normalizing to `535espn` instead of `espn`, causing zero matches against EPG data.
+
+### Security
+- Injection / SSRF (OWASP A03/A10):
+  - ffmpeg protocol allow-list on all invocations — blocks `file://`, `data://`, `concat:` and other dangerous protocols.
+  - URL-scheme validation at input time on M3U, Xtream Codes, and EPG source endpoints — only `http://` and `https://` allowed.
+  - Zip backup path canonicalization — defense-in-depth `resolve()` check alongside existing traversal guards.
+- Logging hardening (OWASP A09):
+  - 500-response scrubbing — global handler returns generic `Internal server error` to clients; real error stays in server logs.
+  - Validation-error log redaction — `Authorization` / `Cookie` headers and auth-endpoint request bodies redacted from logs.
+
+## [0.15.0] — 2026-03-29
+
+### Added
+- **Export & Publish** — generate M3U/XMLTV playlists from channel profiles and publish to cloud targets (S3, WebDAV, etc.) on a cron schedule. Includes channel selector, playlist preview, cloud-target management, and publish history.
+- **Low-FPS detection** — streams below a configurable threshold (5/10/15/20 FPS) are flagged with an amber icon and deprioritized in Smart Sort. Zero-overhead, always-on, configurable in Settings → Maintenance.
+- **Black-screen detection** — optional ffmpeg `signalstats` check after each probe flags dark/blank streams with a purple icon. Configurable sample duration (3–30s) in Settings → Maintenance.
+- **Normalize Names engine** — tag-based rules engine for cleaning up stream names during bulk channel creation. YAML import/export, edit/revert controls, drag-and-drop priority ordering.
+- **Backup & Restore** — full configuration backup/restore from Settings, with restore option during the first-run setup wizard.
+- **Merge Channels** — combine two or more channels into one, consolidating their streams.
+- Auto-creation enhancements — EPG logo-source action, Probe Streams action, Set Channel Profile action; Smart Sort option in rule sort dropdown; rule selection in Auto-Create schedule; separate stream sort from channel sort per rule.
+- PUID/PGID support for Docker container user identity.
+- TV Guide print view.
+- JWT authentication in Swagger UI with `/swagger` redirect.
+- Debug bundle for troubleshooting auth issues.
+
+### Changed
+- Server-side migration of EPG matching, stream normalization, and edit consolidation (previously client-side).
+- Settings UI consistency — compact dropdowns, unified admin section CSS, proper field ordering.
+- Scoped reprobe to last scheduled probe's channel groups.
+- Capped Dispatcharr HTTP client connection pool.
+- All GitHub Actions updated to Node.js 24-compatible versions.
+- Migrated 161 `console.log` call sites to the structured logger.
+
+### Fixed
+- Persistent 503 when stream prober not initialized — prober now self-heals and auto-creates.
+- `assign_logo` from EPG and duplicate rule priorities.
+- Radio buttons, undefined CSS variables, and card backgrounds in admin tabs.
+- Push-down renumbering, menu overflow, task-card grid.
+
+### Removed
+- ~2,000+ lines of dead code across backend and frontend, including duplicate `formatDate` implementations.
+
+### Security
+- Secured backup endpoints; improved token handling.
+- Fixed npm audit vulnerabilities in `brace-expansion`, `flatted`, `picomatch`.
+
+## [0.14.0] — 2026-03-06
+
+Highlights: black-screen detection during probes; failed-stream re-probe scheduled task; auto-creation per-rule `skip_struck_streams`, provider order, and channel-number sort; pattern-builder UI for normalization rules; configurable HTTP/HTTPS ports via env vars. Numerous auto-creation and notification-center bug fixes. Full notes: [GitHub Release v0.14.0](https://github.com/MotWakorb/enhancedchannelmanager/releases/tag/v0.14.0).
+
+## [0.13.1] — 2026-02-20
+
+Bug-fix release. Full notes: [GitHub Release v0.13.1](https://github.com/MotWakorb/enhancedchannelmanager/releases/tag/v0.13.1).
+
+## [0.13.0] — 2026-02-19
+
+Full notes: [GitHub Release v0.13.0](https://github.com/MotWakorb/enhancedchannelmanager/releases/tag/v0.13.0).
+
+## Earlier versions
+
+Entries for `0.12.x` and earlier have not been backfilled into this file. See the [GitHub Releases page](https://github.com/MotWakorb/enhancedchannelmanager/releases) for the original release notes. Future releases will be recorded here under the appropriate Keep-a-Changelog sections.
+
+[Unreleased]: https://github.com/MotWakorb/enhancedchannelmanager/compare/v0.15.2...HEAD
+[0.15.2]: https://github.com/MotWakorb/enhancedchannelmanager/releases/tag/v0.15.2
+[0.15.1]: https://github.com/MotWakorb/enhancedchannelmanager/releases/tag/v0.15.1
+[0.15.0]: https://github.com/MotWakorb/enhancedchannelmanager/releases/tag/v0.15.0
+[0.14.0]: https://github.com/MotWakorb/enhancedchannelmanager/releases/tag/v0.14.0
+[0.13.1]: https://github.com/MotWakorb/enhancedchannelmanager/releases/tag/v0.13.1
+[0.13.0]: https://github.com/MotWakorb/enhancedchannelmanager/releases/tag/v0.13.0

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -38,9 +38,11 @@ cd frontend && npm run build
 bd close <id>
 ```
 
-### 5. Update README.md if Needed
+### 5. Update README.md and CHANGELOG.md if Needed
 
 If the change adds, removes, or modifies a feature, update the documentation.
+
+Every user-facing change must also be recorded in [`CHANGELOG.md`](../CHANGELOG.md) under the `[Unreleased]` section, in the appropriate Keep-a-Changelog category (Added / Changed / Deprecated / Removed / Fixed / Security). When cutting a release, rename the `[Unreleased]` heading to the new version with the release date and start a fresh empty `[Unreleased]` section above it.
 
 ### 6. Commit and Push
 


### PR DESCRIPTION
## Summary
- Replaces the `CHANGELOG.md` stub (which pointed at GitHub Releases) with the [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format: `[Unreleased]` at top, per-version sections with Added/Changed/Deprecated/Removed/Fixed/Security categories (bead `enhancedchannelmanager-yopgt`).
- Backfills v0.15.0, v0.15.1, and v0.15.2 in full from their GitHub release notes. v0.14.0, v0.13.1, v0.13.0 recorded as short pointers to GitHub Releases (PO guidance: lean first-version, not a doctoral thesis). 0.12.x and earlier explicitly deferred.
- v0.16.0 recorded as **Yanked 2026-04-20** per `bd-vgm4l` rollback, with a pointer to `docs/runbooks/v0.16.0-rollback.md` (shipping in PR #83).
- `[Unreleased]` captures PR #80 (`bd-ak1db`, observability baseline) and PR #81 (`bd-c5wf5`, Alembic baseline) — both merged to `dev` but not yet tagged, so they correctly live under Unreleased — plus `bd-bwly4` (runbooks scaffold).
- Adds `.github/pull_request_template.md` with a checklist that reminds authors to update CHANGELOG under the appropriate Unreleased category (skip only for docs-only/test-only/CI-only changes with a documented reason).
- Updates `docs/shipping.md` step 5 to require a CHANGELOG update and describes the `[Unreleased] → [X.Y.Z]` promotion at release-cut time.

## Why now
Two baseline PRs (#80 observability, #81 Alembic) merged to `dev` with no changelog entries — the TW flagged RED in the 2026-04-20 standup. Seven more dep bumps are queued in `bd-6rrl5`; without a format contract, release notes will drift further.

## Scope discipline
Per PO: "CHANGELOG scaffold + recent-release backfill is enough." No exhaustive cookbook of older versions — pointers to GitHub Releases for 0.14.x and 0.13.x are explicit and sufficient for this first cut.

## Test plan
- [x] Markdown renders cleanly; Keep-a-Changelog structure matches 1.1.0 spec
- [x] Each backfilled version's content verified against `gh release view v0.15.x` output
- [x] `[Unreleased]` reflects the two merged-but-not-tagged PRs (#80, #81) plus this sprint's runbooks scaffold
- [x] v0.16.0 section documents the rollback with a runbook link
- [x] PR template checklist includes the CHANGELOG reminder
- [x] `docs/shipping.md` step 5 references `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)