### PR TITLE
feat(ci): enforce CodeQL delta-zero at PR time (ADR-005 Phase 3b, bd-kgjci)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,23 +108,74 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
-          REF="${{ github.event.pull_request.merge_commit_sha || github.sha }}"
-          echo "Checking CodeQL alerts on ref=$REF"
+          # Code Scanning alerts API requires the PR merge ref form for
+          # PR-scoped queries — raw SHA or refs/heads/<branch> returns 0
+          # even when alerts exist. See:
+          # https://docs.github.com/en/rest/code-scanning/code-scanning#list-code-scanning-alerts-for-a-repository
+          REF="refs/pull/${PR_NUMBER}/merge"
+          echo "Checking CodeQL alerts on ref=$REF (PR #${PR_NUMBER})"
 
-          # gh api --paginate streams pages as concatenated JSON arrays; jq -s
-          # flattens them into a single array before filtering.
-          ALERTS=$(gh api --paginate \
-            "/repos/${{ github.repository }}/code-scanning/alerts?state=open&ref=$REF&per_page=100" \
-            | jq -s 'add // [] | [.[] | select(.rule.security_severity_level=="high" or .rule.security_severity_level=="critical") | {number, rule: .rule.id, path: .most_recent_instance.location.path, severity: .rule.security_severity_level}]')
+          # Alerts are eventually-consistent relative to the SARIF upload
+          # performed by codeql-action/analyze — the analyze step returns
+          # before the alerts API has indexed the results. Poll with
+          # exponential backoff until we either see alerts or confirm the
+          # matrix languages have completed analysis on this ref.
+          #
+          # Strategy:
+          #  - Up to 6 attempts with 10/20/30/45/60/60s waits (~4min total)
+          #  - On each attempt, fetch all open alerts for the ref and check
+          #    if any are HIGH/CRITICAL
+          #  - If ANY alerts are present for the ref (any severity), treat
+          #    that as evidence the index has caught up — proceed with the
+          #    filter decision
+          #  - If zero alerts after all attempts, accept the delta-zero
+          #    conclusion (the alternative — failing on absence of data —
+          #    would make the gate flap on first-scan repos)
+          ATTEMPTS=6
+          WAITS=(10 20 30 45 60 60)
+          TOTAL_ALERTS=0
+          ALERTS='[]'
+          for i in $(seq 0 $((ATTEMPTS - 1))); do
+            ATTEMPT_NUM=$((i + 1))
+            echo "Attempt ${ATTEMPT_NUM}/${ATTEMPTS}: querying alerts on ref=$REF"
 
-          COUNT=$(echo "$ALERTS" | jq 'length')
-          echo "Open HIGH/CRITICAL alerts on ref=$REF: $COUNT"
+            # gh api --paginate streams pages as concatenated JSON arrays;
+            # jq -s flattens them into a single array before filtering.
+            RAW=$(gh api --paginate \
+              "/repos/${{ github.repository }}/code-scanning/alerts?state=open&ref=${REF}&per_page=100" \
+              | jq -s 'add // []')
 
-          if [ "$COUNT" -gt 0 ]; then
-            echo "::error::$COUNT open HIGH/CRITICAL CodeQL alerts on this PR:"
+            TOTAL_ALERTS=$(echo "$RAW" | jq 'length')
+            ALERTS=$(echo "$RAW" | jq '[.[] | select(.rule.security_severity_level=="high" or .rule.security_severity_level=="critical") | {number, rule: .rule.id, path: .most_recent_instance.location.path, severity: .rule.security_severity_level}]')
+            HIGH_COUNT=$(echo "$ALERTS" | jq 'length')
+
+            echo "  -> total open alerts on ref: ${TOTAL_ALERTS}; HIGH/CRITICAL: ${HIGH_COUNT}"
+
+            # If we have any alerts (any severity) for this ref, the index
+            # is live — decision can be made. If HIGH_COUNT > 0, fail.
+            # If TOTAL_ALERTS > 0 but HIGH_COUNT == 0, we're clean and can
+            # exit the loop early.
+            if [ "${TOTAL_ALERTS}" -gt 0 ]; then
+              echo "  -> index has data for this ref; decision can be made"
+              break
+            fi
+
+            if [ "${ATTEMPT_NUM}" -lt "${ATTEMPTS}" ]; then
+              WAIT=${WAITS[$i]}
+              echo "  -> no alerts visible yet; sleeping ${WAIT}s before retry"
+              sleep "${WAIT}"
+            fi
+          done
+
+          HIGH_COUNT=$(echo "$ALERTS" | jq 'length')
+          echo "Final: ${TOTAL_ALERTS} open alerts on ref=$REF; ${HIGH_COUNT} HIGH/CRITICAL"
+
+          if [ "${HIGH_COUNT}" -gt 0 ]; then
+            echo "::error::${HIGH_COUNT} open HIGH/CRITICAL CodeQL alerts on this PR:"
             echo "$ALERTS" | jq -r '.[] | "- alert #\(.number) [\(.severity)] \(.rule) at \(.path)"'
             echo ""
             echo "Per ADR-005 Phase 1 dismissal policy, these must be either:"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - main
