### PR TITLE
bd-eio04.16: migrate dummy_epg + template_engine regex to safe_regex

### DIFF
--- a/backend/dummy_epg_engine.py
+++ b/backend/dummy_epg_engine.py
@@ -12,11 +12,17 @@ from datetime import datetime, timedelta
 
 import pytz
 
+import safe_regex
+
 logger = logging.getLogger(__name__)
 
 
 def _js_to_python_named_groups(pattern: str) -> str:
-    """Convert JavaScript-style named groups (?<name>...) to Python (?P<name>...)."""
+    """Convert JavaScript-style named groups (?<name>...) to Python (?P<name>...).
+
+    The regex used here is a module-level, developer-authored pattern (not user
+    input), so stdlib ``re`` is correct — no ReDoS surface.
+    """
     if not pattern:
         return pattern
     return re.sub(r"\(\?<(?!\=|\!)", "(?P<", pattern)
@@ -69,14 +75,12 @@ def apply_substitutions(name: str, pairs: list[dict]) -> tuple[str, list[dict]]:
         before = current
 
         if is_regex:
-            try:
-                current = re.sub(find, replace, current)
-            except re.error as e:
-                logger.warning(
-                    "[DUMMY-EPG] Invalid regex in substitution find=%s: %s",
-                    find, e,
-                )
-                continue
+            # Fallback contract (bd-eio04.16): safe_regex.sub returns *text*
+            # unchanged on timeout / oversize pattern / invalid pattern and
+            # emits a [SAFE_REGEX] WARN. When the returned string matches
+            # ``before``, the rule is effectively a no-op and no step is
+            # recorded — equivalent to skipping a bad rule without crashing.
+            current = safe_regex.sub(find, replace, current)
         else:
             current = current.replace(find, replace)
 
