### PR TITLE
feat(ci): extend CodeQL to PR-to-dev and push-to-dev (ADR-005 Phase 1, bd-kgjci)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
   codeql-analysis:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.base_ref == 'main')
+    if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) || (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'dev'))
     permissions:
       security-events: write
       contents: read


### PR DESCRIPTION
## [bd-kgjci] ADR-005 Phase 1 — CodeQL signal on dev

### What
Expands the `codeql-analysis` job trigger in `.github/workflows/build.yml` from two triggers (push-to-main, PR-to-main) to four (push-to-main, push-to-dev, PR-to-main, PR-to-dev). GitHub Actions does not support `in`, so the `if:` clause is written as an expanded `||` form.

One file changed, one line modified. No other files touched. No version bump — this is CI configuration with no user-visible behavior change.

### Why
Per [ADR-005](../blob/dev/docs/adr/ADR-005-code-security-gating-strategy.md) **Implementation Sketch §1**, we need CodeQL running on dev so we have signal on PRs and pushes targeting our integration branch — not just main. Today, problems only surface at the main-bound PR, which is too late in the flow.

This is **Phase 1: signal only, no enforcement.** Merge protection rules, required status checks, and admin-bypass disablement are Phase 3 — gated on remediation of bd-0a1pr (the four open HIGH py/path-injection alerts must be cleared before enforcement can turn on). Phase 3 will land as a separate, coordinated PR.

Bead: `enhancedchannelmanager-kgjci`

### How to Test
1. Merge to dev.
2. Confirm the next push to dev triggers the `CodeQL Analysis` workflow (matrix: python + javascript-typescript).
3. Confirm the next PR-to-dev also triggers CodeQL.
4. Confirm existing main-bound triggers continue to fire unchanged.

### Security
- [x] No code changes — CI config only
- [x] No new dependencies
- [x] No secrets
- [x] Widens when scans run — strictly a security-positive change

### Deployment
- [x] No infrastructure changes
- [x] No database migration
- [x] Rollback: revert this commit

### Follow-ups (out of scope for this PR)
- Phase 2: remediate bd-0a1pr (py/path-injection HIGH alerts)
- Phase 3: Code Scanning merge protection rules + required status checks on dev + main + disable admin bypass
- Phase 4: 10-PR canary observation window
- Phase 5: update `docs/shipping.md`, file first monthly dismissal-log audit bead