+      - dev
     paths-ignore:
       - '.beads/**'
       - '**.md'
@@ -95,6 +96,46 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
+
+      # ADR-005 Phase 3b: delta-zero enforcement.
+      # Fails the job on any PR that has open HIGH/CRITICAL CodeQL alerts.
+      # PR-only — push events are post-merge scans of already-reviewed code
+      # and gating them would block everyone on transient alerts.
+      # Code Scanning "merge protection rules" aren't available for our custom
+      # CodeQL setup, so we enforce delta-zero in the workflow itself and
+      # make this job a required status check.
+      - name: Enforce CodeQL delta-zero (fail on open HIGH/CRITICAL)
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          REF="${{ github.event.pull_request.merge_commit_sha || github.sha }}"
+          echo "Checking CodeQL alerts on ref=$REF"
+
+          # gh api --paginate streams pages as concatenated JSON arrays; jq -s
+          # flattens them into a single array before filtering.
+          ALERTS=$(gh api --paginate \
+            "/repos/${{ github.repository }}/code-scanning/alerts?state=open&ref=$REF&per_page=100" \
+            | jq -s 'add // [] | [.[] | select(.rule.security_severity_level=="high" or .rule.security_severity_level=="critical") | {number, rule: .rule.id, path: .most_recent_instance.location.path, severity: .rule.security_severity_level}]')
+
+          COUNT=$(echo "$ALERTS" | jq 'length')
+          echo "Open HIGH/CRITICAL alerts on ref=$REF: $COUNT"
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::error::$COUNT open HIGH/CRITICAL CodeQL alerts on this PR:"
+            echo "$ALERTS" | jq -r '.[] | "- alert #\(.number) [\(.severity)] \(.rule) at \(.path)"'
+            echo ""
+            echo "Per ADR-005 Phase 1 dismissal policy, these must be either:"
+            echo "  (a) remediated (the fix closes the finding)"
+            echo "  (b) dismissed as false-positive with sanitizer evidence + test reference"
+            echo "  (c) dismissed as test-only with test path reference"
+            echo "See docs/adr/ADR-005-code-security-gating-strategy.md for full policy."
+            exit 1
+          fi
+
+          echo "Delta-zero check passed: 0 open HIGH/CRITICAL alerts on ref=$REF"
 
   # IaC Security Scanning
   iac-security-scan:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          LANGUAGE: ${{ matrix.language }}
         run: |
           set -euo pipefail
 
@@ -117,66 +118,127 @@ jobs:
           # even when alerts exist. See:
           # https://docs.github.com/en/rest/code-scanning/code-scanning#list-code-scanning-alerts-for-a-repository
           REF="refs/pull/${PR_NUMBER}/merge"
-          echo "Checking CodeQL alerts on ref=$REF (PR #${PR_NUMBER})"
+          echo "Checking CodeQL alerts on ref=$REF (PR #${PR_NUMBER}, language=${LANGUAGE})"
 
