### PR TITLE
[bd-dl1bd] SLOs + Prometheus alert rules on observability baseline

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -98,11 +98,14 @@ finally:
 
 Metric emission is wrapped in try/except so a misbehaving collector can never fail a request. This is the invariant: observability is a side effect, not a dependency.
 
+### SLOs and alert rules
+
+See [`docs/sre/slos.md`](./sre/slos.md) (bd-dl1bd) for the initial SLOs built on top of this substrate — readiness availability, HTTP p95 latency, HTTP 5xx error rate, and informational readiness sub-check latency. Corresponding Prometheus alert rules live in [`docs/sre/prometheus_rules.yaml`](./sre/prometheus_rules.yaml); runbooks referenced by each alert are under [`docs/runbooks/`](./runbooks/). Targets are intentionally conservative until 30+ days of production metrics exist — they will be recalibrated after that baseline, tracked as a follow-up bead.
+
 ### Out of scope for this substrate
 
 Explicit non-goals, handed off to future beads:
 
-- **SLOs** — need a baseline of real traffic before committing to numbers.
-- **Alertmanager / Prometheus / Grafana deployment** — this substrate only exposes the endpoint; no scrape target is deployed with ECM.
+- **Alertmanager / Prometheus / Grafana deployment** — this substrate only exposes the endpoint and ships rules-as-code (see SLO section above); no scrape target is deployed with ECM.
 - **Distributed tracing (OpenTelemetry / Jaeger / Tempo)** — the `trace_id` is a correlation id, not a W3C TraceContext id. A future bead will adopt OTel if and when we have a downstream tracer to emit to.
 - **Log aggregation (Loki / ELK)** — JSON on stdout is the substrate; a pipeline is its own bead.

