### PR TITLE
bd-eio04.8: Semgrep no-bare-re CI rule + docs/style_guide.md + fix regex_lint DOCS_URL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,3 +137,42 @@ jobs:
           path: frontend/coverage/
           if-no-files-found: ignore
           retention-days: 14
+
+  # ─── Semgrep lint (ReDoS / safe_regex guard — bd-eio04.8) ──────────────
+  # Enforces the `no-bare-re-on-dynamic-pattern` rule in .semgrep.yml so
+  # new PRs cannot introduce a stdlib `re.search/match/sub/compile/…` call
+  # on a non-literal pattern. See docs/style_guide.md#regex for the
+  # full convention. Rule-level excludes cover backend/tests/** and
+  # backend/safe_regex.py; case-by-case exemptions are annotated inline
+  # with `# nosemgrep: no-bare-re-on-dynamic-pattern` + justification or
+  # a TODO(<bead-id>) pointer to a follow-up migration.
+  semgrep-lint:
+    name: Semgrep Lint
+    runs-on: ubuntu-latest
+    # Pinned image tag — semgrep 1.160.x (matches the version used to
+    # author and validate the .semgrep.yml rule). Bump deliberately; the
+    # rule self-test under .semgrep/tests/ is the canary for regressions.
+    container:
+      image: returntocorp/semgrep:1.160.0
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate Semgrep rule config
+        run: semgrep --validate --config .semgrep.yml
+
+      - name: Run Semgrep rule self-test
+        # Runs the fixture file (`# ruleid:` / `# ok:` annotations) against
+        # the live .semgrep.yml so the test locks the rule's accept/reject
+        # boundary — if the rule drifts, the self-test fails before the
+        # backend scan runs.
+        run: |
+          semgrep --test \
+            --config .semgrep.yml \
+            .semgrep/tests/no-bare-re-on-dynamic-pattern.py
+
+      - name: Run Semgrep against backend/
+        run: |
+          # --error flag exits non-zero on any finding. The rule is
+          # severity: ERROR so any hit blocks the job.
+          semgrep --config .semgrep.yml --error backend/

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,89 @@
+rules:
+  # ---------------------------------------------------------------------
+  # bd-eio04.8 — block bare stdlib `re.*` on dynamic (non-literal) patterns.
+  #
+  # The rule flags a `re.search/match/sub/compile/findall/finditer` call
+  # whose first argument is anything OTHER than a raw-string literal
+  # (`r"..."` / `r'...'`). Raw-string literals are the ECM convention for
+  # module-level compiled constants (`_UPPER_SNAKE_RE = re.compile(r"…")`)
+  # and are safe — their value is authored in source and cannot be
+  # attacker-controlled.
+  #
+  # Any non-literal first arg — a bare variable, an f-string, or a
+  # string-concatenation expression — can carry a user-supplied pattern
+  # and must route through `backend.safe_regex` so the ReDoS timeout and
+  # pattern-length cap apply. See `docs/style_guide.md#regex`.
+  #
+  # Exclusions:
+  #   backend/safe_regex.py  — the wrapper itself calls `regex` not `re`,
+  #                             but we exclude to be defensive.
+  #   backend/tests/**       — test fixtures intentionally exercise
+  #                             dynamic patterns (including malicious
+  #                             ones) to verify ReDoS behaviour. Running
+  #                             safe_regex in tests is already covered
+  #                             by unit tests on safe_regex itself.
+  # ---------------------------------------------------------------------
+  - id: no-bare-re-on-dynamic-pattern
+    patterns:
+      - pattern-either:
+          - pattern: re.search($PAT, ...)
+          - pattern: re.match($PAT, ...)
+          - pattern: re.fullmatch($PAT, ...)
+          - pattern: re.sub($PAT, ...)
+          - pattern: re.subn($PAT, ...)
+          - pattern: re.split($PAT, ...)
+          - pattern: re.compile($PAT, ...)
+          - pattern: re.findall($PAT, ...)
+          - pattern: re.finditer($PAT, ...)
+      # Exempt raw-string literal patterns (`re.compile(r"...")`) — the
+      # ECM convention for module-level compiled constants.
+      - pattern-not: re.search(r"...", ...)
+      - pattern-not: re.match(r"...", ...)
+      - pattern-not: re.fullmatch(r"...", ...)
+      - pattern-not: re.sub(r"...", ...)
+      - pattern-not: re.subn(r"...", ...)
+      - pattern-not: re.split(r"...", ...)
+      - pattern-not: re.compile(r"...", ...)
+      - pattern-not: re.findall(r"...", ...)
+      - pattern-not: re.finditer(r"...", ...)
+      # Exempt f-strings whose interpolations go through `re.escape(...)`.
+      # `re.escape` neutralizes user input as a literal — the resulting
+      # pattern has no metacharacters from the interpolated value and so
+      # cannot backtrack catastrophically on that value. This covers the
+      # `rf"\b{re.escape(x)}\b"` idiom used throughout stream_normalization,
+      # epg_matching, auto_creation_engine, and similar modules where
+      # hardcoded lists are compiled into bounded word-boundary patterns.
+      - pattern-not: re.search(rf"...{re.escape(...)}...", ...)
+      - pattern-not: re.match(rf"...{re.escape(...)}...", ...)
+      - pattern-not: re.fullmatch(rf"...{re.escape(...)}...", ...)
+      - pattern-not: re.sub(rf"...{re.escape(...)}...", ...)
+      - pattern-not: re.subn(rf"...{re.escape(...)}...", ...)
+      - pattern-not: re.split(rf"...{re.escape(...)}...", ...)
+      - pattern-not: re.compile(rf"...{re.escape(...)}...", ...)
+      - pattern-not: re.findall(rf"...{re.escape(...)}...", ...)
+      - pattern-not: re.finditer(rf"...{re.escape(...)}...", ...)
+      # Exempt raw-string concatenations where all interpolated segments
+      # use `re.escape(...)`. Covers `r'\b' + re.escape(x) + r'\b'`.
+      - pattern-not: re.search(r"..." + re.escape(...) + r"...", ...)
+      - pattern-not: re.match(r"..." + re.escape(...) + r"...", ...)
+      - pattern-not: re.compile(r"..." + re.escape(...) + r"...", ...)
+      - pattern-not: re.sub(r"..." + re.escape(...) + r"...", ...)
+      - pattern-not: re.findall(r"..." + re.escape(...) + r"...", ...)
+      - pattern-not: re.finditer(r"..." + re.escape(...) + r"...", ...)
+    message: >-
+      Dynamic regex pattern must use `backend.safe_regex`, not stdlib `re`
+      (ReDoS protection). The stdlib `re` engine has no timeout — a
+      pathological user-supplied pattern can pin a CPU core indefinitely.
+      Route this call through `safe_regex.search/match/sub/compile` which
+      wraps the third-party `regex` library with a 100ms per-call timeout
+      and a 500-char pattern length cap. Module-level compiled constants
+      authored from raw-string literals (`r"..."`) are exempt — this rule
+      only fires on non-literal first arguments. See
+      `docs/style_guide.md#regex` for the full convention.
+    languages:
+      - python
+    severity: ERROR
+    paths:
+      exclude:
+        - "backend/tests/**"
+        - "backend/safe_regex.py"

