### PR TITLE
bd-eio04.17: migrate stream_prober + m3u_digest regex to safe_regex

### DIFF
--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -15,6 +15,7 @@ import os
 import re
 
 import journal
+import safe_regex
 
 import httpx
 
@@ -1762,16 +1763,18 @@ class StreamProber:
         if not search_pattern:
             return original_url
 
-        try:
-            rewritten = re.sub(search_pattern, replace_pattern, original_url)
-            if rewritten != original_url:
-                logger.debug("[STREAM-PROBE] Profile %s: rewrote URL "
-                           "(pattern: %s -> %s)",
-                           profile['id'], search_pattern, replace_pattern)
-            return rewritten
-        except re.error as e:
-            logger.warning("[STREAM-PROBE] Invalid regex in profile %s: %s", profile['id'], e)
-            return original_url
+        # User-supplied regex — run through safe_regex to cap ReDoS exposure.
+        # safe_regex.sub returns the original text unchanged on timeout,
+        # oversize pattern, or compile error, and emits a [SAFE_REGEX] WARN
+        # log with a pattern sha256 + excerpt. That sentinel is the correct
+        # fallback here: an unrewritten URL probes directly against the
+        # source, which is safer than blocking the probe entirely.
+        rewritten = safe_regex.sub(search_pattern, replace_pattern, original_url)
+        if rewritten != original_url:
+            logger.debug("[STREAM-PROBE] Profile %s: rewrote URL "
+                       "(pattern: %s -> %s)",
+                       profile['id'], search_pattern, replace_pattern)
+        return rewritten
 
     async def _auto_reorder_channels(self, channel_groups_override: list[str] = None, stream_to_channels: dict = None) -> list[dict]:
         """

--- a/backend/tasks/m3u_digest.py
+++ b/backend/tasks/m3u_digest.py
@@ -10,6 +10,7 @@ from typing import Optional, List, Dict
 
 from sqlalchemy.orm import Session
 
+import safe_regex
 from database import get_session
 from models import M3UChangeLog, M3UDigestSettings
 from task_scheduler import TaskScheduler, TaskResult, ScheduleConfig, ScheduleType
@@ -186,34 +187,49 @@ class M3UDigestTask(TaskScheduler):
             stream_patterns_raw = settings.get_exclude_stream_patterns()
 
             if group_patterns_raw or stream_patterns_raw:
-                # Compile patterns once
+                # Compile user-supplied patterns via safe_regex so oversized
+                # patterns are rejected up-front (raises PatternTooLongError)
+                # and syntactically invalid ones are logged and skipped
+                # (SafeRegexError). Matching goes through safe_regex.search
+                # below so every call has a per-invocation ReDoS timeout —
+                # on timeout or other failure, search returns None and the
+                # row is treated as NOT matched (i.e. not excluded), which
+                # is the safe default for an exclude filter.
                 group_regexes = []
                 for p in group_patterns_raw:
                     try:
-                        group_regexes.append(re.compile(p, re.IGNORECASE))
-                    except re.error as e:
+                        group_regexes.append(safe_regex.compile(p, flags=re.IGNORECASE))
+                    except safe_regex.SafeRegexError as e:
                         logger.debug("[M3U-DIGEST] Suppressed invalid group regex pattern: %s", e)
 
                 stream_regexes = []
                 for p in stream_patterns_raw:
                     try:
-                        stream_regexes.append(re.compile(p, re.IGNORECASE))
-                    except re.error as e:
+                        stream_regexes.append(safe_regex.compile(p, flags=re.IGNORECASE))
+                    except safe_regex.SafeRegexError as e:
                         logger.debug("[M3U-DIGEST] Suppressed invalid stream regex pattern: %s", e)
 
                 filtered_changes = []
                 for change in changes:
                     # Check group exclude: if group_name matches any pattern, drop it
                     if group_regexes and change.group_name:
-                        if any(rx.search(change.group_name) for rx in group_regexes):
+                        if any(
+                            safe_regex.search(rx, change.group_name) is not None
+                            for rx in group_regexes
+                        ):
                             continue
 
                     # Check stream exclude: filter individual stream names
                     if stream_regexes and change.change_type in ("streams_added", "streams_removed"):
                         original_names = change.get_stream_names()
                         if original_names:
-                            kept = [n for n in original_names
-                                    if not any(rx.search(n) for rx in stream_regexes)]
+                            kept = [
+                                n for n in original_names
+                                if not any(
+                                    safe_regex.search(rx, n) is not None
+                                    for rx in stream_regexes
+                                )
+                            ]
                             if not kept:
                                 continue  # All streams excluded, drop entire entry
                             if len(kept) < len(original_names):

--- a/backend/tests/integration/test_safe_regex_migration_integration.py
+++ b/backend/tests/integration/test_safe_regex_migration_integration.py
@@ -1,0 +1,283 @@
+"""
+Integration tests for the bd-eio04.17 safe_regex migration.
+
+Covers the two user-facing code paths that accept user-supplied regex:
+- backend/stream_prober.py::_rewrite_url_for_profile (stream probe profile URL rewrite)
+- backend/tasks/m3u_digest.py::M3UDigestTask.execute (digest exclude filters)
+
+Each test drives the actual production code path with an evil pattern and
+asserts the graceful-fallback contract:
+- stream_prober: probe proceeds with the original (unrewritten) URL
+- m3u_digest: digest completes without stalling; rows pass through the filter
+
+The fixture patterns match safe_regex's empirically-exercised timeout fixture
+(see backend/tests/unit/test_safe_regex.py TestTimeoutBehavior.REAL_REDOS_PATTERN).
+"""
+import logging
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+import database
+from models import M3UChangeLog, M3UDigestSettings
+
+
+REAL_REDOS_PATTERN = r"(a|aa)+b"
+WALL_CLOCK_BUDGET_MS = 2000  # Integration budget (digest does extra work around filter)
+
+
+@pytest.fixture
+def patched_session_local(test_engine):
+    """
+    Point ``database._SessionLocal`` at the test engine so production code
+    paths that call ``get_session()`` directly (like M3UDigestTask.execute)
+    receive the test session. Restored on teardown.
+    """
+    original = database._SessionLocal
+    database._SessionLocal = sessionmaker(
+        autocommit=False, autoflush=False, bind=test_engine, expire_on_commit=False,
+    )
+    try:
+        yield
+    finally:
+        database._SessionLocal = original
+
+
+# ---------------------------------------------------------------------------
+# stream_prober: probe with evil profile succeeds, URL unrewritten.
+# ---------------------------------------------------------------------------
+
+
+class TestStreamProberProfileRewriteIntegration:
+    """
+    The integration surface for stream profile rewrites is internal —
+    profiles live in Dispatcharr, not ECM's DB. We exercise the actual
+    probe code path (the same call site used in the scheduled and on-demand
+    probe loops) end-to-end with a mocked subprocess so ffprobe doesn't run.
+    """
+
+    @pytest.mark.asyncio
+    async def test_evil_profile_probe_uses_original_url(self, caplog):
+        """
+        End-to-end: the probe code path asks _rewrite_url_for_profile for
+        a URL with an evil profile; the method must return the original URL
+        and the probe must proceed using that URL (not crash, not hang).
+        """
+        from stream_prober import StreamProber
+
+        prober = StreamProber(client=MagicMock(), probe_timeout=1)
+
+        evil_profile = {
+            "id": 42,
+            "is_default": False,
+            "search_pattern": REAL_REDOS_PATTERN,
+            "replace_pattern": "SHOULD_NOT_APPEAR",
+        }
+        original_url = "http://cdn.example.com/" + "a" * 30 + "!"
+
+        with caplog.at_level(logging.WARNING, logger="safe_regex"):
+            start = time.monotonic()
+            rewritten = prober._rewrite_url_for_profile(original_url, evil_profile)
+            elapsed_ms = (time.monotonic() - start) * 1000
+
+        # On timeout the probe continues using the unrewritten URL.
+        assert rewritten == original_url
+        assert "SHOULD_NOT_APPEAR" not in rewritten
+        assert elapsed_ms < WALL_CLOCK_BUDGET_MS
+        # safe_regex emitted the expected WARN log.
+        assert any(
+            "[SAFE_REGEX]" in rec.getMessage() and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# m3u_digest: POST settings + trigger digest with evil pattern; digest completes.
+# ---------------------------------------------------------------------------
+
+
+def _seed_digest_settings(session, *, exclude_group_patterns=None,
+                          exclude_stream_patterns=None):
+    """Insert an enabled M3UDigestSettings row with the given exclude patterns."""
+    settings = M3UDigestSettings(
+        enabled=True,
+        frequency="daily",
+        email_recipients="[]",
+        include_group_changes=True,
+        include_stream_changes=True,
+        show_detailed_list=True,
+        min_changes_threshold=1,
+        send_to_discord=True,  # enables a delivery path we can mock
+    )
+    if exclude_group_patterns is not None:
+        settings.set_exclude_group_patterns(exclude_group_patterns)
+    if exclude_stream_patterns is not None:
+        settings.set_exclude_stream_patterns(exclude_stream_patterns)
+    session.add(settings)
+    session.commit()
+    return settings
+
+
+def _seed_change(session, change_type, group_name, stream_names=None):
+    c = M3UChangeLog(
+        m3u_account_id=1,
+        change_type=change_type,
+        group_name=group_name,
+        count=len(stream_names) if stream_names else 1,
+    )
+    if stream_names:
+        c.set_stream_names(stream_names)
+    session.add(c)
+    session.commit()
+    return c
+
+
+class TestM3UDigestExcludePatternIntegration:
+    """
+    End-to-end: configure the digest with an evil exclude pattern, seed
+    change rows, and run the real M3UDigestTask.execute(). The digest must
+    complete (not stall, not crash) and — per the safe-default contract —
+    the rows must pass through the filter rather than be silently dropped.
+    """
+
+    @pytest.mark.asyncio
+    async def test_digest_completes_with_evil_group_pattern(
+        self, test_session, patched_session_local, monkeypatch, caplog,
+    ):
+        """Evil group exclude pattern: digest completes, row survives."""
+        _seed_digest_settings(
+            test_session,
+            exclude_group_patterns=[REAL_REDOS_PATTERN],
+        )
+        # This group_name hits catastrophic backtracking with (a|aa)+b.
+        evil_group = "a" * 30 + "!"
+        _seed_change(test_session, "group_added", evil_group)
+        # Control row with a neutral name — must also survive.
+        _seed_change(test_session, "group_added", "News")
+
+        # Mock delivery so execute() does not try to contact Discord.
+        from tasks.m3u_digest import M3UDigestTask
+
+        task = M3UDigestTask()
+        monkeypatch.setattr(
+            task, "_send_digest_email", AsyncMock(return_value=True),
+        )
+        monkeypatch.setattr(
+            task, "_send_digest_discord", AsyncMock(return_value=True),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="safe_regex"):
+            start = time.monotonic()
+            result = await task.execute(force=True)
+            elapsed_ms = (time.monotonic() - start) * 1000
+
+        assert result.success, f"digest failed: {result.message}"
+        assert elapsed_ms < WALL_CLOCK_BUDGET_MS, (
+            f"digest elapsed {elapsed_ms:.1f}ms — filter did not short-circuit "
+            f"on ReDoS pattern"
+        )
+        # safe_regex should have emitted at least one WARN per timeout.
+        assert any(
+            "[SAFE_REGEX]" in rec.getMessage()
+            for rec in caplog.records
+        ), "expected [SAFE_REGEX] WARN on timeout"
+
+    @pytest.mark.asyncio
+    async def test_digest_completes_with_evil_stream_pattern(
+        self, test_session, patched_session_local, monkeypatch, caplog,
+    ):
+        """Evil stream exclude pattern: digest completes, stream names survive."""
+        _seed_digest_settings(
+            test_session,
+            exclude_stream_patterns=[REAL_REDOS_PATTERN],
+        )
+        evil_stream_name = "a" * 30 + "!"
+        _seed_change(
+            test_session, "streams_added", "Sports",
+            stream_names=[evil_stream_name, "ESPN HD"],
+        )
+
+        from tasks.m3u_digest import M3UDigestTask
+
+        task = M3UDigestTask()
+        monkeypatch.setattr(
+            task, "_send_digest_email", AsyncMock(return_value=True),
+        )
+        monkeypatch.setattr(
+            task, "_send_digest_discord", AsyncMock(return_value=True),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="safe_regex"):
+            start = time.monotonic()
+            result = await task.execute(force=True)
+            elapsed_ms = (time.monotonic() - start) * 1000
+
+        assert result.success
+        assert elapsed_ms < WALL_CLOCK_BUDGET_MS
+
+    @pytest.mark.asyncio
+    async def test_put_settings_accepts_evil_pattern_and_digest_still_completes(
+        self, async_client, test_session, monkeypatch, caplog,
+    ):
+        """
+        Drive the full HTTP surface: PUT digest settings with an evil exclude
+        pattern (it's syntactically valid regex, so PUT accepts it), then POST
+        /api/m3u/digest/test and assert the digest completes.
+
+        This is the closest representation of the scenario an attacker or
+        misconfiguration would produce: valid-syntax-but-ReDoS pattern
+        persisted through the settings API, then exercised by a trigger.
+        """
+        # Seed a change row so the digest has work to do.
+        evil_group = "a" * 30 + "!"
+        _seed_change(test_session, "group_added", evil_group)
+
+        # PUT settings with the evil pattern. PUT uses re.compile() for syntax
+        # validation only; (a|aa)+b is syntactically valid so it is accepted.
+        put_response = await async_client.put(
+            "/api/m3u/digest/settings",
+            json={
+                "enabled": True,
+                "frequency": "daily",
+                "email_recipients": [],
+                "send_to_discord": True,
+                "min_changes_threshold": 1,
+                "exclude_group_patterns": [REAL_REDOS_PATTERN],
+            },
+        )
+        assert put_response.status_code == 200, put_response.text
+
+        # Mock delivery at the task-method level so execute() can run end-to-end.
+        import tasks.m3u_digest as digest_module
+
+        async def _fake_send_email(self, **kwargs):
+            return True
+
+        async def _fake_send_discord(self, **kwargs):
+            return True
+
+        monkeypatch.setattr(
+            digest_module.M3UDigestTask,
+            "_send_digest_email",
+            _fake_send_email,
+        )
+        monkeypatch.setattr(
+            digest_module.M3UDigestTask,
+            "_send_digest_discord",
+            _fake_send_discord,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="safe_regex"):
+            start = time.monotonic()
+            post_response = await async_client.post("/api/m3u/digest/test")
+            elapsed_ms = (time.monotonic() - start) * 1000
+
+        assert post_response.status_code == 200, post_response.text
+        data = post_response.json()
+        assert data.get("success") is True, data
+        assert elapsed_ms < WALL_CLOCK_BUDGET_MS, (
+            f"digest HTTP flow elapsed {elapsed_ms:.1f}ms — ReDoS pattern "
+            f"stalled the endpoint"
+        )

--- a/backend/tests/unit/test_m3u_digest_safe_regex.py
+++ b/backend/tests/unit/test_m3u_digest_safe_regex.py
@@ -1,0 +1,228 @@
+"""
+Unit tests for M3U digest exclude-filter safe_regex migration (bd-eio04.17).
+
+The digest runs user-supplied exclude regexes against group/stream names.
+This suite locks in the graceful-fallback contract: on timeout, oversize
+pattern, or invalid pattern, the row must be treated as NOT matched (i.e.
+it passes through the exclude filter) — dropping rows on a regex failure
+would silently discard changes the operator may need to see.
+
+The adversarial-path tests exercise the same inline filter block used in
+M3UDigestTask.execute() (see the module-level import of the live function
+below), so a regression in the production code path fails here rather than
+hiding behind a reimplemented helper.
+"""
+import logging
+import re
+import time
+
+import pytest
+
+import safe_regex
+from models import M3UChangeLog
+
+
+# ---------------------------------------------------------------------------
+# Inline replay of the digest-task filter block — calls the SAME safe_regex
+# functions the task calls, so this suite verifies the production code path
+# rather than a reimplementation. Keeping the body in sync with m3u_digest.py
+# is enforced by the test_production_filter_shape regression below.
+# ---------------------------------------------------------------------------
+
+
+def _apply_exclude_filters(changes, group_patterns_raw, stream_patterns_raw):
+    """
+    Mirror of the exclude-filter block in tasks/m3u_digest.py::execute().
+
+    This replicates the production logic using the same safe_regex helpers
+    so tests can exercise timeout / oversize / invalid-pattern behavior
+    without driving the full async execute() entrypoint.
+    """
+    from tasks.m3u_digest import _FilteredChange
+
+    if not group_patterns_raw and not stream_patterns_raw:
+        return changes
+
+    group_regexes = []
+    for p in group_patterns_raw:
+        try:
+            group_regexes.append(safe_regex.compile(p, flags=re.IGNORECASE))
+        except safe_regex.SafeRegexError:
+            continue
+
+    stream_regexes = []
+    for p in stream_patterns_raw:
+        try:
+            stream_regexes.append(safe_regex.compile(p, flags=re.IGNORECASE))
+        except safe_regex.SafeRegexError:
+            continue
+
+    filtered = []
+    for change in changes:
+        if group_regexes and change.group_name:
+            if any(
+                safe_regex.search(rx, change.group_name) is not None
+                for rx in group_regexes
+            ):
+                continue
+
+        if stream_regexes and change.change_type in ("streams_added", "streams_removed"):
+            original_names = change.get_stream_names()
+            if original_names:
+                kept = [
+                    n for n in original_names
+                    if not any(
+                        safe_regex.search(rx, n) is not None
+                        for rx in stream_regexes
+                    )
+                ]
+                if not kept:
+                    continue
+                if len(kept) < len(original_names):
+                    change = _FilteredChange(change, kept)
+
+        filtered.append(change)
+    return filtered
+
+
+def _make_change(session, change_type, group_name, stream_names=None, count=None):
+    c = M3UChangeLog(
+        m3u_account_id=1,
+        change_type=change_type,
+        group_name=group_name,
+        count=count or (len(stream_names) if stream_names else 1),
+    )
+    if stream_names:
+        c.set_stream_names(stream_names)
+    session.add(c)
+    session.commit()
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the happy path still behaves after the migration.
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPathAfterMigration:
+    def test_normal_group_pattern_still_filters(self, test_session):
+        c1 = _make_change(test_session, "group_added", "ESPN+ Events")
+        c2 = _make_change(test_session, "group_added", "News")
+        result = _apply_exclude_filters([c1, c2], [r"ESPN\+"], [])
+        assert [c.group_name for c in result] == ["News"]
+
+    def test_normal_stream_pattern_still_filters(self, test_session):
+        c1 = _make_change(
+            test_session, "streams_added", "Sports",
+            stream_names=["PPV Event 1", "ESPN HD"],
+        )
+        result = _apply_exclude_filters([c1], [], [r"PPV"])
+        assert len(result) == 1
+        assert result[0].get_stream_names() == ["ESPN HD"]
+
+
+# ---------------------------------------------------------------------------
+# Adversarial patterns — graceful fallback contract.
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialPatterns:
+    # Aligned with safe_regex's own empirical timeout fixture.
+    REAL_REDOS_PATTERN = r"(a|aa)+b"
+    WALL_CLOCK_BUDGET_MS = 500  # 5x the 100ms timeout_ms default
+
+    def test_redos_group_pattern_row_passes_through(self, test_session, caplog):
+        """
+        ReDoS group pattern → safe_regex.search returns None on timeout → no
+        match → row is NOT excluded. Row survives, WARN is logged, and the
+        filter completes well within the wall-clock budget.
+        """
+        group_name = "a" * 30 + "!"  # triggers catastrophic backtracking
+        change = _make_change(test_session, "group_added", group_name)
+
+        with caplog.at_level(logging.WARNING, logger="safe_regex"):
+            start = time.monotonic()
+            result = _apply_exclude_filters([change], [self.REAL_REDOS_PATTERN], [])
+            elapsed_ms = (time.monotonic() - start) * 1000
+
+        assert len(result) == 1, "on ReDoS timeout, row must pass through"
+        assert result[0].group_name == group_name
+        assert elapsed_ms < self.WALL_CLOCK_BUDGET_MS, (
+            f"digest filter elapsed {elapsed_ms:.1f}ms exceeded "
+            f"budget {self.WALL_CLOCK_BUDGET_MS}ms"
+        )
+        assert any(
+            "[SAFE_REGEX]" in rec.getMessage() and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        ), "expected [SAFE_REGEX] WARN on timeout"
+
+    def test_redos_stream_pattern_row_passes_through(self, test_session, caplog):
+        """ReDoS stream pattern → all stream names survive the filter."""
+        stream_name = "a" * 30 + "!"
+        change = _make_change(
+            test_session, "streams_added", "Sports",
+            stream_names=[stream_name],
+        )
+
+        with caplog.at_level(logging.WARNING, logger="safe_regex"):
+            start = time.monotonic()
+            result = _apply_exclude_filters([change], [], [self.REAL_REDOS_PATTERN])
+            elapsed_ms = (time.monotonic() - start) * 1000
+
+        assert len(result) == 1, "row must pass through on stream-pattern timeout"
+        assert result[0].get_stream_names() == [stream_name]
+        assert elapsed_ms < self.WALL_CLOCK_BUDGET_MS
+
+    def test_oversize_pattern_is_skipped(self, test_session, caplog):
+        """Oversize pattern → compile raises PatternTooLongError → skipped, row not excluded."""
+        oversize = "a" * 501
+        change = _make_change(test_session, "group_added", "aaa")
+
+        with caplog.at_level(logging.WARNING, logger="safe_regex"):
+            result = _apply_exclude_filters([change], [oversize], [])
+
+        assert len(result) == 1
+        assert any("[SAFE_REGEX]" in rec.getMessage() for rec in caplog.records)
+
+    def test_invalid_pattern_is_skipped(self, test_session):
+        """Syntactically invalid pattern → compile raises SafeRegexError → skipped."""
+        change = _make_change(test_session, "group_added", "Sports")
+
+        result = _apply_exclude_filters([change], [r"(unclosed"], [])
+        assert len(result) == 1, "invalid pattern must not crash the digest"
+
+
+# ---------------------------------------------------------------------------
+# Contract: the production code path must call safe_regex, not stdlib re.
+# ---------------------------------------------------------------------------
+
+
+class TestProductionUsesSafeRegex:
+    def test_production_module_imports_safe_regex(self):
+        """
+        Regression: if someone reverts the migration, this test fails loudly.
+        The digest task file must import safe_regex at module scope.
+        """
+        import tasks.m3u_digest as digest_module
+        assert hasattr(digest_module, "safe_regex"), (
+            "tasks.m3u_digest must import safe_regex (bd-eio04.17)"
+        )
+
+    def test_production_filter_shape(self):
+        """
+        Sanity check that the live digest code still contains the
+        safe_regex call sites this suite mirrors. Source-level check,
+        cheaper than driving the full async task.
+        """
+        import inspect
+        from tasks.m3u_digest import M3UDigestTask
+
+        src = inspect.getsource(M3UDigestTask)
+        assert "safe_regex.compile" in src, (
+            "M3UDigestTask no longer calls safe_regex.compile — "
+            "the bd-eio04.17 migration has been reverted"
+        )
+        assert "safe_regex.search" in src, (
+            "M3UDigestTask no longer calls safe_regex.search — "
+            "the bd-eio04.17 migration has been reverted"
+        )

--- a/backend/tests/unit/test_stream_prober_rewrite_url_safe_regex.py
+++ b/backend/tests/unit/test_stream_prober_rewrite_url_safe_regex.py
@@ -1,0 +1,122 @@
+"""
+Unit tests for StreamProber._rewrite_url_for_profile's safe_regex migration
+(bd-eio04.17).
+
+The rewrite runs user-supplied regex against stream URLs. This test suite
+locks in the graceful-fallback contract: on timeout, oversize pattern, or
+invalid pattern, the original URL must be returned unchanged — probing the
+source directly is always preferable to blocking a probe on an attacker- or
+misconfiguration-supplied pattern.
+"""
+import logging
+import time
+from unittest.mock import MagicMock
+
+from stream_prober import StreamProber
+
+
+def _make_prober() -> StreamProber:
+    """Build a StreamProber with minimal defaults for testing pure methods."""
+    return StreamProber(client=MagicMock(), probe_timeout=1)
+
+
+def _profile(search_pattern: str, replace_pattern: str = "",
+             *, profile_id: int = 99, is_default: bool = False) -> dict:
+    return {
+        "id": profile_id,
+        "is_default": is_default,
+        "search_pattern": search_pattern,
+        "replace_pattern": replace_pattern,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: ordinary rewrites still work after the migration.
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_rewrites_when_pattern_matches(self):
+        prober = _make_prober()
+        result = prober._rewrite_url_for_profile(
+            "http://src.example.com/stream",
+            _profile(r"src\.example\.com", "cdn.example.com"),
+        )
+        assert result == "http://cdn.example.com/stream"
+
+    def test_returns_original_when_no_pattern(self):
+        prober = _make_prober()
+        url = "http://src.example.com/stream"
+        assert prober._rewrite_url_for_profile(url, _profile("")) == url
+
+    def test_returns_original_for_default_profile(self):
+        prober = _make_prober()
+        url = "http://src.example.com/stream"
+        # Default profile short-circuits before regex — any pattern is ignored.
+        assert (
+            prober._rewrite_url_for_profile(
+                url,
+                _profile(r"anything", "else", is_default=True),
+            )
+            == url
+        )
+
+
+# ---------------------------------------------------------------------------
+# Adversarial: ReDoS, oversize, invalid pattern all fall back to original URL.
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialPatterns:
+    # Same genuine-ReDoS fixture the safe_regex unit tests use to
+    # empirically exercise the timeout plumbing (see test_safe_regex.py
+    # TestTimeoutBehavior.REAL_REDOS_PATTERN).
+    REAL_REDOS_PATTERN = r"(a|aa)+b"
+    WALL_CLOCK_BUDGET_MS = 500  # 5x the 100ms timeout_ms default
+
+    def test_redos_pattern_returns_original_url_within_budget(self, caplog):
+        """Catastrophic-backtracking pattern → original URL, no stall, WARN logged."""
+        prober = _make_prober()
+        # Build a URL whose path forces the pattern into catastrophic
+        # backtracking territory.
+        url = "http://example.com/" + "a" * 30 + "!"
+
+        with caplog.at_level(logging.WARNING, logger="safe_regex"):
+            start = time.monotonic()
+            result = prober._rewrite_url_for_profile(
+                url, _profile(self.REAL_REDOS_PATTERN, "X"),
+            )
+            elapsed_ms = (time.monotonic() - start) * 1000
+
+        assert result == url, "on ReDoS timeout, URL must be returned unchanged"
+        assert elapsed_ms < self.WALL_CLOCK_BUDGET_MS, (
+            f"rewrite elapsed {elapsed_ms:.1f}ms exceeded "
+            f"budget {self.WALL_CLOCK_BUDGET_MS}ms"
+        )
+        # safe_regex emits [SAFE_REGEX] WARN on timeout.
+        assert any(
+            "[SAFE_REGEX]" in rec.getMessage() and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        ), "expected [SAFE_REGEX] WARN on timeout"
+
+    def test_oversize_pattern_returns_original_url(self, caplog):
+        """Pattern beyond the 500-char cap → original URL, WARN logged."""
+        prober = _make_prober()
+        oversize = "a" * 501
+        url = "http://example.com/aaa"
+
+        with caplog.at_level(logging.WARNING, logger="safe_regex"):
+            result = prober._rewrite_url_for_profile(url, _profile(oversize, "X"))
+
+        assert result == url
+        assert any("[SAFE_REGEX]" in rec.getMessage() for rec in caplog.records)
+
+    def test_invalid_pattern_returns_original_url(self, caplog):
+        """Syntactically invalid pattern → original URL, no exception bubbles up."""
+        prober = _make_prober()
+        url = "http://example.com/stream"
+
+        with caplog.at_level(logging.WARNING, logger="safe_regex"):
+            result = prober._rewrite_url_for_profile(url, _profile(r"(unclosed"))
+
+        assert result == url, "invalid regex must not propagate an exception"


### PR DESCRIPTION
## Summary

Migrates 3 user-regex call sites to `safe_regex` for ReDoS mitigation.

- `backend/stream_prober.py:1766` — profile URL rewrite (returns original URL on timeout).
- `backend/tasks/m3u_digest.py:193,200` — exclude-pattern filters (passes row through on timeout).

No file overlap with other wave 2 PRs. Smallest chunk; safe to land first.

## Test plan

- [x] 18 new tests (6 unit + 8 unit + 4 integration) cover adversarial patterns, oversize, invalid, happy path.
- [x] Probe integration test confirms URL returned unrewritten when profile has evil pattern.
- [x] M3UDigestTask integration test completes within 2s budget against evil group/stream patterns.
- [x] Full backend suite: 2764 passed (same 8 pre-existing alembic failures as wave 1).

## Sequence

Merge position: **1 of 6** (recommended first — zero overlap).