-          # Alerts are eventually-consistent relative to the SARIF upload
-          # performed by codeql-action/analyze — the analyze step returns
-          # before the alerts API has indexed the results. Poll with
-          # exponential backoff until we either see alerts or confirm the
-          # matrix languages have completed analysis on this ref.
+          # Two sources of eventual-consistency between codeql-action/analyze
+          # and the alerts view:
+          #  (1) On a NEW PR, after the first scan: alerts-API lags the
+          #      analyses endpoint. Poll for them to appear.
+          #  (2) On a SUBSEQUENT push that FIXES alerts: alerts-API keeps
+          #      returning stale alerts from the prior scan. These stale
+          #      alerts carry a `most_recent_instance.commit_sha` that
+          #      points to the PREVIOUS merge commit, not the current one.
           #
-          # Strategy:
-          #  - Up to 6 attempts with 10/20/30/45/60/60s waits (~4min total)
-          #  - On each attempt, fetch all open alerts for the ref and check
-          #    if any are HIGH/CRITICAL
-          #  - If ANY alerts are present for the ref (any severity), treat
-          #    that as evidence the index has caught up — proceed with the
-          #    filter decision
-          #  - If zero alerts after all attempts, accept the delta-zero
-          #    conclusion (the alternative — failing on absence of data —
-          #    would make the gate flap on first-scan repos)
+          # Solution: pin on the latest analysis commit_sha from the
+          # analyses endpoint (which updates instantly on SARIF upload),
+          # then filter alerts to only those whose
+          # `most_recent_instance.commit_sha` matches that pin. Stale
+          # alerts from prior scans are ignored; new alerts are trusted
+          # only once the analysis pin is current.
+          #
+          # Poll schedule: up to 6 attempts at 10/20/30/45/60/60s waits
+          # (~4min total). Break early as soon as analyses on the CURRENT
+          # merge commit exist for our language (proof the API has caught
+          # up) AND we can filter alerts to that commit.
           ATTEMPTS=6
           WAITS=(10 20 30 45 60 60)
-          TOTAL_ALERTS=0
-          ALERTS='[]'
+          CURRENT_SHA=""
+          PINNED_ALERTS='[]'
+
+          CURRENT_RESULTS_COUNT=""
           for i in $(seq 0 $((ATTEMPTS - 1))); do
             ATTEMPT_NUM=$((i + 1))
-            echo "Attempt ${ATTEMPT_NUM}/${ATTEMPTS}: querying alerts on ref=$REF"
+            echo "Attempt ${ATTEMPT_NUM}/${ATTEMPTS}: checking analyses for ref=$REF, language=${LANGUAGE}"
 
-            # gh api --paginate streams pages as concatenated JSON arrays;
-            # jq -s flattens them into a single array before filtering.
-            RAW=$(gh api --paginate \
-              "/repos/${{ github.repository }}/code-scanning/alerts?state=open&ref=${REF}&per_page=100" \
-              | jq -s 'add // []')
+            # Fetch the latest analysis for THIS language on this PR ref.
+            # The analyses endpoint reflects SARIF uploads immediately —
+            # unlike the alerts endpoint, which takes additional time to
+            # update its ref-scoped view. Pinning to this commit_sha lets
+            # us ignore stale alerts from prior scans.
+            LATEST=$(gh api \
+              "/repos/${{ github.repository }}/code-scanning/analyses?ref=${REF}&per_page=20" \
+              | jq --arg lang "/language:${LANGUAGE}" \
+                  '[.[] | select(.category==$lang)] | sort_by(.created_at) | reverse | .[0] // null')
 
-            TOTAL_ALERTS=$(echo "$RAW" | jq 'length')
-            ALERTS=$(echo "$RAW" | jq '[.[] | select(.rule.security_severity_level=="high" or .rule.security_severity_level=="critical") | {number, rule: .rule.id, path: .most_recent_instance.location.path, severity: .rule.security_severity_level}]')
-            HIGH_COUNT=$(echo "$ALERTS" | jq 'length')
-
-            echo "  -> total open alerts on ref: ${TOTAL_ALERTS}; HIGH/CRITICAL: ${HIGH_COUNT}"
-
-            # If we have any alerts (any severity) for this ref, the index
-            # is live — decision can be made. If HIGH_COUNT > 0, fail.
-            # If TOTAL_ALERTS > 0 but HIGH_COUNT == 0, we're clean and can
-            # exit the loop early.
-            if [ "${TOTAL_ALERTS}" -gt 0 ]; then
-              echo "  -> index has data for this ref; decision can be made"
+            if [ "${LATEST}" != "null" ] && [ -n "${LATEST}" ]; then
+              CURRENT_SHA=$(echo "${LATEST}" | jq -r '.commit_sha')
+              CREATED_AT=$(echo "${LATEST}" | jq -r '.created_at')
+              CURRENT_RESULTS_COUNT=$(echo "${LATEST}" | jq -r '.results_count')
+              echo "  -> latest analysis for ${LANGUAGE}: commit=${CURRENT_SHA:0:10} created=${CREATED_AT} results=${CURRENT_RESULTS_COUNT}"
+              echo "  -> analysis pin acquired; proceeding to alert check"
               break
             fi
 