--- a/.semgrep/tests/no-bare-re-on-dynamic-pattern.py
+++ b/.semgrep/tests/no-bare-re-on-dynamic-pattern.py
@@ -1,0 +1,113 @@
+"""Self-test fixtures for the `no-bare-re-on-dynamic-pattern` Semgrep rule.
+
+Run with: ``semgrep --config .semgrep/tests/no-bare-re-test.yml --test``
+
+The `ruleid:` / `ok:` comments mark expected outcomes; `semgrep --test`
+compares actual findings against the annotations and fails if they diverge.
+"""
+# ruff: noqa — this file is a Semgrep rule fixture, not production code.
+# type: ignore
+import re
+
+
+# =============================================================================
+# Positive cases — MUST be flagged.
+# =============================================================================
+
+
+def flagged_dynamic_variable(user_pattern, text):
+    # ruleid: no-bare-re-on-dynamic-pattern
+    return re.search(user_pattern, text)
+
+
+def flagged_dynamic_match(user_pattern, text):
+    # ruleid: no-bare-re-on-dynamic-pattern
+    return re.match(user_pattern, text)
+
+
+def flagged_dynamic_sub(user_pattern, repl, text):
+    # ruleid: no-bare-re-on-dynamic-pattern
+    return re.sub(user_pattern, repl, text)
+
+
+def flagged_dynamic_compile(user_pattern):
+    # ruleid: no-bare-re-on-dynamic-pattern
+    return re.compile(user_pattern)
+
+
+def flagged_dynamic_findall(user_pattern, text):
+    # ruleid: no-bare-re-on-dynamic-pattern
+    return re.findall(user_pattern, text)
+
+
+def flagged_dynamic_finditer(user_pattern, text):
+    # ruleid: no-bare-re-on-dynamic-pattern
+    return re.finditer(user_pattern, text)
+
+
+def flagged_dynamic_split(user_pattern, text):
+    # ruleid: no-bare-re-on-dynamic-pattern
+    return re.split(user_pattern, text)
+
+
+def flagged_dynamic_fullmatch(user_pattern, text):
+    # ruleid: no-bare-re-on-dynamic-pattern
+    return re.fullmatch(user_pattern, text)
+
+
+def flagged_dynamic_subn(user_pattern, repl, text):
+    # ruleid: no-bare-re-on-dynamic-pattern
+    return re.subn(user_pattern, repl, text)
+
+
+def flagged_fstring_no_escape(name, text):
+    # f-string interpolation without re.escape — `name` could carry
+    # metacharacters that change pattern semantics. Must flag.
+    # ruleid: no-bare-re-on-dynamic-pattern
+    return re.search(f"^{name}$", text)
+
+
+def flagged_raw_concat_no_escape(name, text):
+    # Bare concat of user input into a raw-string pattern — no escape.
+    # ruleid: no-bare-re-on-dynamic-pattern
+    return re.search(r"\b" + name + r"\b", text)
+
+
+# =============================================================================
+# Negative cases — MUST NOT be flagged.
+# =============================================================================
+
+# Module-level compiled constant from raw-string literal — the ECM convention.
+# ok: no-bare-re-on-dynamic-pattern
+_CHANNEL_NUMBER_RE = re.compile(r"^\d+\s*\|\s*")
+
+# With flags — still a literal.
+# ok: no-bare-re-on-dynamic-pattern
+_HD_RE = re.compile(r"\bhd\b", re.IGNORECASE)
+
+
+def safe_literal_search(text):
+    # ok: no-bare-re-on-dynamic-pattern
+    return re.search(r"^\d+$", text)
+
+
+def safe_literal_sub(text):
+    # ok: no-bare-re-on-dynamic-pattern
+    return re.sub(r"\s+", " ", text)
+
+
+def safe_fstring_with_escape(name, text):
+    # Interpolation goes through re.escape — neutralised to a literal.
+    # ok: no-bare-re-on-dynamic-pattern
+    return re.search(rf"\b{re.escape(name)}\b", text)
+
+
+def safe_raw_concat_with_escape(name, text):
+    # Concatenation with re.escape — same safety reasoning.
+    # ok: no-bare-re-on-dynamic-pattern
+    return re.search(r"\b" + re.escape(name) + r"\b", text)
+
+
+def safe_compile_fstring_with_escape(name):
+    # ok: no-bare-re-on-dynamic-pattern
+    return re.compile(rf"^{re.escape(name)}\s*$", re.IGNORECASE)

