### PR TITLE
[bd-nmlxi] Coverage ratchet: enforce measured thresholds in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio httpx
+          # Belt-and-suspenders: these are in requirements.txt already, but
+          # pin them here so the CI command is self-documenting.
+          pip install pytest pytest-asyncio pytest-cov httpx
 
       - name: Prepare CI SQLite database
         working-directory: backend
@@ -61,9 +63,26 @@ jobs:
           # only meaningful against a live service. E2E coverage as a CI gate
           # is deferred to bead enhancedchannelmanager-2lw25; skip it here so
           # the backend unit+integration suite can run without a live service.
+          #
+          # Coverage threshold is configured in backend/pytest.ini addopts
+          # (--cov=. --cov-fail-under=56) with paths filtered by .coveragerc.
+          # Pytest exits non-zero if coverage drops below the threshold, so
+          # this step enforces the ratchet automatically.
+          # See docs/testing.md § "Coverage ratchet cadence".
           python -m pytest \
             --ignore=tests/e2e \
             -m "not slow" --tb=short --no-header -p no:warnings
+
+      - name: Upload backend coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: |
+            backend/.coverage
+            backend/coverage.xml
+          if-no-files-found: ignore
+          retention-days: 14
 
   # ─── Frontend lint / typecheck / unit tests ───────────────────────────
   frontend:
@@ -99,15 +118,15 @@ jobs:
         working-directory: frontend
         run: npm run typecheck
 
-      - name: Unit tests
+      - name: Unit tests with coverage (blocking)
         working-directory: frontend
-        run: npm test
-
-      - name: Coverage report (informational only)
-        working-directory: frontend
-        continue-on-error: true
         run: |
-          echo "Coverage report — NON-BLOCKING. Threshold enforcement tracked in bead enhancedchannelmanager-nmlxi."
+          # Coverage thresholds are configured in frontend/vitest.config.ts
+          # (lines 13 / branches 12 / functions 13 / statements 13 —
+          # measured 2026-04-20 − 2 point regression buffer).
+          # Vitest exits non-zero if coverage drops below any threshold, so
+          # this step enforces the ratchet automatically.
+          # See docs/testing.md § "Coverage ratchet cadence".
           npm run test:coverage
 
       - name: Upload coverage artifact

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,11 @@ backend/static/
 dist/
 build/
 
+# Test coverage artifacts (enforced in CI, see docs/testing.md)
+frontend/coverage/
+backend/.coverage
+backend/coverage.xml
+backend/htmlcov/
+
 # User guide screenshots (may contain PII)
 docs/images/

