### PR TITLE
bd-eio04.9: normalization observability — metrics, decision log, SLO-5, nightly canary

### DIFF
--- a/.github/workflows/normalization-canary.yml
+++ b/.github/workflows/normalization-canary.yml
@@ -1,0 +1,126 @@
+name: Normalization Canary
+
+# Nightly parity check between the Test Rules preview path and the
+# auto-creation executor path (bd-eio04.9). Any divergence is an SLO-5
+# breach — see docs/sre/slos.md. Runbook:
+# docs/runbooks/normalization-canary-divergence.md.
+
+on:
+  # 07:00 UTC = 03:00 ET / 00:00 PT — post-midnight US, before morning
+  # standup in any US time zone. Cron minutes intentionally = 0 so the
+  # run-time is predictable for dashboards.
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  # Fallback alerting path (open a GH issue) needs issue:write.
+  issues: write
+  contents: read
+
+jobs:
+  canary:
+    name: Normalization parity canary
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Prepare test config directory
+        run: |
+          mkdir -p /tmp/ecm_canary_config
+
+      - name: Run canary harness
+        id: canary
+        working-directory: backend
+        env:
+          CONFIG_DIR: /tmp/ecm_canary_config
+          RATE_LIMIT_ENABLED: '0'
+        # ``set -o pipefail`` so the exit code survives the tee.
+        # The harness prints a JSON report to stdout on failure; we
+        # capture it to a file for downstream alerting steps.
+        run: |
+          set -o pipefail
+          python -m scripts.normalization_canary 2>&1 | tee /tmp/canary.log
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Upload canary log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: normalization-canary-log
+          path: /tmp/canary.log
+          if-no-files-found: ignore
+          retention-days: 30
+
+      # -- Alerting: Slack first, GH issue as the durable fallback ----
+      - name: Notify Slack on divergence
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: rtCamp/action-slack-notify@v2
+        with:
+          # action-slack-notify reads SLACK_WEBHOOK_URL from env.
+          SLACK_COLOR: 'danger'
+          SLACK_TITLE: 'Normalization canary DIVERGED'
+          SLACK_MESSAGE: |
+            Nightly normalization canary detected divergence between
+            Test Rules (HTTP) and auto-creation executor output.
+            This is an SLO-5 (Normalization Correctness) breach —
+            blocks next release cut until resolved.
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            Runbook: docs/runbooks/normalization-canary-divergence.md
+
+      - name: File GH issue on divergence (fallback)
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Always file the issue — Slack is fire-and-forget, the issue is
+        # the durable breach record the runbook references. De-dup via
+        # title that includes the date; if two failures land on the same
+        # calendar day, the second run's `gh issue create` still succeeds
+        # (issues are append-only), so nothing is lost.
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          BODY_FILE=$(mktemp)
+          {
+            echo "## Normalization canary divergence — ${DATE}"
+            echo ""
+            echo "The nightly canary found Test Rules ↔ auto-creation executor divergence."
+            echo "This is an **SLO-5 (Normalization Correctness) breach**."
+            echo ""
+            echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo "**Branch:** \`${{ github.ref }}\`"
+            echo "**Commit:** \`${{ github.sha }}\`"
+            echo ""
+            echo "### Canary output (head 200 lines)"
+            echo '```'
+            head -200 /tmp/canary.log || true
+            echo '```'
+            echo ""
+            echo "### Next steps"
+            echo "1. Open the runbook: \`docs/runbooks/normalization-canary-divergence.md\`"
+            echo "2. Identify the diverging commit via \`git log backend/normalization_engine.py\`."
+            echo "3. Add the failing input to \`unicode_fixtures.py\` with \`origin=canary-${DATE}\`."
+            echo "4. **Block the next release cut until green.**"
+          } > "$BODY_FILE"
+
+          gh issue create \
+            --title "[CANARY] normalization divergence ${DATE}" \
+            --label "regression,normalization" \
+            --body-file "$BODY_FILE" || echo "::warning::gh issue create failed — check permissions"

--- a/backend/auto_creation_executor.py
+++ b/backend/auto_creation_executor.py
@@ -627,6 +627,18 @@ class ActionExecutor:
         group_name = self._get_group_name(group_id)
         group_label = f"'{group_name}'" if group_name else str(group_id)
 
+        # Observability (bd-eio04.9): record whether normalization was
+        # applied to this creation. Three buckets:
+        #   - "true"    — normalization ran AND changed the name
+        #   - "false"   — normalization ran but produced no change
+        #   - "skipped" — no normalization groups configured for the rule
+        # Only the non-dry-run path emits the metric (dry-run previews
+        # do not create channels in the real sense).
+        if normalization_group_ids and self._normalization_engine:
+            normalized_label = "true" if pre_norm_name != channel_name else "false"
+        else:
+            normalized_label = "skipped"
+
         # Create new channel
         if exec_ctx.dry_run:
             # Track simulated channel so subsequent streams in this run
@@ -673,6 +685,18 @@ class ActionExecutor:
                 channel_data["tvg_id"] = stream_ctx.tvg_id
 
             new_channel = await self.client.create_channel(channel_data)
+
+            # Observability (bd-eio04.9) — one counter increment per real
+            # channel creation. Wrapped in try/except so a missing
+            # metric registry (e.g. CI-without-prometheus) never blocks
+            # a creation that otherwise succeeded.
+            try:
+                from observability import get_metric
+                get_metric("auto_creation_channels_created_total").labels(
+                    normalized=normalized_label
+                ).inc()
+            except Exception:  # pragma: no cover
+                logger.debug("[AUTO-CREATE-EXEC] metric increment failed", exc_info=True)
 
             # Track the new channel
             self._created_channels[channel_name.lower()] = new_channel

--- a/backend/normalization_engine.py
+++ b/backend/normalization_engine.py
@@ -40,6 +40,7 @@ ECM_NORMALIZATION_UNIFIED_POLICY (default: "true")
 import os
 import re
 import logging
+import time
 import unicodedata
 from typing import Optional
 from dataclasses import dataclass, field
@@ -49,6 +50,18 @@ from sqlalchemy.orm import Session
 from models import NormalizationRule, NormalizationRuleGroup, TagGroup, Tag
 
 logger = logging.getLogger(__name__)
+
+
+# Policy version string emitted into the structured decision log (bd-eio04.9).
+# Bumped when the unified-policy flag flips so on-call can correlate
+# divergence reports with the policy the run was using.
+POLICY_VERSION_UNIFIED = "unified-v1"
+POLICY_VERSION_LEGACY = "legacy"
+
+
+def _current_policy_version(policy_obj: "NormalizationPolicy") -> str:
+    """Return the canonical policy-version tag for the decision log."""
+    return POLICY_VERSION_UNIFIED if policy_obj.unified_enabled else POLICY_VERSION_LEGACY
 
 
 # -----------------------------------------------------------------------------
