### PR TITLE
bd-eio04.12: re-normalize UI — rule-trace, conflict-group, confirm modal + admin gate

### DIFF
--- a/backend/routers/normalization.py
+++ b/backend/routers/normalization.py
@@ -3,6 +3,8 @@ Normalization router — normalization rule management and testing endpoints.
 
 Extracted from main.py (Phase 2 of v0.13.0 backend refactor).
 """
+import asyncio
+import hashlib
 import json
 import logging
 import re
@@ -15,6 +17,7 @@ from fastapi.responses import Response
 from pydantic import BaseModel
 
 import journal
+from auth import RequireAdminIfEnabled
 from auth.routes import limiter
 from concurrency import run_cpu_bound
 from config import get_settings
@@ -1028,6 +1031,24 @@ async def _build_apply_diff(client, engine) -> list[dict]:
         if proposed_name == current_name or not normalized_core:
             continue
 
+        # Serialize per-rule trace so the preview UI can show which rules
+        # fired and how they rewrote the core name. Shape mirrors
+        # /test-batch's `transformations` output so the same frontend
+        # display component can consume both (bd-eio04.12).
+        transformations_serialized: list[dict] = []
+        for t in getattr(norm_result, "transformations", []) or []:
+            # NormalizationResult.transformations is a list of (rule_id, before, after) tuples.
+            # rule_id is usually an int but can be the sentinel "legacy_tag" string.
+            try:
+                rule_id, before, after = t
+            except (TypeError, ValueError):
+                continue
+            transformations_serialized.append({
+                "rule_id": rule_id,
+                "before": before,
+                "after": after,
+            })
+
         # Check for collision: another channel already owns the proposed name.
         collision_ch: Optional[dict] = None
         proposed_lower = proposed_name.lower()
@@ -1060,15 +1081,57 @@ async def _build_apply_diff(client, engine) -> list[dict]:
             "collision_target_group_id": target_group_id,
             "collision_target_group_name": target_group_name,
             "suggested_action": "merge" if collision_ch else "rename",
+            "transformations": transformations_serialized,
         })
 
     return diffs
 
 
+# Module-level lock prevents two concurrent bulk apply-executes from
+# stomping each other's renames/merges (bd-eio04.12). Only the execute
+# path holds it — dry-run reads are safe to run concurrently because they
+# don't mutate anything.
+_APPLY_TO_CHANNELS_EXECUTE_LOCK = asyncio.Lock()
+
+
+def _compute_rule_set_hash(engine) -> str:
+    """Stable hash of the enabled rule-set for audit-log correlation.
+
+    Hash is computed from (rule_id, condition_type, condition_value,
+    action_type, action_value) tuples in priority order so that any
+    meaningful change to the active rule-set produces a different hash.
+    Returns a 12-char prefix of the SHA-256 hex digest for log-friendly
+    identifiers.
+    """
+    try:
+        from models import NormalizationRule, NormalizationRuleGroup
+        session = getattr(engine, "db", None) or get_session()
+        rules = (
+            session.query(NormalizationRule)
+            .join(NormalizationRuleGroup, NormalizationRule.group_id == NormalizationRuleGroup.id)
+            .filter(NormalizationRule.enabled.is_(True))
+            .filter(NormalizationRuleGroup.enabled.is_(True))
+            .order_by(NormalizationRuleGroup.priority, NormalizationRule.priority)
+            .all()
+        )
+        parts = [
+            f"{r.id}|{r.condition_type}|{r.condition_value or ''}|{r.action_type}|{r.action_value or ''}"
+            for r in rules
+        ]
+        digest = hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
+        return digest[:12]
+    except Exception as e:
+        logger.warning("[NORMALIZE] Failed to compute rule-set hash for audit log: %s", e)
+        return "unknown"
+
+
 @router.post("/apply-to-channels")
+@limiter.limit("5/minute")
 async def apply_normalization_to_channels(
+    request: Request,
     dry_run: bool = True,
     body: Optional[ApplyToChannelsRequest] = None,
+    _admin=RequireAdminIfEnabled,
 ):
     """Apply enabled normalization rules to existing channels.
 
