### PR TITLE
feat(ci): enforce CodeQL delta-zero at PR time (ADR-005 Phase 3b, bd-kgjci)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - main
+      - dev
     paths-ignore:
       - '.beads/**'
       - '**.md'
@@ -95,6 +96,46 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
+
+      # ADR-005 Phase 3b: delta-zero enforcement.
+      # Fails the job on any PR that has open HIGH/CRITICAL CodeQL alerts.
+      # PR-only — push events are post-merge scans of already-reviewed code
+      # and gating them would block everyone on transient alerts.
+      # Code Scanning "merge protection rules" aren't available for our custom
+      # CodeQL setup, so we enforce delta-zero in the workflow itself and
+      # make this job a required status check.
+      - name: Enforce CodeQL delta-zero (fail on open HIGH/CRITICAL)
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          REF="${{ github.event.pull_request.merge_commit_sha || github.sha }}"
+          echo "Checking CodeQL alerts on ref=$REF"
+
+          # gh api --paginate streams pages as concatenated JSON arrays; jq -s
+          # flattens them into a single array before filtering.
+          ALERTS=$(gh api --paginate \
+            "/repos/${{ github.repository }}/code-scanning/alerts?state=open&ref=$REF&per_page=100" \
+            | jq -s 'add // [] | [.[] | select(.rule.security_severity_level=="high" or .rule.security_severity_level=="critical") | {number, rule: .rule.id, path: .most_recent_instance.location.path, severity: .rule.security_severity_level}]')
+
+          COUNT=$(echo "$ALERTS" | jq 'length')
+          echo "Open HIGH/CRITICAL alerts on ref=$REF: $COUNT"
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::error::$COUNT open HIGH/CRITICAL CodeQL alerts on this PR:"
+            echo "$ALERTS" | jq -r '.[] | "- alert #\(.number) [\(.severity)] \(.rule) at \(.path)"'
+            echo ""
+            echo "Per ADR-005 Phase 1 dismissal policy, these must be either:"
+            echo "  (a) remediated (the fix closes the finding)"
+            echo "  (b) dismissed as false-positive with sanitizer evidence + test reference"
+            echo "  (c) dismissed as test-only with test path reference"
+            echo "See docs/adr/ADR-005-code-security-gating-strategy.md for full policy."
+            exit 1
+          fi
+
+          echo "Delta-zero check passed: 0 open HIGH/CRITICAL alerts on ref=$REF"
 
   # IaC Security Scanning
   iac-security-scan:


### PR DESCRIPTION
## Summary

Implements **ADR-005 Phase 3b**: workflow-level delta-zero enforcement for CodeQL at PR time.

GitHub's Code Scanning merge protection rules aren't available for custom-workflow setups (our configuration uses a custom workflow rather than default setup), so we enforce the delta-zero policy directly in the CI workflow. A dedicated gating step fails the PR build when the CodeQL analyze step introduces any HIGH or CRITICAL findings on the PR ref.

## Implementation notes

- Gate step is scoped to `if: github.event_name == 'pull_request'` so `push` events to `dev`/`main` are not blocked by this logic — they're reported/observed but the gate fires only on PR.
- Fails fast on HIGH / CRITICAL severity delta; lower severities don't block at this phase (see ADR-005 for phased policy).

## Validation

A synthetic-HIGH validation branch (`test/adr-005-phase3b-synthetic-high`) was pushed to exercise the gate. The CodeQL scan completed, but the alerts API returned empty for that ref — either the synthetic trigger was too weak or GitHub's alert indexing is eventually-consistent post-scan. We're **accepting this inconclusive validation** for now; the next real HIGH/CRITICAL finding will confirm gate-firing behavior in production.

## Related

- ADR-005 (CodeQL delta-zero policy)
- bead `bd-kgjci` — remains **in_progress** through Phases 4–5
- Prior phase: `020da4b8` (extend CodeQL to PR-to-dev and push-to-dev)

## Do NOT merge

The companion test branch `test/adr-005-phase3b-synthetic-high` is synthetic-vuln-only and **must not be merged**. It will be deleted alongside this PR's creation.

## Test plan

- [ ] CodeQL workflow runs on this PR and passes (no HIGH/CRITICAL delta introduced)
- [ ] Gate step appears in the workflow run and is scoped to `pull_request` events
- [ ] First real HIGH/CRITICAL finding post-merge confirms gate fires as intended (tracked in Phases 4–5)