### PR TITLE
fix(security): remediate py/path-injection in backup.py (bd-0a1pr, CodeQL 1416-1419)

### DIFF
--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -1159,9 +1159,20 @@ async def list_saved_backups(_admin=RequireAdminIfEnabled):
 @router.get("/saved/{filename}")
 async def download_saved_backup(filename: str, _admin=RequireAdminIfEnabled):
     """Download a saved YAML backup file."""
+    # Layer 1 (defense in depth): strict regex allowlist on filename shape.
     if not _BACKUP_FILENAME_RE.match(filename):
         raise HTTPException(status_code=400, detail="Invalid filename")
-    path = BACKUPS_DIR / filename
+    # Layer 2: canonicalize and verify containment under BACKUPS_DIR.
+    # This closes CodeQL py/path-injection (CWE-22/23/36/73/99) by making
+    # containment explicit — the regex guard alone is not followed by
+    # CodeQL's dataflow tracker. Mirrors zip-restore hardening at lines
+    # 164-167 (commit a591105c).
+    try:
+        safe_root = BACKUPS_DIR.resolve()
+        path = (BACKUPS_DIR / filename).resolve()
+        path.relative_to(safe_root)
+    except (ValueError, OSError):
+        raise HTTPException(status_code=400, detail="Invalid filename")
     if not path.exists():
         raise HTTPException(status_code=404, detail="Backup not found")
     content = path.read_text()
@@ -1175,9 +1186,18 @@ async def download_saved_backup(filename: str, _admin=RequireAdminIfEnabled):
 @router.delete("/saved/{filename}", status_code=200)
 async def delete_saved_backup(filename: str, _admin=RequireAdminIfEnabled):
     """Delete a saved YAML backup file."""
+    # Layer 1 (defense in depth): strict regex allowlist on filename shape.
     if not _BACKUP_FILENAME_RE.match(filename):
         raise HTTPException(status_code=400, detail="Invalid filename")
-    path = BACKUPS_DIR / filename
+    # Layer 2: canonicalize and verify containment under BACKUPS_DIR.
+    # See download_saved_backup above for the rationale — this closes
+    # CodeQL py/path-injection findings that the regex alone cannot.
+    try:
+        safe_root = BACKUPS_DIR.resolve()
+        path = (BACKUPS_DIR / filename).resolve()
+        path.relative_to(safe_root)
+    except (ValueError, OSError):
+        raise HTTPException(status_code=400, detail="Invalid filename")
     if not path.exists():
         raise HTTPException(status_code=404, detail="Backup not found")
     path.unlink()

--- a/backend/tests/routers/test_backup.py
+++ b/backend/tests/routers/test_backup.py
@@ -712,6 +712,150 @@ class TestSavedBackups:
         assert response.status_code == 400
 
 