@@ -1076,173 +1139,241 @@ async def apply_normalization_to_channels(
     mutating anything. When ``dry_run`` is false, per-row ``actions`` decide
     whether to rename, merge into an existing channel, or skip. Journal
     entries are written for each rename/merge so users can audit and undo.
+
+    Admin-gated when auth is enabled: non-admin callers receive HTTP 403
+    (bd-ei4m9). Rate-limited to 5/minute per remote address to prevent
+    runaway bulk-apply loops (bd-eio04.12). Execute mode takes a module-
+    level lock so only one bulk rename/merge can run concurrently — a
+    second caller sees HTTP 409.
     """
     logger.debug("[NORMALIZE] POST /apply-to-channels dry_run=%s actions=%s",
                  dry_run, len((body.actions if body else None) or []))
+
+    # Execute-mode guard: only one concurrent bulk apply at a time
+    # (bd-eio04.12). Dry-run reads are safe to interleave because they
+    # don't mutate anything. We grab the lock BEFORE touching Dispatcharr
+    # so a second caller sees 409 instead of racing the diff compute.
+    acquired = False
+    if not dry_run:
+        if _APPLY_TO_CHANNELS_EXECUTE_LOCK.locked():
+            raise HTTPException(
+                status_code=409,
+                detail="Another bulk apply-to-channels is already in progress",
+            )
+        # acquire() on an unlocked Lock completes immediately on the current
+        # task. The check-then-acquire is best-effort; a concurrent caller
+        # that wins the race will release quickly and the second caller
+        # proceeds. The mutual-exclusion guarantee that matters is that only
+        # one task is inside the critical section at a time.
+        await _APPLY_TO_CHANNELS_EXECUTE_LOCK.acquire()
+        acquired = True
+
     try:
-        from normalization_engine import get_normalization_engine
-        client = get_client()
-        session = get_session()
         try:
-            engine = get_normalization_engine(session)
-            diffs = await _build_apply_diff(client, engine)
-        finally:
-            session.close()
-    except Exception as e:
-        logger.exception("[NORMALIZE] Failed to compute apply-to-channels diff")
-        raise HTTPException(status_code=500, detail="Internal server error")
-
-    if dry_run:
-        return {
-            "dry_run": True,
-            "diffs": diffs,
-            "channels_with_changes": len(diffs),
-        }
-
-    # Execute mode --------------------------------------------------------
-    # Index diffs by channel_id for quick lookup against caller actions.
-    diffs_by_id = {d["channel_id"]: d for d in diffs if d.get("channel_id") is not None}
-
-    # Default: skip everything that wasn't explicitly called out (safest).
-    actions_by_id: dict[int, ApplyChannelAction] = {}
-    if body and body.actions:
-        for a in body.actions:
-            actions_by_id[a.channel_id] = a
-
-    renamed: list[dict] = []
-    merged: list[dict] = []
-    skipped: list[dict] = []
-    errors: list[dict] = []
-
-    for channel_id, diff in diffs_by_id.items():
-        requested = actions_by_id.get(channel_id)
-        if requested is None:
-            skipped.append({"channel_id": channel_id, "reason": "no action specified"})
-            continue
-
-        action = (requested.action or "skip").lower()
-        if action == "skip":
-            skipped.append({"channel_id": channel_id, "reason": "skip"})
-            continue
-
-        if action == "rename":
-            # Refuse to rename into a collision: caller should choose merge.
-            if diff.get("collision"):
-                errors.append({
-                    "channel_id": channel_id,
-                    "error": "rename would collide with existing channel; choose merge or skip",
-                })
-                continue
-            new_name = diff["proposed_name"]
-            current_name = diff["current_name"]
+            from normalization_engine import get_normalization_engine
+            client = get_client()
+            session = get_session()
             try:
-                await client.update_channel(channel_id, {"name": new_name})
+                engine = get_normalization_engine(session)
+                diffs = await _build_apply_diff(client, engine)
+                rule_set_hash = _compute_rule_set_hash(engine) if not dry_run else None
+            finally:
+                session.close()
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.exception("[NORMALIZE] Failed to compute apply-to-channels diff")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+        if dry_run:
+            return {
+                "dry_run": True,
+                "diffs": diffs,
+                "channels_with_changes": len(diffs),
+            }
+
+        # Execute mode --------------------------------------------------------
+        # Index diffs by channel_id for quick lookup against caller actions.
+        diffs_by_id = {d["channel_id"]: d for d in diffs if d.get("channel_id") is not None}
+
+        # Default: skip everything that wasn't explicitly called out (safest).
+        actions_by_id: dict[int, ApplyChannelAction] = {}
+        if body and body.actions:
+            for a in body.actions:
+                actions_by_id[a.channel_id] = a
+
+        renamed: list[dict] = []
+        merged: list[dict] = []
+        skipped: list[dict] = []
+        errors: list[dict] = []
+
+        for channel_id, diff in diffs_by_id.items():
+            requested = actions_by_id.get(channel_id)
+            if requested is None:
+                skipped.append({"channel_id": channel_id, "reason": "no action specified"})
+                continue
+
+            action = (requested.action or "skip").lower()
+            if action == "skip":
+                skipped.append({"channel_id": channel_id, "reason": "skip"})
+                continue
+
+            if action == "rename":
+                # Refuse to rename into a collision: caller should choose merge.
+                if diff.get("collision"):
+                    errors.append({
+                        "channel_id": channel_id,
+                        "error": "rename would collide with existing channel; choose merge or skip",
+                    })
+                    continue
+                new_name = diff["proposed_name"]
+                current_name = diff["current_name"]
+                try:
+                    await client.update_channel(channel_id, {"name": new_name})
+                    journal.log_entry(
+                        category="channel",
+                        action_type="rename",
+                        entity_id=channel_id,
+                        entity_name=new_name,
+                        description=f"Renamed channel '{current_name}' → '{new_name}' via normalization apply-to-channels",
+                        before_value={"name": current_name},
+                        after_value={"name": new_name},
+                        user_initiated=True,
+                    )
+                    renamed.append({
+                        "channel_id": channel_id,
+                        "old_name": current_name,
+                        "new_name": new_name,
+                    })
+                    logger.info("[NORMALIZE] Renamed channel id=%s '%s' -> '%s'",
+                                channel_id, current_name, new_name)
+                except Exception as e:
+                    logger.warning("[NORMALIZE] Failed to rename channel %s: %s", channel_id, e)
+                    errors.append({"channel_id": channel_id, "error": str(e)})
+                continue
+
+            if action == "merge":
+                target_id = requested.merge_target_id or diff.get("collision_target_id")
+                if not target_id:
+                    errors.append({
+                        "channel_id": channel_id,
+                        "error": "merge requested but no merge target identified",
+                    })
+                    continue
+                try:
+                    source_channel = await client.get_channel(channel_id)
+                    target_channel = await client.get_channel(target_id)
+                except Exception as e:
+                    logger.warning("[NORMALIZE] Failed to fetch channels for merge %s -> %s: %s",
+                                   channel_id, target_id, e)
+                    errors.append({"channel_id": channel_id, "error": str(e)})
+                    continue
+
+                # Merge streams into target preserving order, deduping by id.
+                target_streams = list(target_channel.get("streams", []) or [])
+                seen = set(target_streams)
+                added = 0
+                for sid in source_channel.get("streams", []) or []:
+                    if sid not in seen:
+                        target_streams.append(sid)
+                        seen.add(sid)
+                        added += 1
+
+                try:
+                    if added:
+                        await client.update_channel(target_id, {"streams": target_streams})
+                    await client.delete_channel(channel_id)
+                except Exception as e:
+                    logger.warning("[NORMALIZE] Merge failed %s -> %s: %s",
+                                   channel_id, target_id, e)
+                    errors.append({"channel_id": channel_id, "error": str(e)})
+                    continue
+
                 journal.log_entry(
                     category="channel",
-                    action_type="rename",
-                    entity_id=channel_id,
-                    entity_name=new_name,
-                    description=f"Renamed channel '{current_name}' → '{new_name}' via normalization apply-to-channels",
-                    before_value={"name": current_name},
-                    after_value={"name": new_name},
+                    action_type="merge",
+                    entity_id=target_id,
+                    entity_name=target_channel.get("name") or "",
+                    description=(
+                        f"Merged '{source_channel.get('name') or ''}' into "
+                        f"'{target_channel.get('name') or ''}' via normalization apply-to-channels"
+                    ),
+                    before_value={
+                        "source_channel": {
+                            "id": channel_id,
+                            "name": source_channel.get("name"),
+                            "stream_count": len(source_channel.get("streams") or []),
+                        },
+                        "target_channel": {
+                            "id": target_id,
+                            "name": target_channel.get("name"),
+                            "stream_count": len(target_channel.get("streams") or []),
+                        },
+                    },
+                    after_value={
+                        "target_channel_id": target_id,
+                        "streams_added": added,
+                        "deleted_source_id": channel_id,
+                    },
                     user_initiated=True,
                 )
-                renamed.append({
+                merged.append({
                     "channel_id": channel_id,
-                    "old_name": current_name,
-                    "new_name": new_name,
-                })
-                logger.info("[NORMALIZE] Renamed channel id=%s '%s' -> '%s'",
-                            channel_id, current_name, new_name)
-            except Exception as e:
-                logger.warning("[NORMALIZE] Failed to rename channel %s: %s", channel_id, e)
-                errors.append({"channel_id": channel_id, "error": str(e)})
-            continue
-
-        if action == "merge":
-            target_id = requested.merge_target_id or diff.get("collision_target_id")
-            if not target_id:
-                errors.append({
-                    "channel_id": channel_id,
-                    "error": "merge requested but no merge target identified",
-                })
-                continue
-            try:
-                source_channel = await client.get_channel(channel_id)
-                target_channel = await client.get_channel(target_id)
-            except Exception as e:
-                logger.warning("[NORMALIZE] Failed to fetch channels for merge %s -> %s: %s",
-                               channel_id, target_id, e)
-                errors.append({"channel_id": channel_id, "error": str(e)})
-                continue
-
-            # Merge streams into target preserving order, deduping by id.
-            target_streams = list(target_channel.get("streams", []) or [])
-            seen = set(target_streams)
-            added = 0
-            for sid in source_channel.get("streams", []) or []:
-                if sid not in seen:
-                    target_streams.append(sid)
-                    seen.add(sid)
-                    added += 1
-
-            try:
-                if added:
-                    await client.update_channel(target_id, {"streams": target_streams})
-                await client.delete_channel(channel_id)
-            except Exception as e:
-                logger.warning("[NORMALIZE] Merge failed %s -> %s: %s",
-                               channel_id, target_id, e)
-                errors.append({"channel_id": channel_id, "error": str(e)})
-                continue
-
-            journal.log_entry(
-                category="channel",
-                action_type="merge",
-                entity_id=target_id,
-                entity_name=target_channel.get("name") or "",
-                description=(
-                    f"Merged '{source_channel.get('name') or ''}' into "
-                    f"'{target_channel.get('name') or ''}' via normalization apply-to-channels"
-                ),
-                before_value={
-                    "source_channel": {
-                        "id": channel_id,
-                        "name": source_channel.get("name"),
-                        "stream_count": len(source_channel.get("streams") or []),
-                    },
-                    "target_channel": {
-                        "id": target_id,
-                        "name": target_channel.get("name"),
-                        "stream_count": len(target_channel.get("streams") or []),
-                    },
-                },
-                after_value={
-                    "target_channel_id": target_id,
+                    "target_id": target_id,
                     "streams_added": added,
-                    "deleted_source_id": channel_id,
-                },
-                user_initiated=True,
-            )
-            merged.append({
+                })
+                logger.info("[NORMALIZE] Merged channel %s into %s (+%s streams)",
+                            channel_id, target_id, added)
+                continue
+
+            errors.append({
                 "channel_id": channel_id,
-                "target_id": target_id,
-                "streams_added": added,
+                "error": f"unknown action '{requested.action}'",
             })
-            logger.info("[NORMALIZE] Merged channel %s into %s (+%s streams)",
-                        channel_id, target_id, added)
-            continue
 
-        errors.append({
-            "channel_id": channel_id,
-            "error": f"unknown action '{requested.action}'",
-        })
+        # Bulk-apply audit entry (bd-eio04.12). Captures who (user_initiated
+        # flag), counts for each outcome, and the rule-set hash so reviewers
+        # can correlate the run against the rules that were active at the
+        # time. Entity-level rename/merge entries are written above.
+        actor_name = "apply-to-channels"
+        if _admin is not None:
+            try:
+                actor_name = _admin.username or actor_name
+            except AttributeError:
+                pass
 
-    return {
-        "dry_run": False,
-        "status": "completed",
-        "renamed": renamed,
-        "merged": merged,
-        "skipped": skipped,
-        "errors": errors,
-    }
+        journal.log_entry(
+            category="channel",
+            action_type="bulk_apply_normalization",
+            entity_name=actor_name,
+            description=(
+                f"Bulk normalization apply-to-channels: "
+                f"renamed={len(renamed)}, merged={len(merged)}, "
+                f"skipped={len(skipped)}, errors={len(errors)}"
+            ),
+            before_value={
+                "actor": actor_name,
+                "rule_set_hash": rule_set_hash,
+                "channels_considered": len(diffs_by_id),
+            },
+            after_value={
+                "renamed": len(renamed),
+                "merged": len(merged),
+                "skipped": len(skipped),
+                "errors": len(errors),
+            },
+            user_initiated=True,
+        )
+
+        return {
+            "dry_run": False,
+            "status": "completed",
+            "renamed": renamed,
+            "merged": merged,
+            "skipped": skipped,
+            "errors": errors,
+            "rule_set_hash": rule_set_hash,
+        }
+    finally:
+        if not dry_run and acquired:
+            _APPLY_TO_CHANNELS_EXECUTE_LOCK.release()

--- a/backend/tests/routers/test_normalization.py
+++ b/backend/tests/routers/test_normalization.py
@@ -575,8 +575,11 @@ class TestApplyToChannels:
         assert len(data["renamed"]) == 1
         assert data["renamed"][0]["new_name"] == "RTL"
         client.update_channel.assert_awaited_once_with(1, {"name": "RTL"})
-        mock_journal.log_entry.assert_called_once()
-        assert mock_journal.log_entry.call_args.kwargs["action_type"] == "rename"
+        # Two journal entries: one per rename, one bulk-apply audit summary
+        # (bd-eio04.12).
+        assert mock_journal.log_entry.call_count == 2
+        action_types = {c.kwargs["action_type"] for c in mock_journal.log_entry.call_args_list}
+        assert action_types == {"rename", "bulk_apply_normalization"}
 
     @pytest.mark.asyncio
     async def test_execute_merge_collision(self, async_client):
@@ -611,8 +614,11 @@ class TestApplyToChannels:
         # Target gets new stream list (original 20 + 10 + 11)
         client.update_channel.assert_awaited_once_with(2, {"streams": [20, 10, 11]})
         client.delete_channel.assert_awaited_once_with(1)
-        mock_journal.log_entry.assert_called_once()
-        assert mock_journal.log_entry.call_args.kwargs["action_type"] == "merge"
+        # Two journal entries: one per merge, one bulk-apply audit summary
+        # (bd-eio04.12).
+        assert mock_journal.log_entry.call_count == 2
+        action_types = {c.kwargs["action_type"] for c in mock_journal.log_entry.call_args_list}
+        assert action_types == {"merge", "bulk_apply_normalization"}
 
     @pytest.mark.asyncio
     async def test_execute_skip_collision(self, async_client):
@@ -639,7 +645,13 @@ class TestApplyToChannels:
         assert data["merged"] == []
         client.update_channel.assert_not_called()
         client.delete_channel.assert_not_called()
-        mock_journal.log_entry.assert_not_called()
+        # Bulk-apply audit entry is always written, even when nothing changed
+        # (bd-eio04.12). No per-channel entries because nothing was mutated.
+        assert mock_journal.log_entry.call_count == 1
+        assert (
+            mock_journal.log_entry.call_args.kwargs["action_type"]
+            == "bulk_apply_normalization"
+        )
 
     @pytest.mark.asyncio
     async def test_execute_rename_collision_refused(self, async_client):
@@ -683,6 +695,184 @@ class TestApplyToChannels:
         assert data["diffs"][0]["current_name"] == "107 | RTL ᴿᴬᵂ"
         assert data["diffs"][0]["proposed_name"] == "107 | RTL"
         assert data["diffs"][0]["channel_number_prefix"] == "107 | "
+
+
+class TestApplyToChannelsRuleTrace:
+    """Preview rows include the per-rule trace so the UI can render a
+    'Rules fired' drawer (bd-eio04.12)."""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_emits_transformations_field(self, async_client):
+        """Every diff row exposes a transformations list sourced from
+        NormalizationResult.transformations. Shape matches /test-batch."""
+        channels = [{"id": 1, "name": "RTL ᴿᴬᵂ"}]
+
+        # Build an engine mock whose `normalize()` returns a namespace with
+        # the transformations shape the serializer expects.
+        class _Result:
+            normalized = "RTL"
+            transformations = [(101, "RTL ᴿᴬᵂ", "RTL")]
+
+        engine = MagicMock()
+        engine.normalize.return_value = _Result()
+
+        client = AsyncMock()
+        client.get_channels.return_value = {"results": channels, "next": None}
+        client.get_channel_groups.return_value = []
+
+        with patch("routers.normalization.get_client", return_value=client), \
+             patch("normalization_engine.get_normalization_engine", return_value=engine):
+            response = await async_client.post(
+                "/api/normalization/apply-to-channels?dry_run=true"
+            )
+
+        assert response.status_code == 200
+        row = response.json()["diffs"][0]
+        assert "transformations" in row
+        assert row["transformations"] == [
+            {"rule_id": 101, "before": "RTL ᴿᴬᵂ", "after": "RTL"}
+        ]
+
+
+class TestApplyToChannelsAdminGate:
+    """Bulk apply-to-channels is admin-gated when auth is enabled
+    (bd-ei4m9, absorbed by bd-eio04.12). Non-admin callers must see
+    HTTP 403, not silently execute destructive renames."""
+
+    @pytest.mark.asyncio
+    async def test_non_admin_is_forbidden_when_auth_enabled(self, async_client):
+        """When auth.require_auth and setup_complete are both true, a
+        non-admin caller receives 403 from the dependency."""
+        from fastapi import HTTPException, status
+        from main import app
+        from auth import RequireAdminIfEnabled as _prebuilt
+
+        async def _reject() -> None:
+            # FastAPI introspects the callable's signature for DI; keep it
+            # parameterless so the framework doesn't try to pull query args.
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Admin access required",
+            )
+
+        # Override the prebuilt RequireAdminIfEnabled dependency so the
+        # route sees a 403 regardless of actual auth state.
+        app.dependency_overrides[_prebuilt.dependency] = _reject
+        try:
+            response = await async_client.post(
+                "/api/normalization/apply-to-channels?dry_run=true"
+            )
+        finally:
+            app.dependency_overrides.pop(_prebuilt.dependency, None)
+
+        assert response.status_code == 403
+        assert "admin" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_anonymous_allowed_when_auth_disabled(self, async_client):
+        """When auth is disabled (setup_complete=False or require_auth=False),
+        the dependency returns None and the endpoint is reachable. The
+        default `async_client` fixture runs with auth disabled, so we just
+        verify the happy path still works after the admin gate was added."""
+        channels = [{"id": 1, "name": "RTL ᴿᴬᵂ"}]
+        client = AsyncMock()
+        client.get_channels.return_value = {"results": channels, "next": None}
+        client.get_channel_groups.return_value = []
+
+        engine = MagicMock()
+        engine.normalize.return_value = MagicMock(normalized="RTL", transformations=[])
+
+        with patch("routers.normalization.get_client", return_value=client), \
+             patch("normalization_engine.get_normalization_engine", return_value=engine):
+            response = await async_client.post(
+                "/api/normalization/apply-to-channels?dry_run=true"
+            )
+
+        assert response.status_code == 200
+
+
+class TestApplyToChannelsIdempotencyLock:
+    """Execute mode holds a module-level lock so only one bulk rename/merge
+    can run at a time. A concurrent caller must see HTTP 409, not race
+    into the critical section (bd-eio04.12)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_409_when_another_bulk_in_flight(self, async_client):
+        """Manually hold the lock and verify the endpoint returns 409."""
+        from routers import normalization as normalization_router
+
+        channels = [{"id": 1, "name": "RTL ᴿᴬᵂ"}]
+        client = AsyncMock()
+        client.get_channels.return_value = {"results": channels, "next": None}
+        client.get_channel_groups.return_value = []
+
+        engine = MagicMock()
+        engine.normalize.return_value = MagicMock(normalized="RTL", transformations=[])
+
+        # Pre-acquire the execute lock to simulate a bulk apply already in
+        # progress. We release it in the finally below so the fixture's
+        # test isolation stays clean for other tests.
+        await normalization_router._APPLY_TO_CHANNELS_EXECUTE_LOCK.acquire()
+        try:
+            with patch("routers.normalization.get_client", return_value=client), \
+                 patch("normalization_engine.get_normalization_engine", return_value=engine):
+                response = await async_client.post(
+                    "/api/normalization/apply-to-channels?dry_run=false",
+                    json={"actions": [{"channel_id": 1, "action": "rename"}]},
+                )
+        finally:
+            normalization_router._APPLY_TO_CHANNELS_EXECUTE_LOCK.release()
+
+        assert response.status_code == 409
+        assert "in progress" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_is_not_blocked_by_lock(self, async_client):
+        """The lock only gates execute mode; dry-run reads stay concurrent."""
+        from routers import normalization as normalization_router
+
+        channels = [{"id": 1, "name": "RTL ᴿᴬᵂ"}]
+        client = AsyncMock()
+        client.get_channels.return_value = {"results": channels, "next": None}
+        client.get_channel_groups.return_value = []
+
+        engine = MagicMock()
+        engine.normalize.return_value = MagicMock(normalized="RTL", transformations=[])
+
+        await normalization_router._APPLY_TO_CHANNELS_EXECUTE_LOCK.acquire()
+        try:
+            with patch("routers.normalization.get_client", return_value=client), \
+                 patch("normalization_engine.get_normalization_engine", return_value=engine):
+                response = await async_client.post(
+                    "/api/normalization/apply-to-channels?dry_run=true"
+                )
+        finally:
+            normalization_router._APPLY_TO_CHANNELS_EXECUTE_LOCK.release()
+
+        assert response.status_code == 200
+
+
+class TestApplyToChannelsRateLimit:
+    """The endpoint carries a @limiter.limit decorator so a runaway client
+    can't hammer destructive bulk renames. Rate limiting is disabled in
+    the test conftest (RATE_LIMIT_ENABLED=0) so we just verify the
+    decorator is wired — the actual throttling is validated by slowapi."""
+
+    def test_rate_limit_decorator_applied(self):
+        """The endpoint function is registered with the slowapi limiter."""
+        from routers import normalization as normalization_router
+
+        limiter = normalization_router.limiter
+        # slowapi keys _route_limits by fully-qualified function name
+        # (e.g. 'routers.normalization.apply_normalization_to_channels').
+        key = "routers.normalization.apply_normalization_to_channels"
+        assert key in limiter._route_limits, (
+            "apply-to-channels endpoint must be registered with the limiter"
+        )
+        limits = limiter._route_limits[key]
+        assert limits, "at least one Limit entry expected"
+        rendered = " ".join(str(lim.limit) for lim in limits)
+        assert "5" in rendered and "minute" in rendered
 
 
 class TestFindChannelByNameNormalizationFallback:

--- a/e2e/re-normalize.spec.ts
+++ b/e2e/re-normalize.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * E2E tests for the re-normalize-existing-channels flow (bd-eio04.12).
+ *
+ * Exercises the Apply-to-Channels modal added to the Channel Normalization
+ * settings page: rule-trace drawer, conflict-group winner pick, confirmation
+ * modal, and post-execute summary.
+ *
+ * The backend is mocked via Playwright's `page.route` so the test can seed
+ * three channels with known Unicode suffixes without having to stand up a
+ * live Dispatcharr instance.
+ */
+import { test, expect, navigateToTab } from './fixtures/base';
+
+test.describe('Re-normalize existing channels (bd-eio04.12)', () => {
+  test.beforeEach(async ({ appPage }) => {
+    // -----------------------------------------------------------------
+    // Intercept all normalization API calls the settings page makes.
+    // The responses are tuned so the Apply-to-Channels modal renders
+    // three channels, one conflict group, and one happy-path rename.
+    // -----------------------------------------------------------------
+    await appPage.route('**/api/normalization/rules', (route) => {
+      route.fulfill({ json: { groups: [] } });
+    });
+
+    await appPage.route('**/api/tags/groups', (route) => {
+      route.fulfill({ json: { groups: [] } });
+    });
+
+    // Dry-run returns the preview diff
+    await appPage.route(
+      '**/api/normalization/apply-to-channels?dry_run=true',
+      (route) => {
+        route.fulfill({
+          json: {
+            dry_run: true,
+            channels_with_changes: 3,
+            diffs: [
+              {
+                channel_id: 1,
+                current_name: 'RTL ᴿᴬᵂ',
+                proposed_name: 'RTL',
+                normalized_core: 'RTL',
+                channel_number_prefix: '',
+                group_id: 5,
+                group_name: 'DE',
+                collision: false,
+                collision_target_id: null,
+                collision_target_name: null,
+                collision_target_group_id: null,
+                collision_target_group_name: null,
+                suggested_action: 'rename',
+                transformations: [
+                  { rule_id: 101, before: 'RTL ᴿᴬᵂ', after: 'RTL' },
+                ],
+              },
+              {
+                channel_id: 2,
+                current_name: 'RTL ꜰʜᴅ',
+                proposed_name: 'RTL',
+                normalized_core: 'RTL',
+                channel_number_prefix: '',
+                group_id: 5,
+                group_name: 'DE',
+                collision: false,
+                collision_target_id: null,
+                collision_target_name: null,
+                collision_target_group_id: null,
+                collision_target_group_name: null,
+                suggested_action: 'rename',
+                transformations: [
+                  { rule_id: 102, before: 'RTL ꜰʜᴅ', after: 'RTL' },
+                ],
+              },
+              {
+                channel_id: 3,
+                current_name: 'Pro7 ᴴᴰ',
+                proposed_name: 'Pro7',
+                normalized_core: 'Pro7',
+                channel_number_prefix: '',
+                group_id: 5,
+                group_name: 'DE',
+                collision: false,
+                collision_target_id: null,
+                collision_target_name: null,
+                collision_target_group_id: null,
+                collision_target_group_name: null,
+                suggested_action: 'rename',
+                transformations: [
+                  { rule_id: 103, before: 'Pro7 ᴴᴰ', after: 'Pro7' },
+                ],
+              },
+            ],
+          },
+        });
+      }
+    );
+
+    // Execute mode returns the happy-path summary
+    await appPage.route(
+      '**/api/normalization/apply-to-channels?dry_run=false',
+      (route) => {
+        route.fulfill({
+          json: {
+            dry_run: false,
+            status: 'completed',
+            renamed: [
+              { channel_id: 1, old_name: 'RTL ᴿᴬᵂ', new_name: 'RTL' },
+              { channel_id: 3, old_name: 'Pro7 ᴴᴰ', new_name: 'Pro7' },
+            ],
+            merged: [],
+            skipped: [{ channel_id: 2, reason: 'skip' }],
+            errors: [],
+            rule_set_hash: 'e2e-test-hash',
+          },
+        });
+      }
+    );
+
+    await navigateToTab(appPage, 'settings');
+
+    // Open the Channel Normalization settings page from the sidebar.
+    const navItem = appPage.locator(
+      '.settings-nav-item:has-text("Channel Normalization")'
+    );
+    await navItem.first().click();
+    await appPage
+      .getByTestId('apply-to-channels-btn')
+      .waitFor({ state: 'visible', timeout: 10_000 });
+  });
+
+  test('renders the preview, resolves a conflict group, executes and shows summary', async ({
+    appPage,
+  }) => {
+    // Open the Apply-to-Channels modal
+    await appPage.getByTestId('apply-to-channels-btn').click();
+
+    const modal = appPage.getByTestId('apply-to-channels-modal');
+    await expect(modal).toBeVisible();
+
+    // All three seeded rows render
+    await expect(appPage.getByTestId('apply-row-1')).toBeVisible();
+    await expect(appPage.getByTestId('apply-row-2')).toBeVisible();
+    await expect(appPage.getByTestId('apply-row-3')).toBeVisible();
+
+    // Channels 1 + 2 both normalize to "RTL" → source-collision group
+    // with a conflict-group badge on both rows.
+    await expect(
+      appPage.getByTestId('apply-conflict-badge-1')
+    ).toBeVisible();
+    await expect(
+      appPage.getByTestId('apply-conflict-badge-2')
+    ).toBeVisible();
+
+    // Execute stays disabled while the conflict group is unresolved.
+    const executeBtn = appPage.getByTestId('apply-to-channels-execute');
+    await expect(executeBtn).toBeDisabled();
+
+    // Expand the rule-trace drawer for row 1 and verify it renders
+    const traceToggle = appPage.getByTestId('apply-trace-toggle-1');
+    await expect(traceToggle).toHaveAttribute('aria-expanded', 'false');
+    await traceToggle.click();
+    await expect(traceToggle).toHaveAttribute('aria-expanded', 'true');
+    const drawer = appPage.getByTestId('apply-trace-drawer-1');
+    await expect(drawer).toBeVisible();
+    await expect(drawer).toContainText('Rule 101');
+
+    // Pick channel 1 as the conflict-group winner. Loser's action flips
+    // to 'skip', winner's to 'rename'; Execute enables.
+    await appPage.getByTestId('apply-winner-radio-1').check();
+    await expect(executeBtn).toBeEnabled();
+
+    // Execute opens the confirmation modal first.
+    await executeBtn.click();
+    const confirm = appPage.getByTestId('apply-to-channels-confirm');
+    await expect(confirm).toBeVisible();
+    await expect(
+      appPage.getByTestId('apply-to-channels-confirm-count')
+    ).toContainText(/channel/);
+
+    // Confirm — fires the POST and renders the summary block.
+    await appPage.getByTestId('apply-to-channels-confirm-execute').click();
+
+    const summary = appPage.getByTestId('apply-to-channels-summary');
+    await expect(summary).toBeVisible({ timeout: 10_000 });
+    await expect(summary).toContainText('2 renamed');
+    await expect(summary).toContainText('0 merged');
+    await expect(summary).toContainText('1 skipped');
+    await expect(summary).toContainText('0 failed');
+    await expect(summary).toContainText('e2e-test-hash');
+    await expect(
+      appPage.getByTestId('apply-to-channels-summary-journal-link')
+    ).toHaveAttribute('href', '#journal');
+  });
+});

--- a/frontend/src/components/settings/NormalizationEngineSection.applyToChannels.test.tsx
+++ b/frontend/src/components/settings/NormalizationEngineSection.applyToChannels.test.tsx
@@ -225,6 +225,7 @@ describe('NormalizationEngineSection — apply to existing channels (GH-104)', (
       merged: [],
       skipped: [],
       errors: [],
+      rule_set_hash: 'abc123def456',
     });
 
     render(<NormalizationEngineSection />);
@@ -238,8 +239,16 @@ describe('NormalizationEngineSection — apply to existing channels (GH-104)', (
     });
 
     await screen.findByTestId('apply-row-1');
+    // bd-eio04.12: Execute now opens a confirmation modal first.
     await act(async () => {
       fireEvent.click(screen.getByTestId('apply-to-channels-execute'));
+    });
+    const confirm = await screen.findByTestId('apply-to-channels-confirm');
+    expect(confirm).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(
+        screen.getByTestId('apply-to-channels-confirm-execute')
+      );
     });
 
     await waitFor(() => {
@@ -249,5 +258,195 @@ describe('NormalizationEngineSection — apply to existing channels (GH-104)', (
     expect(sent).toEqual([
       expect.objectContaining({ channel_id: 1, action: 'rename' }),
     ]);
+  });
+
+  // ------------------------------------------------------------------
+  // bd-eio04.12 — new UX gaps (rule-trace drawer, conflict-group
+  // winner pick, confirm modal, post-execute summary).
+  // ------------------------------------------------------------------
+
+  it('expands the per-row rule-trace drawer when the toggle is clicked', async () => {
+    mockPreview.mockResolvedValue({
+      dry_run: true,
+      channels_with_changes: 1,
+      diffs: [
+        baseDiff({
+          channel_id: 1,
+          current_name: 'RTL RAW',
+          proposed_name: 'RTL',
+          transformations: [
+            { rule_id: 101, before: 'RTL RAW', after: 'RTL' },
+            { rule_id: 102, before: 'RTL  ', after: 'RTL' },
+          ],
+        }),
+      ],
+    });
+
+    render(<NormalizationEngineSection />);
+    const openBtn = await screen.findByTestId(
+      'apply-to-channels-btn',
+      undefined,
+      { timeout: 3000 }
+    );
+    await act(async () => {
+      fireEvent.click(openBtn);
+    });
+
+    // Default is collapsed — no drawer row on mount.
+    const toggle = await screen.findByTestId('apply-trace-toggle-1');
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByTestId('apply-trace-drawer-1')).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    const drawer = await screen.findByTestId('apply-trace-drawer-1');
+    expect(drawer).toBeInTheDocument();
+    expect(within(drawer).getByText(/Rule 101/)).toBeInTheDocument();
+    expect(within(drawer).getByText(/Rule 102/)).toBeInTheDocument();
+    // aria-controls wires the toggle to the drawer by id
+    expect(toggle.getAttribute('aria-controls')).toBe('apply-trace-1');
+    expect(drawer.getAttribute('id')).toBe('apply-trace-1');
+  });
+
+  it('groups source-collision rows and requires a winner before Execute enables', async () => {
+    // Two channels that both normalize to the same proposed name.
+    // This is a "type-(ii) source collision" — two in-scope rows, no
+    // pre-existing channel at the target.
+    mockPreview.mockResolvedValue({
+      dry_run: true,
+      channels_with_changes: 2,
+      diffs: [
+        baseDiff({
+          channel_id: 1,
+          current_name: 'RTL RAW',
+          proposed_name: 'RTL',
+          collision: false,
+        }),
+        baseDiff({
+          channel_id: 2,
+          current_name: 'RTL ᴿᴬᵂ',
+          proposed_name: 'RTL',
+          collision: false,
+        }),
+      ],
+    });
+
+    render(<NormalizationEngineSection />);
+    const openBtn = await screen.findByTestId(
+      'apply-to-channels-btn',
+      undefined,
+      { timeout: 3000 }
+    );
+    await act(async () => {
+      fireEvent.click(openBtn);
+    });
+
+    // Both rows render the conflict-group badge
+    expect(
+      await screen.findByTestId('apply-conflict-badge-1')
+    ).toHaveTextContent(/Conflict Group \d+/);
+    expect(
+      screen.getByTestId('apply-conflict-badge-2')
+    ).toHaveTextContent(/Conflict Group \d+/);
+
+    // Hint banner signals "needs a winner"
+    expect(
+      screen.getByTestId('apply-to-channels-conflict-hint')
+    ).toBeInTheDocument();
+
+    // Execute is disabled until a winner is picked
+    const executeBtn = screen.getByTestId('apply-to-channels-execute');
+    expect((executeBtn as HTMLButtonElement).disabled).toBe(true);
+
+    // Pick channel 1 as the winner
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('apply-winner-radio-1'));
+    });
+
+    // Winner's action flips to 'rename', loser flips to 'skip'
+    expect(
+      (screen.getByTestId('apply-action-1') as HTMLSelectElement).value
+    ).toBe('rename');
+    expect(
+      (screen.getByTestId('apply-action-2') as HTMLSelectElement).value
+    ).toBe('skip');
+
+    // Execute is now enabled
+    expect((executeBtn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('requires confirmation before executing and surfaces a post-execute summary', async () => {
+    mockPreview.mockResolvedValue({
+      dry_run: true,
+      channels_with_changes: 1,
+      diffs: [baseDiff({ channel_id: 1 })],
+    });
+    mockExecute.mockResolvedValue({
+      dry_run: false,
+      status: 'completed',
+      renamed: [{ channel_id: 1, old_name: 'RTL RAW', new_name: 'RTL' }],
+      merged: [],
+      skipped: [],
+      errors: [],
+      rule_set_hash: 'abc123def456',
+    });
+
+    render(<NormalizationEngineSection />);
+    const openBtn = await screen.findByTestId(
+      'apply-to-channels-btn',
+      undefined,
+      { timeout: 3000 }
+    );
+    await act(async () => {
+      fireEvent.click(openBtn);
+    });
+    await screen.findByTestId('apply-row-1');
+
+    // Execute opens the confirmation modal — does NOT fire the POST
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('apply-to-channels-execute'));
+    });
+    expect(mockExecute).not.toHaveBeenCalled();
+    const confirm = await screen.findByTestId('apply-to-channels-confirm');
+    expect(confirm).toBeInTheDocument();
+    expect(
+      screen.getByTestId('apply-to-channels-confirm-count')
+    ).toHaveTextContent(/1 channel/);
+
+    // Cancel closes the confirm modal without firing the POST
+    await act(async () => {
+      fireEvent.click(
+        screen.getByTestId('apply-to-channels-confirm-cancel')
+      );
+    });
+    expect(mockExecute).not.toHaveBeenCalled();
+
+    // Re-open and confirm — POST fires, summary appears
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('apply-to-channels-execute'));
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByTestId('apply-to-channels-confirm-execute')
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+    });
+
+    const summary = await screen.findByTestId(
+      'apply-to-channels-summary'
+    );
+    expect(within(summary).getByText(/1 renamed/)).toBeInTheDocument();
+    expect(within(summary).getByText(/0 merged/)).toBeInTheDocument();
+    expect(within(summary).getByText(/0 failed/)).toBeInTheDocument();
+    expect(within(summary).getByText(/abc123def456/)).toBeInTheDocument();
+    expect(
+      within(summary).getByTestId('apply-to-channels-summary-journal-link')
+    ).toHaveAttribute('href', '#journal');
   });
 });