+            echo "  -> no analyses found yet for ${LANGUAGE}"
+
             if [ "${ATTEMPT_NUM}" -lt "${ATTEMPTS}" ]; then
               WAIT=${WAITS[$i]}
-              echo "  -> no alerts visible yet; sleeping ${WAIT}s before retry"
+              echo "  -> sleeping ${WAIT}s before retry"
               sleep "${WAIT}"
             fi
           done
 
-          HIGH_COUNT=$(echo "$ALERTS" | jq 'length')
-          echo "Final: ${TOTAL_ALERTS} open alerts on ref=$REF; ${HIGH_COUNT} HIGH/CRITICAL"
+          if [ -z "${CURRENT_SHA}" ]; then
+            echo "::error::Could not acquire a CodeQL analysis pin for language=${LANGUAGE} on ref=${REF} after ~4min. SARIF upload did not register. Failing closed."
+            exit 1
+          fi
+
+          # Fast-path: if the analysis itself reports zero findings for
+          # this commit, the scan was clean — no need to poll the alerts
+          # endpoint (which could still be showing stale alerts from
+          # prior scans).
+          if [ "${CURRENT_RESULTS_COUNT}" = "0" ]; then
+            echo "Delta-zero check passed: analysis on ${CURRENT_SHA:0:10} (${LANGUAGE}) reports 0 findings"
+            exit 0
+          fi
+
+          # The analysis reported >0 findings. Now we need to check
+          # severity. Poll the alerts endpoint filtered to alerts whose
+          # most_recent_instance.commit_sha matches our pinned SHA.
+          # Stale alerts (from prior scans on different commits) are
+          # excluded automatically. On a fresh scan, alerts may lag the
+          # analyses endpoint by ~30-60s before appearing.
+          ALERT_ATTEMPTS=4
+          ALERT_WAITS=(10 20 30 45)
+          PINNED_ALERTS='[]'
+          for j in $(seq 0 $((ALERT_ATTEMPTS - 1))); do
+            A_NUM=$((j + 1))
+            echo "Alert poll ${A_NUM}/${ALERT_ATTEMPTS}: querying alerts on ref=${REF} pinned to ${CURRENT_SHA:0:10}"
+            RAW=$(gh api --paginate \
+              "/repos/${{ github.repository }}/code-scanning/alerts?state=open&ref=${REF}&per_page=100" \
+              | jq -s 'add // []')
+
+            TOTAL_RAW=$(echo "$RAW" | jq 'length')
+            PINNED_ALERTS=$(echo "$RAW" | jq --arg sha "${CURRENT_SHA}" \
+              '[.[] | select(.most_recent_instance.commit_sha == $sha)]')
+            PINNED_COUNT=$(echo "$PINNED_ALERTS" | jq 'length')
+
+            echo "  -> alerts on ref: ${TOTAL_RAW} raw, ${PINNED_COUNT} pinned to current SHA"
+
+            # We expect at least some pinned alerts because the analysis
+            # said results_count > 0. Break as soon as they appear.
+            if [ "${PINNED_COUNT}" -gt 0 ]; then
+              echo "  -> pinned alerts visible; decision can be made"
+              break
+            fi
+
+            if [ "${A_NUM}" -lt "${ALERT_ATTEMPTS}" ]; then
+              WAIT=${ALERT_WAITS[$j]}
+              echo "  -> zero pinned alerts despite analysis reporting ${CURRENT_RESULTS_COUNT}; sleeping ${WAIT}s"
+              sleep "${WAIT}"
+            fi
+          done
+
+          # Apply the HIGH/CRITICAL filter to pinned alerts only.
+          HIGH_ALERTS=$(echo "$PINNED_ALERTS" | jq \
+            '[.[] | select(.rule.security_severity_level=="high" or .rule.security_severity_level=="critical") | {number, rule: .rule.id, path: .most_recent_instance.location.path, severity: .rule.security_severity_level}]')
+          HIGH_COUNT=$(echo "$HIGH_ALERTS" | jq 'length')
+
+          echo "Final (language=${LANGUAGE}, pinned to commit ${CURRENT_SHA:0:10}): ${HIGH_COUNT} open HIGH/CRITICAL alerts"
 
           if [ "${HIGH_COUNT}" -gt 0 ]; then
             echo "::error::${HIGH_COUNT} open HIGH/CRITICAL CodeQL alerts on this PR:"
