### PR TITLE
docs: implement ADR-004 release-cut discipline in shipping.md and rollback runbook (bd-tvlxz)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 - `docs/backend_architecture.md` expanded with an Observability section covering logging schema, metric naming conventions, cardinality rules, `bind_context` usage, and the process for adding new metrics (`bd-ak1db`, PR #80).
+- `docs/shipping.md` — replaced the "Release Workflow (Merging to Main)" section with the ADR-004-authoritative Cut Mechanics (steps 0–10), a verbatim Pre-Cut Gate Checklist (G1a–G7) for pasting into release-cut PR descriptions, and a new Hotfix Path subsection covering the one carve-out from the "no non-release PRs to `main`" rule. The "When User Says 'Ship the Fix'" dev-cycle section is unchanged (`bd-tvlxz`).
+- `docs/runbooks/v0.16.0-rollback.md` — reordered the two force-push paths: Option 2 (temporary `allow_force_pushes` flip) is now primary per ADR-005 (admin-bypass disabled on `main`), with Option 1 (admin bypass) retained as a fallback only for the transitional window. Added a mandatory post-action verification step (`gh api ... | jq '.allow_force_pushes.enabled'` must return `false`) and a design note considering a short-TTL wrapper that auto-reverts via `trap` regardless of outcome (`bd-tvlxz`).
 
 ### Fixed
 - Auto-creation rule duplicate preserves stream/channel sort, normalization groups, orphan cleanup, and option toggles — duplicates now match the original's configuration instead of silently dropping fields (PR #94, external contributor stevencoutts, bd-x3lto).

--- a/docs/runbooks/v0.16.0-rollback.md
+++ b/docs/runbooks/v0.16.0-rollback.md
@@ -37,7 +37,7 @@ Ordered confirmation steps before any destructive action.
    ```bash
    gh api /repos/<org>/<repo>/branches/main/protection
    ```
-   Record `allow_force_pushes`, `enforce_admins`, required status checks. If admin bypass is available (`enforce_admins: false`), prefer it. If not, you will need to flip `allow_force_pushes: true` for the reset and flip it back afterward.
+   Record `allow_force_pushes`, `enforce_admins`, required status checks. Under [ADR-005](../adr/ADR-005-code-security-gating-strategy.md), admin bypass is disabled on `main` — Option 2 below (temporary `allow_force_pushes` flip) is the default path. Option 1 (admin bypass via `enforce_admins: false`) remains documented as a fallback only for the transitional window before ADR-005 Phase 3 lands on this repo; do not rely on it.
 4. Check for open PRs based on post-rollback commits — they will lose their base branch and need a heads-up comment.
 
 **Escalate instead of continuing** if:
@@ -74,19 +74,31 @@ git worktree remove /tmp/ecm-main
 
 If the force-push is rejected by branch protection:
 
-1. First try admin bypass (if `enforce_admins: false`) by re-running the push — the CLI uses your admin creds.
-2. If still rejected, temporarily flip protection:
-   ```bash
-   # BACKUP current protection first
-   gh api /repos/<org>/<repo>/branches/main/protection > /tmp/main-protection-backup.json
-   gh api -X PATCH /repos/<org>/<repo>/branches/main/protection \
-     -F allow_force_pushes=true
-   # Perform the push as above.
-   # RESTORE the original protection — this is mandatory; do not leave ffp open.
-   gh api -X PUT /repos/<org>/<repo>/branches/main/protection \
-     --input /tmp/main-protection-backup.json
-   rm /tmp/main-protection-backup.json
-   ```
+**Option 2 (primary) — Temporarily flip `allow_force_pushes`.** Per [ADR-005](../adr/ADR-005-code-security-gating-strategy.md), admin bypass on `main` is disabled, so this is the default path for all post-ADR-005 rollbacks.
+
+```bash
+# BACKUP current protection first
+gh api /repos/<org>/<repo>/branches/main/protection > /tmp/main-protection-backup.json
+gh api -X PATCH /repos/<org>/<repo>/branches/main/protection \
+  -F allow_force_pushes=true
+# Perform the push as above.
+# RESTORE the original protection — this is mandatory; do not leave ffp open.
+gh api -X PUT /repos/<org>/<repo>/branches/main/protection \
+  --input /tmp/main-protection-backup.json
+rm /tmp/main-protection-backup.json
+
+# MANDATORY post-action verification — step is NOT complete until this returns `false`.
+gh api /repos/<org>/<repo>/branches/main/protection | jq '.allow_force_pushes.enabled'
+# Must print:  false
+# If it prints `true`, protection was not restored — STOP, page the PO, and re-run the
+# restore PUT above. Do not move on to subsequent runbook steps with ffp still open.
+```
+
+> **TOCTOU risk.** The flip-open → push → flip-closed window is a real operational risk: a forgotten flip-back silently degrades `main`'s protection, and a CI-triggered push racing into the window bypasses every gate. Keep the window as short as possible (seconds, not minutes), and the post-action `jq` check above is mandatory — not optional.
+>
+> **Design note — short-TTL wrapper (follow-on, optional).** A wrapper script that flips `allow_force_pushes: true`, runs the supplied command, and flips it back via `trap` regardless of success or failure (plus an asynchronous N-minute watchdog that force-reverts if the script crashes mid-run) would remove the "forgotten flip-back" class of error entirely. Implementation is optional follow-on work; the design consideration is logged here so the next rollback author can weigh writing it before running the procedure manually. SRE should also fold unsanctioned `allow_force_pushes` flip events into the repo audit log review cadence (see ADR-004 §Interaction with ADR-005).
+
+**Option 1 (fallback only — pre-ADR-005 or transitional windows) — Admin bypass.** Available only if `enforce_admins: false` on the branch protection rule. Re-run the push — the CLI uses your admin creds. **Do not use this path once ADR-005 Phase 3 has landed on this repo**; use Option 2 instead.
 
 ### 3. Reset `dev` to the pre-version-bump commit
 

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -73,17 +73,138 @@ Create beads for anything that needs follow-up.
 
 ## Release Workflow (Merging to Main)
 
-1. Bump version to release number (e.g., `0.12.0`) in `frontend/package.json`
-2. Rebuild: `cd frontend && npm run build`
-3. Commit version bump on dev, push
-4. Merge dev to main — use a temporary worktree to avoid displacing dev from root:
-   ```bash
-   git worktree add /tmp/ecm-main main
-   cd /tmp/ecm-main && git merge dev --no-edit && git push origin main
-   git worktree remove /tmp/ecm-main
-   ```
-5. Create GitHub release: `gh release create vX.Y.Z --target main --title "vX.Y.Z" --notes-file /tmp/release-notes.md`
-6. **Root checkout MUST stay on dev** — never leave it on main
+Release cuts are **intentional, gated acts** — not emergent side effects of whatever PR next targets `main`. This workflow is authoritative per [ADR-004: Release-Cut Promotion Discipline](adr/ADR-004-release-cut-promotion-discipline.md); read that ADR for full context on why each step exists and which alternatives were rejected.
+
+**Who**: PO (authorizes the cut) + Project Engineer (executes the mechanics). **When**: on PO decision to promote a specific `dev` SHA to `main`. **Why this shape**: the short-lived `release/vX.Y.Z` branch creates an explicit cut point, the merge-commit PR preserves per-commit bisection/forensics into `main`, and the pre-cut gate (G1a–G7 below) closes the 0.16.0-rollback failure mode (shipped with open P0/P1 bugs) and the PR #82 failure mode (scope-sprawl doc PR swept 90 unrelated commits).
+
+Non-release PRs to `main` are forbidden — documentation, dep bumps, config tweaks, and feature work all flow through `dev` and reach `main` only via the next release cut. The one exception is the hotfix path below.
+
+### Cut Mechanics (Step-by-Step)
+
+Copied verbatim from ADR-004 §"Cut Mechanics". Steps 0 and 5 are load-bearing discipline; steps 1–4 and 6–10 are mechanical.
+
+```bash
+# 0. Pre-flight — gate items G1a, G1b, G7 (human checks)
+bd list --status open --priority 0                # G1a: must be empty
+bd list --status open --priority 1                # G1a: must be empty (or each justified in PR)
+gh api repos/:owner/:repo/code-scanning/alerts --paginate \
+  | jq '[.[] | select(.state=="open" and (.rule.security_severity_level=="high" or .rule.security_severity_level=="critical"))] | length'
+                                                   # G1b: must be 0 (or each formally waived)
+gh pr list --base main --state open --json number,title
+                                                   # G7: must be empty (or only a hotfix PR with priority)
+
+# 1. Cut the release branch from the chosen dev SHA
+git fetch origin
+git checkout -b release/v0.17.0 <dev-cut-sha>
+
+# 2. Bump version
+# Edit frontend/package.json: "version": "0.17.0" (target release version per G6)
+cd frontend && npm run build                      # validates the bump
+cd ..
+
+# 3. Promote CHANGELOG
+# Edit CHANGELOG.md:
+#   - Rename [Unreleased] heading to "[0.17.0] — 2026-MM-DD"
+#   - Insert a fresh empty [Unreleased] section above it
+
+# 4. Commit on release branch
+git add frontend/package.json CHANGELOG.md
+git commit -m "Release v0.17.0"
+git push -u origin release/v0.17.0
+
+# 5. Open the release-cut PR — capture the PR number for steps 6 & 7
+# Replace the <paste ...> placeholder with the promoted CHANGELOG [0.17.0] block before running.
+PR_URL=$(gh pr create --base main --head release/v0.17.0 \
+  --title "Release v0.17.0" \
+  --body "$(cat <<'EOF'
+## Release v0.17.0
+
+<paste the promoted CHANGELOG [0.17.0] block here>
+
+### Pre-Cut Gate Checklist
+- [ ] G1a: Zero open P0/P1 bugs at cut SHA (verified via `bd list`)
+- [ ] G1b: Zero open HIGH/CRITICAL security findings not formally waived (GitHub Security tab)
+- [x] G2: Backend Tests green (CI will verify)
+- [x] G3: Frontend Tests green (CI will verify)
+- [x] G4: CodeQL delta-zero vs. `main` (CI will verify via Code Scanning merge protection rule)
+- [ ] G5: CHANGELOG [Unreleased] promoted to [0.17.0] with today's date, fresh empty [Unreleased] above
+- [ ] G6: Version in frontend/package.json matches `0.17.0` (release branch name)
+- [ ] G7: No other release-cut or hotfix PR targeting main is open
+EOF
+)")
+PR_NUM="${PR_URL##*/}"                             # extract trailing number from gh pr create URL
+echo "Release PR: $PR_URL (#$PR_NUM)"
+
+# 6. Wait for CI green on all required checks, confirm all gate items, then merge
+# --merge produces a merge commit (not --squash or --rebase); preserves per-commit bisection/forensics.
+gh pr merge "$PR_NUM" --merge --delete-branch
+
+# 7. Tag and release
+# Use annotated tag (-a) so `git describe` and `git log --decorate` carry author/date metadata.
+git checkout main && git pull
+git tag -a v0.17.0 -m "Release v0.17.0"
+git push origin v0.17.0
+gh release create v0.17.0 --target main --title "v0.17.0" \
+  --notes-file <(gh pr view "$PR_NUM" --json body -q .body)
+
+# 8. Back-merge release branch into dev (catches CHANGELOG/version bump)
+# Expected to be conflict-free if only version + CHANGELOG changed on the release branch.
+# If stabilization fixes landed on the release branch, resolve any dev conflicts here.
+git checkout dev
+git pull
+git merge release/v0.17.0 --no-edit
+git push origin dev
+
+# 9. Delete the release branch
+git branch -d release/v0.17.0
+git push origin --delete release/v0.17.0
+
+# 10. Re-open the dev build counter
+# After step 8, dev's frontend/package.json is at "0.17.0" (no suffix). Next dev push would
+# violate shipping.md:28 convention. Bump dev to the next build-numbered version:
+# Edit frontend/package.json: "version": "0.17.1-0000" (or next planned minor's -0000)
+cd frontend && npm run build
+cd ..
+git add frontend/package.json
+git commit -m "Bump dev to 0.17.1-0000"
+git push origin dev
+```
+
+**Root checkout MUST stay on `dev`** throughout — never leave it on `main`.
+
+### Pre-Cut Gate Checklist
+
+All seven items must pass before the release-cut PR can merge. Copy-paste this block into the release-cut PR description (step 5 above already includes it). G1a, G1b, G5, G6, G7 are author/reviewer-verified at Phase 1 and can be lifted to CI at Phase 2 (separate follow-on bead). G2, G3, G4 are mechanically enforced from day one.
+
+| # | Gate | Enforcement | Cites |
+|---|---|---|---|
+| G1a | **Zero open P0/P1 bugs at the `dev` cut SHA** (beads board, all scopes) | Manual verification by cut-authorizer; checklist item in the release-cut PR description | `bd-vgm4l` root cause |
+| G1b | **Zero open HIGH/CRITICAL security findings not formally waived** (GitHub Security tab + active advisories) — distinct from G1a so a mis-triaged finding cannot slip through "the bug board is clean" | Manual verification at Phase 1 via `gh api .../code-scanning/alerts` + Security tab review; mechanical at Phase 2 | Complement to ADR-005 gate G4 |
+| G2 | `Backend Tests` green on the release branch | Branch protection required check | Existing `bd-8w33i` |
+| G3 | `Frontend Tests` green on the release branch | Branch protection required check | Existing `bd-8w33i` |
+| G4 | **CodeQL delta-zero vs. `main` base** (both matrix check-runs). The delta is computed between the release-cut PR head and `main`, **not** against the release-branch cut SHA — the release branch's own base is transparent to GitHub's merge protection rule, which compares the incoming head to the target branch. | Code Scanning merge protection rule + branch protection required checks | ADR-005 |
+| G5 | `CHANGELOG.md` `[Unreleased]` has been promoted to `[X.Y.Z]` with today's date and a fresh empty `[Unreleased]` above | Manual in PR review; Phase 2 CI check possible | `shipping.md` §CHANGELOG convention |
+| G6 | Version updated in `frontend/package.json` from the current `0.A.B-NNNN` dev build to the target release version `X.Y.Z`. The target is not necessarily `A.B` with the suffix stripped — a minor or patch bump is permitted (e.g., current dev tip `0.16.0-0041` → release `0.17.0`) — but must match the release-branch name (`release/vX.Y.Z`) | Manual in PR review; trivially automatable | `shipping.md` §Increment the Version |
+| G7 | **No other release-cut or hotfix PR targeting `main` is open at merge time.** If a hotfix PR and a release-cut PR contend simultaneously, the **hotfix has priority**: the release-cut PR rebases on the merged hotfix and re-runs the gate. Prevents live-lock during an incident. | Manual verification; one-line `gh pr list --base main --state open --json number,title` | PR #82 root cause |
+
+### Hotfix Path
+
+Genuine production-blocking bugs, critical security advisories, and GHCR/branch-protection emergencies can bypass the release-branch mechanism via a **hotfix PR branched directly from `main`** — not from `dev`. Prose rules (per ADR-004 §4):
+
+- **Branch name**: `hotfix/vX.Y.(Z+1)-description` — patch version increment by default. Minor bump permitted only with explicit PO authorization recorded in the hotfix PR description (e.g., schema change to mitigate a CVE).
+- **Scope**: minimal. One bug or one advisory per hotfix; no opportunistic cleanup.
+- **Gates that apply**:
+  - G2, G3, G4 (tests + CodeQL) — must pass as on any release cut. **Exception — G4 re-attribution waiver**: if a security hotfix trips CodeQL delta-zero solely because its touched code is near a pre-existing `main` finding that CodeQL re-attributes to the new commit, the author may waive G4 with a linked Security-tab dismissal rationale in the PR description. Genuinely new HIGH/CRITICAL findings introduced by the hotfix code **cannot** be waived.
+  - G1a applies only to bugs *regressed or introduced* by the hotfix — pre-existing P0/P1s on `dev` are being bypassed intentionally because the hotfix is more urgent.
+  - G1b applies only to findings *introduced* by the hotfix — the hotfix is often the remediation of a pre-existing finding and must not block itself.
+  - G5 (CHANGELOG) applies with a hotfix-scoped entry.
+  - G6 (version) applies as a patch bump.
+  - G7 (no other main-bound PRs) applies; hotfix-has-priority tiebreaker.
+- **Back-merge to `dev` within 24 hours**, manual, via a standard `dev`-targeting PR that merges the hotfix branch. Merge (not cherry-pick) preserves the hotfix commit chain in `dev`'s history and keeps bisection symmetric with the release-cut pattern.
+- **Hotfixes should be rare.** Every hotfix is a signal the pre-cut gate failed — file a retro bead for each.
+- **Mechanical ceiling**: if more than **two hotfixes** land between consecutive release cuts, a **mandatory incident review bead** must be filed and landed before the next release cut can proceed. This prevents the `hotfix/*` branch from becoming a de facto replacement for the release-cut PR (the PR #82 pattern with different branch names).
+
+Step-by-step hotfix commands follow the same shell pattern as the release cut above, substituting `release/vX.Y.Z` with `hotfix/vX.Y.(Z+1)-description` and branching from `main` rather than a `dev` SHA. CHANGELOG entry goes under a hotfix-scoped version heading.
 
 ## Branch Protection on Main
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "enhanced-channel-manager",
-  "version": "0.16.0-0040",
+  "version": "0.16.0-0044",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "enhanced-channel-manager",
-      "version": "0.16.0-0040",
+      "version": "0.16.0-0044",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/sortable": "8.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.16.0-0043",
+  "version": "0.16.0-0044",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Docs-only implementation of items 1 and 2 from `bd-tvlxz`. Closes the gap between accepted ADR-004 / ADR-005 and the working docs engineers actually read.

Per [ADR-004](../blob/dev/docs/adr/ADR-004-release-cut-promotion-discipline.md) §Implementation Sketch item 1 and §Interaction with ADR-005, `docs/shipping.md` and `docs/runbooks/v0.16.0-rollback.md` must be updated when ADR-004 is accepted. Both ADRs landed in v0.16.0-0042. This PR makes the working docs match.

## Changes

- **`docs/shipping.md`** — Replaced the "Release Workflow (Merging to Main)" section with the ADR-004-authoritative Cut Mechanics (steps 0–10 verbatim from the ADR), verbatim Pre-Cut Gate Checklist (G1a–G7 table) for copy-paste into release-cut PR descriptions, and a new Hotfix Path subsection covering the one exception to the "no non-release PRs to `main`" rule. The "When User Says 'Ship the Fix'" dev-cycle section (lines 3–72) is **intentionally unchanged** — that covers dev ship cycles which ADR-004 does not touch.
- **`docs/runbooks/v0.16.0-rollback.md`** — Reordered the two force-push paths: Option 2 (temporary `allow_force_pushes` flip) is now primary per [ADR-005](../blob/dev/docs/adr/ADR-005-code-security-gating-strategy.md) (admin-bypass disabled on `main`), with Option 1 (admin bypass) retained as a fallback only for the transitional window before ADR-005 Phase 3 lands. Added a mandatory post-action verification step (`gh api .../branches/main/protection | jq '.allow_force_pushes.enabled'` must return `false` before the step is marked complete) and a design note considering a short-TTL wrapper script that auto-reverts `allow_force_pushes` via `trap` regardless of outcome (implementation optional follow-on).
- **`frontend/package.json`**, **`frontend/package-lock.json`** — Version bump `0.16.0-0042` → `0.16.0-0043`. Verified via `npm run build`.
- **`CHANGELOG.md`** — Two `[Unreleased]` → `### Changed` bullets, one per doc file.

## Scope note — items 3–6 of `bd-tvlxz` remain open

This PR covers **only items 1 and 2** of the bead description. Out of scope here, to be filed as follow-on beads:

- Item 3: `.github/PULL_REQUEST_TEMPLATE/release.md` (optional polish).
- Item 4: SRE audit-cadence expansion for P1→P2 downgrades and `allow_force_pushes` flips.
- Item 5: G1b "formally waived" semantics clarification (Security-tab dismissal + PR-description cross-reference).
- Item 6: Phase 2 mechanical gate automation via GitHub Action.

## Test plan

- [x] `cd frontend && npm run build` — passes with new version
- [x] `docs/shipping.md` "When User Says 'Ship the Fix'" section byte-identical to pre-PR (manual diff)
- [x] All Cut Mechanics shell, Hotfix Path prose rules, and G1a–G7 table content sourced verbatim from ADR-004
- [ ] Reviewer sanity-check that the new Release Workflow subsection order (preamble → Cut Mechanics → Pre-Cut Gate Checklist → Hotfix Path) reads cleanly
- [ ] Reviewer confirms the "When User Says 'Ship the Fix'" section is unchanged