### PR TITLE
[bd-bqpq0] Smart sort: primary criteria within failed-rank buckets (auto-create)

### DIFF
--- a/backend/auto_creation_engine.py
+++ b/backend/auto_creation_engine.py
@@ -2171,6 +2171,64 @@ def _smart_sort_streams(
         channel_name, active_criteria, deprioritize_failed, fail_order
     )
 
+    def compute_criteria_values(stats: dict | None, sid: int) -> list:
+        """Compute sort-key values for active_criteria in priority order.
+
+        Used for both successful streams (primary ordering) and deprioritized
+        streams (within-bucket tiebreaker — bd-bqpq0, mirrors bd-sw883 in
+        stream_prober.py). For a deprioritized stream where ``stats`` is None
+        (no probe row at all), only m3u_priority can be computed; all other
+        criteria are 0.
+        """
+        values = []
+        for criterion in active_criteria:
+            if criterion == "resolution":
+                resolution_value = 0
+                if stats and stats.get("resolution"):
+                    try:
+                        parts = stats["resolution"].split("x")
+                        if len(parts) == 2:
+                            resolution_value = int(parts[1])
+                    except (ValueError, IndexError) as e:
+                        logger.debug("[AUTO-CREATE-ENGINE] Suppressed resolution parse error: %s", e)
+                values.append(-resolution_value)
+
+            elif criterion == "bitrate":
+                bitrate_value = 0
+                if stats:
+                    bitrate_value = stats.get("video_bitrate") or stats.get("bitrate") or 0
+                values.append(-bitrate_value)
+
+            elif criterion == "framerate":
+                framerate_value = 0
+                fps = stats.get("fps") if stats else None
+                if fps:
+                    try:
+                        framerate_value = float(fps)
+                    except (ValueError, TypeError) as e:
+                        logger.debug("[AUTO-CREATE-ENGINE] Suppressed fps parse error: %s", e)
+                values.append(-framerate_value)
+
+            elif criterion == "m3u_priority":
+                # m3u_priority does NOT require a successful probe — it comes
+                # from the m3u account map, so it's always meaningful.
+                m3u_priority_value = 0
+                m3u_account_id = stream_m3u_map.get(sid)
+                if m3u_account_id is not None:
+                    m3u_priority_value = m3u_priorities.get(str(m3u_account_id), 0)
+                values.append(-m3u_priority_value)
+
+            elif criterion == "audio_channels":
+                audio_ch = (stats.get("audio_channels") if stats else 0) or 0
+                values.append(-audio_ch)
+
+            elif criterion == "video_codec":
+                from stream_prober import get_codec_rank
+                codec_value = get_codec_rank(stats.get("video_codec")) if stats else 0
+                values.append(-codec_value)
+
+        return values
+
     def get_sort_value(sid: int) -> tuple:
         stats = stats_cache.get(sid)
 