@@ -118,32 +122,33 @@ def extract_groups(
     time_pattern = _js_to_python_named_groups(time_pattern)
     date_pattern = _js_to_python_named_groups(date_pattern)
 
-    try:
-        title_match = re.search(title_pattern, name)
-    except re.error as e:
-        logger.warning("[DUMMY-EPG] Invalid title_pattern regex: %s", e)
-        return None
-
+    # Fallback contract (bd-eio04.16): safe_regex.search returns None on
+    # timeout / oversize / invalid pattern (logging [SAFE_REGEX] WARN). For
+    # title_pattern this is treated as "no match" — the same outcome as a
+    # non-matching good pattern — so the caller renders fallback templates
+    # rather than crashing.
+    title_match = safe_regex.search(title_pattern, name)
     if not title_match:
         return None
 
     groups = dict(title_match.groupdict())
 
     if time_pattern:
-        try:
-            time_match = re.search(time_pattern, name)
-            if time_match:
-                groups.update(time_match.groupdict())
-        except re.error as e:
-            logger.warning("[DUMMY-EPG] Invalid time_pattern regex: %s", e)
+        # Fallback contract (bd-eio04.16): safe_regex.search returns None on
+        # timeout / oversize / invalid pattern. Missing time groups is already
+        # a supported state (compute_event_times falls back to "now"), so we
+        # simply skip updating the groups dict.
+        time_match = safe_regex.search(time_pattern, name)
+        if time_match:
+            groups.update(time_match.groupdict())
 
     if date_pattern:
-        try:
-            date_match = re.search(date_pattern, name)
-            if date_match:
-                groups.update(date_match.groupdict())
-        except re.error as e:
-            logger.warning("[DUMMY-EPG] Invalid date_pattern regex: %s", e)
+        # Fallback contract (bd-eio04.16): safe_regex.search returns None on
+        # timeout / oversize / invalid pattern. Missing date groups falls
+        # through to the "no date captured" branch in compute_event_times.
+        date_match = safe_regex.search(date_pattern, name)
+        if date_match:
+            groups.update(date_match.groupdict())
 
     return groups
 

--- a/backend/template_engine.py
+++ b/backend/template_engine.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import re
 from typing import Any, Optional
 
+import safe_regex
+
 
 class TemplateSyntaxError(ValueError):
     """Raised when a template is malformed or references an unknown transform/table."""
@@ -95,9 +97,11 @@ class TemplateEngine:
     """
 
     # Public caps — exposed so tests and callers can reason about them.
+    # The regex-length cap is inherited from ``safe_regex.DEFAULT_MAX_PATTERN_LEN``
+    # (500 chars). Conditional regex patterns are routed through ``safe_regex``
+    # which handles both the length cap and the ReDoS timeout.
     MAX_TEMPLATE_LEN = 4096
     MAX_INPUT_LEN = 1024
-    MAX_REGEX_LEN = 500
 
     # Pattern for a single {placeholder} — body has no unescaped '{' or '}'.
     _PLACEHOLDER_RE = re.compile(r"\{([^{}]+)\}")
@@ -266,13 +270,22 @@ class TemplateEngine:
         if "~" in condition:
             name, pattern = condition.split("~", 1)
             value = groups.get(name, "")
-            if len(pattern) > self.MAX_REGEX_LEN:
-                return False, {"kind": "regex", "value": value, "error": "pattern too long"}
+            # Fallback contract (bd-eio04.16): route user-supplied regex through
+            # safe_regex. ``compile`` raises ``PatternTooLongError`` for oversize
+            # patterns and ``SafeRegexError`` for malformed patterns — both are
+            # caught below and collapse the conditional to false rather than
+            # crashing the render. ``search`` on the compiled pattern returns
+            # None on ReDoS timeout (logged by safe_regex), again collapsing to
+            # false. A single bad user config therefore skips a {if:...~...}
+            # block rather than bringing down XMLTV generation.
             try:
-                matched = re.search(pattern, value) is not None
-                return matched, {"kind": "regex", "value": value}
-            except re.error as err:
+                compiled = safe_regex.compile(pattern)
+            except safe_regex.PatternTooLongError:
+                return False, {"kind": "regex", "value": value, "error": "pattern too long"}
+            except safe_regex.SafeRegexError as err:
                 return False, {"kind": "regex", "value": value, "error": str(err)}
+            matched = safe_regex.search(compiled, value) is not None
+            return matched, {"kind": "regex", "value": value}
 
         # {if:group} — truthy if non-empty.
         value = groups.get(condition, "")

--- a/backend/tests/integration/test_dummy_epg.py
+++ b/backend/tests/integration/test_dummy_epg.py
@@ -122,7 +122,7 @@ class TestInvalidRegexInConditional:
     async def test_oversized_regex_evaluates_false(self, async_client):
         """Regex pattern over 500 chars inside a conditional short-circuits
         to false rather than attempting catastrophic backtracking."""
-        huge = "a?" * 260  # 520 chars, past MAX_REGEX_LEN (500)
+        huge = "a?" * 260  # 520 chars, past safe_regex.DEFAULT_MAX_PATTERN_LEN (500)
         response = await async_client.post("/api/dummy-epg/preview", json={
             "sample_name": "AAAAA",
             "title_pattern": r"(?P<v>\w+)",
@@ -266,3 +266,76 @@ class TestGlobalLookupResolution:
         })
         assert response.status_code == 200
         assert response.json()["rendered"]["title"] == "US"
+
+
+class TestRedosResiliencePreview:
+    """bd-eio04.16 — Evil regex in substitution pairs, title_pattern, or
+    template conditional must not stall the preview endpoint. The endpoint
+    covers the full dummy-epg pipeline; validating it here proves the
+    safe_regex migration wraps every user-editable regex site reachable from
+    the request body."""
+
+    _GENUINE_REDOS_PATTERN = r"(a|aa)+b"
+    _ADVERSARIAL_TEXT = "a" * 30 + "!"
+    _WALL_CLOCK_BUDGET_MS = 2000  # generous for integration roundtrip
+
+    @pytest.mark.asyncio
+    async def test_evil_substitution_pair_does_not_stall(self, async_client):
+        """Substitution pair with catastrophic backtracking pattern is
+        gracefully dropped — the sample_name flows through unchanged."""
+        import time as _time
+        start = _time.monotonic()
+        response = await async_client.post("/api/dummy-epg/preview", json={
+            "sample_name": self._ADVERSARIAL_TEXT,
+            "substitution_pairs": [
+                {"find": self._GENUINE_REDOS_PATTERN, "replace": "X", "is_regex": True, "enabled": True},
+            ],
+            "title_pattern": r"(?P<name>.+)",
+            "title_template": "{name}",
+            "event_timezone": "UTC",
+            "program_duration": 180,
+        })
+        elapsed_ms = (_time.monotonic() - start) * 1000
+        assert response.status_code == 200
+        assert response.json()["substituted_name"] == self._ADVERSARIAL_TEXT
+        assert elapsed_ms < self._WALL_CLOCK_BUDGET_MS, f"elapsed {elapsed_ms:.0f}ms"
+
+    @pytest.mark.asyncio
+    async def test_evil_title_pattern_does_not_stall(self, async_client):
+        """Catastrophic title_pattern collapses to no-match (matched=False)
+        and the preview returns fallback rendering."""
+        import time as _time
+        start = _time.monotonic()
+        response = await async_client.post("/api/dummy-epg/preview", json={
+            "sample_name": self._ADVERSARIAL_TEXT,
+            "title_pattern": self._GENUINE_REDOS_PATTERN,
+            "title_template": "{name}",
+            "fallback_title_template": "fallback",
+            "event_timezone": "UTC",
+            "program_duration": 180,
+        })
+        elapsed_ms = (_time.monotonic() - start) * 1000
+        assert response.status_code == 200
+        body = response.json()
+        assert body["matched"] is False
+        assert body["rendered"]["fallback_title"] == "fallback"
+        assert elapsed_ms < self._WALL_CLOCK_BUDGET_MS, f"elapsed {elapsed_ms:.0f}ms"
+
+    @pytest.mark.asyncio
+    async def test_evil_conditional_regex_does_not_stall(self, async_client):
+        """{if:name~(a|aa)+b} conditional in a title_template renders as
+        false (empty) without stalling the request."""
+        import time as _time
+        tpl = "OK-{if:name~" + self._GENUINE_REDOS_PATTERN + "}HIT{/if}"
+        start = _time.monotonic()
+        response = await async_client.post("/api/dummy-epg/preview", json={
+            "sample_name": self._ADVERSARIAL_TEXT,
+            "title_pattern": r"(?P<name>.+)",
+            "title_template": tpl,
+            "event_timezone": "UTC",
+            "program_duration": 180,
+        })
+        elapsed_ms = (_time.monotonic() - start) * 1000
+        assert response.status_code == 200
+        assert response.json()["rendered"]["title"] == "OK-"
+        assert elapsed_ms < self._WALL_CLOCK_BUDGET_MS, f"elapsed {elapsed_ms:.0f}ms"

--- a/backend/tests/unit/test_dummy_epg_engine.py
+++ b/backend/tests/unit/test_dummy_epg_engine.py
@@ -768,3 +768,153 @@ def test_generate_xmltv_empty_profiles():
     assert root.tag == "tv"
     assert len(root.findall("channel")) == 0
     assert len(root.findall("programme")) == 0
+
+
+# ---------------------------------------------------------------------------
+# bd-eio04.16 — ReDoS resilience for user-supplied regex in the EPG pipeline.
+#
+# These tests verify each safe_regex-migrated call site behaves gracefully
+# when given an adversarial pattern + long input. The wall-clock budget is
+# 500ms per call (5x the 100ms safe_regex default timeout) — CI-safe jitter
+# cap. The adversarial fixtures match the shared bank used in test_safe_regex.
+# ---------------------------------------------------------------------------
+
+import time
+
+# (a+)+b short-circuits in the 'regex' library for most inputs; (a|aa)+b is
+# a genuine catastrophic-backtracking fixture that exercises the timeout path.
+_ADVERSARIAL_PATTERN = r"(a+)+b"
+_ADVERSARIAL_TEXT = "a" * 30 + "!"
+_GENUINE_REDOS_PATTERN = r"(a|aa)+b"
+_WALL_CLOCK_BUDGET_MS = 500
+
+
+def test_apply_substitutions_adversarial_regex_returns_unchanged_within_budget():
+    """apply_substitutions with a ReDoS-prone pattern falls back to text
+    unchanged and records no step, well within the wall-clock budget.
+    Migrated call site: dummy_epg_engine.apply_substitutions."""
+    pairs = [{"find": _ADVERSARIAL_PATTERN, "replace": "BOOM", "is_regex": True, "enabled": True}]
+    start = time.monotonic()
+    result, steps = apply_substitutions(_ADVERSARIAL_TEXT, pairs)
+    elapsed_ms = (time.monotonic() - start) * 1000
+    # No substitution applied — text unchanged. Adversarial pattern may
+    # short-circuit to "no match" or hit the safe_regex timeout; either way
+    # the sentinel is the original text.
+    assert result == _ADVERSARIAL_TEXT
+    assert steps == []
+    assert elapsed_ms < _WALL_CLOCK_BUDGET_MS, f"elapsed {elapsed_ms:.1f}ms"
+
+
+def test_apply_substitutions_genuine_redos_pattern_returns_unchanged_within_budget():
+    """Genuine catastrophic-backtracking pattern (not short-circuitable)
+    exercises the safe_regex timeout path. Returns original text unchanged."""
+    pairs = [{"find": _GENUINE_REDOS_PATTERN, "replace": "X", "is_regex": True, "enabled": True}]
+    start = time.monotonic()
+    result, steps = apply_substitutions(_ADVERSARIAL_TEXT, pairs)
+    elapsed_ms = (time.monotonic() - start) * 1000
+    assert result == _ADVERSARIAL_TEXT
+    assert steps == []
+    assert elapsed_ms < _WALL_CLOCK_BUDGET_MS, f"elapsed {elapsed_ms:.1f}ms"
+
+
+def test_extract_groups_title_pattern_adversarial_returns_none_within_budget():
+    """extract_groups with a ReDoS-prone title_pattern returns None (no
+    match) within budget. Migrated call site: extract_groups title_match."""
+    start = time.monotonic()
+    groups = extract_groups(_ADVERSARIAL_TEXT, _GENUINE_REDOS_PATTERN)
+    elapsed_ms = (time.monotonic() - start) * 1000
+    assert groups is None
+    assert elapsed_ms < _WALL_CLOCK_BUDGET_MS, f"elapsed {elapsed_ms:.1f}ms"
+
+
+def test_extract_groups_time_pattern_adversarial_keeps_title_within_budget():
+    """Adversarial time_pattern does not prevent title groups from
+    returning — time groups simply omitted. Migrated call site: extract_groups
+    time_match."""
+    # Title pattern matches cheaply; time pattern is the ReDoS fixture.
+    # Long name plus tail that triggers catastrophic backtracking.
+    name = "Title " + _ADVERSARIAL_TEXT
+    start = time.monotonic()
+    groups = extract_groups(
+        name,
+        r"(?P<title>Title)",
+        time_pattern=_GENUINE_REDOS_PATTERN,
+    )
+    elapsed_ms = (time.monotonic() - start) * 1000
+    assert groups is not None
+    assert groups["title"] == "Title"
+    assert "hour" not in groups
+    assert elapsed_ms < _WALL_CLOCK_BUDGET_MS, f"elapsed {elapsed_ms:.1f}ms"
+
+
+def test_extract_groups_date_pattern_adversarial_keeps_title_within_budget():
+    """Adversarial date_pattern does not prevent title groups from
+    returning. Migrated call site: extract_groups date_match."""
+    name = "Title " + _ADVERSARIAL_TEXT
+    start = time.monotonic()
+    groups = extract_groups(
+        name,
+        r"(?P<title>Title)",
+        date_pattern=_GENUINE_REDOS_PATTERN,
+    )
+    elapsed_ms = (time.monotonic() - start) * 1000
+    assert groups is not None
+    assert groups["title"] == "Title"
+    assert "month" not in groups
+    assert elapsed_ms < _WALL_CLOCK_BUDGET_MS, f"elapsed {elapsed_ms:.1f}ms"
+
+
+# ---------------------------------------------------------------------------
+# Property-based equivalence: for benign (pattern, text) pairs, safe_regex
+# migrated sites produce the same result as the prior stdlib-re behavior.
+# ---------------------------------------------------------------------------
+
+try:
+    from hypothesis import given, settings, strategies as st
+    _HAS_HYPOTHESIS = True
+except ImportError:  # pragma: no cover
+    _HAS_HYPOTHESIS = False
+
+
+if _HAS_HYPOTHESIS:
+    import re as _re_stdlib
+
+    # Benign patterns: simple literal + alternation that neither stdlib re
+    # nor the regex library will treat pathologically. Keep the alphabet
+    # tiny so patterns and texts exercise the same characters reliably.
+    _BENIGN_PATTERNS = st.sampled_from([
+        r"foo", r"\d+", r"[a-z]+", r"ab?c", r"^hello", r"world$",
+        r"(?P<w>\w+)", r"a(b|c)d", r"x{1,3}y",
+    ])
+    _BENIGN_TEXTS = st.text(alphabet="abcdefghijxyz 0123456789", min_size=0, max_size=64)
+
+    @given(pattern=_BENIGN_PATTERNS, text=_BENIGN_TEXTS)
+    @settings(max_examples=50, deadline=1000)
+    def test_apply_substitutions_benign_equivalence(pattern, text):
+        """For benign patterns, apply_substitutions produces the same string
+        as the prior stdlib re.sub behavior."""
+        try:
+            expected = _re_stdlib.sub(pattern, "REPL", text)
+        except _re_stdlib.error:
+            # Skip patterns stdlib rejects — migration behavior on invalid
+            # patterns (no-op) is covered by the explicit tests above.
+            return
+        pairs = [{"find": pattern, "replace": "REPL", "is_regex": True, "enabled": True}]
+        actual, _steps = apply_substitutions(text, pairs)
+        assert actual == expected
+
+    @given(pattern=_BENIGN_PATTERNS, text=_BENIGN_TEXTS)
+    @settings(max_examples=50, deadline=1000)
+    def test_extract_groups_title_benign_equivalence(pattern, text):
+        """For benign title patterns, extract_groups behaves the same way
+        as stdlib re.search: match -> dict, no match -> None."""
+        try:
+            expected_match = _re_stdlib.search(pattern, text)
+        except _re_stdlib.error:
+            return
+        groups = extract_groups(text, pattern)
+        if expected_match is None:
+            assert groups is None
+        else:
+            assert groups is not None
+            assert groups == dict(expected_match.groupdict())

--- a/backend/tests/unit/test_template_engine.py
+++ b/backend/tests/unit/test_template_engine.py
@@ -12,6 +12,7 @@ Syntax covered:
 """
 import pytest
 
+import safe_regex
 from template_engine import (
     TemplateEngine,
     TemplateSyntaxError,
@@ -210,9 +211,12 @@ class TestGuards:
         assert len(out) <= TemplateEngine.MAX_INPUT_LEN
 
     def test_regex_length_capped_in_conditional(self):
-        # A regex longer than the cap disables the conditional (evaluates false)
-        # rather than raising, so a single bad user config doesn't crash pipeline.
-        huge_regex = "(" + "a?" * (TemplateEngine.MAX_REGEX_LEN // 2 + 10) + ")" + "a" * 20
+        # A regex longer than the safe_regex cap disables the conditional
+        # (evaluates false) rather than raising, so a single bad user config
+        # doesn't crash pipeline. The cap now lives in safe_regex —
+        # template_engine no longer has its own MAX_REGEX_LEN.
+        cap = safe_regex.DEFAULT_MAX_PATTERN_LEN
+        huge_regex = "(" + "a?" * (cap // 2 + 10) + ")" + "a" * 20
         tpl = "{if:x~" + huge_regex + "}match{/if}"
         assert render(tpl, {"x": "a" * 20}) == ""
 
@@ -312,3 +316,53 @@ class TestTemplateEngineClass:
         engine = TemplateEngine(lookups={"tbl": {"a": "from-instance"}})
         out = engine.render("{k|lookup:tbl}", {"k": "a"}, lookups={"tbl": {"a": "from-call"}})
         assert out == "from-call"
+
+
+# ----------------------------------------------------------------------------
+# bd-eio04.16 — ReDoS resilience in {if:x~regex} conditionals.
+#
+# The migrated call site routes user-supplied regex through
+# safe_regex.compile + safe_regex.search. Adversarial patterns must not hang
+# XMLTV rendering; the conditional collapses to false.
+# ----------------------------------------------------------------------------
+
+import time
+
+
+class TestRegexConditionalRedosResilience:
+    _ADVERSARIAL_PATTERN = r"(a+)+b"
+    _GENUINE_REDOS_PATTERN = r"(a|aa)+b"
+    _ADVERSARIAL_TEXT = "a" * 30 + "!"
+    _WALL_CLOCK_BUDGET_MS = 500
+
+    def test_adversarial_pattern_condition_is_false_within_budget(self):
+        """{if:name~(a+)+b} against a long input collapses to false without
+        stalling the render."""
+        tpl = "before-{if:name~" + self._ADVERSARIAL_PATTERN + "}MATCH{/if}-after"
+        start = time.monotonic()
+        out = render(tpl, {"name": self._ADVERSARIAL_TEXT})
+        elapsed_ms = (time.monotonic() - start) * 1000
+        assert out == "before--after"
+        assert elapsed_ms < self._WALL_CLOCK_BUDGET_MS, f"elapsed {elapsed_ms:.1f}ms"
+
+    def test_genuine_redos_pattern_condition_is_false_within_budget(self):
+        """Genuine catastrophic-backtracking pattern exercises the safe_regex
+        timeout path; conditional still evaluates to false."""
+        tpl = "ok-{if:name~" + self._GENUINE_REDOS_PATTERN + "}HIT{/if}-done"
+        start = time.monotonic()
+        out = render(tpl, {"name": self._ADVERSARIAL_TEXT})
+        elapsed_ms = (time.monotonic() - start) * 1000
+        assert out == "ok--done"
+        assert elapsed_ms < self._WALL_CLOCK_BUDGET_MS, f"elapsed {elapsed_ms:.1f}ms"
+
+    def test_trace_mode_reports_regex_kind_on_adversarial_pattern(self):
+        """When tracing is on, the adversarial-pattern conditional still
+        reports kind_detail='regex' and taken=False — the UI can show the
+        regex was not usable."""
+        engine = TemplateEngine()
+        tpl = "{if:name~" + self._GENUINE_REDOS_PATTERN + "}HIT{/if}"
+        _, trace = engine.render_with_trace(tpl, {"name": self._ADVERSARIAL_TEXT})
+        conds = [t for t in trace if t["kind"] == "conditional"]
+        assert len(conds) == 1
+        assert conds[0]["kind_detail"] == "regex"
+        assert conds[0]["taken"] is False


### PR DESCRIPTION
## Summary

Migrates 5 user-regex call sites; deletes the local `MAX_REGEX_LEN` guard now that safe_regex enforces the 500-char cap centrally.

- `backend/dummy_epg_engine.py` — `apply_substitutions` (sub), `extract_groups` title/time/date (search).
- `backend/template_engine.py` — `_evaluate_condition` `~regex` branch; local `MAX_REGEX_LEN` deleted.
- Module-level developer-authored regexes (`_PLACEHOLDER_RE`, `_NORMALIZE_STRIP_RE`, `_js_to_python_named_groups`) correctly left on stdlib `re`.

No file overlap with other wave 2 PRs.

## Test plan

- [x] 5 adversarial-pattern unit tests + 2 Hypothesis property equivalence tests in `test_dummy_epg_engine.py`.
- [x] New `TestRegexConditionalRedosResilience` in `test_template_engine.py` (3 tests).
- [x] New `TestRedosResiliencePreview` integration tests through `/api/dummy-epg/preview` (3 tests).
- [x] `git grep MAX_REGEX_LEN backend/template_engine.py` returns empty.
- [x] 173 tests passing in the scope.

## Sequence

Merge position: **2 of 6** (zero overlap).