--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -1,0 +1,40 @@
+# Coverage.py config for the backend pytest suite.
+#
+# Paired with backend/pytest.ini addopts (--cov=. --cov-fail-under=56).
+# See docs/testing.md § "Coverage ratchet cadence" for the methodology and
+# the ratchet policy. Baseline: 58% line coverage on dev tip, measured
+# 2026-04-20, during bead enhancedchannelmanager-nmlxi.
+
+[run]
+source = .
+branch = False
+# Exclude code we deliberately do not measure:
+#   - tests/*          — the suite itself
+#   - alembic/*        — DB migration files (mechanical, reviewed separately)
+#   - conftest.py      — pytest fixtures, not production code
+#   - reset_password.py, test_dispatcharr_api.py — one-off operator scripts
+#   - obfuscate.py     — build-time code obfuscation tool, not runtime
+#   - __pycache__/*    — bytecode caches
+omit =
+    tests/*
+    alembic/*
+    conftest.py
+    reset_password.py
+    test_dispatcharr_api.py
+    obfuscate.py
+    __pycache__/*
+    */__pycache__/*
+
+[report]
+# Show missing line numbers in term output so contributors can see gaps.
+show_missing = True
+# Skip files that are 100% covered to keep the report short.
+skip_covered = False
+# Exclude well-known lines from coverage consideration (the default set +
+# our project conventions).
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:
+    @abstractmethod

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -9,11 +9,23 @@ python_functions = test_*
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 
-# Coverage settings
+# Coverage settings.
+# Pragmatic baseline ratchet (bead enhancedchannelmanager-nmlxi, measured 2026-04-20).
+# Full-suite measurement on dev tip (--ignore=tests/e2e -m "not slow", source=.,
+# tests/alembic/conftest excluded): TOTAL line coverage = 58%.
+# --cov-fail-under=56 = measured − 2 (regression guard).
+# Re-ratchet cadence + policy: docs/testing.md § "Coverage ratchet cadence".
+# DO NOT lower without PO approval.
+#
+# Coverage is enabled by default here. Pass --no-cov to override locally for
+# debugging when full-suite coverage gets in the way of a single-file run.
 addopts =
     --strict-markers
     -ra
     -q
+    --cov=.
+    --cov-report=term-missing
+    --cov-fail-under=56
 
 # Markers
 markers =

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -106,6 +106,91 @@ npm run test:e2e:debug     # Debug mode with breakpoints
 npm run test:e2e:report    # View test report
 ```
 
+## Coverage ratchet cadence
+
+Coverage is enforced in CI as a **one-way ratchet**: the current floor is the
+baseline measured 2026-04-20 during bead `enhancedchannelmanager-nmlxi`, minus
+a small regression buffer. Crossing below those numbers fails the CI job.
+
+### Current thresholds
+
+| Suite | Metric | Measured 2026-04-20 | Threshold | Buffer | Where enforced |
+|-|-|-|-|-|-|
+| Backend (pytest + coverage.py) | lines | 58% | 56% | 2 pts | `backend/pytest.ini` (`--cov-fail-under=56`), paths in `backend/.coveragerc` |
+| Frontend (vitest + v8) | statements | 15.17% | 13% | 2 pts | `frontend/vitest.config.ts` `thresholds.statements` |
+| Frontend (vitest + v8) | branches | 14.13% | 12% | 2 pts | `frontend/vitest.config.ts` `thresholds.branches` |
+| Frontend (vitest + v8) | functions | 15.28% | 13% | 2 pts | `frontend/vitest.config.ts` `thresholds.functions` |
+| Frontend (vitest + v8) | lines | 15.46% | 13% | 2 pts | `frontend/vitest.config.ts` `thresholds.lines` |
+
+Backend measurement: `docker exec ecm-ecm-1 sh -c 'cd /app && python -m pytest
+--ignore=tests/e2e -m "not slow" --cov-config=/tmp/.coveragerc --cov=.
+--cov-report=term'` with the three known-drift deselects from the flake
+section above. 2427 tests, 3 deselected.
+
+Frontend measurement: `cd frontend && npm run test:coverage`. 1118 tests across
+44 files.
+
+### Rationale for buffer choice
+
+The ideal methodology (from bead `enhancedchannelmanager-nmlxi`) is to wait
+~1 week after the CI test-gate landed (`enhancedchannelmanager-t8xw3`) so we
+can observe real per-PR coverage numbers rather than the full-suite snapshot.
+We didn't have that window — t8xw3 closed the day this bead landed. The PO
+approved a single full-suite snapshot with a 2-point buffer as a pragmatic
+baseline. Expect slightly churny CI on PRs that touch low-coverage modules
+until the first re-ratchet.
+
+### Re-ratchet policy
+
+- **Cadence**: review the thresholds **2-4 weeks after this bead lands**,
+  once real PR coverage data exists. Thereafter, review quarterly (aligned
+  with the flake sweep).
+- **Raise criterion**: if every PR merged in the review window held coverage
+  comfortably (≥ threshold + 3 points) on every metric, raise that metric's
+  threshold by **~5 points**. Never raise by more than 5 points in one
+  review — gives authors time to respond before the ratchet tightens further.
+- **Lower prohibition**: thresholds are **one-way**. Lowering requires
+  explicit PO approval and a one-line rationale in the commit message. Do
+  not lower "because my PR didn't quite make it" — add tests instead.
+- **Per-metric independence**: frontend has four metrics (lines, branches,
+  functions, statements). They ratchet independently. A PR that lifts
+  function coverage to 20% should raise the function threshold to 15% —
+  it does not have to wait for statements to also move.
+- **Scope creep guard**: this bead's predecessor (`t8xw3`) explicitly
+  excludes retroactively force-testing low-coverage modules. The ratchet
+  exists to prevent regression, not to force a coverage sprint.
+
+### Next-iteration upgrade: diff-coverage
+
+The bead scope flagged **diff-coverage** (coverage of CHANGED lines only)
+as a likely better gate for a 61K-line codebase — whole-codebase coverage
+is noisy for small PRs. This is out of scope for the current ratchet bead
+and should be filed as a follow-up. Candidate tools:
+
+- Python: `diff-cover` (PyPI) integrates cleanly with coverage.xml.
+- JavaScript/TypeScript: `diff-cover` also consumes v8/lcov output.
+
+When we file the follow-up, the gate becomes "changed lines must hit X%
+coverage" with X set conservatively (≥ 80% seems reasonable given the base
+rates above) and the whole-codebase thresholds stay as a floor.
+
+### Running coverage locally
+
+```bash
+# Backend — inside the container (matches the CI invocation).
+docker exec ecm-ecm-1 sh -c 'cd /app && python -m pytest \
+  --ignore=tests/e2e -m "not slow" --no-header -p no:warnings'
+# Coverage is auto-enabled via pytest.ini addopts. To disable for a quick
+# single-file run: add --no-cov.
+
+# Frontend — from the host.
+cd frontend && npm run test:coverage
+```
+
+If a local run drops below threshold, fix the root cause (add a test, remove
+dead code, or adjust .coveragerc omit if the file is genuinely non-runtime).
+Do **not** lower the threshold in the config.
+
 ## When to Run Tests
 
 - **Backend tests**: MANDATORY for any backend code changes

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -33,11 +33,16 @@ export default defineConfig({
         'src/vite-env.d.ts',
       ],
       thresholds: {
-        // Start with modest thresholds, increase as coverage improves
-        lines: 20,
-        branches: 20,
-        functions: 20,
-        statements: 20,
+        // Pragmatic baseline ratchet (bead enhancedchannelmanager-nmlxi, measured 2026-04-20).
+        // Full-suite measurement on dev tip:
+        //   statements 15.17%, branches 14.13%, functions 15.28%, lines 15.46%
+        // Thresholds = measured − 2 (regression guard without instantly breaking CI).
+        // Re-ratchet cadence + policy: docs/testing.md § "Coverage ratchet cadence".
+        // DO NOT lower without PO approval.
+        lines: 13,
+        branches: 12,
+        functions: 13,
+        statements: 13,
       },
     },
 


### PR DESCRIPTION
## Summary

Companion to `enhancedchannelmanager-t8xw3` (CI test gate landed today). Sets vitest + pytest coverage thresholds from a measured full-suite baseline so CI fails any regression.

- **Backend baseline**: 58% lines (2427 tests, `--ignore=tests/e2e -m "not slow"`)
- **Frontend baseline**: 15.46% lines / 14.13% branches / 15.28% functions / 15.17% statements (1118 tests / 44 files)
- **Thresholds = measured − 2 points** (regression guard without instantly breaking CI)

## Files changed

- `backend/pytest.ini` — addopts now include `--cov=. --cov-fail-under=56`
- `backend/.coveragerc` — new, sets `source=.` and omits tests/alembic/conftest/etc.
- `frontend/vitest.config.ts` — thresholds ratcheted down from arbitrary 20 to measured − 2 (lines 13, branches 12, functions 13, statements 13)
- `.github/workflows/test.yml` — frontend step now uses blocking `npm run test:coverage` instead of non-blocking informational run; added `backend-coverage` artifact upload
- `docs/testing.md` — new "Coverage ratchet cadence" section documenting thresholds, re-ratchet cadence (2-4 weeks, then quarterly), one-way policy, and diff-coverage as next-iteration follow-up
- `.gitignore` — excludes coverage artifacts

## Methodology caveat

The bead's ideal protocol was to wait ≥1 week post-t8xw3 for real PR-scale coverage data. t8xw3 only closed today, so the PO approved a single-snapshot baseline as a pragmatic floor. First re-ratchet is scheduled 2-4 weeks out using real PR data.

## Test plan

- [x] Backend threshold enforces: `--cov-fail-under=99` → pytest exits 1; current `--cov-fail-under=56` → exits 0 at 57.49%
- [x] Frontend threshold enforces: `--coverage.thresholds.lines=99` → vitest exits 1; current config → exits 0 at 15.46%
- [x] `npm run test:coverage` runs the full 1118-test suite (replaces the separate `npm test` step)
- [x] Container run confirms pytest-cov is installed and `.coveragerc` applies the correct omit list
- [ ] Observe CI run on this PR to confirm both Backend Tests and Frontend Tests jobs pass with enforcement enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)