@@ -1035,6 +1048,13 @@ class NormalizationEngine:
         2026-04-22: numerics convert on every path; there is no
         carve-out for intentional marks like ESPN².
         """
+        # Observability hook (bd-eio04.9) — stamp the start time here so
+        # the decision log captures the full normalize() path including
+        # policy preprocessing + rule loading. The call to
+        # `record_normalization_decision` at the end is deliberately in
+        # a try/finally so the hook never alters the return value when
+        # an exception inside the engine would otherwise surface.
+        _norm_started_at = time.perf_counter()
         result = NormalizationResult(
             original=name,
             normalized=name,
@@ -1081,6 +1101,52 @@ class NormalizationEngine:
             logger.debug("[NORMALIZE] Normalization pass %s: '%s' -> '%s'", pass_num + 1, before_pass, current)
 
         result.normalized = current
+
+        # Observability hook (bd-eio04.9): record a structured decision
+        # for the metrics + sampled INFO log. Import is local so the
+        # module stays importable in environments where observability
+        # is not installed (tests that stub out logging, etc.). The
+        # hook is idempotent and exception-safe — a failure here must
+        # never change the normalize() return value.
+        try:
+            from observability import record_normalization_decision
+
+            elapsed = time.perf_counter() - _norm_started_at
+            policy = get_default_policy()
+            # Best-effort "coarse rule category" for the metric label:
+            # report the action_type of the first transformation when
+            # present, else None so the hook skips the rule_matches
+            # counter. Per-rule-id detail lives in the INFO log.
+            first_action: Optional[str] = None
+            if result.transformations:
+                first_rule_id = result.transformations[0][0]
+                # The rule_id may be the sentinel "legacy_tag" for
+                # settings-based tags; pass through.
+                if first_rule_id == "legacy_tag":
+                    first_action = "legacy_tag"
+                else:
+                    # Resolve rule_id -> action_type from the cached rules.
+                    for _, rules in grouped_rules:
+                        for rule in rules:
+                            if rule.id == first_rule_id:
+                                first_action = rule.action_type
+                                break
+                        if first_action is not None:
+                            break
+
+            record_normalization_decision(
+                input_text=name,
+                output_text=current,
+                matched_rule_ids=list(result.rules_applied),
+                applied=bool(result.rules_applied) or (name != current),
+                policy_version=_current_policy_version(policy),
+                duration_seconds=elapsed,
+                rule_category=first_action,
+                extra={"source": "normalize"},
+            )
+        except Exception:  # pragma: no cover — observability must not break the caller
+            logger.debug("[NORMALIZE] decision-log hook failed", exc_info=True)
+
         return result
 
     def _apply_rules_single_pass(
@@ -1429,6 +1495,32 @@ class NormalizationEngine:
             # Also strip/normalize whitespace for consistency with
             # normalize()'s per-pass cleanup.
             result["after"] = re.sub(r'\s+', ' ', preprocessed_text).strip()
+
+        # Observability hook (bd-eio04.9): emit a decision log for the
+        # Test Rules preview path too, tagged source=test_rule so
+        # SRE can compare the two paths in kibana/loki and catch a
+        # divergence without waiting for the nightly canary.
+        try:
+            from observability import record_normalization_decision
+
+            policy = get_default_policy()
+            applied = bool(match.matched) or result.get("else_applied", False)
+            matched_ids: list = []
+            # test_rule uses a synthetic rule with id=0; surface that
+            # so the log shows the preview path ran a concrete rule.
+            if applied:
+                matched_ids = [0]
+            record_normalization_decision(
+                input_text=text,
+                output_text=result["after"],
+                matched_rule_ids=matched_ids,
+                applied=applied,
+                policy_version=_current_policy_version(policy),
+                rule_category=action_type,
+                extra={"source": "test_rule"},
+            )
+        except Exception:  # pragma: no cover — observability must not break the caller
+            logger.debug("[NORMALIZE] decision-log hook failed in test_rule", exc_info=True)
 
         return result
 

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -34,11 +34,15 @@ The :func:`install_observability` function is the single entry point —
 from __future__ import annotations
 
 import contextvars
+import hashlib
+import itertools
 import json
 import logging
+import os
+import threading
 import time
 import uuid
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Iterable, Optional
 
 try:  # pragma: no cover — defensive for environments without prometheus-client
     from prometheus_client import (
@@ -244,6 +248,13 @@ _HEALTH_CHECK_BUCKETS = (
     0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 3.0,
 )
 
+# Normalization runs at microsecond-to-millisecond scale — well below the
+# floor of the HTTP buckets. A dedicated histogram shape captures the sub-ms
+# distribution that dominates this work's latency profile.
+_NORMALIZATION_LATENCY_BUCKETS = (
+    0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5,
+)
+
 
 def _build_metrics(registry: CollectorRegistry) -> Dict[str, Any]:
     """Instantiate the ECM metric set against ``registry``."""
@@ -274,6 +285,64 @@ def _build_metrics(registry: CollectorRegistry) -> Dict[str, Any]:
             "Duration of each readiness sub-check (database, dispatcharr, ffprobe).",
             ["check"],
             buckets=_HEALTH_CHECK_BUCKETS,
+            registry=registry,
+        ),
+        # ----------------------------------------------------------------
+        # Normalization observability (bd-eio04.9).
+        #
+        # ``rule_matches_total`` labels by ``rule_category`` — a bounded
+        # enum drawn from the NormalizationRule action_type namespace
+        # (``remove``, ``replace``, ``regex_replace``, ``strip_prefix``,
+        # ``strip_suffix``, ``normalize_prefix``, ``capitalize``,
+        # ``tag_group``, ``legacy_tag``, ``other``). Per-rule-id breakdown
+        # is NOT a metric label (cardinality bomb — there is no upper
+        # bound on user-created rules) — it goes in the sampled INFO log
+        # instead, per PO decision 6 (hybrid metric + log).
+        #
+        # ``auto_creation_channels_created_total`` labels by
+        # ``normalized`` ∈ {true, false, skipped} (three fixed values).
+        # "skipped" is emitted when no normalization groups were
+        # configured for the rule — important signal that distinguishes
+        # "ran and did nothing" from "never ran at all".
+        #
+        # ``canary_divergence_total`` has no labels. This is the SLI
+        # numerator for SLO-5 (Normalization Correctness) — any non-zero
+        # rate over the measurement window is an SLO breach.
+        # ----------------------------------------------------------------
+        "normalization_rule_matches_total": Counter(
+            "ecm_normalization_rule_matches_total",
+            "Count of normalization rule matches by rule category. "
+            "rule_category is a bounded enum mapped from NormalizationRule.action_type; "
+            "per-rule-id detail lives in the sampled INFO log.",
+            ["rule_category"],
+            registry=registry,
+        ),
+        "normalization_no_change_total": Counter(
+            "ecm_normalization_no_change_total",
+            "Count of normalize() invocations where the output matched the "
+            "input verbatim (ran but produced no change).",
+            registry=registry,
+        ),
+        "auto_creation_channels_created_total": Counter(
+            "ecm_auto_creation_channels_created_total",
+            "Count of auto-created channels, labeled by whether normalization "
+            "was applied. 'true' = ran and changed name. 'false' = ran and "
+            "produced no change. 'skipped' = no normalization groups configured.",
+            ["normalized"],
+            registry=registry,
+        ),
+        "normalization_duration_seconds": Histogram(
+            "ecm_normalization_duration_seconds",
+            "Duration of a single normalize() call, in seconds. Buckets cover "
+            "the sub-millisecond regime typical for this work.",
+            buckets=_NORMALIZATION_LATENCY_BUCKETS,
+            registry=registry,
+        ),
+        "normalization_canary_divergence_total": Counter(
+            "ecm_normalization_canary_divergence_total",
+            "Count of nightly canary divergences between Test Rules (test_rule / "
+            "test_rules_batch) and auto-creation executor output. "
+            "SLI numerator for SLO-5 — any non-zero rate over the window is a breach.",
             registry=registry,
         ),
     }
@@ -312,6 +381,310 @@ def reset_for_tests() -> None:
     global REGISTRY, _METRICS
     REGISTRY = None
     _METRICS = {}
+    reset_normalization_sampler_for_tests()
+
+
+# =========================================================================
+# Normalization decision log (bd-eio04.9)
+# =========================================================================
+# Structured INFO log for every (sampled) normalization decision. The
+# decision log supplements the metrics in `_build_metrics` — metrics
+# answer "how often" and "how fast", the log answers "which input, which
+# rules, what did it produce?". The two together give on-call a
+# 2-minute path from "SLO-5 burning" → "exactly which fixture diverged".
+#
+# Volume control:
+#   * Baseline stride sampler — default every 10th call (10%).
+#   * Always-sample when the decision is "we changed something": applied
+#     is True AND matched_rule_ids is non-empty. Bug-hunting only cares
+#     about decisions that acted; "ran and did nothing" traffic is what
+#     the stride sampler keeps bounded.
+#   * PO decision (grooming 2026-04-22): deterministic every-N stride,
+#     not random sampling, so the same traffic produces the same log
+#     content across replays (helps canary failure forensics).
+#
+# Truncation + hashing:
+#   * `input` and `output` fields are truncated to 256 chars (they can
+#     be arbitrarily long user content). Truncation marker: trailing
+#     "...[truncated]" sentinel.
+#   * `input_sha256` is ALWAYS included — the full hash of the raw input
+#     — so on-call can correlate across log lines when the truncation
+#     strips the distinguishing tail.
+
+NORMALIZATION_DECISION_LOGGER = "ecm.normalization.decision"
+_DECISION_FIELD_MAX_CHARS = 256
+_DECISION_TRUNCATION_SENTINEL = "...[truncated]"
+
+# Default stride: emit one INFO log per N calls. 10 = 10% baseline. This
+# default tracks the SRE dashboard budget noted in the bead — at peak
+# auto-creation traffic, a 10% baseline combined with "always on
+# applied=true" caps log volume at roughly one line per rule match plus
+# a sample of the no-op traffic.
+_DEFAULT_SAMPLE_STRIDE = 10
+
+# Bounded enum of rule categories used as the `rule_category` metric
+# label. Keys are NormalizationRule.action_type values seen in the
+# codebase (see backend/normalization_engine.py::_apply_action). Anything
+# outside this enum is mapped to "other" by `_normalize_rule_category`
+# so the label cardinality is bounded regardless of future rule types.
+_KNOWN_RULE_CATEGORIES = frozenset({
+    "remove",
+    "replace",
+    "regex_replace",
+    "strip_prefix",
+    "strip_suffix",
+    "normalize_prefix",
+    "capitalize",
+    "tag_group",
+    "legacy_tag",
+})
+
+
+def _normalize_rule_category(raw: Optional[str]) -> str:
+    """Map a raw rule action_type onto the bounded metric-label enum.
+
+    Unknown / empty values collapse to ``"other"`` so the Prometheus
+    label stays bounded regardless of what the caller passes.
+    """
+    if not raw:
+        return "other"
+    normalized = str(raw).strip().lower()
+    if normalized in _KNOWN_RULE_CATEGORIES:
+        return normalized
+    return "other"
+
+
+class _DeterministicSampler:
+    """Every-N stride sampler for structured decision logs.
+
+    Sampling rule (bd-eio04.9):
+        * If ``always_keep`` is True (caller knows this decision
+          actually changed the string) — always emit.
+        * Otherwise emit one out of every ``stride`` calls. Stride is
+          applied deterministically against a monotonically-increasing
+          counter, so replaying the same traffic twice produces the
+          same sampled subset.
+
+    Thread-safe: ``threading.Lock`` guards the counter because the
+    auto-creation executor runs on multiple workers. Locking a single
+    integer increment is ~200ns — negligible next to the normalization
+    work itself.
+    """
+
+    def __init__(self, stride: int = _DEFAULT_SAMPLE_STRIDE) -> None:
+        self._stride = max(1, int(stride))
+        self._counter = 0
+        self._lock = threading.Lock()
+
+    @property
+    def stride(self) -> int:
+        return self._stride
+
+    def set_stride(self, stride: int) -> None:
+        """Update the stride. Resets the counter to 0 so the next call is kept."""
+        with self._lock:
+            self._stride = max(1, int(stride))
+            self._counter = 0
+
+    def should_sample(self, always_keep: bool = False) -> bool:
+        """Return True when this call should be emitted as INFO."""
+        if always_keep:
+            # Advance the counter anyway so "always-keep" traffic does
+            # not desynchronize the stride sampler for the baseline
+            # path. Otherwise a burst of applied decisions would make
+            # the next no-op decision look like a "fresh" cycle start.
+            with self._lock:
+                self._counter += 1
+            return True
+        with self._lock:
+            self._counter += 1
+            # Emit when counter hits 1, stride+1, 2*stride+1, … so the
+            # very first call is always logged (helps smoke-testing
+            # that the hook is wired up).
+            return (self._counter - 1) % self._stride == 0
+
+
+def _read_stride_from_env() -> int:
+    """Read the sampler stride from ECM_NORMALIZATION_LOG_STRIDE.
+
+    Invalid / non-integer values fall back to the default stride. Zero
+    or negative values are clamped to 1 (emit every call) — useful for
+    debugging, never the default.
+    """
+    raw = os.environ.get("ECM_NORMALIZATION_LOG_STRIDE")
+    if not raw:
+        return _DEFAULT_SAMPLE_STRIDE
+    try:
+        value = int(raw.strip())
+    except (TypeError, ValueError):
+        return _DEFAULT_SAMPLE_STRIDE
+    return max(1, value)
+
+
+_normalization_sampler = _DeterministicSampler(stride=_read_stride_from_env())
+
+
+def get_normalization_sampler() -> _DeterministicSampler:
+    """Return the process-wide normalization decision log sampler."""
+    return _normalization_sampler
+
+
+def reset_normalization_sampler_for_tests(stride: Optional[int] = None) -> None:
+    """Reset the sampler to a clean state. ONLY for tests."""
+    global _normalization_sampler
+    _normalization_sampler = _DeterministicSampler(
+        stride=stride if stride is not None else _read_stride_from_env()
+    )
+
+
+def _truncate_for_log(value: str, max_chars: int = _DECISION_FIELD_MAX_CHARS) -> str:
+    """Truncate ``value`` to ``max_chars`` with a visible sentinel.
+
+    Returns the original string when ``len(value) <= max_chars``. Otherwise
+    trims to ``max_chars`` and appends ``...[truncated]`` so operators
+    reading the log know the value was clipped.
+    """
+    if value is None:
+        return ""
+    s = str(value)
+    if len(s) <= max_chars:
+        return s
+    return s[:max_chars] + _DECISION_TRUNCATION_SENTINEL
+
+
+def sha256_of(value: str) -> str:
+    """Return the hex SHA-256 of ``value`` encoded as UTF-8.
+
+    Exposed as a helper so the canary harness (see
+    ``scripts/normalization_canary.py``) can compute the same hash the
+    decision log records without duplicating the logic.
+    """
+    if value is None:
+        value = ""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def record_normalization_decision(
+    *,
+    input_text: str,
+    output_text: str,
+    matched_rule_ids: Iterable[Any],
+    applied: bool,
+    policy_version: str,
+    duration_seconds: Optional[float] = None,
+    rule_category: Optional[str] = None,
+    extra: Optional[Dict[str, Any]] = None,
+    logger_name: str = NORMALIZATION_DECISION_LOGGER,
+) -> bool:
+    """Emit a sampled INFO-level decision log line.
+
+    Always updates the metrics (no-change counter, duration histogram)
+    regardless of whether the log line is emitted — metrics are cheap,
+    the sampler only decides whether to write the log. This is the
+    entry point used by ``normalization_engine.NormalizationEngine``
+    and by the canary harness so the two paths feed the same
+    observability sinks with byte-identical structure.
+
+    Parameters
+    ----------
+    input_text:
+        The raw input to normalize. Truncated to 256 chars in the log;
+        hashed fully into ``input_sha256``.
+    output_text:
+        The normalized output. Truncated to 256 chars.
+    matched_rule_ids:
+        Iterable of rule identifiers that matched. Coerced to a list of
+        ints or strings — whatever the caller already has.
+    applied:
+        True when the output changed relative to the input OR a rule
+        matched. The sampler always keeps decisions where
+        ``applied and matched_rule_ids`` — those are the bug-hunting
+        signal. No-op traffic is throttled to the stride.
+    policy_version:
+        Identifier of the NormalizationPolicy build — e.g.
+        ``"unified-v1"`` vs. ``"legacy"``. Flows into the log so SRE
+        can correlate divergence with the policy flag.
+    duration_seconds:
+        Wall time of the normalize() call. When provided, observed
+        into the duration histogram. Ignored when ``None`` (the caller
+        didn't measure).
+    rule_category:
+        Optional coarse rule category for the metric label. Passed
+        through ``_normalize_rule_category`` so unknown values map to
+        ``"other"``.
+    extra:
+        Optional dict of additional structured fields for the log
+        payload (e.g. ``{"source": "auto_create", "channel_id": 42}``).
+
+    Returns
+    -------
+    bool
+        True when the log line was actually emitted (i.e. the sampler
+        kept this call). Callers generally don't need the return value;
+        it's exposed for testing.
+    """
+    # Metrics are updated unconditionally — they're cheap and the
+    # sampler only applies to logs.
+    try:
+        if duration_seconds is not None:
+            get_metric("normalization_duration_seconds").observe(
+                max(0.0, float(duration_seconds))
+            )
+        if not applied and not list(matched_rule_ids):
+            # "Ran but did nothing" — counted separately so dashboards
+            # can show the ratio of no-op normalize() calls.
+            get_metric("normalization_no_change_total").inc()
+        if rule_category:
+            get_metric("normalization_rule_matches_total").labels(
+                rule_category=_normalize_rule_category(rule_category)
+            ).inc()
+    except Exception:  # pragma: no cover — metrics must never break the pipeline
+        # Observability must never take down the code path it's
+        # instrumenting. Log at DEBUG so the failure is visible in
+        # dev but never fatal.
+        logging.getLogger(__name__).debug(
+            "[NORMALIZE] metric update failed for decision log", exc_info=True
+        )
+
+    rule_ids_list = list(matched_rule_ids or [])
+    always_keep = bool(applied and rule_ids_list)
+    sampler = get_normalization_sampler()
+    if not sampler.should_sample(always_keep=always_keep):
+        return False
+
+    payload: Dict[str, Any] = {
+        "input": _truncate_for_log(input_text),
+        "output": _truncate_for_log(output_text),
+        "matched_rule_ids": rule_ids_list,
+        "applied": bool(applied),
+        "policy_version": policy_version,
+        "input_sha256": sha256_of(input_text),
+    }
+    if rule_category:
+        payload["rule_category"] = _normalize_rule_category(rule_category)
+    if duration_seconds is not None:
+        # Round to microseconds so the log stays compact; the histogram
+        # keeps the raw distribution.
+        payload["duration_seconds"] = round(float(duration_seconds), 6)
+    if extra:
+        for key, value in extra.items():
+            # Don't let callers clobber reserved field names.
+            if key not in payload:
+                payload[key] = value
+
+    # Use lazy %-formatting per the backend logging convention. Passing
+    # the structured dict through `extra` surfaces it as individual
+    # attributes on the LogRecord — the JsonFormatter flattens those
+    # into the top-level JSON body automatically.
+    logger = logging.getLogger(logger_name)
+    logger.info(
+        "[NORMALIZE] decision applied=%s rules=%s sha=%s",
+        payload["applied"],
+        rule_ids_list,
+        payload["input_sha256"][:12],
+        extra=payload,
+    )
+    return True
 
 
 # =========================================================================

--- a/backend/scripts/normalization_canary.py
+++ b/backend/scripts/normalization_canary.py
@@ -1,0 +1,302 @@
+"""
+Nightly normalization canary harness (bd-eio04.9).
+
+Runs every fixture in ``backend/tests/fixtures/unicode_fixtures.py``
+through BOTH normalization code paths and asserts byte-identical output.
+Exits with status 1 on any divergence so the scheduling workflow
+(`.github/workflows/normalization-canary.yml`) goes red.
+
+Paths under test
+----------------
+
+Path 1 — HTTP preview (Test Rules):
+    ``POST /api/normalization/test-batch`` via FastAPI TestClient. This
+    proves the full request boundary — URL routing, JSON encoding
+    (especially for Unicode), middleware, offload-to-thread-pool — does
+    not mutate input or output on the way through.
+
+Path 2 — direct executor call:
+    ``NormalizationEngine.normalize(input)`` invoked in-process, mirroring
+    exactly what ``auto_creation_executor.ActionExecutor`` does when
+    creating channels.
+
+Both paths share the same ``NormalizationPolicy`` by construction
+(bd-eio04.1). Any observable divergence in this canary means that
+contract broke.
+
+What counts as divergence
+-------------------------
+
+1. ``normalized`` output byte-mismatch.
+2. ``rules_applied`` / ``transformations`` rule-id list mismatch.
+
+Any single fixture failing either check aborts the run with a non-zero
+exit code and prints a compact report to stdout. The workflow then:
+  * increments ``ecm_normalization_canary_divergence_total`` (SLI source).
+  * fires a Slack alert if the webhook secret is set.
+  * falls back to opening a GH issue so there's always a durable
+    record of the breach.
+
+Running locally
+---------------
+
+    cd backend
+    python -m scripts.normalization_canary
+
+The harness is deterministic — the same fixture bank with the same
+``NormalizationPolicy`` yields the same outcome on every run. There is
+no randomness, no network, no real database. It uses the in-memory
+SQLite fixture stack the rest of the test suite relies on.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+# Make backend/ importable whether the harness is invoked as
+# ``python -m scripts.normalization_canary`` or directly.
+_THIS_DIR = Path(__file__).resolve().parent
+_BACKEND_DIR = _THIS_DIR.parent
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+# Ensure the test config dir exists before any backend module reads it.
+os.environ.setdefault("CONFIG_DIR", "/tmp/ecm_canary_config")
+os.environ.setdefault("RATE_LIMIT_ENABLED", "0")
+Path(os.environ["CONFIG_DIR"]).mkdir(parents=True, exist_ok=True)
+
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import database  # noqa: E402
+import models  # noqa: E402  — registers tables
+from normalization_engine import (  # noqa: E402
+    NormalizationEngine,
+    get_default_policy,
+)
+from tests.fixtures.unicode_fixtures import ALL_FIXTURES, NormalizationFixture  # noqa: E402
+
+
+@dataclass
+class CanaryDivergence:
+    """One recorded mismatch between Test Rules and Auto-Create."""
+    fixture_name: str
+    input: str
+    http_output: str
+    executor_output: str
+    http_rules: list
+    executor_rules: list
+    reason: str
+
+
+def _build_in_memory_engine() -> tuple[Any, NormalizationEngine]:
+    """Return a session + engine bound to a fresh in-memory SQLite DB.
+
+    The canary does NOT seed any user rules — policy-level preprocessing
+    (NFC, Cf-stripping, superscript conversion) runs unconditionally via
+    NormalizationPolicy and is what we're actually validating. If per-rule
+    divergence becomes a concern, a follow-up bead should extend this
+    harness with a seeded rule pack.
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+    database.Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(
+        autocommit=False, autoflush=False, bind=engine, expire_on_commit=False
+    )
+    session = SessionLocal()
+    return session, NormalizationEngine(session)
+
+
+def _run_executor_path(engine: NormalizationEngine, fixture: NormalizationFixture) -> dict:
+    """Path 2 — direct ``engine.normalize(input)`` call."""
+    result = engine.normalize(fixture.input)
+    return {
+        "normalized": result.normalized,
+        "rules_applied": list(result.rules_applied),
+    }
+
+
+def _run_http_path(client, fixture: NormalizationFixture) -> dict:
+    """Path 1 — ``POST /api/normalization/test-batch`` via TestClient.
+
+    The endpoint returns ``{"results": [{"original", "normalized",
+    "rules_applied", "transformations"}]}`` so we flatten the first
+    result to the same shape as the executor path.
+    """
+    response = client.post(
+        "/api/normalization/test-batch",
+        json={"texts": [fixture.input]},
+    )
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"test-batch HTTP {response.status_code}: {response.text[:200]}"
+        )
+    body = response.json()
+    results = body.get("results") or []
+    if not results:
+        raise RuntimeError("test-batch returned empty results array")
+    first = results[0]
+    return {
+        "normalized": first.get("normalized", ""),
+        "rules_applied": [
+            t.get("rule_id")
+            for t in (first.get("transformations") or [])
+            if t.get("rule_id") is not None
+        ],
+    }
+
+
+def _compare_outputs(
+    fixture: NormalizationFixture,
+    http_out: dict,
+    executor_out: dict,
+) -> Optional[CanaryDivergence]:
+    """Return a CanaryDivergence if the two paths disagree, else None."""
+    http_norm = http_out["normalized"]
+    exec_norm = executor_out["normalized"]
+    http_rules = http_out["rules_applied"]
+    exec_rules = executor_out["rules_applied"]
+
+    if http_norm != exec_norm:
+        return CanaryDivergence(
+            fixture_name=fixture.name,
+            input=fixture.input,
+            http_output=http_norm,
+            executor_output=exec_norm,
+            http_rules=http_rules,
+            executor_rules=exec_rules,
+            reason="normalized output byte-mismatch",
+        )
+    if http_rules != exec_rules:
+        return CanaryDivergence(
+            fixture_name=fixture.name,
+            input=fixture.input,
+            http_output=http_norm,
+            executor_output=exec_norm,
+            http_rules=http_rules,
+            executor_rules=exec_rules,
+            reason="matched_rule_ids mismatch",
+        )
+    return None
+
+
+def run_canary(verbose: bool = True) -> list[CanaryDivergence]:
+    """Execute the canary sweep. Returns the list of divergences (empty on pass)."""
+    # Late-import TestClient / main so a missing FastAPI install fails
+    # loudly in the harness rather than at module import time.
+    from fastapi.testclient import TestClient
+
+    import main as main_module
+
+    session, engine_instance = _build_in_memory_engine()
+    # Bind the in-memory session to the FastAPI dependency injector so
+    # test-batch uses the same DB the executor path uses. ``main.app``
+    # plus ``database.get_session`` override is the standard harness
+    # pattern in this codebase.
+    from database import get_session as real_get_session  # noqa: F401
+
+    def _override_get_session():
+        return session
+
+    main_module.app.dependency_overrides[
+        database.get_session
+    ] = _override_get_session
+
+    divergences: list[CanaryDivergence] = []
+    try:
+        with TestClient(main_module.app) as client:
+            policy = get_default_policy()
+            if verbose:
+                print(
+                    f"[canary] fixtures={len(ALL_FIXTURES)} policy_version="
+                    f"{'unified-v1' if policy.unified_enabled else 'legacy'}"
+                )
+            for fixture in ALL_FIXTURES:
+                try:
+                    http_out = _run_http_path(client, fixture)
+                    executor_out = _run_executor_path(engine_instance, fixture)
+                except Exception as exc:
+                    divergences.append(
+                        CanaryDivergence(
+                            fixture_name=fixture.name,
+                            input=fixture.input,
+                            http_output="<exception>",
+                            executor_output="<exception>",
+                            http_rules=[],
+                            executor_rules=[],
+                            reason=f"harness error: {exc}",
+                        )
+                    )
+                    continue
+                mismatch = _compare_outputs(fixture, http_out, executor_out)
+                if mismatch is not None:
+                    divergences.append(mismatch)
+                    if verbose:
+                        print(f"[canary] DIVERGE {fixture.name}: {mismatch.reason}")
+                elif verbose:
+                    print(f"[canary] ok      {fixture.name}")
+    finally:
+        main_module.app.dependency_overrides.pop(database.get_session, None)
+        session.close()
+
+    return divergences
+
+
+def emit_metric_on_divergence(count: int) -> None:
+    """Increment ``ecm_normalization_canary_divergence_total`` once per failed run.
+
+    The counter represents **runs that failed**, not **individual fixtures
+    that diverged**, so any non-zero divergence list counts as exactly
+    one breach per the SLO-5 error budget policy.
+    """
+    if count <= 0:
+        return
+    try:
+        from observability import get_metric, install_metrics
+
+        install_metrics()
+        get_metric("normalization_canary_divergence_total").inc()
+    except Exception as exc:  # pragma: no cover
+        print(f"[canary] metric emission failed: {exc}", file=sys.stderr)
+
+
+def main() -> int:
+    divergences = run_canary(verbose=True)
+    if not divergences:
+        print(f"[canary] PASS — all {len(ALL_FIXTURES)} fixtures match across paths.")
+        return 0
+
+    emit_metric_on_divergence(len(divergences))
+    print(f"[canary] FAIL — {len(divergences)} divergence(s) detected:")
+    report = {
+        "fixture_count": len(ALL_FIXTURES),
+        "divergence_count": len(divergences),
+        "divergences": [
+            {
+                "fixture": d.fixture_name,
+                "input": d.input,
+                "http_output": d.http_output,
+                "executor_output": d.executor_output,
+                "http_rules": d.http_rules,
+                "executor_rules": d.executor_rules,
+                "reason": d.reason,
+            }
+            for d in divergences
+        ],
+    }
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/unit/test_normalization_observability.py
+++ b/backend/tests/unit/test_normalization_observability.py
@@ -1,0 +1,333 @@
+"""
+Unit tests for normalization observability (bd-eio04.9).
+
+Exercises the metrics + decision-log helpers added to
+``backend/observability.py`` and the canary harness hooks at
+``backend/scripts/normalization_canary.py``. Scope:
+
+- Metric registration — the 5 new ``ecm_normalization_*`` and
+  ``ecm_auto_creation_channels_created_total`` series exist on the
+  registry with the right label sets / bucket shapes.
+- Sampler determinism — every-N stride produces a predictable keep/drop
+  pattern; ``applied=true AND matched_rule_ids != []`` always samples.
+- Decision-log payload shape — `input` / `output` truncation, the
+  `input_sha256` correlation field, the rule-category enum bounding.
+- Rule-category normalization — unknown `action_type` values collapse
+  to ``"other"`` so the Prometheus label stays bounded.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+
+import pytest
+
+import observability
+
+
+@pytest.fixture(autouse=True)
+def _reset_observability():
+    observability.reset_for_tests()
+    yield
+    observability.reset_for_tests()
+
+
+class TestNormalizationMetricsRegistered:
+    """The new Prometheus series exist with the documented label sets."""
+
+    def test_rule_matches_counter_is_labeled_by_rule_category(self):
+        metrics = observability.install_metrics()
+        counter = metrics["normalization_rule_matches_total"]
+        # Label set check — prometheus_client exposes ``_labelnames``
+        # on the parent counter.
+        assert counter._labelnames == ("rule_category",)
+
+    def test_no_change_counter_has_no_labels(self):
+        metrics = observability.install_metrics()
+        counter = metrics["normalization_no_change_total"]
+        assert counter._labelnames == ()
+
+    def test_auto_creation_counter_labeled_by_normalized(self):
+        metrics = observability.install_metrics()
+        counter = metrics["auto_creation_channels_created_total"]
+        assert counter._labelnames == ("normalized",)
+
+    def test_normalization_duration_histogram_uses_sub_ms_buckets(self):
+        metrics = observability.install_metrics()
+        hist = metrics["normalization_duration_seconds"]
+        # Buckets include the required microsecond-scale floor so the
+        # histogram is useful for work in the 100µs–10ms regime.
+        assert 0.0001 in hist._upper_bounds
+        assert 0.5 in hist._upper_bounds
+        # The HTTP histogram's 5ms floor is too coarse — verify we
+        # didn't accidentally reuse the wrong bucket set.
+        assert 0.005 in hist._upper_bounds
+
+    def test_canary_divergence_counter_has_no_labels(self):
+        metrics = observability.install_metrics()
+        counter = metrics["normalization_canary_divergence_total"]
+        assert counter._labelnames == ()
+
+    def test_prometheus_text_exposes_new_series(self):
+        observability.install_metrics()
+        # Increment each new series once so the exposition carries
+        # a sample line (prometheus-client omits zero-unique counters
+        # by default for labeled series).
+        observability.get_metric("normalization_rule_matches_total").labels(
+            rule_category="replace"
+        ).inc()
+        observability.get_metric("normalization_no_change_total").inc()
+        observability.get_metric("auto_creation_channels_created_total").labels(
+            normalized="true"
+        ).inc()
+        observability.get_metric("normalization_duration_seconds").observe(0.001)
+        observability.get_metric("normalization_canary_divergence_total").inc()
+
+        body = observability.render_metrics().decode("utf-8")
+        assert "ecm_normalization_rule_matches_total" in body
+        assert "ecm_normalization_no_change_total" in body
+        assert "ecm_auto_creation_channels_created_total" in body
+        assert "ecm_normalization_duration_seconds" in body
+        assert "ecm_normalization_canary_divergence_total" in body
+
+
+class TestRuleCategoryBounding:
+    def test_known_action_types_pass_through(self):
+        for raw in (
+            "remove",
+            "replace",
+            "regex_replace",
+            "strip_prefix",
+            "strip_suffix",
+            "normalize_prefix",
+            "capitalize",
+            "tag_group",
+            "legacy_tag",
+        ):
+            assert observability._normalize_rule_category(raw) == raw
+
+    def test_unknown_action_type_collapses_to_other(self):
+        # Future rule types or typos must not expand the label set.
+        assert observability._normalize_rule_category("sanitize") == "other"
+        assert observability._normalize_rule_category("") == "other"
+        assert observability._normalize_rule_category(None) == "other"
+
+    def test_case_insensitive_match(self):
+        # `action_type` is stored lower-case in the DB but be defensive.
+        assert observability._normalize_rule_category("Replace") == "replace"
+        assert observability._normalize_rule_category("REMOVE") == "remove"
+
+
+class TestDeterministicSampler:
+    def test_first_call_is_always_sampled(self):
+        sampler = observability._DeterministicSampler(stride=10)
+        assert sampler.should_sample() is True
+
+    def test_stride_of_10_keeps_every_tenth_call(self):
+        sampler = observability._DeterministicSampler(stride=10)
+        kept = [sampler.should_sample() for _ in range(30)]
+        # Expected pattern: True at counter 1, 11, 21 → indices 0, 10, 20.
+        keep_indices = [i for i, k in enumerate(kept) if k]
+        assert keep_indices == [0, 10, 20]
+
+    def test_always_keep_bypasses_stride(self):
+        sampler = observability._DeterministicSampler(stride=1000)
+        # With a huge stride, baseline calls would almost never sample;
+        # always_keep must override.
+        kept = [sampler.should_sample(always_keep=True) for _ in range(5)]
+        assert kept == [True, True, True, True, True]
+
+    def test_always_keep_advances_counter_so_baseline_stride_stays_aligned(self):
+        # Contract: always_keep calls do not desynchronize the stride.
+        # After 3 always-keep calls with stride=5, the next baseline call
+        # is no longer guaranteed to be a "first" call.
+        sampler = observability._DeterministicSampler(stride=5)
+        for _ in range(3):
+            sampler.should_sample(always_keep=True)
+        # Counter = 3; baseline call increments to 4 → (4-1) % 5 != 0 → drop.
+        assert sampler.should_sample() is False
+
+    def test_set_stride_resets_counter(self):
+        sampler = observability._DeterministicSampler(stride=10)
+        for _ in range(7):
+            sampler.should_sample()
+        sampler.set_stride(5)
+        # Counter reset → first call is always a keep.
+        assert sampler.should_sample() is True
+
+
+class TestTruncationAndHashing:
+    def test_short_string_is_not_truncated(self):
+        assert observability._truncate_for_log("hello") == "hello"
+
+    def test_long_string_is_truncated_with_sentinel(self):
+        raw = "A" * 300
+        out = observability._truncate_for_log(raw)
+        assert out.endswith("...[truncated]")
+        assert out.startswith("A" * 256)
+        assert len(out) == 256 + len("...[truncated]")
+
+    def test_truncation_respects_custom_limit(self):
+        raw = "B" * 50
+        out = observability._truncate_for_log(raw, max_chars=10)
+        assert out == "BBBBBBBBBB...[truncated]"
+
+    def test_none_is_coerced_to_empty_string(self):
+        assert observability._truncate_for_log(None) == ""  # type: ignore[arg-type]
+
+    def test_sha256_matches_stdlib(self):
+        raw = "US: ESPN ᴴᴰ ⁶⁰fps"
+        expected = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        assert observability.sha256_of(raw) == expected
+
+    def test_sha256_handles_none(self):
+        assert observability.sha256_of(None) == hashlib.sha256(b"").hexdigest()  # type: ignore[arg-type]
+
+
+class TestRecordNormalizationDecision:
+    """Full-path test of the sampled INFO log + metric updates."""
+
+    def _capture_decision_logs(self):
+        """Return (list_to_capture, cleanup_fn). Logs under the normalization
+        decision logger bypass propagation by default; attach a capturing
+        handler so the tests can inspect the payload."""
+        captured: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                captured.append(record)
+
+        handler = _Capture(level=logging.INFO)
+        handler.addFilter(observability._TraceIdFilter())
+        logger = logging.getLogger(observability.NORMALIZATION_DECISION_LOGGER)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        def cleanup():
+            logger.removeHandler(handler)
+
+        return captured, cleanup
+
+    def test_always_sample_when_applied_and_rule_matched(self):
+        # Even with a gigantic stride, a decision that actually changed
+        # the string must still produce a log line.
+        observability.reset_normalization_sampler_for_tests(stride=1000)
+        captured, cleanup = self._capture_decision_logs()
+        try:
+            emitted = observability.record_normalization_decision(
+                input_text="hello ᴴᴰ",
+                output_text="hello HD",
+                matched_rule_ids=[42],
+                applied=True,
+                policy_version="unified-v1",
+                duration_seconds=0.00123,
+                rule_category="replace",
+                extra={"source": "normalize"},
+            )
+        finally:
+            cleanup()
+        assert emitted is True
+        assert len(captured) == 1
+        rec = captured[0]
+        # JSON formatter flattens ``extra`` onto the record — we can read
+        # the fields off directly via attribute access.
+        assert rec.applied is True
+        assert rec.matched_rule_ids == [42]
+        assert rec.policy_version == "unified-v1"
+        # Correlation hash is full (64 hex chars), not truncated.
+        assert len(rec.input_sha256) == 64
+        # Rule category is the bounded enum value.
+        assert rec.rule_category == "replace"
+        # Source tag from `extra` passes through.
+        assert rec.source == "normalize"
+
+    def test_stride_drops_baseline_no_op_traffic(self):
+        observability.reset_normalization_sampler_for_tests(stride=100)
+        captured, cleanup = self._capture_decision_logs()
+        try:
+            # 10 no-op decisions with stride=100 → only the first one keeps.
+            emitted_flags = [
+                observability.record_normalization_decision(
+                    input_text="nothing to see",
+                    output_text="nothing to see",
+                    matched_rule_ids=[],
+                    applied=False,
+                    policy_version="unified-v1",
+                )
+                for _ in range(10)
+            ]
+        finally:
+            cleanup()
+        # First call always kept, next 9 dropped.
+        assert emitted_flags == [True] + [False] * 9
+        assert len(captured) == 1
+
+    def test_no_change_counter_increments_for_noop_decisions(self):
+        observability.reset_normalization_sampler_for_tests(stride=1)
+        observability.install_metrics()
+        counter = observability.get_metric("normalization_no_change_total")
+        baseline = counter._value.get()
+        observability.record_normalization_decision(
+            input_text="same",
+            output_text="same",
+            matched_rule_ids=[],
+            applied=False,
+            policy_version="unified-v1",
+        )
+        assert counter._value.get() == baseline + 1
+
+    def test_rule_matches_counter_labeled_when_category_given(self):
+        observability.reset_normalization_sampler_for_tests(stride=1)
+        observability.install_metrics()
+        counter = observability.get_metric("normalization_rule_matches_total")
+        # Record with a known category and confirm the labeled child ticks.
+        observability.record_normalization_decision(
+            input_text="x",
+            output_text="y",
+            matched_rule_ids=[1],
+            applied=True,
+            policy_version="unified-v1",
+            rule_category="replace",
+        )
+        child = counter.labels(rule_category="replace")
+        assert child._value.get() == 1.0
+
+    def test_input_field_is_truncated_to_256_chars_in_payload(self):
+        observability.reset_normalization_sampler_for_tests(stride=1)
+        captured, cleanup = self._capture_decision_logs()
+        huge = "X" * 400
+        try:
+            observability.record_normalization_decision(
+                input_text=huge,
+                output_text=huge,
+                matched_rule_ids=[],
+                applied=False,
+                policy_version="unified-v1",
+            )
+        finally:
+            cleanup()
+        rec = captured[0]
+        # Truncated input field, but full-length SHA stays.
+        assert rec.input.endswith("...[truncated]")
+        assert rec.input.startswith("X" * 256)
+        full_hash = hashlib.sha256(huge.encode("utf-8")).hexdigest()
+        assert rec.input_sha256 == full_hash
+
+
+class TestSamplerEnvStride:
+    def test_env_stride_override(self, monkeypatch):
+        monkeypatch.setenv("ECM_NORMALIZATION_LOG_STRIDE", "50")
+        stride = observability._read_stride_from_env()
+        assert stride == 50
+
+    def test_invalid_env_stride_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("ECM_NORMALIZATION_LOG_STRIDE", "not-a-number")
+        stride = observability._read_stride_from_env()
+        assert stride == observability._DEFAULT_SAMPLE_STRIDE
+
+    def test_zero_or_negative_stride_clamps_to_one(self, monkeypatch):
+        monkeypatch.setenv("ECM_NORMALIZATION_LOG_STRIDE", "0")
+        assert observability._read_stride_from_env() == 1
+        monkeypatch.setenv("ECM_NORMALIZATION_LOG_STRIDE", "-5")
+        assert observability._read_stride_from_env() == 1

--- a/docs/runbooks/normalization-canary-divergence.md
+++ b/docs/runbooks/normalization-canary-divergence.md
@@ -1,0 +1,173 @@
+# Runbook: Normalization Canary Divergence
+
+> The nightly canary detected that the Test Rules preview path and the auto-creation executor path produce different output for at least one fixture. This is an **SLO-5 (Normalization Correctness) breach** — zero error budget.
+
+- **Severity**: P2
+- **Owner**: Project Engineer (primary) + SRE (support)
+- **Last reviewed**: 2026-04-22 (bd-eio04.9)
+- **Related beads**: `enhancedchannelmanager-eio04` (epic), `enhancedchannelmanager-eio04.9` (this instrumentation)
+- **SLO**: [`docs/sre/slos.md` § SLO-5 Normalization Correctness](../sre/slos.md)
+
+## Alert / Trigger
+
+The canary fires exactly one of the following:
+
+- **Slack alert** (`#ops` or whichever channel the `SLACK_WEBHOOK_URL` secret routes to): title `Normalization canary DIVERGED`.
+- **GitHub issue** (durable fallback — always created regardless of Slack): label `regression,normalization`, title `[CANARY] normalization divergence YYYY-MM-DD`.
+- **Workflow** (drives both): `.github/workflows/normalization-canary.yml`, job `canary`.
+
+Manual trigger — if you suspect divergence outside the nightly window:
+
+```bash
+gh workflow run normalization-canary.yml
+```
+
+Or run the harness locally from this repo's `backend/` directory:
+
+```bash
+cd backend
+python -m scripts.normalization_canary
+```
+
+## Symptoms
+
+- The `canary` job on the `Normalization Canary` workflow is red.
+- The workflow log ends with `[canary] FAIL — N divergence(s) detected:` followed by a JSON report listing each fixture name, both outputs, and the mismatch reason.
+- `ecm_normalization_canary_divergence_total` has incremented by 1 for this run (visible on the Normalization dashboard once metrics are scraped from the CI-adjacent Prometheus).
+- Users may or may not have reported impact yet — the canary is deliberately a **leading** indicator. Do not wait for a user report to act.
+
+If the canary job is red but the JSON report is absent / truncated, the harness itself crashed. Treat that as a runbook execution failure — skip to **Escalation**.
+
+## Diagnosis
+
+Work the JSON report top-down. Each `divergences[].reason` is one of two classes — they require different diagnostic moves.
+
+1. **Read the JSON report from the workflow run.**
+   - Pull the `normalization-canary-log` artifact from the failed run, or scroll to the `Run canary harness` step for the inline output.
+   - For each entry in `divergences[]`, note the `fixture`, `input`, `http_output`, `executor_output`, and `reason`.
+
+2. **Branch on `reason`:**
+
+   - If `reason == "normalized output byte-mismatch"` → one path mutated characters the other didn't. Most likely cause: a preprocessing step was added to one path (or dropped from one path) without the mirror change. **Go to step 3.**
+   - If `reason == "matched_rule_ids mismatch"` → both produced the same string but via different rule sequences. Most likely cause: a rule ordering / short-circuit change in one path only. **Go to step 4.**
+   - If `reason` starts with `"harness error"` → the canary itself is broken, not the code under test. **Go to step 6.**
+
+3. **Diagnose an output byte-mismatch:**
+
+   ```bash
+   git log --oneline -20 backend/normalization_engine.py backend/observability.py backend/routers/normalization.py backend/auto_creation_executor.py
+   ```
+
+   - Anything touched since the last green canary is a candidate.
+   - Re-run the failing fixture in isolation:
+
+     ```python
+     from normalization_engine import NormalizationEngine, get_default_policy
+     # ... construct engine against a fresh in-memory session ...
+     engine.normalize(INPUT)   # executor path
+     engine.test_rule(INPUT, ...)  # Test Rules path
+     ```
+
+   - Compare `engine.normalize()` output vs. the `test-batch` HTTP response byte-for-byte. If they already diverge without HTTP in the middle, the issue is in the engine. If they match in-process but HTTP differs, the issue is in JSON encoding / middleware.
+
+4. **Diagnose a `matched_rule_ids` mismatch:**
+
+   - Same git-log move as step 3.
+   - The two paths must share one `NormalizationPolicy` instance; confirm that by checking `ECM_NORMALIZATION_UNIFIED_POLICY` is not set to `false` in the failing environment.
+   - Inspect each path's `result.transformations`. A path-specific `stop_processing` shortcut or a new rule filter is the usual culprit.
+
+5. **Check the recent commit set.**
+
+   Look for one of these red-flag patterns:
+
+   - `normalize` touched without a matching change to `test_rule` / `test_rules_batch`, or vice versa.
+   - A new Unicode codepoint added to `_STRIPPED_CF_CODEPOINTS` on one path only.
+   - A change to `_match_single_condition` that bypassed `get_default_policy().apply_to_text(...)`.
+   - A new condition / action type that only one path understands.
+
+6. **Harness error path** (rare): check the `Install dependencies` and `Prepare test config directory` steps. A missing dep or permission error at those steps produces a misleading `harness error` in the JSON report. Fix those, re-run the workflow.
+
+**Escalate** if:
+
+- You've been in diagnosis for more than 60 minutes without finding the diverging commit.
+- The diverging change is in a dependency (FastAPI, Pydantic, uvicorn) rather than our code.
+- You cannot reproduce the divergence locally — the CI environment is producing different results than `python -m scripts.normalization_canary` on your machine.
+
+## Resolution
+
+**Mitigation is not "silence the canary" — it is "close the divergence."** If you cannot close it in one commit, revert the offending change.
+
+Pick the smallest move that makes the canary green, in this order:
+
+1. **Revert the offending commit.**
+
+   ```bash
+   git log --oneline backend/normalization_engine.py | head -5
+   git revert <offending-sha>
+   ```
+
+   - Safe default when the diverging commit is recent and the feature it introduced is deferrable.
+   - Open a follow-up bead to re-land the feature behind the unified policy contract.
+
+2. **Land a corrective fix in both paths.**
+
+   - Patch `normalization_engine.py` so `test_rule` / `test_rules_batch` and `normalize` apply the same preprocessing and rule sequencing.
+   - The parity tests in `backend/tests/unit/test_normalization_parity.py` must pass before merging — they are the same contract the canary enforces.
+
+3. **Add the failing input to the fixture bank.**
+
+   Regardless of which resolution you chose:
+
+   ```python
+   # backend/tests/fixtures/unicode_fixtures.py
+   NormalizationFixture(
+       name="case_canary_YYYY_MM_DD_<slug>",
+       input=<failing_input>,
+       expected_normalized=<correct_output>,
+       origin="canary-YYYY-MM-DD",
+       category=<pick_from_taxonomy>,
+       notes="Added after canary divergence on YYYY-MM-DD. See GH issue #<n>.",
+   )
+   ```
+
+   This is mandatory — without it, the exact same regression can slip back in.
+
+4. **Verify the canary turns green.**
+
+   ```bash
+   cd backend
+   python -m scripts.normalization_canary
+   # Expected: "[canary] PASS — all N fixtures match across paths."
+   ```
+
+5. **Close the GH issue.**
+
+   Cross-reference the fixing PR in the issue body before closing.
+
+If any step fails, **stop** and escalate — do not merge half-fixes. A canary that's green because the failing fixture was removed is worse than a red canary.
+
+## Escalation
+
+If resolution is not complete within **4 hours** of the initial alert:
+
+- Escalate to SRE + the engineer who last touched `backend/normalization_engine.py` per `git log`.
+- Post to the `#ops` channel (or equivalent) with: incident start time, divergence count, fixture names, commits under suspicion, diagnosis steps already run.
+- If release cuts are in-flight, notify the PM — SLO-5 policy blocks the next cut until the canary is green.
+
+## Post-incident
+
+- [ ] Cross-reference the fixing PR in the canary GH issue; close the issue once the next canary run is green.
+- [ ] Add the failing input to `unicode_fixtures.py` with `origin=canary-YYYY-MM-DD` (mandatory — see Resolution step 3).
+- [ ] If the root cause was a class of bug the canary cannot catch (e.g., a divergence that only appears under load), file a bead for a fuzz / load variant.
+- [ ] If this is the second SLO-5 breach within 30 days, schedule a blameless postmortem (`/postmortem` skill) per the SLO-5 error-budget policy.
+- [ ] If the runbook was unclear or missing a step, edit this file and reference the incident in the update commit.
+
+## References
+
+- SLO definition: [`docs/sre/slos.md` § SLO-5 Normalization Correctness](../sre/slos.md)
+- Canary harness source: `backend/scripts/normalization_canary.py`
+- Canary workflow: `.github/workflows/normalization-canary.yml`
+- Parity tests (same contract, different cadence): `backend/tests/unit/test_normalization_parity.py`
+- Unified-policy implementation: `backend/normalization_engine.py` (`NormalizationPolicy`)
+- Observability wiring (metrics + decision log): `backend/observability.py` (`record_normalization_decision`, `NORMALIZATION_DECISION_LOGGER`)
+- Epic: bd-eio04 (Normalization parity) — wave 1 closed GH #104, wave 2 added the observability layer this runbook protects.

--- a/docs/sre/slos.md
+++ b/docs/sre/slos.md
@@ -128,6 +128,62 @@ A follow-up bead should split this SLO by `path` label once we've observed which
 
 ---
 
+## SLO-5: Normalization Correctness
+
+**SLI:** Fraction of nightly canary runs where the Test Rules preview path (`engine.test_rule` / `engine.test_rules_batch`) and the auto-creation executor path (`engine.normalize`) produce byte-identical output — **including identical `matched_rule_ids`** — across the full shared Unicode fixture bank (`backend/tests/fixtures/unicode_fixtures.py`). A single fixture diverging in a single run counts as a full-run failure for the purpose of this SLI.
+
+**Prometheus expression (SLI numerator over denominator):**
+```promql
+1
+-
+(
+  rate(ecm_normalization_canary_divergence_total[7d])
+  /
+  # Denominator: canary runs per 7 days. The workflow runs once per day at
+  # 07:00 UTC, so the steady-state denominator is 7. Exposed as a recording
+  # rule (`ecm:normalization_canary_runs_per_7d`) once alert-manager is wired.
+  7
+)
+```
+
+For SLO evaluation without the recording rule (interim), compute the
+numerator directly — the `ecm_normalization_canary_divergence_total`
+counter increments by 1 per divergent canary run, never per-fixture, so
+`increase(ecm_normalization_canary_divergence_total[7d])` is the
+human-readable number of SLO-5 breaches in the last 7 days.
+
+**SLO target:** **100.0% parity** over a rolling 7-day window — any single divergent canary run is an SLO breach. (Unlike latency/availability SLOs where "99.9%" accepts a statistical tail, correctness is an invariant — the two paths share one NormalizationPolicy by construction; divergence is a structural bug, not a probabilistic event.)
+
+**Error budget:** **Zero.** There is no tolerable rate of Test-Rules vs. Auto-Create divergence. The error budget policy below is punitive because a single divergence reproduces the exact failure mode behind GH #104.
+
+**Why this target:** The entire point of bd-eio04 (epic: "Normalization parity") was to eliminate the divergence class that made Settings → Normalization Test and the auto-creation executor produce different outputs. A non-zero SLI means the unification regressed. 99.9% is not an acceptable answer — it means one bad deploy per thousand canary cycles silently slips through. Correctness is binary.
+
+**Why this uses SLO-5 (not SLO-4):** SLO-4 is already claimed by Readiness Sub-check Latency above — renaming bd-eio04.9 to the next free slot was called out in the grooming comment on the bead.
+
+**What breaks this SLO:**
+
+- A commit to `backend/normalization_engine.py` that changes the Test Rules or Auto-Create preprocessing path without updating the other.
+- An operator disabling the unified policy flag on one path (`ECM_NORMALIZATION_UNIFIED_POLICY`) without disabling it on the other — policy version is logged into the decision record for exactly this correlation.
+- A new rule type or action that the two code paths interpret differently.
+- Adding a fixture to `unicode_fixtures.py` whose `expected_normalized` value one path produces but the other does not.
+
+**Runbook:** [`docs/runbooks/normalization-canary-divergence.md`](../runbooks/normalization-canary-divergence.md)
+
+**Error-budget policy (SLO-5-specific override):**
+
+| Budget state | Trigger | Response |
+|-|-|-|
+| **Healthy** | Zero divergences in window | Normal work. |
+| **Breached** | One or more divergences | File a P2 ticket, open the runbook, **block the next release cut until resolved**. A blameless postmortem is recommended but not mandatory at first occurrence; the second occurrence within 30 days upgrades to mandatory postmortem. |
+
+The "block release cut" rule overrides the normal 25%/50%/75%/100% budget bands above — correctness cannot be deferred by budget math. The standard policy resumes once the breach is closed out (root cause identified, regression test added, canary green for one consecutive run).
+
+**Supplementary diagnostic signal (not the SLI):**
+
+A bug-report ratio — `1 - (bug_reports_containing_normaliz_30d) / (auto_creations_30d)` — is tracked on the normalization dashboard for trend analysis. This is **not** part of the SLI because bug reports lag the incident by days and are subject to reporter self-selection; it's useful as a leading indicator of user-perceived correctness but cannot be the thing we page on.
+
+---
+
 ## SLO-4: Readiness Sub-check Latency (informational)
 
 **SLI:** 95th percentile duration of readiness sub-checks, per `check` label (`database`, `dispatcharr`, `ffprobe`).
@@ -192,4 +248,5 @@ For the scaffold we ship simpler single-window thresholds for SLO-2/3 (p95 laten
 
 ## Changelog
 
+- **2026-04-22 (bd-eio04.9):** Added **SLO-5: Normalization Correctness** — canary-based parity SLI with zero-tolerance target. Supported by new metrics in `observability.py` (`ecm_normalization_canary_divergence_total`, plus rule-match / no-change / duration / per-creation-normalized counters), a structured decision log (see `NORMALIZATION_DECISION_LOGGER`), and a nightly CI canary (`.github/workflows/normalization-canary.yml`). Runbook at `docs/runbooks/normalization-canary-divergence.md`.
 - **2026-04-20 (bd-dl1bd):** Initial scaffold. Four SLOs defined, targets conservative, error-budget policy drafted, alert rules shipped in sibling YAML. **Not yet calibrated against real traffic** — targets must be revisited once 30 days of production metrics exist.


### PR DESCRIPTION
## Summary

Structured observability on the unified NormalizationPolicy path. Catches future regressions via telemetry and a nightly CI canary rather than waiting for user bug reports (GH #104 produced three undetected regressions).

- **5 new metrics** in `backend/observability.py` (bounded cardinality — `rule_category` enum label; per-rule-id detail in INFO log per grooming decision 6 hybrid).
- **Decision log** at INFO with `input_sha256` correlation, 256-char truncation, deterministic every-N sampler, always-sample on `applied=true`.
- **SLO-5** in `docs/sre/slos.md` (not SLO-4 — that's Readiness Sub-check Latency). SLI = `1 - canary_divergence_rate`. Target 100% parity, zero error budget.
- **Nightly canary** workflow runs every fixture from the Unicode bank through both `POST /api/normalization/test-batch` AND direct `engine.normalize()`. Exits 1 on divergence; Slack alert with GH-issue fallback.
- **Runbook** `docs/runbooks/normalization-canary-divergence.md` following template.

**Overlap note:** touches `auto_creation_executor.py` (3-value Counter label wire-up) and `normalization_engine.py` (instrumentation hooks). **Land `.15` first** — its migrations touch the same executor file.

## Test plan

- [x] 28 unit tests in `test_normalization_observability.py` (metric registration, sampler determinism, truncation + hashing, rule-category bounding, env stride override).
- [x] Instrumentation hooks are exception-safe — observability failure never alters return value.
- [x] Canary harness dry-run locally: all 13 fixtures match across paths, exit 0.
- [x] Full backend suite: 2713 passed (same 8 pre-existing alembic failures).

## Sequence

Merge position: **4 of 6** (after `.15`).