### PR TITLE
test(security): add XSS regression test for print-guide title (bd-i3npz, supports CodeQL 1360 dismissal)

### DIFF
--- a/backend/tests/routers/test_export.py
+++ b/backend/tests/routers/test_export.py
@@ -440,3 +440,88 @@ class TestValidation:
             "selection_mode": "groups",
         })
         assert response.status_code == 400
+
+
+# =============================================================================
+# Print-Guide XSS Regression (bd-i3npz / CodeQL 1360)
+# =============================================================================
+#
+# CodeQL alert 1360 flags request.title reaching Response(content=html) in
+# backend/routers/export.py:1243 as a reflected-XSS sink. The sanitizer
+# `_escape_html` IS in fact applied at :1235 before the title is inlined into
+# the HTML document. These tests prove the sanitizer fires and exist so the
+# CodeQL alert can be formally dismissed per ADR-005 Phase 1 policy
+# (sanitizer-based FP dismissals must reference a test that proves the escape).
+# =============================================================================
+
+
+class TestPrintGuideXSS:
+    """Regression tests ensuring print-guide HTML output escapes user input."""
+
+    @pytest.mark.asyncio
+    @patch("routers.export.get_client")
+    async def test_print_guide_escapes_xss_in_title(self, mock_get_client, async_client):
+        """Script tag in title must be HTML-entity encoded in the response body."""
+        mock_client = MagicMock()
+        mock_client.get_channel_groups = AsyncMock(return_value=[])
+        mock_client.get_channels = AsyncMock(return_value={"results": []})
+        mock_get_client.return_value = mock_client
+
+        payload = {
+            "title": "<script>alert(1)</script>",
+            "groups": [],
+        }
+        response = await async_client.post("/api/export/print-guide", json=payload)
+
+        assert response.status_code == 200
+        body = response.text
+        # Raw script tag must NOT appear anywhere in the rendered HTML
+        assert "<script>alert(1)</script>" not in body
+        # Entity-encoded form MUST appear (single-escape, HTML entity form)
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in body
+
+    @pytest.mark.asyncio
+    @patch("routers.export.get_client")
+    async def test_print_guide_escapes_double_quote_in_title(self, mock_get_client, async_client):
+        """Double-quote in title must be entity-encoded to prevent attribute-context escape."""
+        mock_client = MagicMock()
+        mock_client.get_channel_groups = AsyncMock(return_value=[])
+        mock_client.get_channels = AsyncMock(return_value={"results": []})
+        mock_get_client.return_value = mock_client
+
+        payload = {
+            "title": 'abc" def',
+            "groups": [],
+        }
+        response = await async_client.post("/api/export/print-guide", json=payload)
+
+        assert response.status_code == 200
+        body = response.text
+        # The raw `"` from the user input must not survive as an unescaped character
+        # adjacent to its preceding token (which would allow attribute breakout).
+        assert 'abc" def' not in body
+        # The escaped entity form must be present in the body.
+        assert "abc&quot; def" in body
+
+    @pytest.mark.asyncio
+    @patch("routers.export.get_client")
+    async def test_print_guide_escapes_ampersand_in_title(self, mock_get_client, async_client):
+        """Ampersand in title must be encoded first to avoid double-escape drift."""
+        mock_client = MagicMock()
+        mock_client.get_channel_groups = AsyncMock(return_value=[])
+        mock_client.get_channels = AsyncMock(return_value={"results": []})
+        mock_get_client.return_value = mock_client
+
+        payload = {
+            "title": "A & B <tag>",
+            "groups": [],
+        }
+        response = await async_client.post("/api/export/print-guide", json=payload)
+
+        assert response.status_code == 200
+        body = response.text
+        # The ampersand is escaped first, then < and > are escaped — result is
+        # single-pass encoded: "A &amp; B &lt;tag&gt;".
+        assert "A &amp; B &lt;tag&gt;" in body
+        # Raw `<tag>` substring must not appear.
+        assert "A & B <tag>" not in body


### PR DESCRIPTION
## Summary

Adds 3 regression tests for the `/api/export/print-guide` endpoint proving that `_escape_html` fires on the user-supplied `title` field before it reaches the HTML response body. Lands the test evidence required by **ADR-005 Phase 1** sanitizer-based FP dismissal policy so that CodeQL alert **1360** (`py/reflected-xss`) can be formally dismissed as a technically-false-positive.

### Context

- CodeQL 1360 flags `request.title` reaching `Response(content=html)` at `backend/routers/export.py:1243`
- The sanitizer `_escape_html` IS correctly applied at `backend/routers/export.py:1235` — CodeQL's dataflow does not trace through it
- ADR-005 Phase 1 requires sanitizer-based FP dismissals to cite a regression test that proves the sanitizer fires
- This PR lands that test — **dismissal itself is coordinator (PO) work, not in this PR's scope**

### Tests added

File: `backend/tests/routers/test_export.py`

- `TestPrintGuideXSS::test_print_guide_escapes_xss_in_title` — raw `<script>alert(1)</script>` title payload must be entity-encoded in the response body
- `TestPrintGuideXSS::test_print_guide_escapes_double_quote_in_title` — attribute-context edge case: `"` must be encoded to `&quot;`
- `TestPrintGuideXSS::test_print_guide_escapes_ampersand_in_title` — verifies `&` is encoded first to avoid double-escape drift

All three patch `routers.export.get_client` (matches the pattern already used by `TestPreview` in the same file).

## Test plan

- [x] New tests pass locally: `python -m pytest tests/routers/test_export.py::TestPrintGuideXSS -v` → 3 passed
- [x] Full backend suite green: `python -m pytest tests/ --tb=short --no-header -p no:warnings` → **2266 passed**
- [x] Test file deployed to container (`docker cp ... ecm-ecm-1:/app/tests/routers/test_export.py`) — tests do not execute in-container but keep the file in sync for future integration work
- [ ] CodeQL 1360 dismissal (**coordinator / PO task — NOT this PR**) — to be dismissed with reason=false-positive and a comment referencing `backend/tests/routers/test_export.py::TestPrintGuideXSS`
- [ ] PO decision on the auth side-finding below (**separate follow-up**)

## Follow-up for PO — scope-adjacent, NOT fixed here

**`/api/export/print-guide` currently has no `RequireAdminIfEnabled` dependency.**

Location: `backend/routers/export.py:1137-1138`

This endpoint accepts a reflected user-supplied `title` (and reflected group settings) but relies only on the global auth middleware — not on the admin-gated dependency that similar export endpoints use. Combined with reflected output, a future sanitizer regression would create a CSRF-XSS angle: an attacker could craft a link an authenticated admin clicks, producing reflected HTML in the admin's session context.

Recommendation (**for PO decision, not implemented here per bead scope**):

- Add `dependencies=[Depends(RequireAdminIfEnabled)]` to the `/print-guide` route, consistent with other admin-only export endpoints
- File as a separate security-hardening bead if approved

The sanitizer currently closes the direct XSS path, so this is defense-in-depth, not a live vulnerability — worth a PO call, not a same-PR fix.

## References

- Bead: `enhancedchannelmanager-i3npz`
- CodeQL alert: #1360 (`py/reflected-xss`)
- ADR-005 Phase 1: `docs/adr/ADR-005-code-security-gating-strategy.md`
- Sanitizer location: `backend/routers/export.py:1235`
- Sink location: `backend/routers/export.py:1243`
- Test path: `backend/tests/routers/test_export.py` (class `TestPrintGuideXSS`)