--- a/docs/runbooks/http_error_rate.md
+++ b/docs/runbooks/http_error_rate.md
@@ -1,0 +1,71 @@
+# Runbook: ECM HTTP Error Rate
+
+> **Stub** — scaffolded by bd-dl1bd. Reconcile with bd-bwly4 runbook template
+> when that lands.
+
+**Alerts that route here:**
+- `ECMHTTPError5xxElevated` (ticket) — 5xx rate > 1% for 10m
+- `ECMHTTPError5xxCritical` (page) — 5xx rate > 10% for 3m
+
+**SLO:** [SLO-3 HTTP Error Rate](../sre/slos.md#slo-3-http-error-rate)
+
+---
+
+## Symptoms
+
+- Users report "something went wrong" error banners, failed saves, blank pages.
+- 5xx rate visible on `/metrics`:
+  ```promql
+  sum(rate(ecm_http_requests_total{status=~"5.."}[5m]))
+  / sum(rate(ecm_http_requests_total[5m]))
+  ```
+
+## First 5 minutes
+
+1. **Identify the failing path(s).**
+   ```promql
+   sum by (path, status) (
+     rate(ecm_http_requests_total{status=~"5.."}[5m])
+   )
+   ```
+   Is it concentrated on one endpoint or spread across many? Concentrated = a specific bug or dependency. Spread = infrastructure.
+
+2. **Pull ERROR logs for the offending path.**
+   ```bash
+   docker logs ecm-ecm-1 --since 15m \
+     | grep '"level":"ERROR"' \
+     | jq 'select(.path == "/api/<offending-path>")' \
+     | head -20
+   ```
+   Extract one `trace_id` and grep for it across all logs — full request story, ordered.
+
+3. **Check readiness.** If readiness is failing, fix that first; 5xxs often downstream of it.
+
+## Common causes
+
+### Unhandled exception in a router
+- Signals: ERROR logs with stack traces; OWASP 500-scrubber middleware redacts user-facing detail but full trace is in the log.
+- Mitigation: hotfix or rollback. File bug bead.
+
+### Database session exhaustion
+- Signals: Errors cite `sqlalchemy` or `database`; readiness database sub-check also slow/failing.
+- Mitigation: restart container (last resort), investigate session leak in the code path (missing `finally: db.close()`).
+
+### Dispatcharr 5xx passthrough
+- Signals: Errors on proxying endpoints (streams, EPG sync, channel groups); Dispatcharr-side logs confirm upstream failure.
+- Mitigation: no ECM-side fix; upstream recovery. Consider circuit-breaking if sustained.
+
+### Rate-limited (should be 429, not 5xx — investigate if 5xx)
+- slowapi limiter on `/api/auth/login`. If 5xx correlates with auth endpoints during a brute-force attempt, investigate whether the limiter is misconfigured to 5xx instead of 429.
+
+## Mitigation
+
+- Rollback is the fastest remedy for recent-deploy-caused 5xx.
+- For infra issues (database/disk/network), mitigate the infra before the app.
+- Capture a log snapshot (`docker logs ecm-ecm-1 --since 1h > /tmp/incident.log`) **before** restarting — container restart loses in-memory state useful for postmortem.
+
+## See also
+
+- [SLO document](../sre/slos.md)
+- OWASP 500-scrubber: `backend/main.py` (search `scrub_500`)
+- [Observability docs](../backend_architecture.md#observability)

--- a/docs/runbooks/http_latency.md
+++ b/docs/runbooks/http_latency.md
@@ -1,0 +1,70 @@
+# Runbook: ECM HTTP Latency
+
+> **Stub** — scaffolded by bd-dl1bd. Reconcile with bd-bwly4 runbook template
+> when that lands.
+
+**Alerts that route here:**
+- `ECMHTTPLatencyHighP95` (ticket) — p95 > 500ms for 10m
+- `ECMHTTPLatencyCriticalP95` (page) — p95 > 2s for 5m
+
+**SLO:** [SLO-2 HTTP Request Latency](../sre/slos.md#slo-2-http-request-latency)
+
+---
+
+## Symptoms
+
+- Users report slow page loads, spinners that never resolve, saved settings "not sticking" (actually slow roundtrip).
+- `histogram_quantile(0.95, sum by (le) (rate(ecm_http_request_duration_seconds_bucket[5m])))` > 500ms.
+
+## First 5 minutes
+
+1. **Identify the slow route(s).** Group p95 by `path` label to find the offender:
+   ```promql
+   histogram_quantile(
+     0.95,
+     sum by (le, path) (
+       rate(ecm_http_request_duration_seconds_bucket[5m])
+     )
+   )
+   ```
+   Sort descending; one or two routes usually dominate.
+
+2. **Check readiness.** If `ecm_health_ready_ok == 0`, the latency is a downstream effect — go to [readiness runbook](./readiness_availability.md) first.
+
+3. **Grep access logs for slow requests.** Every request emits a structured `ecm.access` line with `duration_ms`:
+   ```bash
+   docker logs ecm-ecm-1 --since 15m \
+     | grep '"logger":"ecm.access"' \
+     | jq 'select(.duration_ms > 1000)' \
+     | head -50
+   ```
+   The `trace_id` on each entry correlates to every other log line from that request — follow the thread to find what was slow.
+
+## Common causes
+
+### Database contention
+- Signals: `path` labels concentrated on write-heavy routes (`/api/channels`, `/api/auto-creation-rules`); readiness `database` sub-check latency also climbing.
+- Mitigation: pause bulk operations (auto-creation, digest), identify the long transaction via logs.
+
+### Dispatcharr upstream slow
+- Signals: readiness `dispatcharr` sub-check latency alert also firing; slow routes are ones that proxy Dispatcharr (streams, EPG).
+- Mitigation: confirm Dispatcharr health independently; no ECM-side fix beyond timeout tuning.
+
+### N+1 frontend loop
+- Signals: high `ecm_http_requests_total` rate from a single path pattern, each individually fast but aggregated slow.
+- Mitigation: usually a frontend bug; file bead and (short-term) rate-limit the offending view.
+
+### Cold cache / first request after restart
+- Signals: Transient — resolves within a few minutes without intervention. Don't page over this.
+
+## Mitigation
+
+- If a specific route is the offender and recently changed: consider rolling back the backend image.
+- If infrastructure (disk I/O, CPU saturation on the host): check host metrics before blaming ECM.
+- If unexplained and sustained: escalate, capture log snapshot for postmortem.
+
+## See also
+
+- [SLO document](../sre/slos.md)
+- [`backend/main.py`](../../backend/main.py) — observability middleware (search `_metric_path_label`)
+- [Observability docs](../backend_architecture.md#observability)

--- a/docs/runbooks/readiness_availability.md
+++ b/docs/runbooks/readiness_availability.md
@@ -1,0 +1,70 @@
+# Runbook: ECM Readiness Availability
+
+> **Stub** — scaffolded by bd-dl1bd alongside the SLOs. Will be reconciled
+> with the runbook template produced by sibling bead bd-bwly4 when that
+> lands; if bwly4 merges first, re-flow this content into their template.
+
+**Alerts that route here:**
+- `ECMReadinessDown` (page) — `ecm_health_ready_ok == 0` sustained 2m+
+- `ECMReadinessFlapping` (ticket) — >4 transitions in 10m
+- `ECMReadiness30dBudgetBurn` (ticket) — 6h availability < 95%
+
+**SLO:** [SLO-1 Readiness Availability](../sre/slos.md#slo-1-readiness-availability)
+
+---
+
+## Symptoms
+
+- Readiness endpoint (`/api/health/ready`) returns `503 Not Ready`.
+- `ecm_health_ready_ok` gauge reads `0` in Prometheus / `/metrics`.
+- Users report ECM "not responding" or "loading forever" on first page load.
+
+## First 5 minutes
+
+1. **Confirm the alert.** Curl `/api/health/ready` directly — the JSON payload names the failing sub-check:
+   ```bash
+   curl -s http://<host>/api/health/ready | jq .
+   ```
+   Look for `checks.<name>.status == "fail"` and read `checks.<name>.detail`.
+
+2. **Check container state.**
+   ```bash
+   docker ps --filter name=ecm-ecm-1
+   docker logs --tail 100 ecm-ecm-1 | grep -E '"level":"(ERROR|WARN)"'
+   ```
+
+3. **Correlate with recent deploys.** Was there a `docker restart` or image rollout in the last hour? If yes, suspect that first.
+
+## Diagnosis by failing sub-check
+
+### `database` fails
+- SQLite file lock: `/config/journal.db` may be write-locked by a long-running transaction. Check for stuck auto-creation runs.
+- Disk full: `docker exec ecm-ecm-1 df -h /config`.
+- Schema drift: compare `/api/health/schema` output to expected Alembic head.
+
+### `dispatcharr` fails
+- Network: can the container reach Dispatcharr? `docker exec ecm-ecm-1 curl -sv <dispatcharr-url>/health`.
+- Credentials: settings UI → Dispatcharr → verify token hasn't expired.
+- Dispatcharr itself down: check Dispatcharr's own health before blaming ECM.
+
+### `ffprobe` fails (or skipped)
+- Binary missing: `docker exec ecm-ecm-1 which ffprobe`.
+- Permissions: should be +x for the container user.
+- Note: `ffprobe` sub-check failure degrades features but is treated as OK for readiness if marked `skipped` — re-read the health.py logic if the status is ambiguous.
+
+## Mitigation
+
+- Database lock: identify the blocking query via logs (`grep trace_id` of the request that kicked it off), cancel if safe.
+- Dispatcharr: if Dispatcharr is down, there is no ECM-side mitigation — set user expectation, wait for upstream.
+- Rollback: if a recent deploy caused the failure, `docker restart ecm-ecm-1` first; if still failing, revert to the previous image.
+
+## Post-incident
+
+- If the error budget burn was material (>10% of 30d budget in one event), file a postmortem via the `postmortem` skill.
+- Update this runbook with the specific failure mode and fix so the next page is faster.
+
+## See also
+
+- [SLO document](../sre/slos.md)
+- [`backend/routers/health.py`](../../backend/routers/health.py) — readiness sub-check implementations
+- [`backend/observability.py`](../../backend/observability.py) — metric registration

--- a/docs/runbooks/readiness_subcheck_latency.md
+++ b/docs/runbooks/readiness_subcheck_latency.md
@@ -1,0 +1,50 @@
+# Runbook: ECM Readiness Sub-check Latency
+
+> **Stub** — scaffolded by bd-dl1bd. Reconcile with bd-bwly4 runbook template
+> when that lands.
+
+**Alerts that route here (warning severity — informational only):**
+- `ECMReadinessDatabaseCheckSlow` — database sub-check p95 > 50ms for 10m
+- `ECMReadinessDispatcharrCheckSlow` — dispatcharr sub-check p95 > 500ms for 10m
+- `ECMReadinessFfprobeCheckSlow` — ffprobe sub-check p95 > 100ms for 10m
+
+**SLO:** [SLO-4 Readiness Sub-check Latency](../sre/slos.md#slo-4-readiness-sub-check-latency-informational)
+
+---
+
+## Why this is a warning, not a page
+
+Readiness sub-check latency is a **leading indicator**, not a user-impacting failure. A slow sub-check is a heads-up that one of the production SLOs (latency or availability) is about to breach. Treat these alerts as "look at this now while you still have time" rather than "wake up at 3am."
+
+If the related production SLO alert (`ECMReadinessDown`, `ECMHTTPLatencyHighP95`) also fires, escalate to that runbook — the warning here was the early signal for that real incident.
+
+## Diagnosis
+
+### database check slow (>50ms)
+- Expected shape: sub-check is a cheap `PRAGMA` read, should be <5ms on warm disk.
+- Likely cause: file lock contention from a long-running write (bulk auto-creation, digest). Check for `[TASKS]` log lines indicating a running job.
+- Check disk: `docker exec ecm-ecm-1 df -h /config` and `iostat 1 5` on the host.
+
+### dispatcharr check slow (>500ms)
+- Expected shape: single HTTP HEAD / `/health` to Dispatcharr, should return in tens of ms on LAN.
+- Likely cause: network latency, Dispatcharr itself slow, DNS resolution delay.
+- Diagnose: `docker exec ecm-ecm-1 curl -w '%{time_total}\n' -so /dev/null <dispatcharr-health-url>`.
+
+### ffprobe check slow (>100ms)
+- Expected shape: a spawn + quick probe, typically <50ms.
+- Likely cause: host disk I/O saturation, binary relocated, missing codecs causing ffprobe to scan harder.
+- Diagnose: `docker exec ecm-ecm-1 which ffprobe && docker exec ecm-ecm-1 ffprobe -version`.
+
+## Mitigation
+
+For a warning-only alert, mitigation is typically "open an investigative ticket, watch the related production SLO." Only escalate to page-level action if:
+
+1. The warning persists beyond one hour.
+2. The corresponding production SLO (latency / availability) starts trending toward breach.
+3. Multiple sub-checks fire simultaneously (indicates infrastructure-level problem, not dependency-level).
+
+## See also
+
+- [SLO document](../sre/slos.md)
+- [`backend/routers/health.py`](../../backend/routers/health.py) — sub-check implementations with `_timed` wrapper
+- Production SLO runbooks: [readiness](./readiness_availability.md), [latency](./http_latency.md), [error rate](./http_error_rate.md)

--- a/docs/sre/prometheus_rules.yaml
+++ b/docs/sre/prometheus_rules.yaml
@@ -1,0 +1,257 @@
+# ECM Prometheus alert rules — initial SLO scaffold.
+#
+# Companion to docs/sre/slos.md (bd-dl1bd).
+# Consumed by a Prometheus instance that scrapes ECM's /metrics endpoint.
+# This file is "rules-as-code" only — no Prometheus/Alertmanager deployment
+# is shipped with ECM yet. A future bead will wire scrape + routing.
+#
+# Conventions:
+#   - severity: "page"     — wake someone up
+#   - severity: "ticket"   — open a ticket, investigate next business hour
+#   - severity: "warning"  — dashboard-visible, informational only
+#   - Every alert carries a `runbook_url` annotation pointing at
+#     docs/runbooks/<name>.md (relative path — scrapers rewrite to absolute
+#     URLs at their discretion).
+#   - Window choices (short / long) are intentionally simple for scaffold.
+#     A follow-up bead introduces multi-window multi-burn-rate (MWMBR)
+#     alerts with recording rules once we have a Prometheus target to
+#     provision them against.
+#
+# Load into Prometheus by pointing `rule_files:` at this path. Validate
+# syntax with `promtool check rules docs/sre/prometheus_rules.yaml`.
+
+groups:
+  # =====================================================================
+  # SLO-1: Readiness Availability
+  # =====================================================================
+  - name: ecm_readiness_availability
+    interval: 30s
+    rules:
+      - alert: ECMReadinessDown
+        expr: ecm_health_ready_ok == 0
+        for: 2m
+        labels:
+          severity: page
+          slo: readiness_availability
+          service: ecm
+        annotations:
+          summary: "ECM readiness probe failing ({{ $value }}) for 2m+"
+          description: |
+            ecm_health_ready_ok has been 0 for at least 2 minutes. One or
+            more readiness sub-checks (database, dispatcharr, ffprobe) is
+            failing. Burns the availability error budget directly.
+          runbook_url: docs/runbooks/readiness_availability.md
+
+      - alert: ECMReadinessFlapping
+        # Flapping = multiple 0->1 transitions in a short window. We detect
+        # via changes() on the gauge — >2 transitions in 10m is suspicious.
+        expr: changes(ecm_health_ready_ok[10m]) > 4
+        for: 5m
+        labels:
+          severity: ticket
+          slo: readiness_availability
+          service: ecm
+        annotations:
+          summary: "ECM readiness probe flapping (>4 transitions in 10m)"
+          description: |
+            ecm_health_ready_ok is oscillating between 0 and 1. Usually
+            indicates an intermittent dependency (Dispatcharr flaky,
+            database momentarily locked) or a race in a sub-check.
+          runbook_url: docs/runbooks/readiness_availability.md
+
+      - alert: ECMReadiness30dBudgetBurn
+        # 30-day SLO = 99.0% means avg_over_time must exceed 0.99.
+        # We alert when the 6-hour average drops below 0.95 — a sustained
+        # 5% unavailability burns budget fast enough to warrant action
+        # even before the 30d window reflects it.
+        expr: avg_over_time(ecm_health_ready_ok[6h]) < 0.95
+        for: 15m
+        labels:
+          severity: ticket
+          slo: readiness_availability
+          service: ecm
+        annotations:
+          summary: "ECM readiness 6h availability {{ $value | humanizePercentage }} — burning 30d budget"
+          description: |
+            Sustained unavailability over the last 6 hours is consuming
+            the 30-day error budget (1% of 30d = ~7h12m). Investigate
+            root cause before the budget exhausts.
+          runbook_url: docs/runbooks/readiness_availability.md
+
+  # =====================================================================
+  # SLO-2: HTTP Request Latency
+  # =====================================================================
+  - name: ecm_http_latency
+    interval: 30s
+    rules:
+      - alert: ECMHTTPLatencyHighP95
+        # p95 > 500ms for 10 consecutive minutes.
+        # Excludes /metrics (self-skipped by middleware) and health probes.
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (
+              rate(ecm_http_request_duration_seconds_bucket{path!~"/metrics|/api/health/.*"}[5m])
+            )
+          ) > 0.5
+        for: 10m
+        labels:
+          severity: ticket
+          slo: http_latency
+          service: ecm
+        annotations:
+          summary: "ECM HTTP p95 latency {{ $value | humanizeDuration }} > 500ms for 10m+"
+          description: |
+            95th percentile request latency has exceeded 500ms for at
+            least 10 minutes. Possible causes: SQLite contention under
+            bulk operations, slow Dispatcharr upstream, N+1 query pattern
+            in a frontend view.
+          runbook_url: docs/runbooks/http_latency.md
+
+      - alert: ECMHTTPLatencyCriticalP95
+        # p95 > 2s sustained — page. Something is very wrong.
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (
+              rate(ecm_http_request_duration_seconds_bucket{path!~"/metrics|/api/health/.*"}[5m])
+            )
+          ) > 2.0
+        for: 5m
+        labels:
+          severity: page
+          slo: http_latency
+          service: ecm
+        annotations:
+          summary: "ECM HTTP p95 latency {{ $value | humanizeDuration }} > 2s — critical"
+          description: |
+            95th percentile request latency has exceeded 2 seconds for
+            at least 5 minutes. Users are noticing. Check readiness,
+            database health, and Dispatcharr connectivity immediately.
+          runbook_url: docs/runbooks/http_latency.md
+
+  # =====================================================================
+  # SLO-3: HTTP Error Rate
+  # =====================================================================
+  - name: ecm_http_error_rate
+    interval: 30s
+    rules:
+      - alert: ECMHTTPError5xxElevated
+        # 5xx rate > 1% over 5m — ticket severity.
+        # Suppress when total rate is tiny to avoid div-by-zero alerting
+        # during idle periods (>= 0.1 rps threshold).
+        expr: |
+          (
+            sum(rate(ecm_http_requests_total{status=~"5..",path!="/metrics"}[5m]))
+            /
+            sum(rate(ecm_http_requests_total{path!="/metrics"}[5m]))
+          ) > 0.01
+          and
+          sum(rate(ecm_http_requests_total{path!="/metrics"}[5m])) > 0.1
+        for: 10m
+        labels:
+          severity: ticket
+          slo: http_error_rate
+          service: ecm
+        annotations:
+          summary: "ECM 5xx error rate {{ $value | humanizePercentage }} > 1% for 10m+"
+          description: |
+            HTTP 5xx response rate has exceeded 1% of total requests for
+            at least 10 minutes. Check logs for repeated stack traces
+            (grep `"level":"ERROR"` in the structured log stream), and
+            correlate by `path` label to identify the failing endpoint.
+          runbook_url: docs/runbooks/http_error_rate.md
+
+      - alert: ECMHTTPError5xxCritical
+        # 5xx rate > 10% over 5m — page. Outage-scale.
+        expr: |
+          (
+            sum(rate(ecm_http_requests_total{status=~"5..",path!="/metrics"}[5m]))
+            /
+            sum(rate(ecm_http_requests_total{path!="/metrics"}[5m]))
+          ) > 0.1
+          and
+          sum(rate(ecm_http_requests_total{path!="/metrics"}[5m])) > 0.1
+        for: 3m
+        labels:
+          severity: page
+          slo: http_error_rate
+          service: ecm
+        annotations:
+          summary: "ECM 5xx error rate {{ $value | humanizePercentage }} > 10% — critical"
+          description: |
+            HTTP 5xx response rate has exceeded 10% for at least 3
+            minutes. Treat as an incident. Begin runbook, page on-call,
+            capture trace_ids from ERROR logs for postmortem.
+          runbook_url: docs/runbooks/http_error_rate.md
+
+  # =====================================================================
+  # SLO-4: Readiness Sub-check Latency (informational / warning only)
+  # =====================================================================
+  - name: ecm_readiness_subcheck_latency
+    interval: 1m
+    rules:
+      - alert: ECMReadinessDatabaseCheckSlow
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (
+              rate(ecm_health_ready_check_duration_seconds_bucket{check="database"}[5m])
+            )
+          ) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+          slo: readiness_subcheck_latency
+          service: ecm
+          check: database
+        annotations:
+          summary: "ECM database readiness check p95 {{ $value | humanizeDuration }} > 50ms"
+          description: |
+            Database readiness sub-check is slow. Leading indicator for
+            SLO-2 latency breach. Likely SQLite file lock contention or
+            a probe that has drifted from a cheap PRAGMA read.
+          runbook_url: docs/runbooks/readiness_subcheck_latency.md
+
+      - alert: ECMReadinessDispatcharrCheckSlow
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (
+              rate(ecm_health_ready_check_duration_seconds_bucket{check="dispatcharr"}[5m])
+            )
+          ) > 0.5
+        for: 10m
+        labels:
+          severity: warning
+          slo: readiness_subcheck_latency
+          service: ecm
+          check: dispatcharr
+        annotations:
+          summary: "ECM dispatcharr readiness check p95 {{ $value | humanizeDuration }} > 500ms"
+          description: |
+            Dispatcharr readiness sub-check is slow. Upstream dependency
+            latency — propagates directly to user-facing endpoints that
+            proxy Dispatcharr.
+          runbook_url: docs/runbooks/readiness_subcheck_latency.md
+
+      - alert: ECMReadinessFfprobeCheckSlow
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (
+              rate(ecm_health_ready_check_duration_seconds_bucket{check="ffprobe"}[5m])
+            )
+          ) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+          slo: readiness_subcheck_latency
+          service: ecm
+          check: ffprobe
+        annotations:
+          summary: "ECM ffprobe readiness check p95 {{ $value | humanizeDuration }} > 100ms"
+          description: |
+            ffprobe readiness sub-check is slow. Typically indicates
+            disk I/O issues on the host or ffprobe binary degradation.
+          runbook_url: docs/runbooks/readiness_subcheck_latency.md

--- a/docs/sre/slos.md
+++ b/docs/sre/slos.md
@@ -1,0 +1,195 @@
+# ECM Service Level Objectives
+
+**Status:** Initial scaffold (v1). Targets are conservative and MUST be recalibrated against 30+ days of production metrics before being treated as commitments.
+**Owner:** SRE persona.
+**Baseline:** Built on the observability substrate shipped in [PR #80](https://github.com/MotWakorb/enhancedchannelmanager/pull/80) (bd-ak1db). The four `ecm_*` series exposed on `/metrics` are the foundation for every SLI below.
+**Last updated:** 2026-04-20 (bd-dl1bd).
+
+## Why this exists
+
+The observability baseline gave ECM *signal*: we can see request rate, latency distributions, error rate, and readiness state on a Prometheus-compatible endpoint. Signal without thresholds is not reliability — it's just telemetry. This document turns signal into **commitments**: what "good" looks like, how much bad we tolerate (error budget), and what we do when the budget burns.
+
+Without SLOs, on-call has no objective criterion for paging. "The app feels slow" is not an incident; "p95 latency breached 500ms for 10 minutes, consuming 15% of the weekly error budget" is. This document exists so that answer is computable, not negotiated.
+
+## Definitions
+
+- **SLI — Service Level Indicator.** The raw metric we measure (e.g., ratio of successful readiness probes to total probes).
+- **SLO — Service Level Objective.** The target we commit to for an SLI over a rolling window (e.g., 99% over 30 days).
+- **Error budget.** `1 - SLO`. The amount of failure we can absorb without breaching the commitment. For a 99% / 30d SLO, the budget is 1% of 30 days = ~7.2 hours of downtime per 30 days.
+- **Burn rate.** Current rate of budget consumption relative to the steady-state burn that would exhaust the budget exactly at window close. A burn rate of 1.0 means we're consuming budget at exactly the rate the SLO allows; 14.4 means we'd exhaust a 30-day budget in ~2 days.
+
+## Scope
+
+These SLOs apply to the `ecm` FastAPI backend (`ecm-ecm-1` container) serving `/api/*` and `/api/health/*` endpoints on the port configured by the container. The `/metrics` endpoint itself is **excluded** from all SLO calculations — the HTTP middleware self-skips it (see `backend/main.py:255`), and it must not influence availability or latency numbers.
+
+Out of scope for v1:
+
+- Frontend asset delivery (served statically; different failure mode).
+- WebSocket long-lived connections (`/ws/*` — no histogram coverage yet).
+- Background task success rate (task scheduler has no `ecm_task_*` metrics yet — separate bead when we instrument it).
+
+---
+
+## SLO-1: Readiness Availability
+
+**SLI:** Fraction of readiness probes that report `ecm_health_ready_ok == 1`, measured as the time-weighted average of the gauge over the window.
+
+**Prometheus expression (SLI numerator over denominator):**
+```promql
+avg_over_time(ecm_health_ready_ok[30d])
+```
+
+**SLO target:** **99.0%** over a rolling 30-day window.
+
+**Error budget:** 1% = ~7h 12m of `ecm_health_ready_ok == 0` per 30d.
+
+**Why this target (initial):** 99.0% is a deliberately conservative starting point. Mature SaaS SLOs for readiness sit at 99.9% (~43 min/month) or higher, but:
+
+1. ECM is a self-hosted LAN app that frequently runs on consumer hardware with non-trivial restart windows (container updates, host reboots, power events). A three-nines commitment would be ambitious without redundancy we haven't built.
+2. The readiness probe includes a Dispatcharr dependency — ECM's availability is bounded above by Dispatcharr's availability, which is outside our control.
+3. We have **zero days** of real production metrics at the time of writing. The target must be calibrated against observed behavior before tightening.
+
+Re-tune after 30 days of production data. If we sustain 99.9% comfortably, tighten to 99.5%; revisit every quarter.
+
+**What breaks this SLO:**
+
+- Database file lock contention (`/config/journal.db` under heavy auto-creation load).
+- Dispatcharr unreachable (network partition, Dispatcharr restart, bad credentials).
+- ffprobe binary missing or permissions broken (degrades but does not fail readiness — see `routers/health.py` skip-vs-fail semantics).
+
+**Runbook:** [`docs/runbooks/readiness_availability.md`](../runbooks/readiness_availability.md)
+
+---
+
+## SLO-2: HTTP Request Latency
+
+**SLI:** 95th percentile request latency over `ecm_http_request_duration_seconds`, across all methods and route patterns (excluding `/metrics` and `/api/health/*` — those are instrumented separately and have different SLOs).
+
+**Prometheus expression:**
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le) (
+    rate(ecm_http_request_duration_seconds_bucket{path!~"/metrics|/api/health/.*"}[5m])
+  )
+)
+```
+
+**SLO target:** **p95 < 500ms** over rolling 5-minute windows, for at least **99%** of those windows over 30 days.
+
+**Error budget:** 1% of 30d * 5m windows = ~86 minutes of windows where p95 ≥ 500ms per 30d.
+
+**Why this target (initial):** The latency histogram buckets ak1db shipped (`0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0`) were tuned for "local web app hitting SQLite + LAN Dispatcharr" where most requests land under 100ms. A 500ms p95 ceiling gives comfortable headroom: if we breach it routinely, we've got a real slowdown worth investigating. This bucket layout also means `histogram_quantile` interpolation is reasonable around the 500ms boundary — the 0.25 and 0.5 buckets straddle it cleanly.
+
+Tighten to p95 < 250ms once we have baseline data showing we comfortably beat 500ms.
+
+**What breaks this SLO:**
+
+- SQLite write amplification during bulk auto-creation (lots of small transactions).
+- Dispatcharr API slowness (ECM proxies many requests).
+- N+1 query patterns in frontends (often the real culprit — a single user view hitting `/api/channels/*` 500 times serially).
+
+**Runbook:** [`docs/runbooks/http_latency.md`](../runbooks/http_latency.md)
+
+---
+
+## SLO-3: HTTP Error Rate
+
+**SLI:** Ratio of HTTP 5xx responses to total responses, across all routes (excluding `/metrics` which is self-skipped by the middleware).
+
+**Prometheus expression:**
+```promql
+sum(rate(ecm_http_requests_total{status=~"5.."}[5m]))
+/
+sum(rate(ecm_http_requests_total[5m]))
+```
+
+**SLO target:** **5xx error rate < 1%** over rolling 5-minute windows, for **99%** of windows over 30 days.
+
+**Error budget:** Same as SLO-2 structurally — ~86 minutes of > 1% 5xx windows per 30d.
+
+**Why this target (initial):** 1% is intentionally loose for a scaffold. A mature SLO would target 0.1% or tighter, but:
+
+1. Some ECM endpoints wrap Dispatcharr (not our failure mode, but our status code).
+2. Auto-creation rules with bad upstream streams will 5xx as designed until the user fixes the rule.
+3. We don't yet separate "our bug" 5xxs from "integration partner down" 5xxs.
+
+A follow-up bead should split this SLO by `path` label once we've observed which routes dominate the error budget, and introduce per-route sub-objectives (e.g., `/api/auth/login` should be far stricter than `/api/stream/probe`).
+
+4xx responses are **not** counted — they reflect client behavior, not service reliability. A spike in 401s during a credential-rotation event is correct behavior, not an SLO breach.
+
+**What breaks this SLO:**
+
+- Database session exhaustion / pool timeouts.
+- Dispatcharr returning 5xx (we pass through).
+- Unhandled exceptions in routers (caught by the OWASP 500-scrubber middleware — still counts as a 5xx for this SLO, which is correct).
+
+**Runbook:** [`docs/runbooks/http_error_rate.md`](../runbooks/http_error_rate.md)
+
+---
+
+## SLO-4: Readiness Sub-check Latency (informational)
+
+**SLI:** 95th percentile duration of readiness sub-checks, per `check` label (`database`, `dispatcharr`, `ffprobe`).
+
+**Prometheus expression (per check):**
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, check) (
+    rate(ecm_health_ready_check_duration_seconds_bucket[5m])
+  )
+)
+```
+
+**SLO target (soft / informational only):**
+
+- `database` sub-check p95 < 50ms
+- `dispatcharr` sub-check p95 < 500ms
+- `ffprobe` sub-check p95 < 100ms
+
+**Why informational only:** These are diagnostic signals — a slow readiness sub-check is a leading indicator for SLO-1 and SLO-2, but users don't directly experience readiness probe latency. We alert **warning** (not page) on breach so on-call gets situational awareness without being woken up.
+
+**Runbook:** [`docs/runbooks/readiness_subcheck_latency.md`](../runbooks/readiness_subcheck_latency.md)
+
+---
+
+## Error-budget policy
+
+What happens when the error budget burns? The rules below apply per-SLO; burns are evaluated weekly.
+
+| Budget state | Trigger | Response |
+|-|-|-|
+| **Healthy** | <25% budget consumed in window | Normal feature work. No action required. |
+| **Concerned** | 25–50% consumed | SRE posts weekly status in the sprint channel. No scope change. |
+| **Warning** | 50–75% consumed | Reliability work is prioritized in the next sprint grooming. New features not yet started are deferred if they risk further burn. |
+| **Critical** | 75–100% consumed | All feature work stops. Incident review. Reliability fixes ship before anything else resumes. |
+| **Exhausted** | 100%+ consumed (SLO breached) | Blameless postmortem within 5 business days. Freeze on new deployments except reliability fixes until the budget resets or recovers by ≥10 percentage points. |
+
+**Budget resets** on a rolling basis — the 30-day window always looks at the last 30 days, so a burn today drops out 30 days from now if no new burn occurs.
+
+**Exceptions:** Security fixes always ship regardless of budget state. A zero-day 4pm on Friday doesn't wait for the error budget to heal — but it's tracked and the postmortem captures the reliability cost.
+
+---
+
+## Alerting strategy
+
+Alert rules are defined in [`prometheus_rules.yaml`](./prometheus_rules.yaml). The strategy is multi-window multi-burn-rate (MWMBR) where feasible:
+
+- **Fast burn (page):** If the current burn rate would consume 2% of a 30-day budget in 1 hour (14.4x burn), page immediately. This catches acute incidents.
+- **Slow burn (ticket):** If the current burn rate would consume 10% of a 30-day budget in 6 hours (6x burn) sustained, open a ticket / warning alert. This catches chronic degradation.
+
+For the scaffold we ship simpler single-window thresholds for SLO-2/3 (p95 latency breach, 5xx rate breach) because burn-rate alerts on histogram-derived SLIs require recording rules we haven't provisioned. Follow-up bead: add recording rules + multi-window burn-rate alerts once a Prometheus scrape target exists to consume them.
+
+---
+
+## Open questions / known gaps
+
+- **No traffic-weighted availability.** SLO-1 treats every 15-second scrape of `ecm_health_ready_ok` as equal weight, regardless of how many user requests landed during that interval. A future refinement: weight by `ecm_http_requests_total` rate.
+- **No per-tenant SLO.** ECM is single-tenant by deployment, but the SLOs above are global — they don't distinguish a power user from a casual one. Fine for v1; revisit if we ship multi-tenant.
+- **No Dispatcharr-upstream vs ECM-self attribution.** When `ecm_http_requests_total{status="502"}` fires because Dispatcharr returned 502, it still counts against our SLO. The fix is a separate label or metric, tracked as a follow-up.
+- **No SLO for long-running tasks.** Task success rate matters (restore jobs, auto-creation runs) but has no metric today. Separate bead.
+
+## Changelog
+
+- **2026-04-20 (bd-dl1bd):** Initial scaffold. Four SLOs defined, targets conservative, error-budget policy drafted, alert rules shipped in sibling YAML. **Not yet calibrated against real traffic** — targets must be revisited once 30 days of production metrics exist.


### PR DESCRIPTION
## Summary

Resolves bd-dl1bd. Builds on the `/metrics` observability substrate shipped in #80 (bd-ak1db) by defining the first-usable SLOs and matching Prometheus alert rules — turning signal into thresholds. Resolves the SRE YELLOW condition PO uplifted this sprint: *signal without thresholds*.

**Deliverables:**

- `docs/sre/slos.md` — four SLOs:
  - **SLO-1 Readiness Availability** — `ecm_health_ready_ok == 1` for 99.0% of 30d (conservative start, ~7h error budget).
  - **SLO-2 HTTP p95 Latency** — `ecm_http_request_duration_seconds` p95 < 500ms for 99% of 5m windows over 30d.
  - **SLO-3 HTTP 5xx Error Rate** — `ecm_http_requests_total{status=~"5.."}` rate < 1% for 99% of 5m windows.
  - **SLO-4 Readiness Sub-check Latency** (informational/warning only) — per-check p95 thresholds as leading indicators.
  - Error-budget policy with 5 states (healthy → exhausted) and actions per state.
- `docs/sre/prometheus_rules.yaml` — 10 alert rules, page/ticket/warning severity tiers, each carrying a `runbook_url` annotation.
- `docs/runbooks/{readiness_availability,http_latency,http_error_rate,readiness_subcheck_latency}.md` — runbook stubs per SLO. Will reconcile with the template from sibling bead bwly4 on whichever merges second.
- `docs/backend_architecture.md` — cross-links SLO docs from Observability section; removes "SLOs" from the substrate's out-of-scope list.

## Conservative by design

Per PO guidance ("we're scaffolding a lot here — LEAN first version"), targets are intentionally loose:

- We have **zero days** of production metrics at the time of writing. Committing to 99.9% without a baseline would be an aspiration, not an SLO.
- Targets MUST be recalibrated against 30 days of production data before being treated as binding. This is documented in every target's "Why this target (initial)" section.

## Explicitly still out of scope (future beads)

- Prometheus / Alertmanager deployment (rules-as-code only).
- Grafana dashboards.
- Distributed tracing (ak1db deferred).
- Per-route sub-SLOs.
- Recording rules for multi-window multi-burn-rate alerts.

## Coordination with sibling bead

bd-bwly4 (TW) is scaffolding `docs/runbooks/` with a runbook template. I created the directory with the runbook stubs needed to satisfy this bead's acceptance criteria; both beads touch `docs/runbooks/` but on different files. Expect clean merge; if bwly4 ships a template, a small follow-up re-flows these stubs into it.

## Test plan

- [x] YAML validated with `python3 -c "yaml.safe_load(...)"` — parses clean, 10 alerts across 4 groups.
- [ ] `promtool check rules docs/sre/prometheus_rules.yaml` when a Prometheus scrape target exists (future bead).
- [x] All runbooks linked from alert `runbook_url` annotations — paths exist in this branch.
- [x] `docs/backend_architecture.md` Observability section still renders and links forward to SLO docs.

## References

- Closes bd-dl1bd.
- Baseline: #80 (bd-ak1db) — observability substrate.
- Sibling: bd-bwly4 — runbook template (in-flight).
- Sprint context: PO SRE YELLOW uplifted 2026-04-20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)