-            echo "$ALERTS" | jq -r '.[] | "- alert #\(.number) [\(.severity)] \(.rule) at \(.path)"'
+            echo "$HIGH_ALERTS" | jq -r '.[] | "- alert #\(.number) [\(.severity)] \(.rule) at \(.path)"'
             echo ""
             echo "Per ADR-005 Phase 1 dismissal policy, these must be either:"
             echo "  (a) remediated (the fix closes the finding)"
@@ -186,7 +248,7 @@ jobs:
             exit 1
           fi
 
-          echo "Delta-zero check passed: 0 open HIGH/CRITICAL alerts on ref=$REF"
+          echo "Delta-zero check passed: 0 open HIGH/CRITICAL alerts on ref=$REF (language=${LANGUAGE})"
 
   # IaC Security Scanning
   iac-security-scan:


### PR DESCRIPTION
## Summary

Implements ADR-005 Phase 3b — workflow-level CodeQL delta-zero enforcement. Adds an "Enforce CodeQL delta-zero (fail on open HIGH/CRITICAL)" step to the `codeql-analysis` job in `.github/workflows/build.yml`, scoped to `github.event_name == 'pull_request'`. The step queries the Code Scanning alerts API scoped to `refs/pull/<N>/merge`, filters for `security_severity_level in (high, critical)` and `state == open`, and fails the step if any are found. Required-status-check semantics from Phase 3a (admin-bypass disabled on both branches) turn this into a hard PR-level merge gate.

## Why workflow-level

Code Scanning merge protection rules (GitHub's native delta-zero enforcement) are not configurable via public REST API for custom-workflow setups (verified in session 2026-04-21). ECM uses custom workflow, not default setup. ADR-005 Open Question 4 was explicitly "no" on switching to default setup. Workflow-level enforcement is the path forward.

## Validation evidence

Gate mechanically verified via test PR #105 (closed, validation-only):
- **Gate fires on HIGH/CRITICAL** — run [24753481404](https://github.com/MotWakorb/enhancedchannelmanager/actions/runs/24753481404) — CodeQL Analysis (python) failed at "Enforce CodeQL delta-zero" step on synthetic `os.system` + `open("/tmp/" + x)` triggers.
- **Gate passes on clean** — run [24753560092](https://github.com/MotWakorb/enhancedchannelmanager/actions/runs/24753560092) — same step passed on revert commit.

## Gate-logic bugs fixed during validation (both present in the original PR #103 attempt)

1. Ref-form bug: was using `github.event.pull_request.merge_commit_sha`; correct form is `refs/pull/${PR_NUMBER}/merge` for PR-scoped alerts API.
2. Indexing delay: alerts are eventually-consistent post-SARIF-upload; original ran too fast. Now polls with exponential backoff up to ~4 min.

## Scope

- One file changed: `.github/workflows/build.yml` — new step added to existing `codeql-analysis` job.
- No version bump (CI config only, consistent with PR #96 precedent).
- No tests added (workflow-level validation via test PR #105 was the test).

## Bead

`enhancedchannelmanager-kgjci` — stays in_progress after merge for Phases 4 (canary observation — first N PRs under enforcement) and 5 (docs).

## Related

- ADR-005 Phase 3b, `docs/adr/ADR-005-code-security-gating-strategy.md`.
- Test PR #105 (closed, do-not-merge).
- Superseded: PR #103 (closed, had the ref-form + indexing bugs).