+class TestSavedBackupsPathInjection:
+    """Path-injection regression tests for download/delete saved backup endpoints.
+
+    Remediates CodeQL HIGH alerts 1416-1419 (py/path-injection, CWE-22/23/36/73/99).
+    Backstops the canonicalize-and-verify containment check in
+    routers.backup.download_saved_backup / delete_saved_backup.
+    """
+
+    # Traversal payloads that must be rejected at the 400 boundary before any
+    # filesystem call reaches Path.exists / Path.read_text / Path.unlink.
+    # Each is URL-encoded where needed to survive the FastAPI path parameter.
+    TRAVERSAL_PAYLOADS = [
+        # URL-encoded '../' traversal
+        "..%2Fecm-backup-2026-01-01_000000.yaml",
+        "..%2F..%2Fetc%2Fpasswd",
+        # URL-encoded absolute paths
+        "%2Fetc%2Fpasswd",
+        "%2Ftmp%2Fecm-backup-2026-01-01_000000.yaml",
+        # Null-byte splice (URL-encoded) — legacy-Python filename smuggling
+        "ecm-backup-2026-01-01_000000.yaml%00.evil",
+        # Backslash (Windows-style traversal)
+        "..%5Cecm-backup-2026-01-01_000000.yaml",
+    ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", TRAVERSAL_PAYLOADS)
+    async def test_download_rejects_traversal_payloads(self, async_client, tmp_path, payload):
+        """download_saved_backup must reject traversal / absolute / null-byte payloads with 400."""
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        with patch("routers.backup.BACKUPS_DIR", backups_dir):
+            response = await async_client.get(f"/api/backup/saved/{payload}")
+        # Any non-2xx rejection is acceptable; the critical guarantee is that
+        # we never reach Path.read_text on an attacker-controlled path.
+        assert response.status_code in (400, 404, 422), (
+            f"payload {payload!r} was not rejected: status={response.status_code}"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", TRAVERSAL_PAYLOADS)
+    async def test_delete_rejects_traversal_payloads(self, async_client, tmp_path, payload):
+        """delete_saved_backup must reject traversal / absolute / null-byte payloads with 400."""
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        with patch("routers.backup.BACKUPS_DIR", backups_dir):
+            response = await async_client.delete(f"/api/backup/saved/{payload}")
+        assert response.status_code in (400, 404, 422), (
+            f"payload {payload!r} was not rejected: status={response.status_code}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_download_rejects_symlink_escape(self, async_client, tmp_path):
+        """A symlink inside BACKUPS_DIR pointing outside must not leak contents.
+
+        Creates a symlink whose *name* passes the regex but whose resolved
+        target is outside BACKUPS_DIR. After canonicalization, .relative_to()
+        must raise and produce a 400.
+        """
+        import os
+
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        secret = outside / "secret.yaml"
+        secret.write_text("top-secret-contents")
+
+        # Symlink name satisfies _BACKUP_FILENAME_RE but points outside the dir.
+        link_name = "ecm-backup-2099-12-31_235959.yaml"
+        link_path = backups_dir / link_name
+        try:
+            os.symlink(secret, link_path)
+        except (OSError, NotImplementedError):
+            pytest.skip("Symlinks not supported in this environment")
+
+        with patch("routers.backup.BACKUPS_DIR", backups_dir):
+            response = await async_client.get(f"/api/backup/saved/{link_name}")
+
+        # The canonicalized path resolves outside BACKUPS_DIR, so the
+        # containment check must reject with 400. If the check regressed, the
+        # response body would contain "top-secret-contents".
+        assert response.status_code == 400
+        assert "top-secret-contents" not in response.text
+
+    @pytest.mark.asyncio
+    async def test_delete_rejects_symlink_escape(self, async_client, tmp_path):
+        """A symlink inside BACKUPS_DIR pointing outside must not be deleted via resolve()."""
+        import os
+
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        secret = outside / "secret.yaml"
+        secret.write_text("do-not-delete-me")
+
+        link_name = "ecm-backup-2099-12-31_235959.yaml"
+        link_path = backups_dir / link_name
+        try:
+            os.symlink(secret, link_path)
+        except (OSError, NotImplementedError):
+            pytest.skip("Symlinks not supported in this environment")
+
+        with patch("routers.backup.BACKUPS_DIR", backups_dir):
+            response = await async_client.delete(f"/api/backup/saved/{link_name}")
+
+        assert response.status_code == 400
+        # The real file outside BACKUPS_DIR must still exist — the symlink
+        # resolution must not have caused us to unlink the target.
+        assert secret.exists()
+        assert secret.read_text() == "do-not-delete-me"
+
+    @pytest.mark.asyncio
+    async def test_download_valid_filename_still_works(self, async_client, tmp_path):
+        """Regression: the containment check must not break legitimate downloads."""
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        (backups_dir / "ecm-backup-2026-01-15_123456.yaml").write_text("legitimate")
+
+        with patch("routers.backup.BACKUPS_DIR", backups_dir):
+            response = await async_client.get(
+                "/api/backup/saved/ecm-backup-2026-01-15_123456.yaml"
+            )
+
+        assert response.status_code == 200
+        assert response.text == "legitimate"
+
+    @pytest.mark.asyncio
+    async def test_delete_valid_filename_still_works(self, async_client, tmp_path):
+        """Regression: the containment check must not break legitimate deletes."""
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        target = backups_dir / "ecm-backup-2026-01-15_123456.yaml"
+        target.write_text("legitimate")
+
+        with patch("routers.backup.BACKUPS_DIR", backups_dir):
+            response = await async_client.delete(
+                "/api/backup/saved/ecm-backup-2026-01-15_123456.yaml"
+            )
+
+        assert response.status_code == 200
+        assert not target.exists()
+
+
 def _make_yaml_export(**overrides):
     """Create a YAML export string for testing.
 


### PR DESCRIPTION
## Summary

Remediates the 4 HIGH-severity CodeQL `py/path-injection` alerts (CWE-22/23/36/73/99) in `backend/routers/backup.py`:

- Alert **1416** — `Path.exists()` in `download_saved_backup` (line 1165)
- Alert **1417** — `Path.read_text()` in `download_saved_backup` (line 1167)
- Alert **1418** — `Path.exists()` in `delete_saved_backup` (line 1181)
- Alert **1419** — `Path.unlink()` in `delete_saved_backup` (line 1183)

Bead: [enhancedchannelmanager-0a1pr](https://github.com/MotWakorb/enhancedchannelmanager/blob/dev/.beads) (P1) — gates ADR-005 Phase 3 CodeQL enforcement (bd-kgjci).

## Pattern Applied

Defense-in-depth: keep the strict regex allowlist (`_BACKUP_FILENAME_RE`) as layer 1, add canonicalize-and-verify containment as layer 2. Identical shape to the zip-restore hardening already in this file at [`backup.py:164-167`](https://github.com/MotWakorb/enhancedchannelmanager/blob/dev/backend/routers/backup.py#L164-L167) (commit `a591105c`).

```python
try:
    safe_root = BACKUPS_DIR.resolve()
    path = (BACKUPS_DIR / filename).resolve()
    path.relative_to(safe_root)
except (ValueError, OSError):
    raise HTTPException(status_code=400, detail="Invalid filename")
```

CodeQL's dataflow tracker does not follow anchored-regex validators, so the regex alone does not clear the alerts — the explicit `.resolve().relative_to()` call is what dataflow can prove.

## Why the regex stays

1. First-line rejection keeps shape errors out of the filesystem layer
2. Defends against future regressions in canonicalization behavior
3. Aligned with OWASP A03 defense-in-depth guidance

## New tests (16 total)

Added `TestSavedBackupsPathInjection` class in `backend/tests/routers/test_backup.py`:

- 12 parametrized payloads (6 each for download + delete): URL-encoded `../` traversal, absolute paths (`/etc/passwd`), null-byte splice (`%00.evil`), backslash traversal
- 2 symlink-escape tests: symlink name satisfies regex but resolves outside `BACKUPS_DIR` — asserts 400 and that the outside file is neither leaked (download) nor unlinked (delete)
- 2 happy-path regressions: legitimate filename still works for download + delete

## Test plan

- [x] `python -m pytest tests/routers/test_backup.py -p no:warnings` → **63 passed** (47 existing + 16 new)
- [x] Full backend suite: **2503 passed**, 8 pre-existing alembic baseline failures unrelated to this change (verified via `git stash`)
- [x] Container deploy (`docker cp` + `docker restart ecm-ecm-1`) — healthy
- [x] Legitimate download returns 200 with correct body (`yaml_test_content_abc123`)
- [x] Legitimate delete returns `{"status":"ok","deleted":...}` and file is removed
- [x] Traversal / absolute path / null-byte rejected with `HTTPException("Invalid filename")` on the live container
- [ ] Post-merge CodeQL run closes alerts 1416-1419 (will confirm on next scheduled scan)

## Files changed

| File | Lines |
|-|-|
| `backend/routers/backup.py` | +22 / -2 |
| `backend/tests/routers/test_backup.py` | +144 / 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)