@@ -2178,65 +2236,26 @@ def _smart_sort_streams(
         if deprioritize_failed:
             if not stats or stats.get("probe_status") in ("failed", "timeout", "pending"):
                 rank = failed_rank.get('failed', 0)
-                return (1, rank) + tuple(0 for _ in active_criteria)
+                # bd-bqpq0: apply primary criteria within the failed bucket too.
+                return (1, rank) + tuple(compute_criteria_values(stats, sid))
 
         # Deprioritize black screen streams (probe succeeded but content is black)
         if deprioritize_failed and stats and stats.get("is_black_screen"):
             rank = failed_rank.get('black_screen', 1)
-            return (1, rank) + tuple(0 for _ in active_criteria)
+            # bd-bqpq0: apply primary criteria within the black_screen bucket too.
+            return (1, rank) + tuple(compute_criteria_values(stats, sid))
 
         # Deprioritize low FPS streams (probe succeeded but FPS below threshold)
         if deprioritize_failed and stats and stats.get("is_low_fps"):
             rank = failed_rank.get('low_fps', 2)
-            return (1, rank) + tuple(0 for _ in active_criteria)
+            # bd-bqpq0: apply primary criteria within the low_fps bucket too.
+            return (1, rank) + tuple(compute_criteria_values(stats, sid))
 
         if not stats or stats.get("probe_status") != "success":
             return (0, 0) + tuple(0 for _ in active_criteria)
 
         sort_values = [0, 0]  # 0 = successful stream, 0 = sub-rank (unused)
-
-        for criterion in active_criteria:
-            if criterion == "resolution":
-                resolution_value = 0
-                if stats.get("resolution"):
-                    try:
-                        parts = stats["resolution"].split("x")
-                        if len(parts) == 2:
-                            resolution_value = int(parts[1])
-                    except (ValueError, IndexError) as e:
-                        logger.debug("[AUTO-CREATE-ENGINE] Suppressed resolution parse error: %s", e)
-                sort_values.append(-resolution_value)
-
-            elif criterion == "bitrate":
-                bitrate_value = stats.get("video_bitrate") or stats.get("bitrate") or 0
-                sort_values.append(-bitrate_value)
-
-            elif criterion == "framerate":
-                framerate_value = 0
-                fps = stats.get("fps")
-                if fps:
-                    try:
-                        framerate_value = float(fps)
-                    except (ValueError, TypeError) as e:
-                        logger.debug("[AUTO-CREATE-ENGINE] Suppressed fps parse error: %s", e)
-                sort_values.append(-framerate_value)
-
-            elif criterion == "m3u_priority":
-                m3u_priority_value = 0
-                m3u_account_id = stream_m3u_map.get(sid)
-                if m3u_account_id is not None:
-                    m3u_priority_value = m3u_priorities.get(str(m3u_account_id), 0)
-                sort_values.append(-m3u_priority_value)
-
-            elif criterion == "audio_channels":
-                audio_ch = stats.get("audio_channels") or 0
-                sort_values.append(-audio_ch)
-
-            elif criterion == "video_codec":
-                from stream_prober import get_codec_rank
-                codec_value = get_codec_rank(stats.get("video_codec"))
-                sort_values.append(-codec_value)
-
+        sort_values.extend(compute_criteria_values(stats, sid))
         return tuple(sort_values)
 
     # Log each stream's sort values

--- a/backend/tests/unit/test_auto_creation_engine.py
+++ b/backend/tests/unit/test_auto_creation_engine.py
@@ -13,6 +13,7 @@ from auto_creation_engine import (
     set_auto_creation_engine,
     init_auto_creation_engine,
     _sort_key,
+    _smart_sort_streams,
     _sort_streams_by_m3u_account_priority,
     _reorder_streams_for_rule,
 )
@@ -937,3 +938,197 @@ class TestSortKey:
         """channel_number sort returns infinity when stream_chno is None."""
         stream = StreamContext(stream_id=1, stream_name="ESPN", stream_chno=None)
         assert _sort_key(stream, "channel_number") == float('inf')
+
+
+def _mk_smart_sort_settings(
+    stream_sort_priority=None,
+    stream_sort_enabled=None,
+    m3u_account_priorities=None,
+    deprioritize_failed_streams=True,
+    failed_stream_sort_order=None,
+):
+    """Build a MagicMock-backed settings object for _smart_sort_streams.
+
+    Mirrors the DispatcharrSettings attribute surface that
+    ``auto_creation_engine._smart_sort_streams`` reads via ``getattr``.
+    """
+    settings = MagicMock()
+    settings.stream_sort_priority = stream_sort_priority or [
+        "resolution", "framerate", "m3u_priority", "bitrate", "audio_channels", "video_codec",
+    ]
+    settings.stream_sort_enabled = stream_sort_enabled or {
+        "resolution": True, "framerate": True, "m3u_priority": True,
+        "bitrate": True, "audio_channels": True, "video_codec": True,
+    }
+    settings.m3u_account_priorities = m3u_account_priorities or {}
+    settings.deprioritize_failed_streams = deprioritize_failed_streams
+    settings.failed_stream_sort_order = failed_stream_sort_order or [
+        "black_screen", "low_fps", "failed",
+    ]
+    return settings
+
+
+def _bs_stats_dict(stream_id, resolution, fps, stream_name=None):
+    """Build a stats-dict for a black-screen success-probed stream (rank=0 under
+    failed_stream_sort_order=['black_screen', 'low_fps', 'failed'])."""
+    return {
+        "stream_id": stream_id,
+        "stream_name": stream_name or f"Stream {stream_id}",
+        "resolution": resolution,
+        "fps": fps,
+        "video_codec": "h264",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "bitrate": 5_000_000,
+        "video_bitrate": 5_000_000,
+        "probe_status": "success",
+        "is_black_screen": True,
+        "is_low_fps": False,
+    }
+
+
+def _failed_stats_dict(stream_id, resolution, fps, stream_name=None):
+    """Build a stats-dict for a status=failed stream (rank=2 under
+    failed_stream_sort_order=['black_screen', 'low_fps', 'failed'])."""
+    return {
+        "stream_id": stream_id,
+        "stream_name": stream_name or f"Stream {stream_id}",
+        "resolution": resolution,
+        "fps": fps,
+        "video_codec": "h264",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "bitrate": 5_000_000,
+        "video_bitrate": 5_000_000,
+        "probe_status": "failed",
+        "is_black_screen": False,
+        "is_low_fps": False,
+    }
+
+
+class TestAutoCreateSmartSortWithinBucketPrimaryCriteria:
+    """Regression tests for bd-bqpq0 (same pattern as bd-sw883 / GitHub #73)
+    applied to ``auto_creation_engine._smart_sort_streams``.
+
+    Primary sort criteria (resolution, framerate, ...) must be applied WITHIN
+    each failed-rank bucket — not just at the bucket-boundary level. Previously
+    the composite sort key for deprioritized streams was
+    ``(1, rank) + (0,)*len(active_criteria)`` so every stream inside a bucket
+    collided on the key and Python's stable sort kept insertion order.
+    """
+
+    def test_black_screen_bucket_sorted_by_resolution_desc(self):
+        """Within the black_screen bucket, higher resolution sorts first."""
+        settings = _mk_smart_sort_settings()
+        stats_cache = {
+            1: _bs_stats_dict(1, resolution="1024x576", fps="25"),
+            2: _bs_stats_dict(2, resolution="1920x1080", fps="25"),
+            3: _bs_stats_dict(3, resolution="1024x576", fps="25"),
+        }
+        result = _smart_sort_streams(
+            [1, 2, 3],
+            stats_cache,
+            stream_m3u_map={},
+            channel_name="bqpq0-bs-bucket",
+            settings=settings,
+        )
+        assert result[0] == 2, (
+            f"Expected 1920x1080 stream (id=2) at #1 in black_screen bucket, "
+            f"got ordering {result}"
+        )
+
+    def test_failed_bucket_sorted_by_resolution_then_framerate(self):
+        """Within the status=failed bucket, resolution desc then framerate desc apply.
+
+        Reporter's exact scenario from issue #73: 1280x720@25 was landing ahead
+        of 1920x1080@50 inside the failed bucket because the within-bucket
+        tiebreaker was a tuple of zeros across all primary criteria.
+        """
+        settings = _mk_smart_sort_settings()
+        stats_cache = {
+            10: _failed_stats_dict(10, resolution="1280x720", fps="25"),
+            20: _failed_stats_dict(20, resolution="1920x1080", fps="50"),
+            30: _failed_stats_dict(30, resolution="1280x720", fps="25"),
+            40: _failed_stats_dict(40, resolution="1920x1080", fps="50"),
+        }
+        result = _smart_sort_streams(
+            [10, 20, 30, 40],
+            stats_cache,
+            stream_m3u_map={},
+            channel_name="bqpq0-failed-bucket",
+            settings=settings,
+        )
+        # Expected: 1920x1080@50 streams (20, 40) lead the bucket, then the
+        # 1280x720@25 streams (10, 30). Python's stable sort preserves
+        # insertion order within each equal-key group.
+        assert result[:2] == [20, 40], (
+            f"Expected 1920x1080@50 streams (20, 40) to lead the failed bucket, "
+            f"got {result}"
+        )
+        assert result[2:] == [10, 30], (
+            f"Expected 1280x720@25 streams (10, 30) at the tail of the failed bucket, "
+            f"got {result}"
+        )
+
+    def test_cross_bucket_ordering_preserved(self):
+        """Cross-bucket invariant must not regress: rank=0 (black_screen) still
+        precedes rank=2 (failed) even when primary criteria would invert it.
+        """
+        settings = _mk_smart_sort_settings()
+        stats_cache = {
+            # rank=0 (black_screen) but lower-resolution content
+            1: _bs_stats_dict(1, resolution="1024x576", fps="25"),
+            # rank=2 (failed) but higher-resolution content
+            2: _failed_stats_dict(2, resolution="1920x1080", fps="50"),
+        }
+        result = _smart_sort_streams(
+            [1, 2],
+            stats_cache,
+            stream_m3u_map={},
+            channel_name="bqpq0-cross-bucket",
+            settings=settings,
+        )
+        assert result == [1, 2], (
+            f"Cross-bucket invariant broken: expected rank=0 before rank=2, "
+            f"got {result}"
+        )
+
+    def test_ferteque_channel_scenario(self):
+        """Condensed reproduction of reporter's channel-591424 case.
+
+        3 black_screen streams (rank=0) and 3 failed streams (rank=2). Expected:
+        - Black_screen bucket leads.
+        - Within black_screen, the 1920x1080 stream leads (was landing #2 in prod).
+        - Within failed, the 1920x1080@50 stream leads (was landing #8 in prod).
+        """
+        settings = _mk_smart_sort_settings()
+        stats_cache = {
+            # Black-screen bucket — from reporter's log
+            101: _bs_stats_dict(101, resolution="1024x576", fps="25"),   # D.LaLiga2
+            102: _bs_stats_dict(102, resolution="1920x1080", fps="25"),  # UHD
+            103: _bs_stats_dict(103, resolution="1024x576", fps="25"),   # SD
+            # Failed bucket — condensed
+            201: _failed_stats_dict(201, resolution="1280x720", fps="25"),   # HD
+            202: _failed_stats_dict(202, resolution="1920x1080", fps="50"),  # HD 1080
+            203: _failed_stats_dict(203, resolution="1920x1080", fps="25"),  # S.LaLiga2
+        }
+        result = _smart_sort_streams(
+            [101, 102, 103, 201, 202, 203],
+            stats_cache,
+            stream_m3u_map={},
+            channel_name="bqpq0-ferteque",
+            settings=settings,
+        )
+        bs_bucket = result[:3]
+        failed_bucket = result[3:]
+        # Within black_screen bucket — 1920x1080 (id=102) leads
+        assert bs_bucket[0] == 102, (
+            f"Expected 1920x1080 black_screen stream (102) to lead bucket, "
+            f"got black_screen bucket order {bs_bucket}"
+        )
+        # Within failed bucket — 1920x1080@50 (id=202) leads,
+        # then 1920x1080@25 (id=203), then 1280x720@25 (id=201)
+        assert failed_bucket == [202, 203, 201], (
+            f"Expected failed bucket ordered by resolution desc then framerate desc "
+            f"— [202, 203, 201] — got {failed_bucket}"
+        )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.16.0-0040",
+  "version": "0.16.0-0041",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Mirrors the [bd-sw883](https://github.com/MotWakorb/enhancedchannelmanager/pull/74) fix in `auto_creation_engine._smart_sort_streams`. The composite sort key for deprioritized streams was `(1, rank) + (0,)*len(active_criteria)`, collapsing the within-bucket order to insertion order instead of the configured primary criteria.

- Extracted a local `compute_criteria_values()` helper (same semantics as the stream_prober counterpart).
- Applied it on all three deprioritized paths (`failed`, `black_screen`, `low_fps`) and the successful path.
- Scope kept minimal per bugfix-sprint rule — no refactor beyond the fix, no touch to `stream_prober.py`.

## Background
- Parent bug: bd-sw883 / issue #73 — fixed in `stream_prober.py` via PR #74.
- bd-bqpq0 filed as the same pattern in `auto_creation_engine.py` (lines 2181/2186/2191).
- Sprint label: `sprint:v0.16.0-rerelease` — blocks the v0.16.0 re-cut.

## Test plan
- [x] 4 new regression tests in `TestAutoCreateSmartSortWithinBucketPrimaryCriteria` — 3 RED pre-fix, GREEN post-fix. Cross-bucket invariant test guards against regressing the already-correct boundary ordering.
- [x] Full backend suite: 2483 passing. 6 pre-existing alembic-env failures unchanged (all unrelated to this change — missing alembic package in local venv).
- [x] Container smoke: `docker cp` + restart `ecm-ecm-1`, then ran the ferteque channel-591424 condensed scenario in-container. Result: `[102, 101, 103, 202, 203, 201]` — 1920x1080 leads each bucket, matching the sw883 smoke output.

## Version
`0.16.0-0040` -> `0.16.0-0041`

## Beads
- Closes bd-bqpq0 (after merge)
- Parent: bd-sw883 / PR #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)