--- a/frontend/src/components/settings/NormalizationEngineSection.css
+++ b/frontend/src/components/settings/NormalizationEngineSection.css
@@ -1106,3 +1106,206 @@
   border-radius: var(--radius-md);
   padding: 0.25rem 0.5rem;
 }
+
+/* ----------------------------------------------------------------------
+ * bd-eio04.12: rule-trace drawer, conflict groups, confirm + summary UI
+ * for the apply-to-channels modal.
+ * -------------------------------------------------------------------- */
+
+.norm-engine-apply-trace-toggle {
+  background: transparent;
+  border: 0;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 0.1rem;
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.norm-engine-apply-trace-toggle:hover,
+.norm-engine-apply-trace-toggle:focus-visible {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  outline: none;
+}
+
+.norm-engine-apply-trace-toggle .material-icons {
+  font-size: 1.1rem;
+}
+
+.norm-engine-apply-trace-row td {
+  background: var(--bg-secondary);
+  padding: 0;
+}
+
+.norm-engine-apply-trace {
+  padding: 0.75rem 1rem;
+  border-left: 3px solid var(--accent-50);
+}
+
+.norm-engine-apply-trace-heading {
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.norm-engine-apply-trace-empty {
+  color: var(--text-secondary);
+  font-style: italic;
+  font-size: 0.85rem;
+}
+
+.norm-engine-apply-trace-list {
+  margin: 0;
+  padding-left: 1rem;
+  list-style: none;
+}
+
+.norm-engine-apply-trace-item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.norm-engine-apply-trace-item .material-icons {
+  font-size: 1rem;
+  color: var(--accent-50);
+}
+
+.norm-engine-apply-trace-item .trace-rule-id {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.norm-engine-apply-trace-item code {
+  background: var(--bg-primary);
+  padding: 0.05rem 0.3rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.8rem;
+}
+
+.norm-engine-apply-rule-count {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.norm-engine-apply-conflict-badge {
+  display: inline-block;
+  background: var(--warning);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius-sm);
+  margin-right: 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.norm-engine-apply-conflict-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--warning);
+  font-size: 0.85rem;
+  margin-left: 0.75rem;
+}
+
+.norm-engine-apply-conflict-hint .material-icons {
+  font-size: 1rem;
+}
+
+.norm-engine-apply-table tr.apply-row-source-conflict {
+  background: rgba(245, 158, 11, 0.08);
+}
+
+.norm-engine-apply-table tr.apply-row-winner {
+  background: rgba(16, 185, 129, 0.1);
+}
+
+.norm-engine-apply-winner-radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+/* Confirm modal */
+.norm-engine-apply-confirm .modal-body p {
+  margin: 0.5rem 0;
+  color: var(--text-primary);
+}
+
+.norm-engine-apply-confirm-warning {
+  color: var(--warning);
+  font-size: 0.9rem;
+}
+
+.norm-engine-apply-confirm-count {
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-top: 0.75rem;
+}
+
+/* Post-execute summary */
+.norm-engine-apply-summary {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.norm-engine-apply-summary-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--success);
+  margin-bottom: 0.5rem;
+}
+
+.norm-engine-apply-summary-counts {
+  display: flex;
+  gap: 1.25rem;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.norm-engine-apply-summary-errors {
+  color: var(--error);
+  font-weight: 600;
+}
+
+.norm-engine-apply-summary-hash {
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.norm-engine-apply-summary-hash code {
+  background: var(--bg-primary);
+  padding: 0.05rem 0.3rem;
+  border-radius: var(--radius-sm);
+}
+
+.norm-engine-apply-summary-link {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.norm-engine-apply-summary-link a {
+  color: var(--accent-50);
+  text-decoration: underline;
+}

--- a/frontend/src/components/settings/NormalizationEngineSection.tsx
+++ b/frontend/src/components/settings/NormalizationEngineSection.tsx
@@ -4,7 +4,7 @@
  * Advanced normalization rules management UI for the Settings tab.
  * Allows viewing, creating, editing, and testing normalization rules.
  */
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { Fragment, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   DndContext,
   closestCenter,
@@ -308,12 +308,28 @@ export function NormalizationEngineSection() {
   const [importing, setImporting] = useState(false);
   const importFileRef = useRef<HTMLInputElement>(null);
 
-  // Apply-to-channels state (GH-104)
+  // Apply-to-channels state (GH-104, bd-eio04.12)
   const [showApplyModal, setShowApplyModal] = useState(false);
   const [applyLoading, setApplyLoading] = useState(false);
   const [applyExecuting, setApplyExecuting] = useState(false);
   const [applyDiffs, setApplyDiffs] = useState<ApplyToChannelsDiffRow[]>([]);
   const [applyActions, setApplyActions] = useState<Record<number, ApplyToChannelsAction>>({});
+  // bd-eio04.12: rows whose rule-trace drawer is currently expanded
+  const [applyExpandedRows, setApplyExpandedRows] = useState<Set<number>>(new Set());
+  // bd-eio04.12: per conflict group (keyed by lowercased proposed_name),
+  // which channel_id the user picked as the winner. The winner defaults
+  // to unset so Execute stays disabled until the user chooses explicitly.
+  const [conflictGroupWinners, setConflictGroupWinners] = useState<Record<string, number>>({});
+  // bd-eio04.12: confirm-modal + post-execute summary
+  const [showApplyConfirm, setShowApplyConfirm] = useState(false);
+  const [applyResultSummary, setApplyResultSummary] =
+    useState<{
+      renamed: number;
+      merged: number;
+      skipped: number;
+      errors: number;
+      ruleSetHash?: string;
+    } | null>(null);
 
   // Drag-and-drop sensors for rule reordering
   const sensors = useSensors(
@@ -840,7 +856,103 @@ export function NormalizationEngineSection() {
     });
   }, [applyDiffs]);
 
-  // Execute the selected actions
+  // Toggle the rule-trace drawer for a row (bd-eio04.12).
+  const toggleApplyRowExpanded = useCallback((channelId: number) => {
+    setApplyExpandedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(channelId)) {
+        next.delete(channelId);
+      } else {
+        next.add(channelId);
+      }
+      return next;
+    });
+  }, []);
+
+  // Group rows that would rename to the same target name. Two flavors:
+  //   (i)  "collision" rows target a pre-existing channel outside this
+  //        preview set — each is its own 1-row group with an "existing
+  //        channel" winner pre-selected (merge into existing).
+  //   (ii) "source collision" groups are two or more rows in this preview
+  //        set whose proposed_name lands on the same target — the user
+  //        must pick exactly one winner before Execute enables.
+  // bd-eio04.12.
+  const conflictGroups = useMemo(() => {
+    const byTarget = new Map<string, ApplyToChannelsDiffRow[]>();
+    applyDiffs.forEach((row) => {
+      const key = (row.proposed_name || '').toLowerCase();
+      if (!key) return;
+      const bucket = byTarget.get(key) || [];
+      bucket.push(row);
+      byTarget.set(key, bucket);
+    });
+    const groups: Array<{
+      key: string;
+      rows: ApplyToChannelsDiffRow[];
+      kind: 'source' | 'existing' | 'none';
+    }> = [];
+    byTarget.forEach((rows, key) => {
+      if (rows.length > 1) {
+        groups.push({ key, rows, kind: 'source' });
+      } else if (rows[0].collision) {
+        groups.push({ key, rows, kind: 'existing' });
+      } else {
+        groups.push({ key, rows, kind: 'none' });
+      }
+    });
+    return groups;
+  }, [applyDiffs]);
+
+  // Map channel_id -> conflict group index (1-based for display badges).
+  const conflictGroupIndexByChannelId = useMemo(() => {
+    const map = new Map<number, number>();
+    let badge = 0;
+    conflictGroups.forEach((grp) => {
+      if (grp.kind === 'source' || grp.kind === 'existing') {
+        badge += 1;
+        grp.rows.forEach((row) => map.set(row.channel_id, badge));
+      }
+    });
+    return map;
+  }, [conflictGroups]);
+
+  // Source-collision groups that still need a winner before Execute enables.
+  const unresolvedSourceGroupKeys = useMemo(() => {
+    return conflictGroups
+      .filter((g) => g.kind === 'source' && conflictGroupWinners[g.key] == null)
+      .map((g) => g.key);
+  }, [conflictGroups, conflictGroupWinners]);
+
+  const canExecute = useMemo(() => {
+    if (applyDiffs.length === 0) return false;
+    if (unresolvedSourceGroupKeys.length > 0) return false;
+    return true;
+  }, [applyDiffs, unresolvedSourceGroupKeys]);
+
+  // Pick the winner inside a source-collision group. Non-winners flip to
+  // 'skip' automatically so the user can't double-rename onto the same
+  // target.
+  const pickConflictWinner = useCallback(
+    (groupKey: string, winnerChannelId: number) => {
+      setConflictGroupWinners((prev) => ({ ...prev, [groupKey]: winnerChannelId }));
+      setApplyActions((prev) => {
+        const next = { ...prev };
+        conflictGroups
+          .find((g) => g.key === groupKey)
+          ?.rows.forEach((row) => {
+            if (row.channel_id === winnerChannelId) {
+              next[row.channel_id] = row.collision ? 'merge' : 'rename';
+            } else {
+              next[row.channel_id] = 'skip';
+            }
+          });
+        return next;
+      });
+    },
+    [conflictGroups]
+  );
+
+  // Execute the selected actions — now gated by a confirmation modal.
   const handleExecuteApply = useCallback(async () => {
     const overrides: ApplyToChannelsActionOverride[] = applyDiffs.map((row) => {
       const action = applyActions[row.channel_id] || 'skip';
@@ -867,9 +979,20 @@ export function NormalizationEngineSection() {
       } else {
         notifications.success(summary, 'Normalization');
       }
-      setShowApplyModal(false);
+      // Surface the post-execute summary inline so the user sees counts +
+      // journal-log link without dismissing the modal (bd-eio04.12).
+      setApplyResultSummary({
+        renamed: result.renamed.length,
+        merged: result.merged.length,
+        skipped: result.skipped.length,
+        errors: result.errors.length,
+        ruleSetHash: result.rule_set_hash,
+      });
+      setShowApplyConfirm(false);
       setApplyDiffs([]);
       setApplyActions({});
+      setApplyExpandedRows(new Set());
+      setConflictGroupWinners({});
     } catch (err) {
       notifications.error(
         err instanceof Error ? err.message : 'Failed to apply normalization',
@@ -879,6 +1002,17 @@ export function NormalizationEngineSection() {
       setApplyExecuting(false);
     }
   }, [applyActions, applyDiffs, notifications]);
+
+  const closeApplyModal = useCallback(() => {
+    if (applyExecuting) return;
+    setShowApplyModal(false);
+    setApplyDiffs([]);
+    setApplyActions({});
+    setApplyExpandedRows(new Set());
+    setConflictGroupWinners({});
+    setApplyResultSummary(null);
+    setShowApplyConfirm(false);
+  }, [applyExecuting]);
 
   // Stats
   const stats = useMemo(() => {
@@ -1682,9 +1816,9 @@ export function NormalizationEngineSection() {
         </ModalOverlay>
       )}
 
-      {/* Apply-to-channels Modal (GH-104) */}
+      {/* Apply-to-channels Modal (GH-104, bd-eio04.12) */}
       {showApplyModal && (
-        <ModalOverlay onClose={() => (applyExecuting ? null : setShowApplyModal(false))}>
+        <ModalOverlay onClose={closeApplyModal}>
           <div
             className="modal-container modal-lg norm-engine-apply-modal"
             data-testid="apply-to-channels-modal"
@@ -1693,7 +1827,7 @@ export function NormalizationEngineSection() {
               <h2 className="modal-title">Apply Normalization to Existing Channels</h2>
               <button
                 className="modal-close-btn"
-                onClick={() => setShowApplyModal(false)}
+                onClick={closeApplyModal}
                 type="button"
                 disabled={applyExecuting}
               >
@@ -1717,7 +1851,47 @@ export function NormalizationEngineSection() {
                 </div>
               )}
 
-              {!applyLoading && applyDiffs.length === 0 && (
+              {!applyLoading && applyResultSummary && (
+                <div
+                  className="norm-engine-apply-summary"
+                  data-testid="apply-to-channels-summary"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <div className="norm-engine-apply-summary-heading">
+                    <span className="material-icons">check_circle</span>
+                    Apply complete
+                  </div>
+                  <div className="norm-engine-apply-summary-counts">
+                    <span>{applyResultSummary.renamed} renamed</span>
+                    <span>{applyResultSummary.merged} merged</span>
+                    <span>{applyResultSummary.skipped} skipped</span>
+                    <span
+                      className={
+                        applyResultSummary.errors > 0
+                          ? 'norm-engine-apply-summary-errors'
+                          : ''
+                      }
+                    >
+                      {applyResultSummary.errors} failed
+                    </span>
+                  </div>
+                  {applyResultSummary.ruleSetHash && (
+                    <div className="norm-engine-apply-summary-hash">
+                      Rule-set hash: <code>{applyResultSummary.ruleSetHash}</code>
+                    </div>
+                  )}
+                  <p className="norm-engine-apply-summary-link">
+                    Review each change in the{' '}
+                    <a href="#journal" data-testid="apply-to-channels-summary-journal-link">
+                      Activity Log (Journal tab)
+                    </a>
+                    .
+                  </p>
+                </div>
+              )}
+
+              {!applyLoading && !applyResultSummary && applyDiffs.length === 0 && (
                 <div
                   className="norm-engine-apply-empty"
                   data-testid="apply-to-channels-empty"
@@ -1727,7 +1901,7 @@ export function NormalizationEngineSection() {
                 </div>
               )}
 
-              {!applyLoading && applyDiffs.length > 0 && (
+              {!applyLoading && !applyResultSummary && applyDiffs.length > 0 && (
                 <>
                   <div className="norm-engine-apply-toolbar">
                     <button
@@ -1741,6 +1915,17 @@ export function NormalizationEngineSection() {
                     <span className="norm-engine-apply-count">
                       {applyDiffs.length} channel{applyDiffs.length === 1 ? '' : 's'} with changes
                     </span>
+                    {unresolvedSourceGroupKeys.length > 0 && (
+                      <span
+                        className="norm-engine-apply-conflict-hint"
+                        data-testid="apply-to-channels-conflict-hint"
+                      >
+                        <span className="material-icons">warning</span>
+                        {unresolvedSourceGroupKeys.length} conflict group
+                        {unresolvedSourceGroupKeys.length === 1 ? '' : 's'} need
+                        {unresolvedSourceGroupKeys.length === 1 ? 's' : ''} a winner
+                      </span>
+                    )}
                   </div>
 
                   <div
@@ -1750,56 +1935,195 @@ export function NormalizationEngineSection() {
                     <table className="norm-engine-apply-table">
                       <thead>
                         <tr>
+                          <th aria-label="Expand rule trace" />
                           <th>Current name</th>
                           <th>Proposed name</th>
-                          <th>Collision?</th>
+                          <th>Conflict</th>
+                          <th>Rules fired</th>
                           <th>Action</th>
                         </tr>
                       </thead>
                       <tbody>
-                        {applyDiffs.map((row) => (
-                          <tr
-                            key={row.channel_id}
-                            className={row.collision ? 'apply-row-collision' : ''}
-                            data-testid={`apply-row-${row.channel_id}`}
-                          >
-                            <td>{row.current_name}</td>
-                            <td>{row.proposed_name}</td>
-                            <td>
-                              {row.collision ? (
-                                <span
-                                  className="norm-engine-apply-collision"
-                                  title={`Matches existing channel '${row.collision_target_name ?? ''}'`}
-                                >
-                                  <span className="material-icons">warning</span>
-                                  {row.collision_target_name ?? 'collision'}
-                                </span>
-                              ) : (
-                                <span className="norm-engine-apply-ok">—</span>
-                              )}
-                            </td>
-                            <td>
-                              <select
-                                value={applyActions[row.channel_id] ?? 'skip'}
-                                onChange={(e) =>
-                                  setApplyAction(
-                                    row.channel_id,
-                                    e.target.value as ApplyToChannelsAction
-                                  )
-                                }
-                                data-testid={`apply-action-${row.channel_id}`}
+                        {applyDiffs.map((row) => {
+                          const expanded = applyExpandedRows.has(row.channel_id);
+                          const groupKey = (row.proposed_name || '').toLowerCase();
+                          const sourceGroup = conflictGroups.find(
+                            (g) => g.key === groupKey && g.kind === 'source'
+                          );
+                          const badge = conflictGroupIndexByChannelId.get(row.channel_id);
+                          const isWinner =
+                            sourceGroup &&
+                            conflictGroupWinners[groupKey] === row.channel_id;
+                          const isInSourceGroup = !!sourceGroup;
+                          const needsWinnerPick =
+                            isInSourceGroup &&
+                            conflictGroupWinners[groupKey] == null;
+                          const rowClasses = [
+                            row.collision ? 'apply-row-collision' : '',
+                            isInSourceGroup ? 'apply-row-source-conflict' : '',
+                            isWinner ? 'apply-row-winner' : '',
+                          ]
+                            .filter(Boolean)
+                            .join(' ');
+                          const traceRowId = `apply-trace-${row.channel_id}`;
+                          return (
+                            <Fragment key={row.channel_id}>
+                              <tr
+                                className={rowClasses}
+                                data-testid={`apply-row-${row.channel_id}`}
                               >
-                                <option value="skip">Skip</option>
-                                <option value="rename" disabled={row.collision}>
-                                  Rename
-                                </option>
-                                <option value="merge" disabled={!row.collision}>
-                                  Merge into existing
-                                </option>
-                              </select>
-                            </td>
-                          </tr>
-                        ))}
+                                <td>
+                                  <button
+                                    type="button"
+                                    className="norm-engine-apply-trace-toggle"
+                                    onClick={() => toggleApplyRowExpanded(row.channel_id)}
+                                    aria-expanded={expanded}
+                                    aria-controls={traceRowId}
+                                    aria-label={
+                                      expanded
+                                        ? 'Collapse rule trace'
+                                        : 'Expand rule trace'
+                                    }
+                                    data-testid={`apply-trace-toggle-${row.channel_id}`}
+                                  >
+                                    <span className="material-icons">
+                                      {expanded ? 'expand_more' : 'chevron_right'}
+                                    </span>
+                                  </button>
+                                </td>
+                                <td>{row.current_name}</td>
+                                <td>{row.proposed_name}</td>
+                                <td>
+                                  {badge && (
+                                    <span
+                                      className="norm-engine-apply-conflict-badge"
+                                      data-testid={`apply-conflict-badge-${row.channel_id}`}
+                                    >
+                                      Conflict Group {badge}
+                                    </span>
+                                  )}
+                                  {row.collision ? (
+                                    <span
+                                      className="norm-engine-apply-collision"
+                                      title={`Matches existing channel '${
+                                        row.collision_target_name ?? ''
+                                      }'`}
+                                    >
+                                      <span className="material-icons">warning</span>
+                                      {row.collision_target_name ?? 'collision'}
+                                    </span>
+                                  ) : !badge ? (
+                                    <span className="norm-engine-apply-ok">—</span>
+                                  ) : null}
+                                  {isInSourceGroup && (
+                                    <label className="norm-engine-apply-winner-radio">
+                                      <input
+                                        type="radio"
+                                        name={`conflict-winner-${groupKey}`}
+                                        checked={!!isWinner}
+                                        onChange={() =>
+                                          pickConflictWinner(groupKey, row.channel_id)
+                                        }
+                                        data-testid={`apply-winner-radio-${row.channel_id}`}
+                                      />
+                                      <span>Winner</span>
+                                    </label>
+                                  )}
+                                </td>
+                                <td>
+                                  <span
+                                    className="norm-engine-apply-rule-count"
+                                    data-testid={`apply-rule-count-${row.channel_id}`}
+                                  >
+                                    {(row.transformations?.length ?? 0)}{' '}
+                                    rule
+                                    {(row.transformations?.length ?? 0) === 1 ? '' : 's'}
+                                  </span>
+                                </td>
+                                <td>
+                                  <select
+                                    value={applyActions[row.channel_id] ?? 'skip'}
+                                    disabled={needsWinnerPick && !isWinner}
+                                    onChange={(e) =>
+                                      setApplyAction(
+                                        row.channel_id,
+                                        e.target.value as ApplyToChannelsAction
+                                      )
+                                    }
+                                    data-testid={`apply-action-${row.channel_id}`}
+                                  >
+                                    <option value="skip">Skip</option>
+                                    <option
+                                      value="rename"
+                                      disabled={
+                                        row.collision ||
+                                        (needsWinnerPick && !isWinner)
+                                      }
+                                    >
+                                      Rename
+                                    </option>
+                                    <option
+                                      value="merge"
+                                      disabled={
+                                        !row.collision &&
+                                        !(isInSourceGroup && isWinner)
+                                      }
+                                    >
+                                      {row.collision
+                                        ? 'Merge into existing'
+                                        : 'Merge'}
+                                    </option>
+                                  </select>
+                                </td>
+                              </tr>
+                              {expanded && (
+                                <tr
+                                  id={traceRowId}
+                                  className="norm-engine-apply-trace-row"
+                                  data-testid={`apply-trace-drawer-${row.channel_id}`}
+                                >
+                                  <td colSpan={6}>
+                                    <div className="norm-engine-apply-trace">
+                                      <div className="norm-engine-apply-trace-heading">
+                                        Rules fired for &quot;{row.current_name}&quot;
+                                      </div>
+                                      {(row.transformations?.length ?? 0) === 0 ? (
+                                        <div className="norm-engine-apply-trace-empty">
+                                          No rule trace recorded. The diff may be
+                                          due to Unicode normalization only.
+                                        </div>
+                                      ) : (
+                                        <ol className="norm-engine-apply-trace-list">
+                                          {row.transformations?.map((t, i) => (
+                                            <li
+                                              key={`${row.channel_id}-${i}`}
+                                              className="norm-engine-apply-trace-item"
+                                            >
+                                              <span className="material-icons">
+                                                chevron_right
+                                              </span>
+                                              <span className="trace-rule-id">
+                                                Rule {t.rule_id}
+                                              </span>
+                                              :{' '}
+                                              <code className="trace-before">
+                                                {t.before}
+                                              </code>{' '}
+                                              →{' '}
+                                              <code className="trace-after">
+                                                {t.after}
+                                              </code>
+                                            </li>
+                                          ))}
+                                        </ol>
+                                      )}
+                                    </div>
+                                  </td>
+                                </tr>
+                              )}
+                            </Fragment>
+                          );
+                        })}
                       </tbody>
                     </table>
                   </div>
@@ -1810,20 +2134,110 @@ export function NormalizationEngineSection() {
             <div className="modal-footer">
               <button
                 className="modal-btn"
-                onClick={() => setShowApplyModal(false)}
+                onClick={closeApplyModal}
                 type="button"
                 disabled={applyExecuting}
+              >
+                {applyResultSummary ? 'Close' : 'Cancel'}
+              </button>
+              {!applyResultSummary && (
+                <button
+                  className="modal-btn modal-btn-primary"
+                  onClick={() => setShowApplyConfirm(true)}
+                  disabled={applyExecuting || applyLoading || !canExecute}
+                  type="button"
+                  data-testid="apply-to-channels-execute"
+                >
+                  {applyExecuting ? 'Applying...' : 'Execute'}
+                </button>
+              )}
+            </div>
+          </div>
+        </ModalOverlay>
+      )}
+
+      {/* Apply-to-channels confirm modal (bd-eio04.12).
+          Wraps the destructive Execute action with an explicit count +
+          "cannot be undone" copy. Escape closes unless the execute is
+          actually in flight (loading lock). */}
+      {showApplyConfirm && (
+        <ModalOverlay
+          onClose={() => (applyExecuting ? null : setShowApplyConfirm(false))}
+        >
+          <div
+            className="modal-container modal-sm norm-engine-apply-confirm"
+            data-testid="apply-to-channels-confirm"
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="apply-confirm-title"
+          >
+            <div className="modal-header">
+              <h2 className="modal-title" id="apply-confirm-title">
+                Confirm bulk rename
+              </h2>
+              <button
+                className="modal-close-btn"
+                onClick={() => setShowApplyConfirm(false)}
+                type="button"
+                disabled={applyExecuting}
+              >
+                <span className="material-icons">close</span>
+              </button>
+            </div>
+            <div className="modal-body">
+              {(() => {
+                const counts = {
+                  rename: 0,
+                  merge: 0,
+                  skip: 0,
+                };
+                applyDiffs.forEach((row) => {
+                  const action = applyActions[row.channel_id] || 'skip';
+                  counts[action] += 1;
+                });
+                const mutating = counts.rename + counts.merge;
+                return (
+                  <>
+                    <p>
+                      About to rename <strong>{counts.rename}</strong> channel
+                      {counts.rename === 1 ? '' : 's'} and merge{' '}
+                      <strong>{counts.merge}</strong> channel
+                      {counts.merge === 1 ? '' : 's'} into existing targets.{' '}
+                      <strong>{counts.skip}</strong> will be skipped.
+                    </p>
+                    <p className="norm-engine-apply-confirm-warning">
+                      This cannot be undone from this screen. See the
+                      Activity Log (Journal tab) to review each change.
+                    </p>
+                    <p
+                      className="norm-engine-apply-confirm-count"
+                      data-testid="apply-to-channels-confirm-count"
+                    >
+                      {mutating} channel{mutating === 1 ? '' : 's'} will be
+                      modified.
+                    </p>
+                  </>
+                );
+              })()}
+            </div>
+            <div className="modal-footer">
+              <button
+                className="modal-btn"
+                type="button"
+                onClick={() => setShowApplyConfirm(false)}
+                disabled={applyExecuting}
+                data-testid="apply-to-channels-confirm-cancel"
               >
                 Cancel
               </button>
               <button
                 className="modal-btn modal-btn-primary"
-                onClick={handleExecuteApply}
-                disabled={applyExecuting || applyLoading || applyDiffs.length === 0}
                 type="button"
-                data-testid="apply-to-channels-execute"
+                onClick={handleExecuteApply}
+                disabled={applyExecuting}
+                data-testid="apply-to-channels-confirm-execute"
               >
-                {applyExecuting ? 'Applying...' : 'Execute'}
+                {applyExecuting ? 'Applying...' : 'Yes, apply'}
               </button>
             </div>
           </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -793,6 +793,9 @@ export interface ApplyToChannelsDiffRow {
   collision_target_group_id: number | null;
   collision_target_group_name: string | null;
   suggested_action: 'rename' | 'merge' | 'skip';
+  // bd-eio04.12: per-rule trace so the UI can render a "Rules fired"
+  // drawer that matches the Test Rules preview shape.
+  transformations?: NormalizationTransformation[];
 }
 
 // Response from dry-run apply-to-channels
@@ -819,6 +822,9 @@ export interface ApplyToChannelsExecuteResponse {
   merged: Array<{ channel_id: number; target_id: number; streams_added: number }>;
   skipped: Array<{ channel_id: number; reason: string }>;
   errors: Array<{ channel_id: number; error: string }>;
+  // bd-eio04.12: correlates the audit-log entry with the rule-set that
+  // was active when the bulk apply ran.
+  rule_set_hash?: string;
 }
 
 // Migration status response


### PR DESCRIPTION
## Summary

Closes the remaining Apply-to-Channels UX gaps from PR #107 and absorbs bd-ei4m9 (admin gate on the bulk destructive endpoint).

**Backend** (`routers/normalization.py`):
- `RequireAdminIfEnabled` on `POST /apply-to-channels`.
- Rate limit `5/minute`.
- Module-level `asyncio.Lock` — concurrent execute returns 409 Conflict.
- `_build_apply_diff` serializes `engine.normalize().transformations` per row (shape matches `/test-batch`).
- `_compute_rule_set_hash()` (SHA-256 prefix over enabled rules) captured in journal + echoed on response for UI correlation.

**Frontend** (`NormalizationEngineSection.tsx`):
- Rule-trace drawer per preview row (`aria-expanded`/`aria-controls`), "Rules fired" count in trigger.
- Conflict-group UX: type-(i) existing-target collision offers Merge; type-(ii) two in-scope rows normalizing to same target get a "Conflict Group N" badge and radio-picker forcing a winner. Execute disabled while any type-(ii) group is unresolved.
- Execute-guard confirm modal (`role="alertdialog"`, count, "cannot be undone from this screen").
- Post-execute summary with `rule_set_hash` + journal deep link.

**Overlap note:** touches `routers/normalization.py`. PR #bd-eio04.7 (write-time lint) also touches this file at different endpoints (POST/PATCH `/rules` vs. POST `/apply-to-channels`). Conflict is textual, not semantic — either order works.

## Test plan

- [x] 4 new backend test classes + 3 existing updated for new audit shape — 42 router tests green.
- [x] 3 new frontend tests (trace drawer, conflict winner, confirm+summary) — 8 tests green.
- [x] New `e2e/re-normalize.spec.ts` — seeds 3 Unicode-suffixed channels, walks full flow. Passes against live container.
- [x] Full backend suite: 2752 passed. Full frontend suite: 1127/1127.
- [x] Deployed to `ecm-ecm-1` and verified during development.

## Sequence

Merge position: **5 of 6**. Either order with `.7` — both touch `routers/normalization.py` additively at different endpoints.