--- a/backend/auto_creation_engine.py
+++ b/backend/auto_creation_engine.py
@@ -2693,7 +2693,9 @@ def _get_rule_starting_number(rule) -> Optional[int]:
 # Pattern: stream name contains EAST or WEST near the end, possibly followed by
 # quality indicators (HD, FHD, UHD, SD, 4K, HEVC, H.264/5) or parenthesized/bracketed
 # tags like (CX), [HD], etc.
-_TZ_SUFFIX_RE = re.compile(
+# Module-level constant assembled from raw-string literal fragments (multi-line
+# string concatenation); no runtime interpolation — safe by construction.
+_TZ_SUFFIX_RE = re.compile(  # nosemgrep: no-bare-re-on-dynamic-pattern
     r'[\s\-_.\(|\[](EAST|WEST)[\s\)\]]*'
     r'(?:\s*(?:F?HD|UHD|SD|4K|HEVC|H\.?26[45]|\([^)]*\)|\[[^\]]*\]))*'
     r'\s*$',

--- a/backend/auto_creation_executor.py
+++ b/backend/auto_creation_executor.py
@@ -1549,12 +1549,14 @@ class ActionExecutor:
         n = re.sub(r'^[A-Z]{2}\s*[:|]\s*', '', n)
         # Strip league prefix: "NFL: Arizona Cardinals"
         n = ActionExecutor._LEAGUE_PREFIXES_RE.sub('', n)
-        # Strip quality suffixes
+        # Strip quality suffixes — {suffix} iterates the hardcoded
+        # ActionExecutor._QUALITY_SUFFIXES tuple, not user input.
         for suffix in ActionExecutor._QUALITY_SUFFIXES:
-            n = re.sub(rf'[\s\-_|:]*{suffix}\s*$', '', n, flags=re.IGNORECASE)
-        # Strip timezone suffixes
+            n = re.sub(rf'[\s\-_|:]*{suffix}\s*$', '', n, flags=re.IGNORECASE)  # nosemgrep: no-bare-re-on-dynamic-pattern
+        # Strip timezone suffixes — {suffix} iterates the hardcoded
+        # ActionExecutor._TIMEZONE_SUFFIXES tuple.
         for suffix in ActionExecutor._TIMEZONE_SUFFIXES:
-            n = re.sub(rf'[\s\-_|:]*{suffix}\s*$', '', n, flags=re.IGNORECASE)
+            n = re.sub(rf'[\s\-_|:]*{suffix}\s*$', '', n, flags=re.IGNORECASE)  # nosemgrep: no-bare-re-on-dynamic-pattern
         # Convert semantic characters
         n = n.replace('+', 'plus').replace('&', 'and')
         # Lowercase alphanumeric only

--- a/backend/auto_creation_schema.py
+++ b/backend/auto_creation_schema.py
@@ -160,8 +160,11 @@ class Condition:
                 ConditionType.TVG_ID_MATCHES,
                 ConditionType.CHANNEL_EXISTS_MATCHING,
             ):
+                # TODO(enhancedchannelmanager-ltjyx): migrate write-time syntax validation
+                # to safe_regex.compile so length cap + compile-error surface match
+                # regex_lint.py (bd-eio04.7).
                 try:
-                    re.compile(self.value)
+                    re.compile(self.value)  # nosemgrep: no-bare-re-on-dynamic-pattern
                 except re.error as e:
                     errors.append(f"Invalid regex pattern for {self.type}: {e}")
 
@@ -484,8 +487,9 @@ class Action:
                     if not pattern or not isinstance(pattern, str):
                         errors.append(f"set_variable with mode '{mode}' requires a 'pattern'")
                     else:
+                        # TODO(enhancedchannelmanager-ltjyx): migrate to safe_regex.compile.
                         try:
-                            re.compile(pattern)
+                            re.compile(pattern)  # nosemgrep: no-bare-re-on-dynamic-pattern
                         except re.error as e:
                             errors.append(f"Invalid regex pattern for set_variable: {e}")
                     if mode == "regex_replace":
@@ -511,8 +515,9 @@ class Action:
             if not isinstance(pattern, str):
                 errors.append("name_transform_pattern must be a string")
             else:
+                # TODO(enhancedchannelmanager-ltjyx): migrate to safe_regex.compile.
                 try:
-                    re.compile(pattern)
+                    re.compile(pattern)  # nosemgrep: no-bare-re-on-dynamic-pattern
                 except re.error as e:
                     errors.append(f"Invalid name_transform_pattern: {e}")
             # replacement is optional (defaults to empty string), but must be string if present

--- a/backend/cloud_storage/onedrive_adapter.py
+++ b/backend/cloud_storage/onedrive_adapter.py
@@ -19,7 +19,9 @@ TOKEN_URL = "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
 # Azure AD tenant IDs are either GUIDs (common.onmicrosoft.com case not permitted
 # for app-only flows) or verified domain names such as `contoso.onmicrosoft.com`.
 # Anchored start/end to prevent URL injection (e.g. `evil.com/`, `../`, null bytes).
-_TENANT_ID_RE = re.compile(
+# Module-level constant assembled from raw-string literal fragments; no runtime
+# interpolation — safe by construction.
+_TENANT_ID_RE = re.compile(  # nosemgrep: no-bare-re-on-dynamic-pattern
     r"\A(?:"
     # GUID form
     r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"

--- a/backend/normalization_engine.py
+++ b/backend/normalization_engine.py
@@ -1409,7 +1409,7 @@ class NormalizationEngine:
         # channel number — this prevents matching random words in names
         # like "(MC Radio) New Wave" or "DOCUBOX: MILITARY AND WAR"
         has_network = any(
-            re.search(r'\b' + net + r'\b', upper)
+            safe_regex.search(r'\b' + net + r'\b', upper)
             for net in NormalizationEngine._BROADCAST_NETWORKS
         )
         has_channel_num = bool(re.search(r'\b\d{1,2}\b', upper))

--- a/backend/normalization_engine.py
+++ b/backend/normalization_engine.py
@@ -664,9 +664,11 @@ class NormalizationEngine:
             return RuleMatch(matched=False)
 
         elif condition_type == "regex":
+            # TODO(enhancedchannelmanager-eio04.14): migrate user-supplied
+            # normalization rule pattern to safe_regex.search.
             try:
                 flags = 0 if case_sensitive else re.IGNORECASE
-                match = re.search(pattern, text, flags)
+                match = re.search(pattern, text, flags)  # nosemgrep: no-bare-re-on-dynamic-pattern
                 if match:
                     return RuleMatch(
                         matched=True,
@@ -752,9 +754,11 @@ class NormalizationEngine:
                 sep = r'[\s:\-|/]+'
                 tag_pat = re.escape(match_tag)
                 flags = 0 if case_sensitive else re.IGNORECASE
+                # TODO(enhancedchannelmanager-eio04.14): migrate user-supplied
+                # tag-group regex in this block to safe_regex.search / safe_regex.match.
                 # Try to match with separators on both sides first
                 pattern = r'(' + sep + r')' + tag_pat + r'(?=' + sep + r'|$)'
-                m = re.search(pattern, text, flags)
+                m = re.search(pattern, text, flags)  # nosemgrep: no-bare-re-on-dynamic-pattern
                 if m:
                     # Consume the leading separator group + tag, leave trailing for next segment
                     return RuleMatch(
@@ -765,7 +769,7 @@ class NormalizationEngine:
                     )
                 # Try at start of string: tag followed by separator
                 pattern = tag_pat + r'(' + sep + r')'
-                m = re.match(pattern, text, flags)
+                m = re.match(pattern, text, flags)  # nosemgrep: no-bare-re-on-dynamic-pattern
                 if m:
                     return RuleMatch(
                         matched=True,
@@ -877,11 +881,13 @@ class NormalizationEngine:
             if rule.condition_type != "regex":
                 logger.warning("[NORMALIZE] regex_replace requires regex condition in rule %s", rule.id)
                 return text
+            # TODO(enhancedchannelmanager-eio04.14): migrate user-supplied
+            # regex_replace to safe_regex.sub.
             try:
                 flags = 0 if case_sensitive else re.IGNORECASE
                 # Convert JS-style backreferences ($1, $2) to Python (\1, \2)
                 py_replacement = re.sub(r'\$(\d+)', r'\\\1', action_value)
-                return re.sub(pattern, py_replacement, text, flags=flags)
+                return re.sub(pattern, py_replacement, text, flags=flags)  # nosemgrep: no-bare-re-on-dynamic-pattern
             except re.error as e:
                 logger.warning("[NORMALIZE] Regex replace error in rule %s: %s", rule.id, e)
                 return text
@@ -972,12 +978,14 @@ class NormalizationEngine:
 
         elif action_type == "regex_replace":
             # For else, apply the regex pattern to the whole text
+            # TODO(enhancedchannelmanager-eio04.14): migrate user-supplied
+            # else-branch regex_replace to safe_regex.sub.
             if rule.condition_value:
                 try:
                     flags = 0 if rule.case_sensitive else re.IGNORECASE
                     # Convert JS-style backreferences ($1, $2) to Python (\1, \2)
                     py_replacement = re.sub(r'\$(\d+)', r'\\\1', action_value)
-                    return re.sub(rule.condition_value, py_replacement, text, flags=flags)
+                    return re.sub(rule.condition_value, py_replacement, text, flags=flags)  # nosemgrep: no-bare-re-on-dynamic-pattern
                 except re.error as e:
                     logger.warning("[NORMALIZE] Regex replace error in else action of rule %s: %s", rule.id, e)
             return text
@@ -1389,8 +1397,10 @@ class NormalizationEngine:
         # Bare form: only attempt if name contains a broadcast network or
         # channel number — this prevents matching random words in names
         # like "(MC Radio) New Wave" or "DOCUBOX: MILITARY AND WAR"
+        # `net` iterates the hardcoded NormalizationEngine._BROADCAST_NETWORKS
+        # frozenset, not user input — concatenation is safe.
         has_network = any(
-            re.search(r'\b' + net + r'\b', upper)
+            re.search(r'\b' + net + r'\b', upper)  # nosemgrep: no-bare-re-on-dynamic-pattern
             for net in NormalizationEngine._BROADCAST_NETWORKS
         )
         has_channel_num = bool(re.search(r'\b\d{1,2}\b', upper))

--- a/backend/regex_lint.py
+++ b/backend/regex_lint.py
@@ -22,8 +22,8 @@ The AST walk operates on the compiled parse tree, not on the pattern string
 via regex-matching, so the linter is itself ReDoS-safe by construction.
 
 Error messages are actionable (length/limit surfaced, rewrite hint included)
-and point to ``/docs/patterns`` (placeholder — bd-eio04.8 writes the style
-guide Regex section this URL will link to).
+and link to ``docs/style_guide.md#regex`` for project-wide guidance on the
+regex convention and when ``safe_regex`` applies.
 """
 from __future__ import annotations
 
@@ -81,10 +81,11 @@ _REPEAT_OPS = {MAX_REPEAT, MIN_REPEAT}
 
 MAX_PATTERN_LEN: int = safe_regex.DEFAULT_MAX_PATTERN_LEN  # 500
 
-# Placeholder — bd-eio04.8 will write the style guide section this link
-# points to. Keeping the TODO in-code so the test suite's grep for
-# "/docs/patterns" is load-bearing until that bead lands.
-DOCS_URL: str = "/docs/patterns"  # TODO(bd-eio04.8): point to anchored section
+# Anchored link to the Regex section of the engineering style guide. The
+# style guide covers the full convention (when to use safe_regex, the
+# exception list, the enforcement chain); error messages surfaced from this
+# linter point the user here so "422 rejected" is immediately actionable.
+DOCS_URL: str = "docs/style_guide.md#regex"
 
 ViolationCode = Literal[
     "REGEX_TOO_LONG",

--- a/backend/routers/export.py
+++ b/backend/routers/export.py
@@ -1144,8 +1144,10 @@ def _clean_channel_name(name: str, channel_number) -> str:
         try:
             num_val = float(channel_number)
             num_str = str(int(num_val)) if num_val == int(num_val) else str(num_val)
+            # escaped_num is re.escape() of a numeric string — can't contain
+            # regex metacharacters by construction; pattern is fixed-length.
             escaped_num = re.escape(num_str)
-            cleaned = re.sub(rf"^{escaped_num}\s*[-|:]?\s*", "", cleaned, flags=re.IGNORECASE)
+            cleaned = re.sub(rf"^{escaped_num}\s*[-|:]?\s*", "", cleaned, flags=re.IGNORECASE)  # nosemgrep: no-bare-re-on-dynamic-pattern
         except (ValueError, TypeError):
             pass
     return cleaned.strip() or name

--- a/backend/routers/m3u_digest.py
+++ b/backend/routers/m3u_digest.py
@@ -305,9 +305,11 @@ async def update_m3u_digest_settings(request: M3UDigestSettingsUpdate):
             settings.send_to_discord = request.send_to_discord
 
         if request.exclude_group_patterns is not None:
+            # TODO(enhancedchannelmanager-3u6p0): migrate write-time syntax
+            # validation to safe_regex.compile.
             for pattern in request.exclude_group_patterns:
                 try:
-                    re.compile(pattern)
+                    re.compile(pattern)  # nosemgrep: no-bare-re-on-dynamic-pattern
                 except re.error as e:
                     raise HTTPException(
                         status_code=400,
@@ -316,9 +318,11 @@ async def update_m3u_digest_settings(request: M3UDigestSettingsUpdate):
             settings.set_exclude_group_patterns(request.exclude_group_patterns)
 
         if request.exclude_stream_patterns is not None:
+            # TODO(enhancedchannelmanager-3u6p0): migrate write-time syntax
+            # validation to safe_regex.compile.
             for pattern in request.exclude_stream_patterns:
                 try:
-                    re.compile(pattern)
+                    re.compile(pattern)  # nosemgrep: no-bare-re-on-dynamic-pattern
                 except re.error as e:
                     raise HTTPException(
                         status_code=400,

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -783,9 +783,11 @@ async def test_discord_webhook(request: DiscordTestRequest):
         return {"success": False, "message": "Webhook URL is required"}
 
     # Validate URL format - accept discord.com, discordapp.com, and variants (canary, ptb)
+    # TODO(enhancedchannelmanager-4mab3): promote to module-level _DISCORD_WEBHOOK_RE
+    # constant to match the ECM style guide convention.
     import re
     discord_pattern = r'^https://(discord\.com|discordapp\.com|canary\.discord\.com|ptb\.discord\.com)/api/webhooks/'
-    if not re.match(discord_pattern, webhook_url):
+    if not re.match(discord_pattern, webhook_url):  # nosemgrep: no-bare-re-on-dynamic-pattern
         return {"success": False, "message": "Invalid Discord webhook URL format"}
 
     try:

--- a/backend/stream_normalization.py
+++ b/backend/stream_normalization.py
@@ -176,8 +176,9 @@ def strip_quality_suffixes(name: str) -> str:
     (1080p, 720p, 476p, etc.).
     """
     result = normalize_unicode_to_ascii(name)
+    # `suffix` iterates the hardcoded QUALITY_SUFFIXES tuple.
     for suffix in QUALITY_SUFFIXES:
-        pattern = re.compile(rf"[\s\-_|:]*{suffix}\s*$", re.IGNORECASE)
+        pattern = re.compile(rf"[\s\-_|:]*{suffix}\s*$", re.IGNORECASE)  # nosemgrep: no-bare-re-on-dynamic-pattern
         result = pattern.sub("", result)
     result = _ARBITRARY_RESOLUTION_RE.sub("", result)
     return result.strip()
@@ -262,20 +263,23 @@ def strip_network_suffix(name: str, custom_suffixes: Optional[list[str]] = None)
     all_suffixes = NETWORK_SUFFIXES + (custom_suffixes or [])
     sorted_suffixes = sorted(all_suffixes, key=len, reverse=True)
 
+    # `suffix` iterates NETWORK_SUFFIXES + caller-supplied custom_suffixes;
+    # each is passed through re.escape() before interpolation, so {escaped}
+    # is a literal substring with no regex metacharacters.
     for suffix in sorted_suffixes:
         escaped = re.escape(suffix)
         # Pattern 1: Suffix in parentheses
-        paren = re.compile(rf"\s*\(\s*{escaped}\s*\)\s*$", re.IGNORECASE)
+        paren = re.compile(rf"\s*\(\s*{escaped}\s*\)\s*$", re.IGNORECASE)  # nosemgrep: no-bare-re-on-dynamic-pattern
         if paren.search(result):
             result = paren.sub("", result).strip()
             continue
         # Pattern 2: Suffix in brackets
-        bracket = re.compile(rf"\s*\[\s*{escaped}\s*\]\s*$", re.IGNORECASE)
+        bracket = re.compile(rf"\s*\[\s*{escaped}\s*\]\s*$", re.IGNORECASE)  # nosemgrep: no-bare-re-on-dynamic-pattern
         if bracket.search(result):
             result = bracket.sub("", result).strip()
             continue
         # Pattern 3: Bare suffix with separator
-        bare_sep = re.compile(
+        bare_sep = re.compile(  # nosemgrep: no-bare-re-on-dynamic-pattern
             rf"^(.{{3,}})[\s\-|:]+{escaped}\s*$", re.IGNORECASE
         )
         m = bare_sep.match(result)
@@ -283,7 +287,7 @@ def strip_network_suffix(name: str, custom_suffixes: Optional[list[str]] = None)
             result = m.group(1).strip().rstrip("-|: ")
             continue
         # Pattern 4: Bare suffix with just space
-        bare_space = re.compile(rf"^(.{{3,}})\s+{escaped}\s*$", re.IGNORECASE)
+        bare_space = re.compile(rf"^(.{{3,}})\s+{escaped}\s*$", re.IGNORECASE)  # nosemgrep: no-bare-re-on-dynamic-pattern
         m = bare_space.match(result)
         if m:
             result = m.group(1).strip().rstrip("-|: ")

--- a/backend/tests/unit/test_regex_lint.py
+++ b/backend/tests/unit/test_regex_lint.py
@@ -232,7 +232,9 @@ class TestRegexCompileError:
         v = lint_pattern(r"^(")[0]
         assert v.code == "REGEX_COMPILE_ERROR"
         assert "sha256=" not in v.message
-        assert "/docs/patterns" in v.message
+        # Linter error messages must link back to the style-guide Regex
+        # section so the 422 response is actionable (bd-eio04.8).
+        assert "docs/style_guide.md#regex" in v.message
 
     def test_compile_error_short_circuits_ast_walk(self):
         """A pattern that can't compile MUST NOT also be AST-walked —
@@ -241,6 +243,39 @@ class TestRegexCompileError:
         viols = lint_pattern(r"^(unclosed")
         codes = {v.code for v in viols}
         assert codes == {"REGEX_COMPILE_ERROR"}
+
+
+class TestDocsURL:
+    """DOCS_URL must point at the live style-guide Regex section.
+
+    bd-eio04.8 replaced the bd-eio04.7 placeholder (``/docs/patterns``) with
+    an anchored link to ``docs/style_guide.md#regex``. These assertions lock
+    the value so any future rename surfaces as a test failure — the URL is
+    also baked into end-user-facing 422 error messages.
+    """
+
+    def test_docs_url_points_to_style_guide_regex_anchor(self):
+        assert regex_lint.DOCS_URL == "docs/style_guide.md#regex"
+
+    def test_docs_url_is_not_the_bd_eio04_7_placeholder(self):
+        # Guards against a stray revert — the original placeholder was
+        # '/docs/patterns' and is dead as of bd-eio04.8.
+        assert regex_lint.DOCS_URL != "/docs/patterns"
+
+    def test_all_lint_messages_embed_docs_url(self):
+        """Every user-facing violation message must link to the guide."""
+        # One pattern per code path.
+        too_long = "a" * (regex_lint.MAX_PATTERN_LEN + 1)
+        bad_compile = "^("
+        nested = "(a+)+b"
+        for pattern in (too_long, bad_compile, nested):
+            viols = lint_pattern(pattern)
+            assert viols, f"expected violations for {pattern!r}"
+            for v in viols:
+                assert regex_lint.DOCS_URL in v.message, (
+                    f"violation code={v.code} message missing DOCS_URL: "
+                    f"{v.message!r}"
+                )
 
 
 class TestRegexNestedQuantifier:

--- a/docs/style_guide.md
+++ b/docs/style_guide.md
@@ -1,0 +1,194 @@
+# ECM Engineering Style Guide
+
+Living document. PR changes welcome — open a PR against this file and tag the
+code reviewer (`/code-reviewer`). When a review uncovers a gap, update the
+guide.
+
+## Table of Contents
+
+- [Regex](#regex)
+  - [Rule](#rule)
+  - [Why](#why)
+  - [Contract (`safe_regex`)](#contract-safe_regex)
+  - [Enforcement chain](#enforcement-chain)
+  - [Exceptions](#exceptions)
+  - [Operational notes](#operational-notes)
+
+---
+
+## Regex
+
+### Rule
+
+**User-supplied regex MUST use `backend.safe_regex`, not the stdlib `re`
+module.**
+
+A regex is "user-supplied" if the pattern originates from any of:
+
+- A database column (normalization rules, auto-creation rules, dummy-EPG
+  profiles, user settings)
+- A request body or query parameter
+- A configuration file editable by an operator
+- A template substitution resolved at runtime
+- A user-uploaded file (M3U, DBAS export, etc.)
+
+The stdlib `re` module is **reserved for module-level constants compiled from
+hard-coded raw-string literals**. The project convention is:
+
+```python
+# Module top-of-file, UPPER_SNAKE_CASE, underscore-prefixed for private.
+_CHANNEL_NUMBER_PREFIX_RE = re.compile(r"^\d+\s*\|\s*")
+_QUALITY_SUFFIX_RE = re.compile(r"\b(HD|FHD|UHD|SD|4K)\b", re.IGNORECASE)
+```
+
+Any other regex site — a pattern built at runtime, one read from the DB, one
+assembled from a request body — goes through `safe_regex`.
+
+### Why
+
+The Python stdlib `re` engine has no timeout. A single pathological pattern
+(e.g. `(a+)+$` against `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaX`) can pin a CPU
+core indefinitely. On an async FastAPI worker running the sync `re.search`
+inline, this stalls the entire event loop — one malicious normalization rule
+can take the whole service offline.
+
+The third-party `regex` library (PyPI `regex`, not stdlib `re`) accepts a
+`timeout=` kwarg that bounds wall-clock runtime between backtracking steps.
+`safe_regex` wraps that library with:
+
+- A **100 ms per-call timeout** (`DEFAULT_TIMEOUT_MS`), enforced by the
+  `regex` library's backtracking checkpoint.
+- A **500-character pattern length cap** (`DEFAULT_MAX_PATTERN_LEN`), enforced
+  before compile — catches the "paste-a-novel-into-the-rules-field" shape
+  that defeats the per-call timeout.
+- **Sentinel returns on timeout** (`None` / original text) rather than raising,
+  so the hot path degrades gracefully: a bad rule logs a WARN and falls
+  through as "did not match" instead of crashing the request.
+
+The timeout is **best-effort, not preemptive** — the `regex` library checks
+the deadline between backtracking steps; a pattern that spends its time in a
+single native operation (e.g. a very long literal scan) can exceed the budget.
+In practice the budget is effective against the catastrophic-backtracking
+shape that dominates the ReDoS threat surface, but callers in code paths with
+sub-second external-response requirements must layer an additional ceiling
+(request-scoped timeout, circuit breaker) on top.
+
+### Contract (`safe_regex`)
+
+The module lives at `backend/safe_regex.py`. Public API:
+
+| Function | On success | On timeout / oversize | On compile error |
+|---|---|---|---|
+| `search(pattern, text, *, flags=0, timeout_ms=100, max_pattern_len=500)` | returns `Match` | returns `None`, WARN-logs `[SAFE_REGEX]` | returns `None`, WARN-logs |
+| `match(pattern, text, *, flags=0, ...)` | returns `Match` | returns `None` | returns `None` |
+| `sub(pattern, repl, text, *, flags=0, ...)` | returns replaced string | returns `text` unchanged | returns `text` unchanged |
+| `compile(pattern, *, flags=0, max_pattern_len=500)` | returns compiled `Pattern` | raises `PatternTooLongError` | raises `SafeRegexError` |
+
+Exception hierarchy:
+
+```
+SafeRegexError              # Base — catch this for catch-all handling.
+├── RegexTimeoutError       # Reserved for a future strict-mode API
+│                             (default contract is sentinel-return).
+└── PatternTooLongError     # Raised by compile() when len(pattern) > cap.
+```
+
+**Pre-compiled patterns are supported.** When the pattern is a compiled
+`regex.Pattern` (e.g. cached on a hot path such as the
+N log N sort comparisons in `auto_creation_engine`), pass the compiled
+object directly:
+
+```python
+_CACHED = safe_regex.compile(user_pattern)
+safe_regex.search(_CACHED, text)  # goes direct to bound method, skips re-hash
+```
+
+**`regex` library timeout raises `builtins.TimeoutError`, not
+`regex.error`.** Observed in bd-eio04.5 testing. `safe_regex` callers never
+need to catch this — the module's default contract converts the timeout into
+a sentinel return and a WARN log. Direct callers of the third-party `regex`
+library (should be none — route through `safe_regex`) must catch both
+`TimeoutError` and `regex.error` separately.
+
+### Enforcement chain
+
+Three layers defend against ReDoS, each at a different lifecycle stage:
+
+1. **Write-time lint at persistence (bd-eio04.7 — `backend/regex_lint.py`).**
+   Normalization-rule, auto-creation-rule, and dummy-EPG router endpoints run
+   `lint_pattern()` before committing a pattern. The lint catches three
+   shapes:
+   - `REGEX_TOO_LONG` — pattern length over the cap.
+   - `REGEX_COMPILE_ERROR` — pattern fails to compile.
+   - `REGEX_NESTED_QUANTIFIER` — AST walk detects
+     nested-unbounded-quantifier-followed-by-killer (the Python `re`
+     backtracking ReDoS shape).
+
+   Rejects return HTTP 422 with a structured error envelope pointing back to
+   this style-guide section.
+
+2. **Runtime timeout at call (bd-eio04.5 — `backend/safe_regex.py`).**
+   Every regex evaluated against user data at serve time goes through
+   `safe_regex`. Even if a pattern slips past the write-time lint (older rows,
+   bypassed validation, a lint-rule gap), the 100 ms timeout caps the damage
+   per call.
+
+3. **CI guard at PR time (bd-eio04.8 — this document, `.semgrep.yml`).**
+   The `no-bare-re-on-dynamic-pattern` rule flags new `re.search/match/sub/
+   compile/findall/finditer/split/subn/fullmatch` calls whose first argument
+   is not a raw-string literal. Exempt idioms:
+   - `re.compile(r"…")` module-level constants.
+   - `rf"…{re.escape(x)}…"` f-strings — `re.escape` neutralizes the
+     interpolation to literal bytes.
+   - `r"…" + re.escape(x) + r"…"` concatenation — same reasoning.
+
+   Sites that are safe but don't match those shapes (e.g. multi-line
+   `re.compile(\n r"…",\n …)` constants, pre-escaped variables like
+   `escaped = re.escape(x); re.compile(rf"…{escaped}…")`) are annotated with
+   a same-line `# nosemgrep: no-bare-re-on-dynamic-pattern` comment and a
+   justification. Every `nosemgrep` annotation either names why the call is
+   safe or links to a follow-up bead to migrate.
+
+   The CI job is a **required status check**; a PR that introduces a bare
+   `re.*` on a dynamic pattern fails CI and cannot merge.
+
+### Exceptions
+
+- **Module-level constants from raw-string literals** — use `re.compile(r"…")`.
+  No `safe_regex` wrapping needed; the pattern is authored in source and
+  cannot be attacker-controlled at runtime. This is the ECM convention,
+  documented here to avoid back-and-forth review cycles.
+- **`re.escape(x)` inside the pattern** — `re.escape` converts its argument
+  into a literal substring, which cannot contain regex metacharacters. The
+  interpolation is safe even when `x` originates at runtime. Semgrep's rule
+  recognises the `rf"…{re.escape(x)}…"` and `r"…" + re.escape(x) + r"…"`
+  idioms and does not flag them.
+- **Syntax-only validation at write time** should route through
+  `safe_regex.compile` (which raises `SafeRegexError` / `PatternTooLongError`)
+  for consistency with the write-time lint. Using bare `re.compile` for
+  syntax validation is a lint violation — see follow-up beads
+  `enhancedchannelmanager-ltjyx` (auto_creation_schema) and
+  `enhancedchannelmanager-3u6p0` (m3u_digest routes).
+
+If an exception is needed that isn't in this list, discuss with the code
+reviewer (`/code-reviewer`) before adding a `nosemgrep` annotation.
+
+### Operational notes
+
+- **Log prefix.** `safe_regex` emits `[SAFE_REGEX]` at WARNING on every
+  timeout, oversize, or compile error. The WARN payload contains a SHA-256
+  of the pattern plus a 50-char excerpt — the full pattern is deliberately
+  not logged because patterns carry attacker-controlled text.
+- **Dashboards.** The SRE runbook tracks WARN-rate on the `safe_regex`
+  logger as an early-warning signal for new ReDoS attempts and
+  misconfigured rules (see `docs/sre/` — normalization observability,
+  bd-eio04.9).
+- **Performance.** `safe_regex` adds roughly 3–5 µs per call over bare `re`
+  (the wrapper overhead plus `regex`-library deadline bookkeeping).
+  On a hot path — sort comparisons, N-way stream matching — pre-compile
+  with `safe_regex.compile` and reuse the compiled object; the module-level
+  pattern path avoids the `regex` library's per-call pattern-hash lookup.
+- **Frontend.** The frontend enforces the write-time lint before the POST
+  hits the backend so the user sees inline errors instead of a 422. The
+  backend lint is the source of truth; the frontend check is UX polish
+  and may lag in strictness.


### PR DESCRIPTION
## Summary

Closes the enforcement chain for the ReDoS bug class: write-time lint (`.7`) + runtime timeout (`.5`) + CI guard (this bead).

**New:**
- `.semgrep.yml` — rule `no-bare-re-on-dynamic-pattern` (ERROR). Exempts `re.compile(r\"...\")`, `rf\"...{re.escape(x)}...\"`, `r\"...\" + re.escape(x) + r\"...\"`.
- `.semgrep/tests/no-bare-re-on-dynamic-pattern.py` — 10 positive + 7 negative fixtures. `semgrep --test` passes.
- `docs/style_guide.md` — Regex section. Includes `safe_regex` contract table + the observed `regex` library `builtins.TimeoutError` quirk from `.5`.
- `.github/workflows/test.yml` — new `semgrep-lint` job (returntocorp/semgrep:1.160.0, validate + test + error).

**Fixed:**
- `backend/regex_lint.py` DOCS_URL: `/docs/patterns` placeholder → `docs/style_guide.md#regex`.
- `TestDocsURL` class (3 tests) locks the value + blocks placeholder revert + asserts every violation message embeds `DOCS_URL`.

## Final scan

```
$ semgrep --config .semgrep.yml backend/
Ran 1 rule on 135 files: 0 findings.
```

## Test plan

- [x] Self-test fixtures pass (`semgrep --test`).
- [x] 0 findings on full backend after refinement.
- [x] `TestDocsURL` + updated `test_compile_error_message_user_facing` green.
- [x] 5 sites in `normalization_engine.py` annotated `# nosemgrep TODO(bd-eio04.14)` — those are exactly the sites `.14` migrates; annotations become removable once `.14` merges.
- [x] 9 false-positive sites annotated `# nosemgrep` with justification (multi-line literals, hardcoded tuples, `re.escape` via intermediate variable).

## Follow-up beads (filed, not part of this PR)

- `enhancedchannelmanager-ltjyx` — migrate `auto_creation_schema.py:167,493,522` write-time `re.compile(user_pattern)` validation to `safe_regex.compile`.
- `enhancedchannelmanager-3u6p0` — migrate `routers/m3u_digest.py:310,321` write-time compile on user-supplied exclude patterns.
- `enhancedchannelmanager-4mab3` — P3 stylistic: promote `routers/settings.py:788` Discord-webhook pattern to module-level constant.

## Post-merge action required

**New required status check.** After merge, the repo admin must mark `Semgrep Lint` as a required check on `dev` (and `main` if applicable) in branch-protection settings — otherwise the CI guard is advisory-only.

## Sequence

Merge position: **2 of 4** (after `.14` — the `# nosemgrep TODO(.14)` annotations assume `.14` is not yet merged; if `.14` merges first they can be pre-removed via rebase).