### PR TITLE
bd-eio04.7: write-time pattern linting at persistence boundaries

### DIFF
--- a/backend/alembic/versions/20260422_1500_0003_rule_lint_findings.py
+++ b/backend/alembic/versions/20260422_1500_0003_rule_lint_findings.py
@@ -1,0 +1,58 @@
+"""rule_lint_findings
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-22 15:00:00.000000
+
+Adds the ``rule_lint_findings`` table for bd-eio04.7 write-time pattern
+linting. The table stores diagnostic findings from the migration-scan
+step that flags pre-lint rule rows whose patterns would now fail the
+write-time checks. Findings do NOT disable or modify the underlying
+rules — UI surfaces them so an operator can decide whether to edit.
+
+DB-engineer grooming note: separate table (not columns on the three
+rule tables) so the hot-path rule rows aren't widened with optional
+audit metadata.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0003'
+down_revision: Union[str, Sequence[str], None] = '0002'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema — create the rule_lint_findings table."""
+    op.create_table(
+        'rule_lint_findings',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('rule_type', sa.String(length=30), nullable=False),
+        sa.Column('rule_id', sa.Integer(), nullable=False),
+        sa.Column('field', sa.String(length=120), nullable=False),
+        sa.Column('code', sa.String(length=40), nullable=False),
+        sa.Column('message', sa.Text(), nullable=False),
+        sa.Column('detail', sa.Text(), nullable=True),
+        sa.Column('detected_at', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    with op.batch_alter_table('rule_lint_findings', schema=None) as batch_op:
+        batch_op.create_index(
+            'idx_rule_lint_finding_rule', ['rule_type', 'rule_id'], unique=False
+        )
+        batch_op.create_index(
+            'idx_rule_lint_finding_code', ['code'], unique=False
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema — drop the rule_lint_findings table."""
+    with op.batch_alter_table('rule_lint_findings', schema=None) as batch_op:
+        batch_op.drop_index('idx_rule_lint_finding_code')
+        batch_op.drop_index('idx_rule_lint_finding_rule')
+    op.drop_table('rule_lint_findings')

--- a/backend/main.py
+++ b/backend/main.py
@@ -714,6 +714,25 @@ async def startup_event():
     except Exception as e:
         logger.warning("[MAIN] Could not check auto-creation rule priorities: %s", e)
 
+    # Scan existing rule rows for pathological regex patterns (bd-eio04.7).
+    # Read-only diagnostic pass — findings are written to rule_lint_findings
+    # so the UI can surface pre-lint rows that would now fail the write-time
+    # linter. Does NOT disable or modify any rule.
+    try:
+        from tasks.rule_lint_scan import run_scan
+        sess = get_session()
+        try:
+            summary = run_scan(sess)
+            if summary.get("total_findings", 0) > 0:
+                logger.info(
+                    "[MAIN] Rule lint scan surfaced %d finding(s) across existing rules",
+                    summary["total_findings"],
+                )
+        finally:
+            sess.close()
+    except Exception as e:
+        logger.warning("[MAIN] Rule lint scan failed (non-fatal): %s", e)
+
     logger.info("[MAIN] CONFIG_DIR: %s", CONFIG_DIR)
     logger.info("[MAIN] CONFIG_FILE: %s", CONFIG_FILE)
     logger.info("[MAIN] CONFIG_DIR exists: %s", CONFIG_DIR.exists())

--- a/backend/models.py
+++ b/backend/models.py
@@ -2105,3 +2105,76 @@ class LookupTable(Base):
 
     def __repr__(self):
         return f"<LookupTable(id={self.id}, name={self.name})>"
+
+
+class RuleLintFinding(Base):
+    """
+    Persistent lint finding for a stored rule pattern (bd-eio04.7).
+
+    Written by :mod:`regex_lint`'s migration-scan step for pre-lint rows
+    that would now fail the write-time lint. Kept separate from the rule
+    tables so the hot-path rows aren't widened with optional
+    audit-style metadata (DB-engineer grooming decision).
+
+    The table is purely diagnostic: findings do NOT disable or modify the
+    underlying rule. UI surfaces the findings via GET endpoints on each
+    router so an operator can decide whether to edit or keep the rule.
+
+    Scan semantics:
+    - Idempotent. Before each scan the existing findings for that
+      ``(rule_type, rule_id)`` pair are cleared; re-running the scan on
+      the same corpus produces the same flagged set.
+    - Best-effort. If a rule's JSON payload fails to deserialize the scan
+      logs and skips that row — a separate concern from the pattern
+      being pathological.
+    """
+
+    __tablename__ = "rule_lint_findings"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    # Logical rule type — one of "normalization", "auto_creation",
+    # "dummy_epg". Not a real FK because the three rule tables can't share
+    # one; the scan keeps the string coordinate and the rule_id together.
+    rule_type = Column(String(30), nullable=False)
+    rule_id = Column(Integer, nullable=False)
+    # Human-readable path (e.g., "condition_value", "actions[1].pattern").
+    field = Column(String(120), nullable=False)
+    # REGEX_TOO_LONG / REGEX_COMPILE_ERROR / REGEX_NESTED_QUANTIFIER —
+    # kept as a String column rather than an Enum so a newer scan can
+    # surface codes this column wasn't built knowing about.
+    code = Column(String(40), nullable=False)
+    message = Column(Text, nullable=False)
+    # JSON-encoded per-code context (pattern_len, compile_error, reason).
+    detail = Column(Text, nullable=True)
+    detected_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        Index("idx_rule_lint_finding_rule", rule_type, rule_id),
+        Index("idx_rule_lint_finding_code", code),
+    )
+
+    def to_dict(self) -> dict:
+        import json as _json
+
+        try:
+            detail_obj = _json.loads(self.detail) if self.detail else {}
+        except (ValueError, TypeError):
+            detail_obj = {}
+        return {
+            "id": self.id,
+            "rule_type": self.rule_type,
+            "rule_id": self.rule_id,
+            "field": self.field,
+            "code": self.code,
+            "message": self.message,
+            "detail": detail_obj,
+            "detected_at": (
+                self.detected_at.isoformat() + "Z" if self.detected_at else None
+            ),
+        }
+
+    def __repr__(self):
+        return (
+            f"<RuleLintFinding(id={self.id}, rule_type={self.rule_type}, "
+            f"rule_id={self.rule_id}, code={self.code})>"
+        )

--- a/backend/regex_lint.py
+++ b/backend/regex_lint.py
@@ -1,0 +1,531 @@
+"""
+regex_lint — write-time pattern linter for user-supplied regex.
+
+Rejects pathological patterns at persistence boundaries (normalization rules,
+auto-creation rules, dummy-EPG profiles). The detector is the hand-rolled AST
+walker selected by the bd-eio04.11 spike — it walks the stdlib ``re._parser``
+parse tree and flags only the nested-unbounded-quantifier-with-killer shape
+Python's ``re`` engine is actually vulnerable to. Zero external dependencies.
+
+Bead: bd-eio04.7. Depends on ``safe_regex`` (bd-eio04.5) for the length cap
+and compile-error surface. Spike: bd-eio04.11 (hand-rolled won over
+regexploit 0 FP vs 1 FP on the production corpus).
+
+Three violation codes are emitted:
+
+* ``REGEX_TOO_LONG`` — pattern length > ``MAX_PATTERN_LEN`` (shared with
+  ``safe_regex.DEFAULT_MAX_PATTERN_LEN``).
+* ``REGEX_COMPILE_ERROR`` — pattern failed to compile via ``safe_regex``.
+* ``REGEX_NESTED_QUANTIFIER`` — AST walk detected the ReDoS shape.
+
+The AST walk operates on the compiled parse tree, not on the pattern string
+via regex-matching, so the linter is itself ReDoS-safe by construction.
+
+Error messages are actionable (length/limit surfaced, rewrite hint included)
+and point to ``/docs/patterns`` (placeholder — bd-eio04.8 writes the style
+guide Regex section this URL will link to).
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field as _dc_field
+from typing import Any, Iterable, Literal
+
+import safe_regex
+
+logger = logging.getLogger(__name__)
+
+# -------------------------------------------------------------------------
+# Stdlib AST plumbing — private modules, post-3.11 names with fallback.
+# -------------------------------------------------------------------------
+try:  # Python 3.11+
+    import re._parser as _sre_parse  # type: ignore[import-not-found]
+    from re._constants import (  # type: ignore[import-not-found]
+        MAX_REPEAT,
+        MIN_REPEAT,
+        SUBPATTERN,
+        BRANCH,
+        IN,
+        LITERAL,
+        NOT_LITERAL,
+        CATEGORY,
+        AT,
+        ASSERT,
+        ASSERT_NOT,
+        MAXREPEAT,
+    )
+except ImportError:  # pragma: no cover — Python < 3.11
+    import sre_parse as _sre_parse  # type: ignore[no-redef]
+    from sre_constants import (  # type: ignore[no-redef]
+        MAX_REPEAT,
+        MIN_REPEAT,
+        SUBPATTERN,
+        BRANCH,
+        IN,
+        LITERAL,
+        NOT_LITERAL,
+        CATEGORY,
+        AT,
+        ASSERT,
+        ASSERT_NOT,
+        MAXREPEAT,
+    )
+
+_REPEAT_OPS = {MAX_REPEAT, MIN_REPEAT}
+
+
+# -------------------------------------------------------------------------
+# Public constants and types.
+# -------------------------------------------------------------------------
+
+MAX_PATTERN_LEN: int = safe_regex.DEFAULT_MAX_PATTERN_LEN  # 500
+
+# Placeholder — bd-eio04.8 will write the style guide section this link
+# points to. Keeping the TODO in-code so the test suite's grep for
+# "/docs/patterns" is load-bearing until that bead lands.
+DOCS_URL: str = "/docs/patterns"  # TODO(bd-eio04.8): point to anchored section
+
+ViolationCode = Literal[
+    "REGEX_TOO_LONG",
+    "REGEX_NESTED_QUANTIFIER",
+    "REGEX_COMPILE_ERROR",
+]
+
+
+@dataclass
+class LintViolation:
+    """One lint finding. See :func:`lint_pattern` for semantics."""
+
+    code: ViolationCode
+    message: str
+    field: str = "pattern"
+    detail: dict = _dc_field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "field": self.field,
+            "code": self.code,
+            "message": self.message,
+            "detail": dict(self.detail),
+        }
+
+
+# -------------------------------------------------------------------------
+# The nested-unbounded-quantifier detector — lifted verbatim from
+# /tmp/bd-eio04.11-eval.py (spike winner). See the spike report for the
+# 0-FP/7-TP empirical results and the rationale for only flagging
+# nested-unbounded-with-killer.
+# -------------------------------------------------------------------------
+
+
+def _is_unbounded(repeat_args: Any) -> bool:
+    _min, _max, _body = repeat_args
+    return _max == MAXREPEAT
+
+
+def _contains_unbounded_repeat(parsed: Any) -> bool:
+    for op, args in parsed:
+        if op in _REPEAT_OPS and _is_unbounded(args):
+            return True
+        if op is SUBPATTERN:
+            _gid, _a, _b, subp = args
+            if _contains_unbounded_repeat(subp):
+                return True
+        elif op is BRANCH:
+            _none, branches = args
+            for b in branches:
+                if _contains_unbounded_repeat(b):
+                    return True
+        elif op in (ASSERT, ASSERT_NOT):
+            _dir, subp = args
+            if _contains_unbounded_repeat(subp):
+                return True
+    return False
+
+
+def _has_post_killer(subp_tail: Any) -> bool:
+    """Return True if anything in ``subp_tail`` can force a match failure.
+
+    Literals, char classes, and anchors are "killers" — they fail against
+    the wrong character and force the outer repeat to backtrack. A required
+    inner repeat (min>=1) whose body itself contains a killer also counts.
+    """
+    for op, args in subp_tail:
+        if op in (LITERAL, NOT_LITERAL, IN, CATEGORY, AT):
+            return True
+        if op is SUBPATTERN:
+            _gid, _a, _b, inner = args
+            if _has_post_killer(inner):
+                return True
+        if op in _REPEAT_OPS:
+            _min, _max, body = args
+            if _min >= 1 and _has_post_killer(body):
+                return True
+    return False
+
+
+def _js_to_python_named_groups(pattern: str) -> str:
+    """Mirror ``backend/dummy_epg_engine.py``: convert JS-style ``(?<name>``
+    to Python's ``(?P<name>`` so we parse exactly the pattern the engine
+    will execute. Leaves lookbehinds ``(?<=`` / ``(?<!`` untouched."""
+    if not pattern:
+        return pattern
+    return re.sub(r"\(\?<(?!\=|\!)", "(?P<", pattern)
+
+
+def _detect_nested_quantifier(pattern: str) -> tuple[bool, str]:
+    """Return ``(is_vulnerable, reason)``. Empty reason means safe.
+
+    Mirrors the spike's ``detect_redos`` (bd-eio04.11). Only flags
+    nested-unbounded-quantifier-with-post-match-killer — the shape Python's
+    ``re`` engine is actually vulnerable to.
+    """
+    try:
+        converted = _js_to_python_named_groups(pattern)
+        parsed = _sre_parse.parse(converted)
+    except re.error as exc:
+        # Compile errors are surfaced by the compile step — we don't flag
+        # them here to avoid double-reporting.
+        return (False, f"syntax-error:{exc}")
+
+    def walk(subp: Any, outer_suffix_has_killer: bool) -> str | None:
+        for idx, (op, args) in enumerate(subp):
+            remainder = subp[idx + 1 :]
+            local_killer = _has_post_killer(remainder) or outer_suffix_has_killer
+
+            if op in _REPEAT_OPS:
+                _min, _max, body = args
+                if (
+                    _is_unbounded((_min, _max, body))
+                    and _contains_unbounded_repeat(body)
+                    and local_killer
+                ):
+                    return "nested-unbounded-repeat-with-killer"
+                r = walk(body, local_killer)
+                if r:
+                    return r
+            elif op is SUBPATTERN:
+                _gid, _a, _b, subp2 = args
+                r = walk(subp2, local_killer)
+                if r:
+                    return r
+            elif op is BRANCH:
+                _none, branches = args
+                for b in branches:
+                    r = walk(b, local_killer)
+                    if r:
+                        return r
+            elif op in (ASSERT, ASSERT_NOT):
+                _dir, subp2 = args
+                # Lookarounds are zero-width; they don't propagate outer killer.
+                r = walk(subp2, False)
+                if r:
+                    return r
+        return None
+
+    reason = walk(parsed, outer_suffix_has_killer=False)
+    return (reason is not None, reason or "")
+
+
+# -------------------------------------------------------------------------
+# Public API.
+# -------------------------------------------------------------------------
+
+
+def lint_pattern(
+    pattern: str | None,
+    field: str = "pattern",
+    *,
+    max_pattern_len: int = MAX_PATTERN_LEN,
+) -> list[LintViolation]:
+    """Run all lint checks against ``pattern``; return the violations list.
+
+    Returns an empty list when the pattern is safe to persist. Empty,
+    ``None``, or whitespace-only patterns are treated as "no regex
+    supplied" and pass (router-level required-field validation is a
+    separate concern).
+
+    Check order — fail fast on the cheapest check:
+
+    1. **Length** (``REGEX_TOO_LONG``). No further checks run if this
+       trips, since oversize patterns also fail compile and we don't want
+       to waste CPU on the AST walk.
+    2. **Compile** (``REGEX_COMPILE_ERROR``). Skipped if length already
+       failed. Syntax errors short-circuit the AST walk.
+    3. **Nested quantifier** (``REGEX_NESTED_QUANTIFIER``). AST-level
+       check on the parsed pattern.
+    """
+    violations: list[LintViolation] = []
+
+    if pattern is None:
+        return violations
+    if not isinstance(pattern, str):
+        # Caller passed something weird; don't crash the endpoint, flag it
+        # as an invalid pattern so the UI can display the message.
+        violations.append(
+            LintViolation(
+                code="REGEX_COMPILE_ERROR",
+                message=(
+                    f"Pattern must be a string, got {type(pattern).__name__}. "
+                    f"See {DOCS_URL} for guidance."
+                ),
+                field=field,
+                detail={"compile_error": f"type={type(pattern).__name__}"},
+            )
+        )
+        return violations
+    # Empty / whitespace-only: treat as no pattern supplied.
+    if not pattern.strip():
+        return violations
+
+    # 1. Length check.
+    if len(pattern) > max_pattern_len:
+        violations.append(
+            LintViolation(
+                code="REGEX_TOO_LONG",
+                message=(
+                    f"Pattern is too long ({len(pattern)} chars, max "
+                    f"{max_pattern_len}). Try breaking this into multiple "
+                    f"rules. See {DOCS_URL} for guidance."
+                ),
+                field=field,
+                detail={
+                    "pattern_len": len(pattern),
+                    "max_pattern_len": max_pattern_len,
+                },
+            )
+        )
+        # Skip further checks — a too-long pattern will also fail compile
+        # (safe_regex.compile raises PatternTooLongError on the same cap),
+        # and we don't want to spend CPU walking an oversized AST.
+        return violations
+
+    # 2. Compile check via safe_regex. We apply the same named-group
+    # conversion as the runtime engines so the compile check exercises
+    # the actual pattern the engines will see.
+    converted = _js_to_python_named_groups(pattern)
+    try:
+        safe_regex.compile(converted, max_pattern_len=max_pattern_len)
+    except safe_regex.PatternTooLongError:
+        # Length already handled above; reaching here means conversion
+        # made the string longer than the cap, which is abnormal. Report
+        # as too-long.
+        violations.append(
+            LintViolation(
+                code="REGEX_TOO_LONG",
+                message=(
+                    f"Pattern is too long after named-group conversion "
+                    f"({len(converted)} chars, max {max_pattern_len}). "
+                    f"See {DOCS_URL} for guidance."
+                ),
+                field=field,
+                detail={
+                    "pattern_len": len(converted),
+                    "max_pattern_len": max_pattern_len,
+                },
+            )
+        )
+        return violations
+    except safe_regex.SafeRegexError as exc:
+        # Compile error. Message strips the internal sha256 framing that
+        # safe_regex adds so the user-facing message is focused on the
+        # underlying regex.error text.
+        compile_error = _extract_compile_error(exc)
+        violations.append(
+            LintViolation(
+                code="REGEX_COMPILE_ERROR",
+                message=(
+                    f"Pattern failed to compile: {compile_error}. "
+                    f"Check for unescaped metacharacters or unbalanced "
+                    f"parentheses. See {DOCS_URL} for guidance."
+                ),
+                field=field,
+                detail={"compile_error": compile_error},
+            )
+        )
+        # If it can't compile, the AST walk below would also fail — stop
+        # here to avoid reporting the same error twice.
+        return violations
+
+    # 3. Nested-quantifier AST walk.
+    is_vuln, reason = _detect_nested_quantifier(pattern)
+    if is_vuln:
+        violations.append(
+            LintViolation(
+                code="REGEX_NESTED_QUANTIFIER",
+                message=(
+                    "Pattern contains a nested unbounded quantifier followed "
+                    "by a terminator — this can catastrophically backtrack "
+                    "on adversarial input. Rewrite to avoid nesting + and * "
+                    f"inside another + or *. See {DOCS_URL} for guidance."
+                ),
+                field=field,
+                detail={"reason": reason},
+            )
+        )
+
+    return violations
+
+
+def _extract_compile_error(exc: Exception) -> str:
+    """Pull the user-meaningful portion out of a SafeRegexError.
+
+    ``safe_regex.compile`` wraps errors as
+    ``"failed to compile pattern (sha256=...): <real error>"``. Strip the
+    sha256 framing for UI display but preserve the ``regex.error`` text.
+    """
+    msg = str(exc)
+    marker = "): "
+    idx = msg.find(marker)
+    if idx != -1:
+        return msg[idx + len(marker) :]
+    return msg
+
+
+# -------------------------------------------------------------------------
+# Bulk helpers for router wiring.
+# -------------------------------------------------------------------------
+
+
+def lint_pattern_fields(fields: Iterable[tuple[str, str | None]]) -> list[LintViolation]:
+    """Lint several ``(field_name, pattern)`` pairs; aggregate violations.
+
+    Convenience for endpoints that have multiple pattern-bearing columns
+    (e.g. dummy-EPG profile has ``title_pattern`` + ``time_pattern`` +
+    ``date_pattern`` + substitution pair ``find`` values). Passing
+    ``None`` or ``""`` for a pattern is a no-op.
+    """
+    out: list[LintViolation] = []
+    for name, pattern in fields:
+        out.extend(lint_pattern(pattern, field=name))
+    return out
+
+
+def lint_conditions_json(conditions: list | None, prefix: str = "conditions") -> list[LintViolation]:
+    """Walk a list of condition objects; lint any pattern-bearing values.
+
+    Used by the normalization and auto-creation routers which store
+    compound conditions as JSON blobs. The condition shape is
+    ``{type, value, ...}`` — for regex-flavored types we lint
+    ``value``; all other types are skipped. Auto-creation condition
+    types that take regex: ``stream_name_matches``, ``stream_group_matches``,
+    ``tvg_id_matches``, ``channel_exists_matching``. Normalization
+    rule condition type ``regex`` also has a regex value.
+    """
+    if not conditions:
+        return []
+
+    regex_condition_types = {
+        # Normalization
+        "regex",
+        # Auto-creation
+        "stream_name_matches",
+        "stream_group_matches",
+        "tvg_id_matches",
+        "channel_exists_matching",
+    }
+    out: list[LintViolation] = []
+    for idx, cond in enumerate(conditions):
+        if not isinstance(cond, dict):
+            continue
+        ctype = cond.get("type")
+        # Logical operators recurse.
+        if ctype in ("and", "or", "not"):
+            sub = cond.get("conditions")
+            if isinstance(sub, list):
+                out.extend(
+                    lint_conditions_json(sub, prefix=f"{prefix}[{idx}].conditions")
+                )
+            continue
+        if ctype in regex_condition_types:
+            value = cond.get("value")
+            out.extend(lint_pattern(value, field=f"{prefix}[{idx}].value"))
+    return out
+
+
+def lint_actions_json(actions: list | None, prefix: str = "actions") -> list[LintViolation]:
+    """Walk a list of action objects; lint any pattern-bearing values.
+
+    Normalization ``regex_replace`` actions store their pattern on the
+    rule's ``condition_value`` (linted separately). Auto-creation
+    ``set_variable`` actions in ``regex_extract`` / ``regex_replace``
+    modes store the pattern in ``action.pattern``. Name-transform fields
+    (``name_transform_pattern``) appear on ``create_channel`` /
+    ``create_group`` actions.
+    """
+    if not actions:
+        return []
+    out: list[LintViolation] = []
+    for idx, action in enumerate(actions):
+        if not isinstance(action, dict):
+            continue
+        atype = action.get("type")
+        # set_variable regex modes.
+        if atype == "set_variable":
+            mode = action.get("variable_mode")
+            if mode in ("regex_extract", "regex_replace"):
+                out.extend(
+                    lint_pattern(action.get("pattern"), field=f"{prefix}[{idx}].pattern")
+                )
+        # Name transform on create_channel / create_group.
+        if "name_transform_pattern" in action:
+            out.extend(
+                lint_pattern(
+                    action.get("name_transform_pattern"),
+                    field=f"{prefix}[{idx}].name_transform_pattern",
+                )
+            )
+    return out
+
+
+def lint_substitution_pairs(
+    pairs: list | None, prefix: str = "substitution_pairs"
+) -> list[LintViolation]:
+    """Lint ``find`` values on substitution pairs that have ``is_regex: True``.
+
+    Substitution pairs shape:
+    ``{"find": "...", "replace": "...", "is_regex": bool, "enabled": bool}``.
+    Non-regex pairs are literal strings and don't need the lint.
+    """
+    if not pairs:
+        return []
+    out: list[LintViolation] = []
+    for idx, pair in enumerate(pairs):
+        if not isinstance(pair, dict):
+            continue
+        if pair.get("is_regex"):
+            out.extend(
+                lint_pattern(pair.get("find"), field=f"{prefix}[{idx}].find")
+            )
+    return out
+
+
+def violations_to_http_detail(violations: list[LintViolation]) -> dict:
+    """Build the HTTP 422 ``detail`` dict for a list of violations.
+
+    Response envelope (matches the bead-eio04.7 grooming decision —
+    single top-level code + per-violation breakdown)::
+
+        {
+          "error": {
+            "code": "REGEX_VALIDATION_ERROR",
+            "message": "<first violation's message>",
+            "details": [<each violation as a dict>]
+          }
+        }
+
+    FastAPI ``HTTPException(status_code=422, detail=...)`` wraps this under
+    ``detail`` at the response level — the sanitized handler in ``main.py``
+    passes ``detail`` through unchanged for non-500 codes.
+    """
+    # Use the first violation's message as the top-level human message —
+    # it's the one the UI will show in the inline error banner.
+    top_message = violations[0].message if violations else "Pattern validation failed"
+    return {
+        "error": {
+            "code": "REGEX_VALIDATION_ERROR",
+            "message": top_message,
+            "details": [v.to_dict() for v in violations],
+        }
+    }

--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -20,6 +20,12 @@ from starlette.responses import StreamingResponse
 from concurrency import run_cpu_bound
 from database import get_session
 from dispatcharr_client import get_client
+from regex_lint import (
+    lint_actions_json,
+    lint_conditions_json,
+    lint_pattern,
+    violations_to_http_detail,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +165,38 @@ async def get_auto_creation_rule(rule_id: int):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+def _lint_auto_creation_rule_request(
+    conditions: Optional[list], actions: Optional[list], sort_regex: Optional[str]
+) -> None:
+    """Raise HTTP 422 if any pattern field fails the regex linter (bd-eio04.7).
+
+    Auto-creation rules have regex-bearing fields scattered across:
+      - ``sort_regex`` (top-level rule column)
+      - Condition ``value`` for regex-flavored condition types
+        (``stream_name_matches``, ``stream_group_matches``,
+        ``tvg_id_matches``, ``channel_exists_matching``)
+      - Action ``pattern`` for ``set_variable`` in ``regex_extract`` /
+        ``regex_replace`` modes
+      - Action ``name_transform_pattern`` on ``create_channel`` /
+        ``create_group``
+    """
+    violations = []
+    violations.extend(lint_pattern(sort_regex, field="sort_regex"))
+    if conditions:
+        violations.extend(lint_conditions_json(conditions, prefix="conditions"))
+    if actions:
+        violations.extend(lint_actions_json(actions, prefix="actions"))
+    if violations:
+        logger.warning(
+            "[AUTO-CREATE] Rejected rule — %d lint violation(s): %s",
+            len(violations),
+            [(v.field, v.code) for v in violations],
+        )
+        raise HTTPException(
+            status_code=422, detail=violations_to_http_detail(violations)
+        )
+
+
 @router.post("/rules")
 async def create_auto_creation_rule(request: CreateAutoCreationRuleRequest):
     """Create a new auto-creation rule."""
@@ -170,6 +208,11 @@ async def create_auto_creation_rule(request: CreateAutoCreationRuleRequest):
         logger.debug("[AUTO-CREATE] Creating rule '%s' with %s actions", request.name, len(request.actions))
         for j, action in enumerate(request.actions):
             logger.debug("[AUTO-CREATE]   Action %s: %s", j, action)
+        # Lint regex patterns (bd-eio04.7) BEFORE schema validation so users
+        # see the specific pattern error rather than a generic schema message.
+        _lint_auto_creation_rule_request(
+            request.conditions, request.actions, request.sort_regex
+        )
         validation = validate_rule(request.conditions, request.actions)
         if not validation["valid"]:
             raise HTTPException(status_code=400, detail={
@@ -292,6 +335,16 @@ async def update_auto_creation_rule(rule_id: int, request: UpdateAutoCreationRul
             logger.debug("[AUTO-CREATE] Updating rule id=%s '%s' with %s actions", rule_id, rule.name, len(actions))
             for j, action in enumerate(actions):
                 logger.debug("[AUTO-CREATE]   Action %s: %s", j, action)
+
+            # Lint regex patterns (bd-eio04.7). Only fields actually
+            # supplied on the PUT are linted — an operator renaming a rule
+            # shouldn't hit a 422 for a pattern they didn't edit. Pre-lint
+            # rows are surfaced separately by the startup scan.
+            _lint_auto_creation_rule_request(
+                request.conditions if request.conditions is not None else None,
+                request.actions if request.actions is not None else None,
+                request.sort_regex if request.sort_regex is not None else None,
+            )
 
             validation = validate_rule(conditions, actions)
             if not validation["valid"]:
@@ -1443,3 +1496,33 @@ async def generate_debug_bundle():
     except Exception as e:
         logger.exception("[AUTO-CREATE] Failed to generate debug bundle: %s", e)
         raise HTTPException(status_code=500, detail="Failed to generate debug bundle")
+
+
+# =============================================================================
+# Lint findings (bd-eio04.7) — read-only view of the startup migration scan.
+# =============================================================================
+
+
+@router.get("/lint-findings")
+async def get_auto_creation_lint_findings():
+    """Return the cached lint findings for auto-creation rules.
+
+    See ``routers/normalization.py::get_normalization_lint_findings`` for
+    semantics. Findings are scoped to ``rule_type='auto_creation'``.
+    """
+    logger.debug("[AUTO-CREATE] GET /lint-findings")
+    try:
+        from models import RuleLintFinding
+        from tasks.rule_lint_scan import RULE_TYPE_AUTO_CREATION
+
+        session = get_session()
+        try:
+            findings = session.query(RuleLintFinding).filter(
+                RuleLintFinding.rule_type == RULE_TYPE_AUTO_CREATION
+            ).order_by(RuleLintFinding.rule_id, RuleLintFinding.id).all()
+            return {"findings": [f.to_dict() for f in findings]}
+        finally:
+            session.close()
+    except Exception as e:
+        logger.exception("[AUTO-CREATE] Failed to get lint findings: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/routers/dummy_epg.py
+++ b/backend/routers/dummy_epg.py
@@ -13,6 +13,11 @@ from cache import get_cache
 from concurrency import run_cpu_bound
 from database import get_session
 from dispatcharr_client import get_client
+from regex_lint import (
+    lint_pattern,
+    lint_substitution_pairs,
+    violations_to_http_detail,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -201,12 +206,61 @@ async def list_profiles(db: Session = Depends(get_session)):
         db.close()
 
 
+def _lint_dummy_epg_profile_request(req) -> None:
+    """Raise HTTP 422 if any pattern field on the profile request fails
+    the regex linter (bd-eio04.7).
+
+    Lints:
+      - ``title_pattern``, ``time_pattern``, ``date_pattern`` (top-level)
+      - ``find`` on substitution pairs flagged ``is_regex=True``
+      - Pattern fields inside each ``pattern_variants`` entry
+    """
+    violations = []
+    for name in ("title_pattern", "time_pattern", "date_pattern"):
+        violations.extend(lint_pattern(getattr(req, name, None), field=name))
+
+    sub_pairs = getattr(req, "substitution_pairs", None)
+    if sub_pairs:
+        # Pydantic models need to be serialized so the helper sees dicts.
+        pairs_as_dicts = [
+            p.model_dump() if hasattr(p, "model_dump") else p for p in sub_pairs
+        ]
+        violations.extend(
+            lint_substitution_pairs(pairs_as_dicts, prefix="substitution_pairs")
+        )
+
+    variants = getattr(req, "pattern_variants", None)
+    if variants:
+        for idx, variant in enumerate(variants):
+            v = variant.model_dump() if hasattr(variant, "model_dump") else variant
+            if not isinstance(v, dict):
+                continue
+            for name in ("title_pattern", "time_pattern", "date_pattern"):
+                violations.extend(
+                    lint_pattern(
+                        v.get(name), field=f"pattern_variants[{idx}].{name}"
+                    )
+                )
+
+    if violations:
+        logger.warning(
+            "[DUMMY-EPG] Rejected profile — %d lint violation(s): %s",
+            len(violations),
+            [(v.field, v.code) for v in violations],
+        )
+        raise HTTPException(
+            status_code=422, detail=violations_to_http_detail(violations)
+        )
+
+
 @router.post("/profiles")
 async def create_profile(req: ProfileCreateRequest, db: Session = Depends(get_session)):
     """Create a new Dummy EPG profile."""
     logger.debug("[DUMMY-EPG] POST /profiles name=%s", req.name)
     try:
         from models import DummyEPGProfile
+        # Lint regex patterns before any DB work (bd-eio04.7).
+        _lint_dummy_epg_profile_request(req)
         # Check for duplicate name
         existing = db.query(DummyEPGProfile).filter(
             DummyEPGProfile.name == req.name
@@ -295,6 +349,10 @@ async def update_profile(profile_id: int, req: ProfileUpdateRequest, db: Session
     logger.debug("[DUMMY-EPG] PATCH /profiles/%s", profile_id)
     try:
         from models import DummyEPGProfile
+        # Lint regex patterns on the update (bd-eio04.7). Only fields
+        # actually present in the PATCH are linted — an operator renaming
+        # a profile shouldn't hit a 422 for a pattern they didn't edit.
+        _lint_dummy_epg_profile_request(req)
         profile = db.query(DummyEPGProfile).filter(
             DummyEPGProfile.id == profile_id
         ).first()
@@ -865,3 +923,29 @@ def _apply_profile_fields(profile, data: dict):
         profile.set_pattern_variants(data["pattern_variants"])
     if "channel_group_ids" in data and data["channel_group_ids"] is not None:
         profile.set_channel_group_ids(data["channel_group_ids"])
+
+
+# =============================================================================
+# Lint findings (bd-eio04.7) — read-only view of the startup migration scan.
+# =============================================================================
+
+
+@router.get("/lint-findings")
+async def get_dummy_epg_lint_findings(db: Session = Depends(get_session)):
+    """Return the cached lint findings for dummy-EPG profiles.
+
+    See ``routers/normalization.py::get_normalization_lint_findings`` for
+    semantics. Findings are scoped to ``rule_type='dummy_epg'``.
+    """
+    logger.debug("[DUMMY-EPG] GET /lint-findings")
+    try:
+        from models import RuleLintFinding
+        from tasks.rule_lint_scan import RULE_TYPE_DUMMY_EPG
+
+        findings = db.query(RuleLintFinding).filter(
+            RuleLintFinding.rule_type == RULE_TYPE_DUMMY_EPG
+        ).order_by(RuleLintFinding.rule_id, RuleLintFinding.id).all()
+        return {"findings": [f.to_dict() for f in findings]}
+    except Exception as e:
+        logger.warning("[DUMMY-EPG] Failed to get lint findings: %s", e)
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/routers/normalization.py
+++ b/backend/routers/normalization.py
@@ -20,6 +20,11 @@ from concurrency import run_cpu_bound
 from config import get_settings
 from database import get_session
 from dispatcharr_client import get_client
+from regex_lint import (
+    lint_conditions_json,
+    lint_pattern,
+    violations_to_http_detail,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -351,12 +356,42 @@ async def get_normalization_rule(rule_id: int):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+def _lint_normalization_rule_request(request) -> None:
+    """Raise HTTP 422 if the rule's pattern fields fail the regex linter.
+
+    Lints (bd-eio04.7):
+      - ``condition_value`` when ``condition_type == "regex"``
+      - Any pattern inside the compound ``conditions[]`` JSON (regex types)
+
+    Replacement strings on ``action_value`` / ``else_action_value`` are
+    templates, not regexes, so they are not linted here.
+    """
+    violations = []
+    if getattr(request, "condition_type", None) == "regex":
+        violations.extend(
+            lint_pattern(getattr(request, "condition_value", None), field="condition_value")
+        )
+    conditions = getattr(request, "conditions", None)
+    if conditions:
+        violations.extend(lint_conditions_json(conditions, prefix="conditions"))
+    if violations:
+        logger.warning(
+            "[NORMALIZE] Rejected rule — %d lint violation(s): %s",
+            len(violations),
+            [(v.field, v.code) for v in violations],
+        )
+        raise HTTPException(
+            status_code=422, detail=violations_to_http_detail(violations)
+        )
+
+
 @router.post("/rules")
 async def create_normalization_rule(request: CreateRuleRequest):
     """Create a new normalization rule."""
     logger.debug("[NORMALIZE] POST /rules - name=%s group_id=%s", request.name, request.group_id)
     try:
         from models import NormalizationRule, NormalizationRuleGroup
+        _lint_normalization_rule_request(request)
         session = get_session()
         try:
             # Verify group exists
@@ -409,6 +444,10 @@ async def update_normalization_rule(rule_id: int, request: UpdateRuleRequest):
     logger.debug("[NORMALIZE] PATCH /rules/%s", rule_id)
     try:
         from models import NormalizationRule
+        # Lint any pattern-bearing fields on the update request. The helper
+        # only lints what's actually supplied — PATCH semantics are
+        # preserved (unset fields pass through unchanged).
+        _lint_normalization_rule_request(request)
         session = get_session()
         try:
             rule = session.query(NormalizationRule).filter(
@@ -1246,3 +1285,36 @@ async def apply_normalization_to_channels(
         "skipped": skipped,
         "errors": errors,
     }
+
+
+# =============================================================================
+# Lint findings (bd-eio04.7) — read-only view of the startup migration scan.
+# =============================================================================
+
+
+@router.get("/lint-findings")
+async def get_normalization_lint_findings():
+    """Return the cached lint findings for normalization rules.
+
+    Findings are produced by the one-time startup scan (bd-eio04.7 migration
+    pass) and also refreshed implicitly by write-time validation (write-time
+    rejections never reach here because they fail with 422). UI surfaces
+    these so pre-lint rows that would now fail can be fixed by the operator.
+    The scan does not modify or disable any rule — this is a pure view.
+    """
+    logger.debug("[NORMALIZE] GET /lint-findings")
+    try:
+        from models import RuleLintFinding
+        from tasks.rule_lint_scan import RULE_TYPE_NORMALIZATION
+
+        session = get_session()
+        try:
+            findings = session.query(RuleLintFinding).filter(
+                RuleLintFinding.rule_type == RULE_TYPE_NORMALIZATION
+            ).order_by(RuleLintFinding.rule_id, RuleLintFinding.id).all()
+            return {"findings": [f.to_dict() for f in findings]}
+        finally:
+            session.close()
+    except Exception as e:
+        logger.exception("[NORMALIZE] Failed to get lint findings: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/tasks/rule_lint_scan.py
+++ b/backend/tasks/rule_lint_scan.py
@@ -1,0 +1,304 @@
+"""
+Rule Lint Scan — one-time read-only scan of existing rule rows.
+
+Walks ``normalization_rules``, ``auto_creation_rules``, and
+``dummy_epg_profiles``, runs :func:`regex_lint.lint_pattern` against
+every user-supplied pattern field (including patterns buried inside the
+JSON-encoded ``conditions`` / ``actions`` / ``substitution_pairs`` columns),
+and writes findings to ``rule_lint_findings``. Does NOT mutate any rule
+row — the scan is purely diagnostic.
+
+Bead: bd-eio04.7. Runs on startup (see :func:`main.startup_event`) so pre-lint
+rows that would now fail the write-time linter become visible in the UI
+without the operator having to manually re-save every rule.
+
+Idempotency contract: before each scan, existing findings for each rule
+row are deleted and rewritten. Re-running the scan against an unchanged
+corpus produces an identical result set (same count, same codes, same
+messages; ``detected_at`` refreshes).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from regex_lint import (
+    LintViolation,
+    lint_actions_json,
+    lint_conditions_json,
+    lint_pattern,
+    lint_substitution_pairs,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Rule-type constants — persisted in the rule_type column. Kept here so
+# that the scan writer and the API reader don't drift.
+RULE_TYPE_NORMALIZATION = "normalization"
+RULE_TYPE_AUTO_CREATION = "auto_creation"
+RULE_TYPE_DUMMY_EPG = "dummy_epg"
+
+
+def _safe_json_loads(raw: Any) -> Any:
+    """JSON-decode ``raw`` if it's a string; return the parsed value, or
+    ``None`` if decode fails. Passes non-strings through unchanged."""
+    if raw is None or raw == "":
+        return None
+    if not isinstance(raw, str):
+        return raw
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def _scan_normalization_rule(rule: Any) -> list[LintViolation]:
+    """Collect lint violations for one ``NormalizationRule`` row.
+
+    Fields linted:
+      - ``condition_value`` when ``condition_type == "regex"`` (the legacy
+        single-condition shape).
+      - ``action_value`` when ``action_type == "regex_replace"``.
+      - ``else_action_value`` when ``else_action_type == "regex_replace"``.
+      - Any pattern in the JSON ``conditions[]`` compound shape.
+    """
+    violations: list[LintViolation] = []
+    if rule.condition_type == "regex":
+        violations.extend(lint_pattern(rule.condition_value, field="condition_value"))
+    if rule.action_type == "regex_replace":
+        # regex_replace stores its pattern on condition_value and its
+        # replacement on action_value — the replacement is a template,
+        # not a regex, so we don't lint it. If the user got the
+        # action_type wrong and condition_type is not 'regex', we still
+        # skip linting action_value because it's a replacement string.
+        pass
+    # Compound conditions JSON.
+    conditions = _safe_json_loads(rule.conditions)
+    if isinstance(conditions, list):
+        violations.extend(lint_conditions_json(conditions, prefix="conditions"))
+    return violations
+
+
+def _scan_auto_creation_rule(rule: Any) -> list[LintViolation]:
+    """Collect lint violations for one ``AutoCreationRule`` row.
+
+    Fields linted:
+      - ``sort_regex`` (top-level column).
+      - Patterns inside the JSON ``conditions[]`` (regex-flavored types).
+      - ``action.pattern`` for ``set_variable`` regex modes.
+      - ``action.name_transform_pattern`` on create_channel / create_group.
+    """
+    violations: list[LintViolation] = []
+    violations.extend(lint_pattern(rule.sort_regex, field="sort_regex"))
+    conditions = _safe_json_loads(rule.conditions)
+    if isinstance(conditions, list):
+        violations.extend(lint_conditions_json(conditions, prefix="conditions"))
+    actions = _safe_json_loads(rule.actions)
+    if isinstance(actions, list):
+        violations.extend(lint_actions_json(actions, prefix="actions"))
+    return violations
+
+
+def _scan_dummy_epg_profile(profile: Any) -> list[LintViolation]:
+    """Collect lint violations for one ``DummyEPGProfile`` row.
+
+    Fields linted:
+      - ``title_pattern``, ``time_pattern``, ``date_pattern`` (top-level).
+      - ``find`` on substitution pairs with ``is_regex: True``.
+      - Pattern fields inside each ``pattern_variants`` entry
+        (``title_pattern`` / ``time_pattern`` / ``date_pattern``).
+    """
+    violations: list[LintViolation] = []
+    violations.extend(lint_pattern(profile.title_pattern, field="title_pattern"))
+    violations.extend(lint_pattern(profile.time_pattern, field="time_pattern"))
+    violations.extend(lint_pattern(profile.date_pattern, field="date_pattern"))
+
+    pairs = _safe_json_loads(profile.substitution_pairs)
+    if isinstance(pairs, list):
+        violations.extend(
+            lint_substitution_pairs(pairs, prefix="substitution_pairs")
+        )
+
+    variants = _safe_json_loads(profile.pattern_variants)
+    if isinstance(variants, list):
+        for idx, variant in enumerate(variants):
+            if not isinstance(variant, dict):
+                continue
+            violations.extend(
+                lint_pattern(
+                    variant.get("title_pattern"),
+                    field=f"pattern_variants[{idx}].title_pattern",
+                )
+            )
+            violations.extend(
+                lint_pattern(
+                    variant.get("time_pattern"),
+                    field=f"pattern_variants[{idx}].time_pattern",
+                )
+            )
+            violations.extend(
+                lint_pattern(
+                    variant.get("date_pattern"),
+                    field=f"pattern_variants[{idx}].date_pattern",
+                )
+            )
+
+    return violations
+
+
+def _write_findings(
+    session: Session,
+    rule_type: str,
+    rule_id: int,
+    violations: list[LintViolation],
+) -> int:
+    """Replace any existing findings for ``(rule_type, rule_id)`` with the
+    given list. Returns the number of findings written. No-op when
+    ``violations`` is empty AND no prior findings exist (still wipes any
+    stale rows from a previous scan when the pattern has since been fixed
+    out of band)."""
+    from models import RuleLintFinding
+
+    # Idempotent: wipe prior findings for this rule before writing.
+    session.query(RuleLintFinding).filter(
+        RuleLintFinding.rule_type == rule_type,
+        RuleLintFinding.rule_id == rule_id,
+    ).delete(synchronize_session=False)
+
+    if not violations:
+        return 0
+
+    now = datetime.utcnow()
+    for v in violations:
+        session.add(
+            RuleLintFinding(
+                rule_type=rule_type,
+                rule_id=rule_id,
+                field=v.field,
+                code=v.code,
+                message=v.message,
+                detail=json.dumps(v.detail) if v.detail else None,
+                detected_at=now,
+            )
+        )
+    return len(violations)
+
+
+def run_scan(session: Session) -> dict:
+    """Scan all rule tables; write findings; return summary counts.
+
+    Returns a summary dict::
+
+        {
+          "normalization": {"rules_scanned": 8, "rules_flagged": 1, "findings": 2},
+          "auto_creation": {"rules_scanned": 3, "rules_flagged": 0, "findings": 0},
+          "dummy_epg":     {"rules_scanned": 1, "rules_flagged": 0, "findings": 0},
+          "total_findings": 2,
+        }
+
+    Safe to call from an idle ``on_event("startup")`` hook — it closes
+    and commits its own transactions. Best-effort: any exception per-row
+    is logged and the scan continues.
+    """
+    from models import AutoCreationRule, DummyEPGProfile, NormalizationRule
+
+    summary: dict = {}
+    total_findings = 0
+
+    # --- normalization ---
+    norm_rules = session.query(NormalizationRule).all()
+    norm_flagged = 0
+    norm_findings = 0
+    for rule in norm_rules:
+        try:
+            viols = _scan_normalization_rule(rule)
+        except Exception as e:
+            logger.warning(
+                "[RULE-LINT-SCAN] Failed to scan normalization rule id=%s: %s",
+                rule.id,
+                e,
+            )
+            continue
+        written = _write_findings(
+            session, RULE_TYPE_NORMALIZATION, rule.id, viols
+        )
+        if written:
+            norm_flagged += 1
+            norm_findings += written
+    summary["normalization"] = {
+        "rules_scanned": len(norm_rules),
+        "rules_flagged": norm_flagged,
+        "findings": norm_findings,
+    }
+    total_findings += norm_findings
+
+    # --- auto_creation ---
+    ac_rules = session.query(AutoCreationRule).all()
+    ac_flagged = 0
+    ac_findings = 0
+    for rule in ac_rules:
+        try:
+            viols = _scan_auto_creation_rule(rule)
+        except Exception as e:
+            logger.warning(
+                "[RULE-LINT-SCAN] Failed to scan auto_creation rule id=%s: %s",
+                rule.id,
+                e,
+            )
+            continue
+        written = _write_findings(
+            session, RULE_TYPE_AUTO_CREATION, rule.id, viols
+        )
+        if written:
+            ac_flagged += 1
+            ac_findings += written
+    summary["auto_creation"] = {
+        "rules_scanned": len(ac_rules),
+        "rules_flagged": ac_flagged,
+        "findings": ac_findings,
+    }
+    total_findings += ac_findings
+
+    # --- dummy_epg ---
+    de_profiles = session.query(DummyEPGProfile).all()
+    de_flagged = 0
+    de_findings = 0
+    for profile in de_profiles:
+        try:
+            viols = _scan_dummy_epg_profile(profile)
+        except Exception as e:
+            logger.warning(
+                "[RULE-LINT-SCAN] Failed to scan dummy_epg profile id=%s: %s",
+                profile.id,
+                e,
+            )
+            continue
+        written = _write_findings(
+            session, RULE_TYPE_DUMMY_EPG, profile.id, viols
+        )
+        if written:
+            de_flagged += 1
+            de_findings += written
+    summary["dummy_epg"] = {
+        "rules_scanned": len(de_profiles),
+        "rules_flagged": de_flagged,
+        "findings": de_findings,
+    }
+    total_findings += de_findings
+
+    session.commit()
+    summary["total_findings"] = total_findings
+    logger.info(
+        "[RULE-LINT-SCAN] Scan complete — total_findings=%d "
+        "(normalization=%d, auto_creation=%d, dummy_epg=%d)",
+        total_findings,
+        norm_findings,
+        ac_findings,
+        de_findings,
+    )
+    return summary

--- a/backend/tests/integration/test_api_auto_creation.py
+++ b/backend/tests/integration/test_api_auto_creation.py
@@ -114,7 +114,13 @@ class TestAutoCreationRulesAPI:
         assert response.status_code == 200
 
     def test_create_rule_invalid_conditions(self, test_client, mock_db_session):
-        """Create rule fails with invalid conditions."""
+        """Create rule fails with invalid regex conditions.
+
+        Pre-bd-eio04.7 this returned 400 from ``validate_rule``. Now the
+        regex linter runs FIRST (so the error envelope is the new
+        ``REGEX_VALIDATION_ERROR`` shape) and an uncompilable pattern
+        yields 422 with a ``REGEX_COMPILE_ERROR`` code.
+        """
         response = test_client.post(
             "/api/auto-creation/rules",
             json={
@@ -124,8 +130,11 @@ class TestAutoCreationRulesAPI:
             }
         )
 
-        assert response.status_code == 400
-        assert "Invalid" in str(response.json()["detail"])
+        assert response.status_code == 422
+        body = response.json()
+        err = body["detail"]["error"]
+        assert err["code"] == "REGEX_VALIDATION_ERROR"
+        assert err["details"][0]["code"] == "REGEX_COMPILE_ERROR"
 
     def test_create_rule_invalid_actions(self, test_client, mock_db_session):
         """Create rule fails with invalid actions."""

--- a/backend/tests/routers/test_regex_lint_integration.py
+++ b/backend/tests/routers/test_regex_lint_integration.py
@@ -1,0 +1,464 @@
+"""
+Integration tests for bd-eio04.7 write-time pattern linting.
+
+Negative tests: each POST/PUT endpoint returns 422 with the
+``REGEX_VALIDATION_ERROR`` envelope when a pathological pattern is
+submitted. Positive tests: a benign pattern produces a 200/201.
+
+Also verifies the new ``GET /lint-findings`` endpoints return the
+findings written by the migration scan.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+import pytest
+
+from models import (
+    AutoCreationRule,
+    DummyEPGProfile,
+    NormalizationRule,
+    NormalizationRuleGroup,
+    RuleLintFinding,
+)
+
+
+EVIL_PATTERN = r"(a+)+b"  # nested unbounded quantifier with killer
+
+
+# =========================================================================
+# Normalization router.
+# =========================================================================
+
+
+@pytest.fixture
+def norm_group(test_session):
+    group = NormalizationRuleGroup(
+        name="Test Group", enabled=True, priority=0, is_builtin=False
+    )
+    test_session.add(group)
+    test_session.commit()
+    test_session.refresh(group)
+    return group
+
+
+class TestNormalizationCreateRuleLinting:
+    @pytest.mark.asyncio
+    async def test_rejects_evil_condition_value(self, async_client, norm_group):
+        payload = {
+            "group_id": norm_group.id,
+            "name": "Evil Rule",
+            "condition_type": "regex",
+            "condition_value": EVIL_PATTERN,
+            "action_type": "remove",
+        }
+        response = await async_client.post("/api/normalization/rules", json=payload)
+        assert response.status_code == 422
+        body = response.json()
+        # FastAPI wraps our custom detail under "detail".
+        err = body["detail"]["error"]
+        assert err["code"] == "REGEX_VALIDATION_ERROR"
+        details = err["details"]
+        assert len(details) == 1
+        assert details[0]["field"] == "condition_value"
+        assert details[0]["code"] == "REGEX_NESTED_QUANTIFIER"
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversize_condition_value(self, async_client, norm_group):
+        payload = {
+            "group_id": norm_group.id,
+            "name": "Oversize",
+            "condition_type": "regex",
+            "condition_value": "a" * 600,
+            "action_type": "remove",
+        }
+        response = await async_client.post("/api/normalization/rules", json=payload)
+        assert response.status_code == 422
+        err = response.json()["detail"]["error"]
+        assert err["details"][0]["code"] == "REGEX_TOO_LONG"
+
+    @pytest.mark.asyncio
+    async def test_rejects_uncompilable_condition_value(
+        self, async_client, norm_group
+    ):
+        payload = {
+            "group_id": norm_group.id,
+            "name": "Bad syntax",
+            "condition_type": "regex",
+            "condition_value": r"^(unclosed",
+            "action_type": "remove",
+        }
+        response = await async_client.post("/api/normalization/rules", json=payload)
+        assert response.status_code == 422
+        err = response.json()["detail"]["error"]
+        assert err["details"][0]["code"] == "REGEX_COMPILE_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_accepts_benign_pattern(self, async_client, norm_group):
+        payload = {
+            "group_id": norm_group.id,
+            "name": "Strip HD",
+            "condition_type": "regex",
+            "condition_value": r"\s*HD$",
+            "action_type": "remove",
+        }
+        response = await async_client.post("/api/normalization/rules", json=payload)
+        assert response.status_code == 200
+        assert response.json()["name"] == "Strip HD"
+
+    @pytest.mark.asyncio
+    async def test_skips_lint_when_condition_type_not_regex(
+        self, async_client, norm_group
+    ):
+        """Non-regex condition types pass even if the value looks pathological
+        as a regex — it's treated as a literal string, not a pattern."""
+        payload = {
+            "group_id": norm_group.id,
+            "name": "Literal contains",
+            "condition_type": "contains",
+            "condition_value": EVIL_PATTERN,  # literal — fine
+            "action_type": "remove",
+        }
+        response = await async_client.post("/api/normalization/rules", json=payload)
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_compound_conditions_are_linted(self, async_client, norm_group):
+        payload = {
+            "group_id": norm_group.id,
+            "name": "Compound evil",
+            "action_type": "remove",
+            "conditions": [
+                {"type": "regex", "value": EVIL_PATTERN},
+            ],
+        }
+        response = await async_client.post("/api/normalization/rules", json=payload)
+        assert response.status_code == 422
+        err = response.json()["detail"]["error"]
+        assert err["details"][0]["field"] == "conditions[0].value"
+
+
+class TestNormalizationUpdateRuleLinting:
+    @pytest.mark.asyncio
+    async def test_patch_rejects_evil_pattern(
+        self, async_client, test_session, norm_group
+    ):
+        rule = NormalizationRule(
+            group_id=norm_group.id,
+            name="Initial",
+            condition_type="regex",
+            condition_value=r"\s*HD$",
+            action_type="remove",
+        )
+        test_session.add(rule)
+        test_session.commit()
+        test_session.refresh(rule)
+
+        response = await async_client.patch(
+            f"/api/normalization/rules/{rule.id}",
+            json={"condition_type": "regex", "condition_value": EVIL_PATTERN},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_patch_allows_unrelated_field_change(
+        self, async_client, test_session, norm_group
+    ):
+        """Renaming a rule without touching the pattern MUST pass, even
+        if the stored pattern would fail a fresh lint — pre-lint rows
+        are surfaced by the startup scan, not the update path."""
+        rule = NormalizationRule(
+            group_id=norm_group.id,
+            name="Initial",
+            condition_type="regex",
+            condition_value=EVIL_PATTERN,  # pre-lint
+            action_type="remove",
+        )
+        test_session.add(rule)
+        test_session.commit()
+        test_session.refresh(rule)
+
+        response = await async_client.patch(
+            f"/api/normalization/rules/{rule.id}",
+            json={"name": "Renamed"},
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] == "Renamed"
+
+
+# =========================================================================
+# Auto-creation router.
+# =========================================================================
+
+
+class TestAutoCreationCreateRuleLinting:
+    @pytest.mark.asyncio
+    async def test_rejects_evil_sort_regex(self, async_client):
+        payload = {
+            "name": "Evil sort",
+            "conditions": [{"type": "stream_name_contains", "value": "ESPN"}],
+            "actions": [{"type": "create_channel", "name_template": "{stream_name}"}],
+            "sort_regex": EVIL_PATTERN,
+        }
+        response = await async_client.post("/api/auto-creation/rules", json=payload)
+        assert response.status_code == 422
+        err = response.json()["detail"]["error"]
+        assert err["details"][0]["field"] == "sort_regex"
+        assert err["details"][0]["code"] == "REGEX_NESTED_QUANTIFIER"
+
+    @pytest.mark.asyncio
+    async def test_rejects_evil_condition_value(self, async_client):
+        payload = {
+            "name": "Evil cond",
+            "conditions": [{"type": "stream_name_matches", "value": EVIL_PATTERN}],
+            "actions": [{"type": "create_channel", "name_template": "{stream_name}"}],
+        }
+        response = await async_client.post("/api/auto-creation/rules", json=payload)
+        assert response.status_code == 422
+        err = response.json()["detail"]["error"]
+        assert err["details"][0]["field"] == "conditions[0].value"
+
+    @pytest.mark.asyncio
+    async def test_rejects_evil_action_name_transform(self, async_client):
+        payload = {
+            "name": "Evil name transform",
+            "conditions": [{"type": "stream_name_contains", "value": "ESPN"}],
+            "actions": [
+                {
+                    "type": "create_channel",
+                    "name_template": "{stream_name}",
+                    "name_transform_pattern": EVIL_PATTERN,
+                    "name_transform_replacement": "",
+                }
+            ],
+        }
+        response = await async_client.post("/api/auto-creation/rules", json=payload)
+        assert response.status_code == 422
+        err = response.json()["detail"]["error"]
+        assert err["details"][0]["field"] == "actions[0].name_transform_pattern"
+
+    @pytest.mark.asyncio
+    async def test_rejects_evil_set_variable_pattern(self, async_client):
+        payload = {
+            "name": "Evil set var",
+            "conditions": [{"type": "stream_name_contains", "value": "ESPN"}],
+            "actions": [
+                {
+                    "type": "set_variable",
+                    "variable_name": "foo",
+                    "variable_mode": "regex_extract",
+                    "source_field": "stream_name",
+                    "pattern": EVIL_PATTERN,
+                }
+            ],
+        }
+        response = await async_client.post("/api/auto-creation/rules", json=payload)
+        assert response.status_code == 422
+        err = response.json()["detail"]["error"]
+        assert err["details"][0]["field"] == "actions[0].pattern"
+
+    @pytest.mark.asyncio
+    async def test_accepts_benign_rule(self, async_client):
+        payload = {
+            "name": "Benign",
+            "conditions": [{"type": "stream_name_contains", "value": "ESPN"}],
+            "actions": [{"type": "create_channel", "name_template": "{stream_name}"}],
+            "sort_regex": r"(\d+)$",
+        }
+        response = await async_client.post("/api/auto-creation/rules", json=payload)
+        assert response.status_code == 200
+
+
+class TestAutoCreationUpdateRuleLinting:
+    @pytest.mark.asyncio
+    async def test_put_rejects_evil_pattern(self, async_client, test_session):
+        rule = AutoCreationRule(
+            name="Initial",
+            conditions=json.dumps(
+                [{"type": "stream_name_contains", "value": "ESPN"}]
+            ),
+            actions=json.dumps(
+                [{"type": "create_channel", "name_template": "{stream_name}"}]
+            ),
+        )
+        test_session.add(rule)
+        test_session.commit()
+        test_session.refresh(rule)
+
+        response = await async_client.put(
+            f"/api/auto-creation/rules/{rule.id}",
+            json={"sort_regex": EVIL_PATTERN},
+        )
+        assert response.status_code == 422
+
+
+# =========================================================================
+# Dummy-EPG router.
+# =========================================================================
+
+
+class TestDummyEPGCreateProfileLinting:
+    @pytest.mark.asyncio
+    async def test_rejects_evil_title_pattern(self, async_client):
+        payload = {
+            "name": "Evil title",
+            "title_pattern": EVIL_PATTERN,
+        }
+        response = await async_client.post("/api/dummy-epg/profiles", json=payload)
+        assert response.status_code == 422
+        err = response.json()["detail"]["error"]
+        assert err["details"][0]["field"] == "title_pattern"
+
+    @pytest.mark.asyncio
+    async def test_rejects_evil_substitution_find_when_is_regex(self, async_client):
+        payload = {
+            "name": "Evil sub",
+            "substitution_pairs": [
+                {"find": EVIL_PATTERN, "replace": "", "is_regex": True, "enabled": True}
+            ],
+        }
+        response = await async_client.post("/api/dummy-epg/profiles", json=payload)
+        assert response.status_code == 422
+        err = response.json()["detail"]["error"]
+        assert err["details"][0]["field"] == "substitution_pairs[0].find"
+
+    @pytest.mark.asyncio
+    async def test_accepts_literal_substitution_find(self, async_client):
+        """Literal (non-regex) substitution pairs are not linted."""
+        payload = {
+            "name": "Literal sub",
+            "substitution_pairs": [
+                {"find": EVIL_PATTERN, "replace": "", "is_regex": False, "enabled": True}
+            ],
+        }
+        response = await async_client.post("/api/dummy-epg/profiles", json=payload)
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_accepts_b1g_title_pattern(self, async_client):
+        """The spike's critical regression case — B1G production
+        ``title_pattern`` MUST be accepted (regexploit falsely flagged
+        it; hand-rolled correctly passes)."""
+        b1g_pattern = (
+            r"(?<channel>.+?):\s+(?<event>"
+            r"(?:(?<sport>.+?)\s+\|\s+(?<team1>.+?)\s+vs\s+(?<team2>.+?))"
+            r"|(?:.+?))\s+@\s+"
+        )
+        payload = {
+            "name": "B1G Advanced EPG",
+            "title_pattern": b1g_pattern,
+        }
+        response = await async_client.post("/api/dummy-epg/profiles", json=payload)
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_accepts_all_three_benign_patterns(self, async_client):
+        payload = {
+            "name": "Three good patterns",
+            "title_pattern": r"(?P<title>.+)",
+            "time_pattern": r"(?P<hour>\d+):(?P<minute>\d+)",
+            "date_pattern": r"(?P<month>\d{2})/(?P<day>\d{2})",
+        }
+        response = await async_client.post("/api/dummy-epg/profiles", json=payload)
+        assert response.status_code == 200
+
+
+class TestDummyEPGUpdateProfileLinting:
+    @pytest.mark.asyncio
+    async def test_patch_rejects_evil_pattern(self, async_client, test_session):
+        profile = DummyEPGProfile(
+            name="Initial",
+            title_pattern=r"(?P<title>.+)",
+        )
+        test_session.add(profile)
+        test_session.commit()
+        test_session.refresh(profile)
+
+        response = await async_client.patch(
+            f"/api/dummy-epg/profiles/{profile.id}",
+            json={"title_pattern": EVIL_PATTERN},
+        )
+        assert response.status_code == 422
+
+
+# =========================================================================
+# GET /lint-findings endpoints.
+# =========================================================================
+
+
+class TestLintFindingsEndpoints:
+    @pytest.mark.asyncio
+    async def test_normalization_lint_findings_empty(self, async_client):
+        response = await async_client.get("/api/normalization/lint-findings")
+        assert response.status_code == 200
+        assert response.json() == {"findings": []}
+
+    @pytest.mark.asyncio
+    async def test_normalization_lint_findings_returns_seeded_rows(
+        self, async_client, test_session
+    ):
+        finding = RuleLintFinding(
+            rule_type="normalization",
+            rule_id=99,
+            field="condition_value",
+            code="REGEX_NESTED_QUANTIFIER",
+            message="Pattern contains a nested unbounded quantifier ...",
+            detail=json.dumps({"reason": "nested-unbounded-repeat-with-killer"}),
+            detected_at=datetime.utcnow(),
+        )
+        test_session.add(finding)
+        test_session.commit()
+
+        response = await async_client.get("/api/normalization/lint-findings")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["findings"]) == 1
+        f = data["findings"][0]
+        assert f["rule_type"] == "normalization"
+        assert f["rule_id"] == 99
+        assert f["code"] == "REGEX_NESTED_QUANTIFIER"
+        assert f["detail"] == {"reason": "nested-unbounded-repeat-with-killer"}
+
+    @pytest.mark.asyncio
+    async def test_lint_findings_scoped_by_rule_type(
+        self, async_client, test_session
+    ):
+        """Each endpoint returns only its own ``rule_type`` — not a
+        shared blob of all findings."""
+        now = datetime.utcnow()
+        test_session.add_all([
+            RuleLintFinding(
+                rule_type="normalization",
+                rule_id=1,
+                field="condition_value",
+                code="REGEX_NESTED_QUANTIFIER",
+                message="norm",
+                detected_at=now,
+            ),
+            RuleLintFinding(
+                rule_type="auto_creation",
+                rule_id=2,
+                field="sort_regex",
+                code="REGEX_TOO_LONG",
+                message="ac",
+                detected_at=now,
+            ),
+            RuleLintFinding(
+                rule_type="dummy_epg",
+                rule_id=3,
+                field="title_pattern",
+                code="REGEX_COMPILE_ERROR",
+                message="de",
+                detected_at=now,
+            ),
+        ])
+        test_session.commit()
+
+        norm = (await async_client.get("/api/normalization/lint-findings")).json()
+        ac = (await async_client.get("/api/auto-creation/lint-findings")).json()
+        de = (await async_client.get("/api/dummy-epg/lint-findings")).json()
+
+        assert [f["rule_id"] for f in norm["findings"]] == [1]
+        assert [f["rule_id"] for f in ac["findings"]] == [2]
+        assert [f["rule_id"] for f in de["findings"]] == [3]

--- a/backend/tests/unit/test_regex_lint.py
+++ b/backend/tests/unit/test_regex_lint.py
@@ -1,0 +1,461 @@
+"""
+Unit tests for :mod:`regex_lint` — write-time pattern linter (bd-eio04.7).
+
+The detector was selected by the bd-eio04.11 spike (hand-rolled AST walker
+over regexploit). These tests lock in the spike's empirical results:
+
+  - 7/7 known-evil-with-killer patterns must flag.
+  - 32/32 real-corpus patterns (including the B1G production
+    ``title_pattern``) must NOT flag.
+  - 3/3 ambiguous-no-killer patterns must NOT flag (Python ``re``
+    optimizes them to O(n)).
+
+Fixtures mirror the spike's test sets so future detector changes are
+verified against the same corpus.
+"""
+from __future__ import annotations
+
+import pytest
+
+import regex_lint
+from regex_lint import (
+    LintViolation,
+    lint_actions_json,
+    lint_conditions_json,
+    lint_pattern,
+    lint_pattern_fields,
+    lint_substitution_pairs,
+    violations_to_http_detail,
+)
+
+
+# =========================================================================
+# Fixture sets (lifted from /tmp/bd-eio04.11-eval.py KNOWN_EVIL / corpus).
+# =========================================================================
+
+# Known-evil: nested unbounded quantifier + killer. Empirically exploitable
+# in stdlib re (verified in the spike with 5 s timeouts). The linter MUST
+# flag all seven.
+KNOWN_EVIL_WITH_KILLER: list[str] = [
+    r"(a+)+b",
+    r"^(\w+\s?)*$",
+    r"(a*)*b",
+    r"(.*)*X",
+    r"(a+)*b",
+    r"(.+)+X",
+    r"(\w+)+$",
+]
+
+# Ambiguous-no-killer: Python's re engine either optimizes these to O(n)
+# (bare (a*)*) or factors common prefixes ((a|a) -> a). NOT exploitable in
+# our engine — the linter MUST NOT flag them.
+AMBIGUOUS_NO_KILLER: list[str] = [
+    r"(a*)*",
+    r"(.*)*",
+    r"(a|a)+$",
+]
+
+# Real-corpus: the 32 patterns harvested from production in the bd-eio04.11
+# spike. Zero-false-positive target — all must pass lint. The critical
+# entry is the B1G ``title_pattern`` (index 14 below) which regexploit
+# falsely flagged.
+REAL_CORPUS: list[str] = [
+    r".*",
+    r"HD",
+    r"^\w+:",
+    r"^(\w+):",
+    r"^US:\s*",
+    r"^(NOTFOUND)",
+    r"(?P<name>.+)",
+    r"^(\w+):\s*(.*)",
+    r"(?P<hour>\d+)pm",
+    r"(?<hour>\d+)(?<ampm>pm)",
+    r"(?P<hour>\d+)(?P<ampm>pm)",
+    r"(?<month>\d{2})/(?<day>\d{2})",
+    r"(?P<month>\d{2})/(?P<day>\d{2})",
+    (
+        r"(?<hour>\d{1,2})(?:\s*:\s*(?<minute>\d{2}))?\s*"
+        r"(?<ampm>[AaPp][Mm])(?:\s+(?<timezone>[A-Z]{1,5}))?"
+    ),
+    # Critical false-positive regression case — B1G Advanced EPG
+    # title_pattern. regexploit flagged this; hand-rolled correctly passes.
+    (
+        r"(?<channel>.+?):\s+(?<event>"
+        r"(?:(?<sport>.+?)\s+\|\s+(?<team1>.+?)\s+vs\s+(?<team2>.+?))"
+        r"|(?:.+?))\s+@\s+"
+    ),
+    (
+        r"(?<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|\d{1,2})"
+        r"[/\s]\s*(?<day>\d{1,2})(?:[/,\s]+(?<year>\d{2,4}))?"
+    ),
+    r"(?P<title>.+)",
+    r"(?P<title>.+?)\\s*HD",
+    r"(?P<title>NEVER_MATCHES)",
+    r"(?P<callsign>.+)",
+    r"(?P<code>.+)",
+    r"(?P<k>.+)",
+    r"(?P<league>.+)",
+    r"(?P<callsign>\S+)\s+(?P<quality>HD|SD)?",
+    r"(?P<league>\w+)-(?P<team>\w+)",
+    r"(?P<a>\w+)-(?P<b>\w+)-(?P<c>\w+)",
+    r"(?P<a>\w+)",
+    r"(?P<ch>\w+)",
+    r"(?P<v>\w+)",
+    r"(?P<v>.+)",
+    r"(?P<title>.+) (?P<hour>\d+):(?P<minute>\d+)(?P<ampm>[AP]M)",
+    r"(?P<title>.+) (?P<hour>\d+):(?P<minute>\d+)",
+]
+
+
+# =========================================================================
+# Core detector contract — spike parity lock.
+# =========================================================================
+
+
+class TestSpikeParityKnownEvil:
+    """Every known-evil pattern must emit REGEX_NESTED_QUANTIFIER."""
+
+    @pytest.mark.parametrize("pattern", KNOWN_EVIL_WITH_KILLER)
+    def test_known_evil_flagged(self, pattern):
+        viols = lint_pattern(pattern, field="condition_value")
+        codes = [v.code for v in viols]
+        assert "REGEX_NESTED_QUANTIFIER" in codes, (
+            f"Expected REGEX_NESTED_QUANTIFIER for {pattern!r}; got {codes}"
+        )
+
+
+class TestSpikeParityAmbiguousNoKiller:
+    """Python re optimizes these — MUST NOT flag."""
+
+    @pytest.mark.parametrize("pattern", AMBIGUOUS_NO_KILLER)
+    def test_ambiguous_no_killer_passes(self, pattern):
+        viols = lint_pattern(pattern, field="condition_value")
+        assert viols == [], (
+            f"Expected no violations for {pattern!r}; got "
+            f"{[(v.code, v.message) for v in viols]}"
+        )
+
+
+class TestSpikeParityRealCorpus:
+    """All 32 real-corpus patterns must pass — zero-FP target."""
+
+    @pytest.mark.parametrize("pattern", REAL_CORPUS)
+    def test_real_corpus_passes(self, pattern):
+        viols = lint_pattern(pattern, field="title_pattern")
+        assert viols == [], (
+            f"Regression: real-corpus pattern flagged — {pattern!r}: "
+            f"{[(v.code, v.message) for v in viols]}"
+        )
+
+    def test_b1g_title_pattern_critical_regression(self):
+        """The one pattern regexploit falsely flagged in the spike.
+
+        Lifted explicitly so a grep for the bead ID finds this test.
+        bd-eio04.11 spike empirically verified this pattern runs in ~2.6 ms
+        on a 393-char adversarial input — NOT exploitable.
+        """
+        b1g_pattern = (
+            r"(?<channel>.+?):\s+(?<event>"
+            r"(?:(?<sport>.+?)\s+\|\s+(?<team1>.+?)\s+vs\s+(?<team2>.+?))"
+            r"|(?:.+?))\s+@\s+"
+        )
+        viols = lint_pattern(b1g_pattern, field="title_pattern")
+        assert viols == [], (
+            f"bd-eio04.11 regression: B1G title_pattern flagged: "
+            f"{[(v.code, v.message) for v in viols]}"
+        )
+
+    def test_fp_rate_is_zero_on_full_corpus(self):
+        """Explicit FP-rate assertion — the spike's headline metric."""
+        fps = [p for p in REAL_CORPUS if lint_pattern(p)]
+        assert len(fps) == 0, (
+            f"FP rate on real corpus: {len(fps)}/{len(REAL_CORPUS)} "
+            f"(spike target: 0). Flagged: {fps!r}"
+        )
+
+
+# =========================================================================
+# Per-code fixture tests.
+# =========================================================================
+
+
+class TestRegexTooLong:
+    def test_pattern_at_limit_passes(self):
+        """Exactly at the 500-char cap is still accepted."""
+        pattern = "a" * regex_lint.MAX_PATTERN_LEN
+        viols = lint_pattern(pattern)
+        assert not any(v.code == "REGEX_TOO_LONG" for v in viols)
+
+    def test_pattern_over_limit_flagged(self):
+        """One char over the cap must emit REGEX_TOO_LONG."""
+        pattern = "a" * (regex_lint.MAX_PATTERN_LEN + 1)
+        viols = lint_pattern(pattern, field="condition_value")
+        assert len(viols) == 1
+        v = viols[0]
+        assert v.code == "REGEX_TOO_LONG"
+        assert v.field == "condition_value"
+        assert v.detail["pattern_len"] == regex_lint.MAX_PATTERN_LEN + 1
+        assert v.detail["max_pattern_len"] == regex_lint.MAX_PATTERN_LEN
+
+    def test_message_is_actionable(self):
+        """The message must include the concrete length, the cap, and a
+        rewrite hint (per grooming decision — not 'invalid pattern')."""
+        pattern = "a" * 612
+        v = lint_pattern(pattern)[0]
+        assert "612" in v.message
+        assert "500" in v.message
+        assert "multiple rules" in v.message
+
+    def test_too_long_short_circuits_other_checks(self):
+        """Oversize patterns should not also emit COMPILE / NESTED codes."""
+        pattern = "a" * (regex_lint.MAX_PATTERN_LEN + 100)
+        viols = lint_pattern(pattern)
+        codes = {v.code for v in viols}
+        assert codes == {"REGEX_TOO_LONG"}
+
+
+class TestRegexCompileError:
+    def test_unbalanced_parens_flagged(self):
+        viols = lint_pattern(r"^(unclosed", field="condition_value")
+        assert len(viols) == 1
+        v = viols[0]
+        assert v.code == "REGEX_COMPILE_ERROR"
+        assert v.field == "condition_value"
+        assert "compile_error" in v.detail
+
+    def test_invalid_quantifier_flagged(self):
+        viols = lint_pattern(r"*invalid")
+        assert any(v.code == "REGEX_COMPILE_ERROR" for v in viols)
+
+    def test_compile_error_message_user_facing(self):
+        """The message must not leak the internal sha256 framing."""
+        v = lint_pattern(r"^(")[0]
+        assert v.code == "REGEX_COMPILE_ERROR"
+        assert "sha256=" not in v.message
+        assert "/docs/patterns" in v.message
+
+    def test_compile_error_short_circuits_ast_walk(self):
+        """A pattern that can't compile MUST NOT also be AST-walked —
+        the walker would fail with the same syntax error and we'd
+        double-report."""
+        viols = lint_pattern(r"^(unclosed")
+        codes = {v.code for v in viols}
+        assert codes == {"REGEX_COMPILE_ERROR"}
+
+
+class TestRegexNestedQuantifier:
+    def test_classic_aplus_plus_flagged(self):
+        viols = lint_pattern(r"(a+)+b", field="condition_value")
+        assert len(viols) == 1
+        assert viols[0].code == "REGEX_NESTED_QUANTIFIER"
+        assert viols[0].field == "condition_value"
+        assert viols[0].detail.get("reason") == "nested-unbounded-repeat-with-killer"
+
+    def test_message_mentions_rewrite_hint(self):
+        viols = lint_pattern(r"(a+)+b")
+        assert "nested" in viols[0].message.lower() or "+" in viols[0].message
+
+    def test_compiles_cleanly_so_no_compile_error(self):
+        """Nested-quantifier patterns still compile — the linter must
+        emit ONLY the nested code, not compile + nested."""
+        viols = lint_pattern(r"(a+)+b")
+        codes = {v.code for v in viols}
+        assert codes == {"REGEX_NESTED_QUANTIFIER"}
+
+
+# =========================================================================
+# Empty / edge cases.
+# =========================================================================
+
+
+class TestEdgeCases:
+    def test_none_returns_empty(self):
+        """``None`` is not an oversight — it means the user didn't
+        supply a pattern for this field. Empty list = no findings."""
+        assert lint_pattern(None) == []
+
+    def test_empty_string_returns_empty(self):
+        assert lint_pattern("") == []
+
+    def test_whitespace_only_returns_empty(self):
+        assert lint_pattern("   \n\t ") == []
+
+    def test_non_string_flagged_as_compile_error(self):
+        """Defensive: caller passes a non-string by mistake. Don't
+        crash the request — flag it so the UI can show something."""
+        viols = lint_pattern(123)  # type: ignore[arg-type]
+        assert len(viols) == 1
+        assert viols[0].code == "REGEX_COMPILE_ERROR"
+
+    def test_js_style_named_group_accepted(self):
+        """``(?<name>...)`` is the JS syntax the dummy-EPG engine
+        converts at runtime. Linter accepts both styles."""
+        viols = lint_pattern(r"(?<hour>\d+)(?<ampm>pm)")
+        assert viols == []
+
+    def test_lookbehind_not_confused_for_named_group(self):
+        """``(?<=...)`` and ``(?<!...)`` are lookbehinds, not named
+        groups. The conversion helper must leave them alone."""
+        viols = lint_pattern(r"(?<=foo)\d+")
+        assert viols == []
+
+
+# =========================================================================
+# Bulk helpers.
+# =========================================================================
+
+
+class TestBulkHelpers:
+    def test_lint_pattern_fields_multiple(self):
+        """Multiple fields — each violation keeps its own ``field`` path."""
+        viols = lint_pattern_fields([
+            ("title_pattern", "(a+)+b"),
+            ("time_pattern", None),  # no-op
+            ("date_pattern", "a" * 600),
+        ])
+        assert len(viols) == 2
+        by_field = {v.field: v.code for v in viols}
+        assert by_field["title_pattern"] == "REGEX_NESTED_QUANTIFIER"
+        assert by_field["date_pattern"] == "REGEX_TOO_LONG"
+
+    def test_lint_conditions_json_flat(self):
+        """Regex-flavored condition types are linted; others skipped."""
+        viols = lint_conditions_json([
+            {"type": "stream_name_matches", "value": "(a+)+b"},
+            {"type": "stream_name_contains", "value": "(a+)+b"},  # non-regex
+            {"type": "quality_min", "value": 1080},
+        ])
+        assert len(viols) == 1
+        assert viols[0].field == "conditions[0].value"
+        assert viols[0].code == "REGEX_NESTED_QUANTIFIER"
+
+    def test_lint_conditions_json_recurses_into_logical_operators(self):
+        """AND/OR/NOT compound conditions must be walked recursively."""
+        viols = lint_conditions_json([
+            {
+                "type": "and",
+                "conditions": [
+                    {"type": "stream_name_matches", "value": "ok"},
+                    {"type": "stream_group_matches", "value": "(a+)+b"},
+                ],
+            }
+        ])
+        assert len(viols) == 1
+        assert "conditions[0].conditions[1].value" == viols[0].field
+
+    def test_lint_actions_json_set_variable(self):
+        viols = lint_actions_json([
+            {
+                "type": "set_variable",
+                "variable_name": "foo",
+                "variable_mode": "regex_extract",
+                "source_field": "stream_name",
+                "pattern": "(a+)+b",
+            }
+        ])
+        assert len(viols) == 1
+        assert viols[0].field == "actions[0].pattern"
+
+    def test_lint_actions_json_name_transform(self):
+        viols = lint_actions_json([
+            {
+                "type": "create_channel",
+                "name_template": "{stream_name}",
+                "name_transform_pattern": "(a+)+b",
+                "name_transform_replacement": "",
+            }
+        ])
+        assert len(viols) == 1
+        assert viols[0].field == "actions[0].name_transform_pattern"
+
+    def test_lint_actions_json_skips_literal_set_variable(self):
+        """``literal`` mode has no regex — must not be linted."""
+        viols = lint_actions_json([
+            {
+                "type": "set_variable",
+                "variable_name": "foo",
+                "variable_mode": "literal",
+                "template": "{stream_name}",
+            }
+        ])
+        assert viols == []
+
+    def test_lint_substitution_pairs_only_is_regex(self):
+        """Non-regex pairs are literal strings — must not be linted."""
+        viols = lint_substitution_pairs([
+            {"find": "(a+)+b", "replace": "", "is_regex": False, "enabled": True},
+            {"find": "(a+)+b", "replace": "", "is_regex": True, "enabled": True},
+        ])
+        assert len(viols) == 1
+        assert viols[0].field == "substitution_pairs[1].find"
+
+
+# =========================================================================
+# HTTP envelope.
+# =========================================================================
+
+
+class TestHttpEnvelope:
+    def test_envelope_shape(self):
+        v = LintViolation(
+            code="REGEX_TOO_LONG",
+            message="Pattern is too long (612 chars, max 500).",
+            field="condition_value",
+            detail={"pattern_len": 612, "max_pattern_len": 500},
+        )
+        envelope = violations_to_http_detail([v])
+        assert envelope == {
+            "error": {
+                "code": "REGEX_VALIDATION_ERROR",
+                "message": "Pattern is too long (612 chars, max 500).",
+                "details": [
+                    {
+                        "field": "condition_value",
+                        "code": "REGEX_TOO_LONG",
+                        "message": "Pattern is too long (612 chars, max 500).",
+                        "detail": {"pattern_len": 612, "max_pattern_len": 500},
+                    }
+                ],
+            }
+        }
+
+    def test_envelope_with_multiple_violations_keeps_first_message(self):
+        a = LintViolation(code="REGEX_TOO_LONG", message="first", field="a")
+        b = LintViolation(code="REGEX_NESTED_QUANTIFIER", message="second", field="b")
+        envelope = violations_to_http_detail([a, b])
+        assert envelope["error"]["message"] == "first"
+        assert len(envelope["error"]["details"]) == 2
+
+
+# =========================================================================
+# Property-based smoke test (optional — skipped if hypothesis isn't
+# installed. The full pathologically-generated sweep is in
+# test_regex_lint_property.py.)
+# =========================================================================
+
+
+class TestBenignSmokeSweep:
+    """A hand-curated sweep of known-benign shapes.
+
+    Runs without hypothesis so it's always executed. Property-based
+    generation of 'should pass' patterns is in a sibling file that skips
+    when hypothesis isn't available."""
+
+    BENIGN: list[str] = [
+        r"foo",
+        r"foo.*bar",
+        r"\d{3}-\d{4}",
+        r"^ESPN\s+\d+",
+        r"[a-zA-Z]{2,10}",
+        r"^(?:US|CA|UK):\s*",
+        r"Season\s+\d+\s+Episode\s+\d+",
+        r"(HD|SD|UHD|4K)",
+        r"\b[A-Z]{3,5}\b",
+    ]
+
+    @pytest.mark.parametrize("pattern", BENIGN)
+    def test_benign_passes(self, pattern):
+        viols = lint_pattern(pattern)
+        assert viols == [], (
+            f"benign sweep FP: {pattern!r} — {[v.code for v in viols]}"
+        )

--- a/backend/tests/unit/test_regex_lint_property.py
+++ b/backend/tests/unit/test_regex_lint_property.py
@@ -1,0 +1,119 @@
+"""
+Property-based tests for :mod:`regex_lint` (bd-eio04.7).
+
+Uses Hypothesis to generate patterns from a "known-benign" grammar and
+asserts the linter returns an empty violations list for every one. The
+grammar is deliberately conservative — it builds patterns out of
+anchors, literals, character classes, bounded quantifiers, optional
+named groups, and simple branches — covering the shapes that dominate
+the real production corpus without ever composing a nested-unbounded
+quantifier.
+
+Skipped cleanly if ``hypothesis`` is not installed. The hand-curated
+sweep in :mod:`test_regex_lint.TestBenignSmokeSweep` runs unconditionally
+and is the minimum guaranteed coverage.
+"""
+from __future__ import annotations
+
+import pytest
+
+hypothesis = pytest.importorskip(
+    "hypothesis",
+    reason="hypothesis not installed; hand-curated sweep in test_regex_lint covers the minimum",
+)
+
+from hypothesis import given, settings, strategies as st  # noqa: E402
+
+from regex_lint import lint_pattern  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Benign-pattern grammar.
+# Each leaf emits a string; compose into longer patterns via st.lists + join.
+# Deliberately NO unbounded quantifiers — property target is the
+# should-pass slice of the lint contract.
+# ---------------------------------------------------------------------------
+
+_LITERAL_CHARS = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ",
+    min_size=1,
+    max_size=10,
+).map(lambda s: s)
+
+
+def _escape_literal(s: str) -> str:
+    """Escape regex metacharacters so the string is a valid literal part."""
+    import re as _re
+
+    return _re.escape(s)
+
+
+_literal = _LITERAL_CHARS.map(_escape_literal)
+
+_char_class = st.sampled_from([
+    r"\d",
+    r"\w",
+    r"\s",
+    r"[A-Z]",
+    r"[a-z]",
+    r"[0-9]",
+    r"[A-Za-z]",
+    r"[A-Z]{2,5}",
+    r"[0-9]{1,4}",
+])
+
+_bounded_quantified = st.sampled_from([
+    r"\d{2,4}",
+    r"\w{3,8}",
+    r"[A-Z]{2,5}",
+    r"\s{1,3}",
+])
+
+_anchor = st.sampled_from(["^", "$", r"\b"])
+
+_optional_group = st.sampled_from([
+    r"(?:HD|SD|UHD)?",
+    r"(?:\s+HD)?",
+    r"(?:\s*-\s*\w+)?",
+])
+
+_named_group = st.sampled_from([
+    r"(?P<hour>\d{1,2})",
+    r"(?P<minute>\d{2})",
+    r"(?P<ampm>[AP]M)",
+    r"(?<channel>\w+)",  # JS style — engine converts at runtime
+    r"(?<day>\d{1,2})",
+])
+
+_part = st.one_of(
+    _literal,
+    _char_class,
+    _bounded_quantified,
+    _anchor,
+    _optional_group,
+    _named_group,
+)
+
+_benign_pattern = st.lists(_part, min_size=1, max_size=8).map("".join)
+
+
+@settings(max_examples=200, deadline=None)
+@given(pattern=_benign_pattern)
+def test_benign_grammar_never_flagged(pattern):
+    """Property: every pattern from the benign grammar passes the linter.
+
+    If this ever fails, either (a) the grammar has grown a shape the
+    linter rejects (tighten the grammar), or (b) the detector has a new
+    false positive (fix the detector). The detector target is 0 FPs on
+    the real corpus; this property extends that target to a synthetic
+    sweep of benign shapes.
+    """
+    violations = lint_pattern(pattern)
+    # Patterns can legitimately fail on length — strategies occasionally
+    # produce something over 500 chars. That's a correct REGEX_TOO_LONG
+    # flag; filter it out before asserting benign-ness.
+    non_length = [v for v in violations if v.code != "REGEX_TOO_LONG"]
+    assert non_length == [], (
+        f"benign grammar produced an unexpected lint violation for {pattern!r}: "
+        f"{[(v.code, v.message) for v in non_length]}"
+    )

--- a/backend/tests/unit/test_rule_lint_scan.py
+++ b/backend/tests/unit/test_rule_lint_scan.py
@@ -1,0 +1,439 @@
+"""
+Unit tests for :mod:`tasks.rule_lint_scan` (bd-eio04.7 migration scan).
+
+Seeds the three rule tables with a mix of benign and known-evil
+patterns, runs the scan, and asserts:
+
+  - ``rule_lint_findings`` is populated with the expected codes for the
+    known-evil rows.
+  - No benign row gets flagged.
+  - Rule rows themselves are NOT mutated (scan is read-only).
+  - Re-running the scan is idempotent — same finding set, no duplicates.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from models import (
+    AutoCreationRule,
+    DummyEPGProfile,
+    NormalizationRule,
+    NormalizationRuleGroup,
+    RuleLintFinding,
+)
+from tasks.rule_lint_scan import (
+    RULE_TYPE_AUTO_CREATION,
+    RULE_TYPE_DUMMY_EPG,
+    RULE_TYPE_NORMALIZATION,
+    run_scan,
+)
+
+
+# =========================================================================
+# Helpers to seed rule rows.
+# =========================================================================
+
+
+def _seed_group(session) -> NormalizationRuleGroup:
+    group = NormalizationRuleGroup(
+        name="Test Group", enabled=True, priority=0, is_builtin=False
+    )
+    session.add(group)
+    session.commit()
+    session.refresh(group)
+    return group
+
+
+def _seed_norm_rule_benign(session, group_id: int) -> NormalizationRule:
+    rule = NormalizationRule(
+        group_id=group_id,
+        name="Strip HD suffix",
+        enabled=True,
+        priority=0,
+        condition_type="regex",
+        condition_value=r"\s*HD$",
+        action_type="remove",
+        is_builtin=False,
+    )
+    session.add(rule)
+    session.commit()
+    session.refresh(rule)
+    return rule
+
+
+def _seed_norm_rule_evil(session, group_id: int) -> NormalizationRule:
+    rule = NormalizationRule(
+        group_id=group_id,
+        name="Evil nested quantifier",
+        enabled=True,
+        priority=1,
+        condition_type="regex",
+        condition_value=r"(a+)+b",
+        action_type="remove",
+        is_builtin=False,
+    )
+    session.add(rule)
+    session.commit()
+    session.refresh(rule)
+    return rule
+
+
+def _seed_norm_rule_too_long(session, group_id: int) -> NormalizationRule:
+    """Build a row whose ``condition_value`` is length-capped by the
+    column (500 chars) but whose compound-conditions JSON holds an
+    oversize pattern. Exercises the scan's JSON-walking path."""
+    conditions = [
+        {"type": "regex", "value": "a" * 600},
+    ]
+    rule = NormalizationRule(
+        group_id=group_id,
+        name="Oversize pattern in JSON",
+        enabled=True,
+        priority=2,
+        condition_type=None,
+        condition_value=None,
+        conditions=json.dumps(conditions),
+        condition_logic="AND",
+        action_type="remove",
+        is_builtin=False,
+    )
+    session.add(rule)
+    session.commit()
+    session.refresh(rule)
+    return rule
+
+
+def _seed_auto_creation_rule_evil(session) -> AutoCreationRule:
+    """Evil regex in both sort_regex and a set_variable action pattern."""
+    conditions = [{"type": "stream_name_matches", "value": "(.*)*X"}]
+    actions = [
+        {
+            "type": "set_variable",
+            "variable_name": "foo",
+            "variable_mode": "regex_extract",
+            "source_field": "stream_name",
+            "pattern": "(a+)+b",
+        }
+    ]
+    rule = AutoCreationRule(
+        name="Evil AC rule",
+        enabled=True,
+        priority=0,
+        conditions=json.dumps(conditions),
+        actions=json.dumps(actions),
+        run_on_refresh=False,
+        stop_on_first_match=True,
+        sort_field="stream_name_regex",
+        sort_order="asc",
+        probe_on_sort=False,
+        sort_regex=r"(\w+)+$",  # evil
+        stream_sort_order="asc",
+        skip_struck_streams=False,
+        orphan_action="delete",
+        match_scope_target_group=False,
+    )
+    session.add(rule)
+    session.commit()
+    session.refresh(rule)
+    return rule
+
+
+def _seed_auto_creation_rule_benign(session) -> AutoCreationRule:
+    conditions = [{"type": "stream_name_contains", "value": "Sports"}]
+    actions = [
+        {"type": "create_channel", "name_template": "{stream_name}"}
+    ]
+    rule = AutoCreationRule(
+        name="Benign AC rule",
+        enabled=True,
+        priority=1,
+        conditions=json.dumps(conditions),
+        actions=json.dumps(actions),
+        run_on_refresh=False,
+        stop_on_first_match=True,
+        sort_order="asc",
+        probe_on_sort=False,
+        stream_sort_order="asc",
+        skip_struck_streams=False,
+        orphan_action="delete",
+        match_scope_target_group=False,
+    )
+    session.add(rule)
+    session.commit()
+    session.refresh(rule)
+    return rule
+
+
+def _seed_dummy_epg_profile_evil(session) -> DummyEPGProfile:
+    """Evil pattern in title_pattern, plus an evil is_regex=True
+    substitution pair."""
+    subs = [
+        {"find": "(a+)+b", "replace": "", "is_regex": True, "enabled": True},
+        {"find": "literal-string", "replace": "x", "is_regex": False, "enabled": True},
+    ]
+    profile = DummyEPGProfile(
+        name="Evil Profile",
+        enabled=True,
+        name_source="channel",
+        stream_index=1,
+        title_pattern=r"(.*)*X",  # evil
+        time_pattern=r"\d{1,2}:\d{2}",  # benign
+        date_pattern=None,
+        substitution_pairs=json.dumps(subs),
+        event_timezone="US/Eastern",
+        program_duration=180,
+        tvg_id_template="ecm-{channel_number}",
+    )
+    session.add(profile)
+    session.commit()
+    session.refresh(profile)
+    return profile
+
+
+def _seed_dummy_epg_profile_benign_b1g(session) -> DummyEPGProfile:
+    """Regression case — B1G production title_pattern (spike FP)."""
+    b1g_pattern = (
+        r"(?<channel>.+?):\s+(?<event>"
+        r"(?:(?<sport>.+?)\s+\|\s+(?<team1>.+?)\s+vs\s+(?<team2>.+?))"
+        r"|(?:.+?))\s+@\s+"
+    )
+    profile = DummyEPGProfile(
+        name="B1G Advanced EPG",
+        enabled=True,
+        name_source="channel",
+        stream_index=1,
+        title_pattern=b1g_pattern,
+        event_timezone="US/Eastern",
+        program_duration=180,
+        tvg_id_template="ecm-{channel_number}",
+    )
+    session.add(profile)
+    session.commit()
+    session.refresh(profile)
+    return profile
+
+
+# =========================================================================
+# Tests.
+# =========================================================================
+
+
+class TestRunScanWritesFindings:
+    def test_flags_evil_patterns(self, test_session):
+        group = _seed_group(test_session)
+        _seed_norm_rule_benign(test_session, group.id)
+        evil = _seed_norm_rule_evil(test_session, group.id)
+
+        summary = run_scan(test_session)
+
+        findings = test_session.query(RuleLintFinding).filter(
+            RuleLintFinding.rule_type == RULE_TYPE_NORMALIZATION,
+            RuleLintFinding.rule_id == evil.id,
+        ).all()
+        assert len(findings) == 1
+        assert findings[0].code == "REGEX_NESTED_QUANTIFIER"
+        assert findings[0].field == "condition_value"
+        assert summary["normalization"]["rules_flagged"] == 1
+        assert summary["normalization"]["findings"] == 1
+
+    def test_flags_all_three_rule_types(self, test_session):
+        group = _seed_group(test_session)
+        _seed_norm_rule_evil(test_session, group.id)
+        _seed_auto_creation_rule_evil(test_session)
+        _seed_auto_creation_rule_benign(test_session)
+        _seed_dummy_epg_profile_evil(test_session)
+        _seed_dummy_epg_profile_benign_b1g(test_session)
+
+        summary = run_scan(test_session)
+
+        # Normalization: 1 flagged, 1 finding
+        assert summary["normalization"]["rules_flagged"] == 1
+        # Auto-creation: evil rule has sort_regex + condition + action = 3 findings
+        ac_findings = test_session.query(RuleLintFinding).filter(
+            RuleLintFinding.rule_type == RULE_TYPE_AUTO_CREATION
+        ).all()
+        assert len(ac_findings) == 3
+        ac_fields = {f.field for f in ac_findings}
+        assert "sort_regex" in ac_fields
+        assert "conditions[0].value" in ac_fields
+        assert "actions[0].pattern" in ac_fields
+        # Dummy-EPG: evil profile has title_pattern + substitution[0].find = 2 findings
+        de_findings = test_session.query(RuleLintFinding).filter(
+            RuleLintFinding.rule_type == RULE_TYPE_DUMMY_EPG
+        ).all()
+        # B1G profile must NOT contribute (spike regression case).
+        assert len(de_findings) == 2
+        de_fields = {f.field for f in de_findings}
+        assert "title_pattern" in de_fields
+        assert "substitution_pairs[0].find" in de_fields
+
+    def test_b1g_regression_not_flagged(self, test_session):
+        """The spike's critical regression: B1G title_pattern must NOT be
+        flagged by the scan, because regexploit would have (0 FP target)."""
+        _seed_dummy_epg_profile_benign_b1g(test_session)
+        run_scan(test_session)
+        findings = test_session.query(RuleLintFinding).filter(
+            RuleLintFinding.rule_type == RULE_TYPE_DUMMY_EPG
+        ).all()
+        assert findings == []
+
+    def test_oversize_pattern_in_compound_conditions_flagged(self, test_session):
+        group = _seed_group(test_session)
+        rule = _seed_norm_rule_too_long(test_session, group.id)
+        run_scan(test_session)
+        findings = test_session.query(RuleLintFinding).filter(
+            RuleLintFinding.rule_type == RULE_TYPE_NORMALIZATION,
+            RuleLintFinding.rule_id == rule.id,
+        ).all()
+        assert len(findings) == 1
+        assert findings[0].code == "REGEX_TOO_LONG"
+        assert findings[0].field == "conditions[0].value"
+
+
+class TestRunScanIsIdempotent:
+    def test_second_run_produces_same_findings(self, test_session):
+        group = _seed_group(test_session)
+        _seed_norm_rule_evil(test_session, group.id)
+        _seed_auto_creation_rule_evil(test_session)
+        _seed_dummy_epg_profile_evil(test_session)
+
+        first = run_scan(test_session)
+        first_set = {
+            (f.rule_type, f.rule_id, f.field, f.code)
+            for f in test_session.query(RuleLintFinding).all()
+        }
+
+        second = run_scan(test_session)
+        second_set = {
+            (f.rule_type, f.rule_id, f.field, f.code)
+            for f in test_session.query(RuleLintFinding).all()
+        }
+
+        # Idempotency contract — per-rule findings are wiped and
+        # rewritten, so the (rule_type, rule_id, field, code) set is
+        # stable and the total counts are equal. IDs may or may not be
+        # reused depending on the SQLite autoincrement state; the
+        # content-level assertion is the load-bearing one.
+        assert first["total_findings"] == second["total_findings"]
+        assert first_set == second_set, (
+            f"Scan not idempotent — first={first_set}, second={second_set}"
+        )
+        # And the total row count in the table matches the per-scan total
+        # (no duplicate rows accumulated).
+        assert (
+            test_session.query(RuleLintFinding).count()
+            == second["total_findings"]
+        )
+
+    def test_clears_stale_findings_when_rule_fixed(self, test_session):
+        """If a pattern is fixed out-of-band between scans, the stale
+        finding must be cleared rather than sticking around."""
+        group = _seed_group(test_session)
+        rule = _seed_norm_rule_evil(test_session, group.id)
+        run_scan(test_session)
+        assert test_session.query(RuleLintFinding).count() == 1
+
+        # Simulate an out-of-band fix.
+        rule.condition_value = r"\s*HD$"
+        test_session.commit()
+        run_scan(test_session)
+        assert test_session.query(RuleLintFinding).count() == 0
+
+
+class TestRunScanDoesNotMutateRules:
+    def test_rules_unchanged_after_scan(self, test_session):
+        """Read-only contract: no rule row may have ``updated_at`` or
+        any data field changed by the scan."""
+        group = _seed_group(test_session)
+        evil_norm = _seed_norm_rule_evil(test_session, group.id)
+        evil_ac = _seed_auto_creation_rule_evil(test_session)
+        evil_de = _seed_dummy_epg_profile_evil(test_session)
+
+        before_norm = {
+            "name": evil_norm.name,
+            "condition_value": evil_norm.condition_value,
+            "enabled": evil_norm.enabled,
+            "updated_at": evil_norm.updated_at,
+        }
+        before_ac = {
+            "name": evil_ac.name,
+            "sort_regex": evil_ac.sort_regex,
+            "enabled": evil_ac.enabled,
+            "updated_at": evil_ac.updated_at,
+        }
+        before_de = {
+            "name": evil_de.name,
+            "title_pattern": evil_de.title_pattern,
+            "enabled": evil_de.enabled,
+            "updated_at": evil_de.updated_at,
+        }
+
+        run_scan(test_session)
+        test_session.refresh(evil_norm)
+        test_session.refresh(evil_ac)
+        test_session.refresh(evil_de)
+
+        assert evil_norm.condition_value == before_norm["condition_value"]
+        assert evil_norm.enabled == before_norm["enabled"]
+        assert evil_norm.updated_at == before_norm["updated_at"]
+
+        assert evil_ac.sort_regex == before_ac["sort_regex"]
+        assert evil_ac.enabled == before_ac["enabled"]
+        assert evil_ac.updated_at == before_ac["updated_at"]
+
+        assert evil_de.title_pattern == before_de["title_pattern"]
+        assert evil_de.enabled == before_de["enabled"]
+        assert evil_de.updated_at == before_de["updated_at"]
+
+
+class TestRunScanSummary:
+    def test_summary_shape(self, test_session):
+        summary = run_scan(test_session)
+        assert set(summary.keys()) == {
+            "normalization",
+            "auto_creation",
+            "dummy_epg",
+            "total_findings",
+        }
+        for key in ("normalization", "auto_creation", "dummy_epg"):
+            assert set(summary[key].keys()) == {
+                "rules_scanned",
+                "rules_flagged",
+                "findings",
+            }
+
+    def test_empty_db_produces_zero_findings(self, test_session):
+        summary = run_scan(test_session)
+        assert summary["total_findings"] == 0
+        assert summary["normalization"]["rules_scanned"] == 0
+        assert summary["auto_creation"]["rules_scanned"] == 0
+        assert summary["dummy_epg"]["rules_scanned"] == 0
+
+
+class TestRunScanHandlesBadJson:
+    def test_malformed_conditions_json_is_skipped(self, test_session):
+        """A row with corrupt ``conditions`` JSON should not crash the
+        scan — just skip the JSON walk for that row."""
+        group = _seed_group(test_session)
+        rule = NormalizationRule(
+            group_id=group.id,
+            name="Corrupt JSON",
+            enabled=True,
+            priority=0,
+            condition_type="contains",
+            condition_value="foo",
+            conditions="{not valid json}",
+            condition_logic="AND",
+            action_type="remove",
+            is_builtin=False,
+        )
+        test_session.add(rule)
+        test_session.commit()
+
+        # Should not raise.
+        summary = run_scan(test_session)
+        # And the benign condition_value (contains, not regex) produces
+        # no findings.
+        assert summary["normalization"]["findings"] == 0


### PR DESCRIPTION
## Summary

Rejects pathological regex patterns at save time across all 3 rule persistence boundaries. Detector lifted verbatim from the bd-eio04.11 spike (hand-rolled AST walker — **0 false positives** on 32-pattern production corpus, 7/7 true positives on known-evil, 0.03ms/call).

- **New `backend/regex_lint.py`** — `lint_pattern()` with 3 codes: `REGEX_TOO_LONG`, `REGEX_COMPILE_ERROR`, `REGEX_NESTED_QUANTIFIER`. Detector walks `re._parser` parse tree (not regex-matches the pattern) — linter is itself ReDoS-safe. Pre-3.11 `sre_parse` fallback.
- **Wired into 3 routers**: `normalization.py`, `auto_creation.py`, `dummy_epg.py`. POST/PATCH/PUT lint only fields the request supplied — renaming a rule doesn't trigger 422 for an untouched pattern. `GET /lint-findings` on each.
- **Error envelope**: 422 `{error: {code: "REGEX_VALIDATION_ERROR", message, details}}` with actionable messages ("612 chars, max 500. Try breaking this into multiple rules").
- **New Alembic migration (0003)**: `rule_lint_findings` table (separate from rule tables per DB-engineer grooming).
- **Startup migration scan** (`backend/tasks/rule_lint_scan.py`): read-only, idempotent, bad-JSON-tolerant, does NOT mutate rules.

**Overlap note:** touches `routers/normalization.py`. PR #bd-eio04.12 also touches this file — additive at different endpoints. Either order works.

**Known TODO:** `regex_lint.DOCS_URL` is a placeholder `/docs/patterns` pending bd-eio04.8 style guide.

## Test plan

- [x] 79 unit tests + 200-example Hypothesis property sweep in `test_regex_lint.py`.
- [x] 10 migration-scan tests (idempotent, read-only, stale-clearing, bad-JSON-tolerant).
- [x] 23 router integration tests (negative + positive across all 3 routers + GET /lint-findings).
- [x] B1G production pattern regression locked via `test_b1g_title_pattern_critical_regression`.
- [x] 113 new tests pass. Full backend suite: 2834 passed (13 pre-existing failures reproduce on clean dev; zero regressions).
- [x] 1 adjusted test: `test_create_rule_invalid_conditions` now expects 422 (REGEX_VALIDATION_ERROR) instead of 400 (schema).

## Sequence

Merge position: **6 of 6**. Either order with `.12` — both touch `routers/normalization.py` additively.