### PR TITLE
fix(auto-creation): copy rule settings when duplicating

### DIFF
--- a/frontend/src/hooks/useAutoCreationRules.test.ts
+++ b/frontend/src/hooks/useAutoCreationRules.test.ts
@@ -464,7 +464,7 @@ describe('useAutoCreationRules', () => {
       expect(duplicate!.name).toContain('Original Rule');
       expect(duplicate!.name).toContain('Copy');
       expect(duplicate!.id).not.toBe(original.id);
-      expect(duplicate!.enabled).toBe(true);
+      expect(duplicate!.enabled).toBe(false);
       expect(duplicate!.run_on_refresh).toBe(true);
       expect(duplicate!.stop_on_first_match).toBe(true);
       expect(duplicate!.sort_field).toBe('quality');
@@ -476,6 +476,36 @@ describe('useAutoCreationRules', () => {
       expect(duplicate!.skip_struck_streams).toBe(true);
       expect(duplicate!.orphan_action).toBe('delete');
       expect(result.current.rules).toHaveLength(2);
+    });
+
+    it('round-trips nullable/empty sort config fields', async () => {
+      const original = createMockAutoCreationRule({
+        name: 'Nullable Fields Rule',
+        enabled: true,
+        sort_field: null,
+        sort_regex: null,
+        stream_sort_field: null,
+        normalization_group_ids: [],
+      });
+      mockDataStore.autoCreationRules.push(original);
+
+      const { result } = renderHook(() => useAutoCreationRules());
+
+      await act(async () => {
+        await result.current.fetchRules();
+      });
+
+      let duplicate: AutoCreationRule | undefined;
+      await act(async () => {
+        duplicate = await result.current.duplicateRule(original.id);
+      });
+
+      expect(duplicate).toBeDefined();
+      expect(duplicate!.enabled).toBe(false);
+      expect(duplicate!.sort_field).toBeNull();
+      expect(duplicate!.sort_regex).toBeNull();
+      expect(duplicate!.stream_sort_field).toBeNull();
+      expect(duplicate!.normalization_group_ids).toEqual([]);
     });
 
     it('throws when duplicating non-existent rule', async () => {

--- a/frontend/src/hooks/useAutoCreationRules.test.ts
+++ b/frontend/src/hooks/useAutoCreationRules.test.ts
@@ -435,6 +435,17 @@ describe('useAutoCreationRules', () => {
         name: 'Original Rule',
         conditions: [{ type: 'stream_name_contains', value: 'ESPN' }],
         actions: [{ type: 'create_channel', name_template: '{stream_name}' }],
+        enabled: true,
+        run_on_refresh: true,
+        stop_on_first_match: true,
+        sort_field: 'quality',
+        sort_order: 'desc',
+        probe_on_sort: true,
+        stream_sort_field: 'm3u_priority',
+        stream_sort_order: 'asc',
+        normalization_group_ids: [1, 2, 3],
+        skip_struck_streams: true,
+        orphan_action: 'delete',
       });
       mockDataStore.autoCreationRules.push(original);
 
@@ -453,6 +464,17 @@ describe('useAutoCreationRules', () => {
       expect(duplicate!.name).toContain('Original Rule');
       expect(duplicate!.name).toContain('Copy');
       expect(duplicate!.id).not.toBe(original.id);
+      expect(duplicate!.enabled).toBe(true);
+      expect(duplicate!.run_on_refresh).toBe(true);
+      expect(duplicate!.stop_on_first_match).toBe(true);
+      expect(duplicate!.sort_field).toBe('quality');
+      expect(duplicate!.sort_order).toBe('desc');
+      expect(duplicate!.probe_on_sort).toBe(true);
+      expect(duplicate!.stream_sort_field).toBe('m3u_priority');
+      expect(duplicate!.stream_sort_order).toBe('asc');
+      expect(duplicate!.normalization_group_ids).toEqual([1, 2, 3]);
+      expect(duplicate!.skip_struck_streams).toBe(true);
+      expect(duplicate!.orphan_action).toBe('delete');
       expect(result.current.rules).toHaveLength(2);
     });
 

--- a/frontend/src/hooks/useAutoCreationRules.ts
+++ b/frontend/src/hooks/useAutoCreationRules.ts
@@ -176,7 +176,7 @@ export function useAutoCreationRules(
     const duplicateData: CreateRuleData = {
       name: `${originalRule.name} (Copy)`,
       description: originalRule.description,
-      enabled: false, // Disabled by default
+      enabled: originalRule.enabled,
       priority: maxPriority + 1,
       conditions: originalRule.conditions,
       actions: originalRule.actions,
@@ -184,6 +184,15 @@ export function useAutoCreationRules(
       target_group_id: originalRule.target_group_id,
       run_on_refresh: originalRule.run_on_refresh,
       stop_on_first_match: originalRule.stop_on_first_match,
+      sort_field: originalRule.sort_field ?? null,
+      sort_order: originalRule.sort_order,
+      probe_on_sort: originalRule.probe_on_sort,
+      sort_regex: originalRule.sort_regex ?? null,
+      stream_sort_field: originalRule.stream_sort_field ?? null,
+      stream_sort_order: originalRule.stream_sort_order,
+      normalization_group_ids: originalRule.normalization_group_ids,
+      skip_struck_streams: originalRule.skip_struck_streams,
+      orphan_action: originalRule.orphan_action,
     };
 
     const newRule = await createRule(duplicateData);

--- a/frontend/src/hooks/useAutoCreationRules.ts
+++ b/frontend/src/hooks/useAutoCreationRules.ts
@@ -176,7 +176,7 @@ export function useAutoCreationRules(
     const duplicateData: CreateRuleData = {
       name: `${originalRule.name} (Copy)`,
       description: originalRule.description,
-      enabled: originalRule.enabled,
+      enabled: false, // Disabled by default (safety: avoid duplicate processing)
       priority: maxPriority + 1,
       conditions: originalRule.conditions,
       actions: originalRule.actions,

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -151,7 +151,7 @@ export function createMockAutoCreationRule(overrides: Partial<MockAutoCreationRu
     stream_sort_order: overrides.stream_sort_order ?? 'asc',
     normalization_group_ids: overrides.normalization_group_ids ?? [],
     skip_struck_streams: overrides.skip_struck_streams ?? false,
-    orphan_action: overrides.orphan_action ?? 'none',
+    orphan_action: overrides.orphan_action ?? 'delete',
     last_run_at: overrides.last_run_at ?? null,
     match_count: overrides.match_count ?? 0,
     created_at: overrides.created_at ?? new Date().toISOString(),

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -143,6 +143,15 @@ export function createMockAutoCreationRule(overrides: Partial<MockAutoCreationRu
     target_group_id: overrides.target_group_id ?? null,
     run_on_refresh: overrides.run_on_refresh ?? false,
     stop_on_first_match: overrides.stop_on_first_match ?? false,
+    sort_field: overrides.sort_field ?? null,
+    sort_order: overrides.sort_order ?? 'asc',
+    probe_on_sort: overrides.probe_on_sort ?? false,
+    sort_regex: overrides.sort_regex ?? null,
+    stream_sort_field: overrides.stream_sort_field ?? null,
+    stream_sort_order: overrides.stream_sort_order ?? 'asc',
+    normalization_group_ids: overrides.normalization_group_ids ?? [],
+    skip_struck_streams: overrides.skip_struck_streams ?? false,
+    orphan_action: overrides.orphan_action ?? 'none',
     last_run_at: overrides.last_run_at ?? null,
     match_count: overrides.match_count ?? 0,
     created_at: overrides.created_at ?? new Date().toISOString(),
@@ -293,6 +302,15 @@ interface MockAutoCreationRule {
   target_group_id: number | null
   run_on_refresh: boolean
   stop_on_first_match: boolean
+  sort_field?: string | null
+  sort_order?: 'asc' | 'desc'
+  probe_on_sort?: boolean
+  sort_regex?: string | null
+  stream_sort_field?: string | null
+  stream_sort_order?: 'asc' | 'desc'
+  normalization_group_ids?: number[]
+  skip_struck_streams?: boolean
+  orphan_action?: 'delete' | 'move_uncategorized' | 'delete_and_cleanup_groups' | 'none'
   last_run_at: string | null
   match_count: number
   created_at: string


### PR DESCRIPTION
Duplicate rule now preserves stream/channel sort, normalization groups, orphan cleanup, and option toggles so copied rules match originals.

Made-with: Cursor