### PR TITLE
bd-eio04.10: docs — normalization guide + unicode-suffix runbook + versioning + api + index updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ on:
       - dev
     paths-ignore:
       - '.beads/**'
-      - '**.md'
   workflow_dispatch:
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@ bd sync                       # Sync beads data only (NOT for code commits)
 | Shipping Workflow | `docs/shipping.md` |
 | Dummy EPG Template Engine | `docs/template_engine.md` |
 | DBAS Import Threat Model | `docs/security/threat_model_dbas_import.md` |
+| Normalization (user + dev guide) | `docs/normalization.md` |
+| Versioning Scheme | `docs/versioning.md` |
+| API Reference | `docs/api.md` |
+| SLOs | `docs/sre/slos.md` |
 
 ## Development Workflow
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -228,11 +228,23 @@ All API endpoints require JWT Bearer token authentication. To authenticate in th
 | `POST /api/normalization/test` | Test a rule against sample text |
 | `POST /api/normalization/test-batch` | Test all enabled rules against multiple texts |
 | `POST /api/normalization/normalize` | Normalize text using all enabled rules |
+| `POST /api/normalization/apply-to-channels` | Apply enabled rules to existing channels — admin-gated, rate-limited 5/minute, `dry_run=true` by default (see note below) |
 | `GET /api/normalization/rule-stats` | Get stream match statistics per rule |
+| `GET /api/normalization/lint-findings` | Read-only view of saved normalization rules that fail the current write-time linter (bd-eio04.7) |
 | `GET /api/normalization/export` | Export normalization rules |
 | `POST /api/normalization/import` | Import normalization rules |
 | `GET /api/normalization/migration/status` | Get migration status |
 | `POST /api/normalization/migration/run` | Run demo rules migration |
+
+`POST /api/normalization/apply-to-channels` computes a diff of "what would change if we applied the current rule set to every existing channel" and, in execute mode, renames or merges per-row according to the caller-supplied `actions[]` array. Guarantees:
+
+- **Admin-gated** — protected by `RequireAdminIfEnabled`; non-admin callers see HTTP 403 when auth is enabled.
+- **Rate-limited** — 5 requests/minute per remote address (slowapi) to prevent runaway bulk-apply loops.
+- **Dry-run by default** — `dry_run=true` returns `{dry_run, diffs, channels_with_changes}` without mutating. `dry_run=false` requires an explicit `actions[]` body; unspecified channels default to `skip`.
+- **Single-flight execute** — only one concurrent execute run is allowed; a second caller sees HTTP 409.
+- **Journaled** — every rename and merge writes a journal entry with the `rule_set_hash` captured at execute time for audit and undo.
+
+See [`docs/normalization.md` §Re-normalize existing channels](normalization.md#re-normalize-existing-channels) for the operator workflow.
 
 ## Tags
 
@@ -331,6 +343,7 @@ All API endpoints require JWT Bearer token authentication. To authenticate in th
 | `GET /api/auto-creation/schema/conditions` | Get available condition types |
 | `GET /api/auto-creation/schema/actions` | Get available action types |
 | `GET /api/auto-creation/schema/template-variables` | Get available template variables |
+| `GET /api/auto-creation/lint-findings` | Read-only view of saved auto-creation rules that fail the current write-time linter (bd-eio04.7) |
 | `GET /api/auto-creation/debug-bundle` | Download diagnostic bundle (obfuscated channels, rules, streams, probe stats, settings, task schedules, logs) |
 
 ## FFMPEG Builder
@@ -405,6 +418,7 @@ All API endpoints require JWT Bearer token authentication. To authenticate in th
 | `GET /api/dummy-epg/xmltv/{id}` | Get XMLTV output for a profile |
 | `GET /api/dummy-epg/profiles/export/yaml` | Export profiles as YAML |
 | `POST /api/dummy-epg/profiles/import/yaml` | Import profiles from YAML |
+| `GET /api/dummy-epg/lint-findings` | Read-only view of saved dummy-EPG templates that fail the current write-time linter (bd-eio04.7) |
 
 `POST /api/dummy-epg/preview` accepts the full profile config plus:
 

--- a/docs/commands/analyze-rules.md
+++ b/docs/commands/analyze-rules.md
@@ -44,6 +44,20 @@ The user may provide:
 - **`merge_streams` with `target: auto`** — looks for existing channels by normalized name; if no match, skips the stream entirely.
 - **Sort order affects which stream becomes primary** in a channel.
 
+### Unicode-Suffix Normalization Surprises
+
+If a pattern appears to match when you read it but the engine says otherwise (or vice versa) for inputs containing Unicode suffixes — `ᴴᴰ`, `ᴿᴬᵂ`, `²`, `³`, zero-width joiners, NFD-decomposed accents — the cause is almost always a Unicode-normal-form mismatch between the pattern and the input.
+
+Under the unified NormalizationPolicy (bd-eio04.1), every input is NFC-canonicalized, Cf-stripped (ZWSP/ZWNJ/ZWJ/BOM), and superscript-converted (letters + numerics) **before** any rule pattern runs. A pattern typed against the pre-policy raw bytes (e.g. containing a ZWSP you can't see, or an NFD-decomposed `é`) will not match the post-policy input — and looks identical in the UI.
+
+When diagnosing this class:
+
+- Paste the raw input into Settings → Normalization → Test Rules and read the trace drawer. Test Rules applies the policy and shows you the bytes your pattern actually runs against.
+- Ensure both your pattern and your sample input are in the same normal form (NFC, no stray Cf code points). Re-type the pattern inside the rule editor rather than pasting from a source with unknown provenance.
+- For `²` / `³` / `ᴴᴰ` / `ᴿᴬᵂ`: these now strip on every code path. If a rule expected to see them in the input, the rule is running too late in the pipeline (after the policy has already converted them) — condition against the ASCII equivalent.
+
+Full reference: [`docs/normalization.md`](../normalization.md). Operator triage for duplicate channels caused by Unicode-suffix divergence: [`docs/runbooks/duplicate-channels-unicode-suffix.md`](../runbooks/duplicate-channels-unicode-suffix.md).
+
 ### Execution Log Analysis (when log is provided)
 
 The execution log uses the `[AUTO-CREATE-EXEC]` prefix. Key patterns to look for:

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -1,0 +1,282 @@
+# Normalization
+
+> How ECM collapses noisy stream names into the channel names you want — across Test Rules (the preview you try before saving) and Auto Create (the engine that actually makes channels). This guide is dual-audience: the first half is for operators authoring rules; the [Developer reference](#developer-reference) at the bottom is for engineers integrating with the engine.
+
+## Overview
+
+Normalization is the step between "raw name from an M3U line" and "channel name on disk." It runs in three places:
+
+- **Test Rules** — Settings → Normalization → the preview panel where you paste a sample name and see what the current rule set produces. Safe to use freely; no side effects.
+- **Auto Create** — the auto-creation pipeline reads the stream's raw name, passes it through the same rule set, and uses the output as the channel name (or as the lookup key for matching an existing channel).
+- **Re-normalize Existing Channels** — a one-time bulk rewrite that reapplies the current rule set to channels already on disk. Manual, gated, undoable.
+
+These three paths **must produce the same output for the same input**. That is the *parity contract*, added in bd-eio04.1 and enforced by a nightly canary ([SLO-5 in `docs/sre/slos.md`](sre/slos.md#slo-5-normalization-correctness)). If a user reports "Test Rules says one thing and my auto-created channel got a different name," that is a canary-level bug — follow [the divergence runbook](runbooks/normalization-canary-divergence.md), don't work around it with a rule change.
+
+### When does normalization run?
+
+- **Test Rules**: on demand, when you click "Test" in the rules UI or call `POST /api/normalization/test` / `test-batch`.
+- **Auto Create**: on every stream name processed by an auto-creation rule that has a normalization group configured. If no group is configured on the rule, normalization is **skipped** — `ecm_auto_creation_channels_created_total{normalized="skipped"}` increments.
+- **Re-normalize Existing Channels**: only when an operator explicitly runs it via the Settings UI or `POST /api/normalization/apply-to-channels`. Never automatic.
+
+### What normalization is not
+
+- It is not search. `GET /api/channels?search=foo` does its own matching without invoking the normalization rule set.
+- It is not EPG matching. EPG match uses channel name + TVG-ID against EPG data; normalization affects the channel name that feeds into EPG match but is not itself EPG logic.
+- It is not a regex sandbox. Regex rules run under `safe_regex` (100 ms timeout, bounded pattern size); pathological patterns fail fast with `[SAFE_REGEX]` WARN in logs and are rejected at save time by the linter.
+
+## Quick start
+
+### Your first rule
+
+1. Open **Settings → Normalization Rules**.
+2. Pick a rule group (or create one — groups are ordering buckets; rules within a group run in priority order, groups run in group-priority order).
+3. Click **Add rule**. Choose a condition and an action.
+4. Paste a sample raw name into the **Test Rules** panel on the right and click **Test**.
+5. Review the output. If it matches your intent, **Save**. If not, iterate on the rule before saving — you don't pay for retries on the preview path.
+
+![placeholder — Settings → Normalization Rules panel with Test Rules preview on the right](path/to/screenshots/normalization-test-rules.png)
+
+### Testing a rule before you commit
+
+Test Rules is the single source of truth for "what will Auto Create do with this input." If Test Rules shows the output you want, Auto Create will produce that same output. If it does not, **do not** work around the rule — file a bug, because divergence between the two paths is the exact failure class the parity contract and SLO-5 canary exist to catch.
+
+- `POST /api/normalization/test` — single rule, single input. Useful when authoring one rule at a time.
+- `POST /api/normalization/test-batch` — all enabled rules, multiple inputs. Use this to preview a batch (e.g., pasting 50 raw names from a new M3U).
+
+## Concepts
+
+### Rule groups and ordering
+
+Rules live in groups. Groups run in **group priority** order (lowest number first). Within a group, rules run in **rule priority** order (lowest first). A rule's output feeds into the next rule's input — it's a pipeline, not a set of independent matchers.
+
+Consequences:
+
+- A rule later in the pipeline sees the *output* of earlier rules, not the raw input. If rule 1 strips `HD` and rule 2 matches `HD`, rule 2 will not fire against the original input.
+- Groups are a coarse bucket for sharing across auto-creation rules. You can assign one group to many auto-creation rules; the same group applied twice will produce the same output (idempotent).
+
+### NormalizationPolicy — the Unicode preprocessor
+
+Before any user-authored rule runs, a **policy** preprocesses the input. The policy is not configurable per rule — it applies uniformly to every code path. Under the default `ECM_NORMALIZATION_UNIFIED_POLICY=true` (bd-eio04.1), the policy does three things in order:
+
+1. **NFC canonicalization.** NFD-decomposed input (`e` + U+0301) collapses to pre-composed form (`é` = U+00E9). NFC, *not* NFKC — ligatures (`ﬁ`), fullwidth digits (`１`), and Roman-numeral compatibility forms are preserved because users who typed them intended them.
+2. **Cf-whitelist stripping.** `U+200B` ZWSP, `U+200C` ZWNJ, `U+200D` ZWJ, and `U+FEFF` BOM are removed. RTL/LTR bidi marks (`U+200F`, `U+202E`) are **preserved** — some right-to-left channel names need them.
+3. **Full superscript conversion.** Letter-superscripts (`ᴴᴰ` → `HD`, `ᴿᴬᵂ` → `RAW`) and numeric-superscripts (`²` → `2`, `⁶⁰` → `60`) both convert to ASCII. Both, always.
+
+The policy is a [frozen dataclass](#developer-reference) applied at the same call site by Test Rules, Auto Create, and Re-normalize Existing Channels. It is not extensible from rule configuration — if you need a different Unicode preprocessing step, file a bead.
+
+### Letter vs numeric superscripts — both now strip
+
+Before bd-eio04.1, numeric superscripts were preserved (the `preserve_superscripts=True` carve-out). After bd-eio04.1, both letter and numeric superscripts strip, on every path. This was the root cause of GH #104: one path preserved `²`, another stripped it, and channels created on different paths got different names.
+
+If a channel name created before the bd-eio04.1 cutover still carries `²`, `³`, or `ᴴᴰ`, its stored name is pre-fix data. New channels created after the cutover will have ASCII digits. To reconcile, run [Re-normalize Existing Channels](#re-normalize-existing-channels).
+
+### Unicode handling — what survives, what does not
+
+| Class | Example input | After policy |
+|-|-|-|
+| ASCII | `ESPN HD` | `ESPN HD` (unchanged) |
+| NFD decomposed accent | `Café` | `Café` (NFC) |
+| Letter-superscript | `ESPN ᴴᴰ` | `ESPN HD` |
+| Numeric-superscript | `ESPN²` | `ESPN2` |
+| ZWSP / ZWNJ / ZWJ | `RTL​HD` | `RTLHD` |
+| BOM | `﻿ESPN` | `ESPN` |
+| RTL/LTR bidi marks | `‏ESPN‮` | preserved |
+| Ligature | `ﬁrst` | `ﬁrst` (preserved — NFC, not NFKC) |
+| Fullwidth digit | `ESPN１` | `ESPN１` (preserved — NFC) |
+
+## Authoring rules
+
+### Condition types
+
+- **`contains`** — substring match, case-insensitive.
+- **`starts_with` / `ends_with`** — anchored substring, case-insensitive.
+- **`regex`** — Python regex via `safe_regex` (100 ms timeout, size-bounded). Patterns run against the post-policy input.
+- **`equals`** — exact string match.
+- **Compound** — boolean combinations via the `conditions[]` JSON; useful when one rule needs to match multiple unrelated suffixes.
+
+### Action types
+
+- **`replace`** — replace the matched portion with a literal string.
+- **`remove`** — replace the matched portion with the empty string.
+- **`set`** — overwrite the entire name with a literal (use sparingly; defeats composition).
+- **Conditional else-action** — the `else_action_value` branch fires when the condition does *not* match. Useful for "strip suffix if present, pass through otherwise."
+
+`action_value` and `else_action_value` are literal templates — they are **not** regexes and **not** linted for regex safety.
+
+### Pattern linting — what gets rejected and why
+
+Regex patterns go through two checks:
+
+- **Runtime** — `safe_regex.search/match/sub` with a 100 ms timeout (bd-eio04.5). A pattern that takes longer raises a `[SAFE_REGEX]` WARN log line and the rule acts as if it did not match for that input (no crash, no partial result).
+- **Write-time linter** — `POST /api/normalization/rules` and `PATCH /api/normalization/rules/{id}` run the pattern through the lint scanner (bd-eio04.7) and reject pathological patterns with HTTP 422 before they land on disk. Rejected classes include:
+  - Unbounded repetition of a group that contains another repetition (`(a+)+`, `(.*)*`) — classic ReDoS shapes.
+  - Bounded repetitions with counts above a safety ceiling.
+  - Lookbehind + lookahead combinations that push the engine into backtracking spirals.
+  - Oversize literal patterns (>4 KB).
+
+See the Regex section in [`docs/style_guide.md`](style_guide.md) for the full style rules and rewrites for the common rejected shapes. <!-- pending bd-eio04.8 — style_guide.md is in-flight as of 2026-04-22. -->
+
+### Error messages and fixes
+
+| 422 detail code | What it means | Fix |
+|-|-|-|
+| `regex:nested_quantifier` | Pattern contains a repetition inside a repetition (ReDoS shape) | Replace the inner group with a character class; use possessive/atomic matching where available. |
+| `regex:oversize_bounded_repetition` | `{N,M}` with `N` or `M` over the ceiling | Use an unbounded `+` with an anchor, or split the pattern. |
+| `regex:oversize_pattern` | Pattern length exceeds the safety ceiling | Split into multiple rules chained through the pipeline. |
+| `regex:invalid_pattern` | Python's regex compiler rejected the pattern | Check bracket/paren balance, escape special characters. |
+| `regex:runtime_timeout` | Not raised at save; logged at runtime as `[SAFE_REGEX] pattern timed out` | Rewrite the pattern (see style guide Regex section) then re-save to retrigger the linter. |
+
+To surface already-saved rules that now fail the linter (e.g., a rule saved before the linter existed), call `GET /api/normalization/lint-findings`. The UI shows a **Flagged** badge next to any rule with open findings. This is a view-only scan — it does not disable or modify rules.
+
+## Re-normalize existing channels
+
+### When to use it
+
+After a rule change, your new rules apply only to *new* auto-created channels. Channels already on disk keep their pre-change names. Re-normalize Existing Channels rewrites stored names to match what the current rule set would produce if run against their stored raw names.
+
+Use it when:
+
+- You added a rule to collapse a suffix class and want existing channels to pick up the collapse.
+- You fixed a pathological rule (Resolution C in the [duplicate-channels runbook](runbooks/duplicate-channels-unicode-suffix.md)) and need the already-stored names to catch up.
+- You imported rules from a YAML export and want their effect to apply retroactively.
+
+Do **not** use it to force a one-off rename of a single channel. Edit the channel directly; Re-normalize is a bulk operation and leaves a journal trail for every row it touches.
+
+### Dry-run preview walkthrough
+
+1. Settings → Normalization Rules → **Apply to existing channels**.
+2. The modal opens in **dry-run** mode by default. ECM computes the diff and shows one row per channel with a proposed new name.
+
+   ![placeholder — Apply to Channels modal with rule-trace drawer expanded](path/to/screenshots/apply-to-channels-dry-run.png)
+
+3. For each row you see:
+   - `current_name` — what's stored today.
+   - `new_name` — what the current rule set would produce.
+   - `collision` — `true` if `new_name` matches another existing channel's name. In this case, `rename` is not a legal action; `merge` (into the colliding channel) or `skip` are the choices.
+   - Rule-trace drawer — click to expand and see which rule_ids fired, in order, with the input and output at each step.
+
+4. If the row is correct and the output is what you want, select **rename** (or **merge** if there's a collision you want to fold into an existing channel).
+5. If the row is wrong, select **skip**. Unspecified rows default to **skip** — the endpoint will not touch a channel unless you explicitly asked.
+
+### Per-row skip / accept / merge
+
+The execute call takes an `actions[]` array keyed by `channel_id`. Only the channels listed are acted on; everything else is skipped. This is intentional — a bulk rewrite without per-row confirmation is the exact shape of every "we accidentally renamed 500 channels" postmortem.
+
+### What happens to channel numbers, groups, and history
+
+- **Channel numbers** — preserved. A rename does not renumber; a merge folds the source channel's streams into the target and deletes the source, so the source's number becomes available.
+- **Channel groups** — preserved on rename; the merged channel stays in its original group on merge.
+- **Watch history / stats** — preserved on rename (same `channel_id`); on merge, the source's history is deleted with the source row. The target's history is not backfilled.
+- **Journal** — every rename and every merge is logged under the `normalization` category with the `rule_set_hash` computed at execute time. Use the journal view (Settings → Journal, or `GET /api/journal?category=normalization`) to audit and to drive undo.
+
+### Undo via journal, rollback
+
+- Each journal entry carries enough information to reverse the action: the `channel_id`, the `before_name`, the `after_name`, and the merge pointer if applicable.
+- The undo path is **manual** — there is no "undo all" button today. To reverse a rename, edit the channel back to `before_name` via the channels UI or `PATCH /api/channels/{id}`. To reverse a merge, you must recreate the source channel and re-link its streams; that is non-trivial and is the reason dry-run + per-row review is mandatory.
+- If you need to roll back a whole run, the fastest path is a DB restore from backup (see [`docs/runbooks/v0.16.0-rollback.md`](runbooks/v0.16.0-rollback.md) for the rollback mechanics, though that runbook is for release rollback, not data rollback). File a bead before restoring so the scope is recorded.
+- To roll back the *policy* (not data) — flip `ECM_NORMALIZATION_UNIFIED_POLICY` back to `false` and restart per [`docs/runbooks/normalization-unified-policy.md`](runbooks/normalization-unified-policy.md).
+
+## Troubleshooting
+
+### "My rule doesn't match this input"
+
+Work this checklist in order:
+
+1. **NFC mismatch.** Is the input NFD-decomposed and your pattern composed (or vice versa)? The policy NFCs the input before rules run, but if your *pattern* was typed with composed characters and an older input had NFD, they now match; if your pattern has NFD and the input is now NFC (post-policy), they no longer match. Recompose the pattern.
+2. **Homoglyph.** Cyrillic `А` (U+0410) and Latin `A` (U+0041) render identically. The policy does not normalize homoglyphs. Copy the exact bytes from the raw input into your pattern.
+3. **Cf code point you didn't see.** `​` (ZWSP) is invisible. If the policy strips it, your pattern against `RTL HD` won't see the `​` that was in the raw input — which is correct behavior — but if you're testing against a pre-policy byte stream, the pattern will miss. Always use Test Rules (which applies the policy) for debugging, not raw-byte regex checks.
+4. **Rule ordering.** Does an earlier rule in the pipeline already transform the input away from what your pattern expects? The Test Rules trace drawer shows the intermediate values; read it top-down.
+5. **Regex timeout.** Check logs for `[SAFE_REGEX]` WARN mentioning your rule_id. If present, the pattern is timing out on this input — rewrite per style guide.
+
+### `[SAFE_REGEX]` log entries
+
+```
+[SAFE_REGEX] pattern timed out rule_id=42 pattern=<redacted>
+[SAFE_REGEX] oversize pattern rejected field=condition_value
+[SAFE_REGEX] compile error at search pattern=<redacted>
+```
+
+- **Timeout** — the pattern exceeded 100 ms against a specific input. The rule *did not match* for that input; the log is the only signal. Rewrite the pattern and re-save.
+- **Oversize** — caught at runtime as a secondary defense; the write-time linter should have caught it first. If you see this without a matching 422 on save, file a bead.
+- **Compile error** — pattern is malformed. The write-time linter should reject these; a compile error at runtime means the pattern was stored before the linter existed.
+
+### Flagged pre-lint rows
+
+`GET /api/normalization/lint-findings` returns one entry per saved rule that would fail the current linter. Rows are not disabled or modified automatically — the scan is view-only. The UI surfaces these in the rule list with a **Flagged** badge.
+
+To clear a flag: edit the rule, fix the pattern per style guide, save. The linter runs on save and the finding is cleared when the pattern passes.
+
+### Self-serve diagnosis — `trace_id` + metrics
+
+Every HTTP request carries a `trace_id` (from the `X-Request-ID` response header, or generated if absent). Structured logs tag every line with the trace_id, so a user report of "Test Rules gave me a weird output at 14:23 UTC" can be pinned to the exact sequence of log lines.
+
+Dashboard metrics to watch during a normalization incident:
+
+- `ecm_normalization_rule_matches_total{rule_category}` — rate of matches per rule category. A rule category that dropped to 0 after a change is a strong signal the change broke matching.
+- `ecm_normalization_no_change_total` — count of `normalize()` calls that produced no output change. A spike here post-rule-edit means the new rules are passing inputs through unchanged.
+- `ecm_normalization_duration_seconds` — histogram of single-call duration. P99 over ~10 ms is a ReDoS smell.
+- `ecm_normalization_canary_divergence_total` — SLO-5 SLI numerator. Non-zero is an immediate [canary runbook](runbooks/normalization-canary-divergence.md) trigger.
+
+## Developer reference
+
+### `NormalizationPolicy` dataclass
+
+`backend/normalization_engine.py`:
+
+```python
+@dataclass(frozen=True)
+class NormalizationPolicy:
+    unified_enabled: bool = True   # latched at module load from ECM_NORMALIZATION_UNIFIED_POLICY
+
+    def apply_to_text(self, text: str) -> str:
+        # Under unified_enabled=True:
+        #   1. NFC canonicalize
+        #   2. strip whitelisted Cf code points
+        #   3. convert superscripts (letters + numerics)
+        # Under unified_enabled=False: only step 3 (legacy behavior)
+```
+
+The instance is process-global. Read it via `get_default_policy()`; mutate it via the env var + container restart. There is no per-request override.
+
+### Engine entrypoints
+
+- `NormalizationEngine.normalize(text)` — the auto-creation and apply-to-channels path.
+- `NormalizationEngine.test_rule(text, rule)` — single-rule preview.
+- `NormalizationEngine.test_rules_batch(texts)` — all-rules multi-input preview.
+
+All three call `get_default_policy().apply_to_text(...)` at the same position at the top of their pipelines. The parity tests in `backend/tests/unit/test_normalization_parity.py` enforce this by fixture sweep; the nightly canary (`backend/scripts/normalization_canary.py`) enforces it end-to-end.
+
+### Metrics (`ecm_normalization_*`)
+
+Defined in `backend/observability.py`:
+
+| Metric | Type | Labels | Purpose |
+|-|-|-|-|
+| `ecm_normalization_rule_matches_total` | Counter | `rule_category` | Per-category match rate. Per-rule detail goes to sampled INFO log, not metrics, for cardinality. |
+| `ecm_normalization_no_change_total` | Counter | — | Count of `normalize()` calls that returned the input unchanged. |
+| `ecm_normalization_duration_seconds` | Histogram | — | Per-call duration. Buckets cover sub-millisecond regime. |
+| `ecm_normalization_canary_divergence_total` | Counter | — | SLI numerator for SLO-5. Non-zero = breach. |
+| `ecm_auto_creation_channels_created_total` | Counter | `normalized ∈ {true, false, skipped}` | Per-auto-creation outcome. `skipped` = no normalization group on the rule. |
+
+SLO-5 ties the canary counter to zero-tolerance. See [`docs/sre/slos.md` §SLO-5](sre/slos.md#slo-5-normalization-correctness).
+
+### API reference
+
+See [`docs/api.md` §Normalization](api.md#normalization) for the full endpoint list. The endpoints this guide references most often:
+
+- `POST /api/normalization/test`
+- `POST /api/normalization/test-batch`
+- `POST /api/normalization/normalize`
+- `POST /api/normalization/apply-to-channels` — admin-gated, rate-limited 5/minute.
+- `GET /api/normalization/lint-findings` — view-only scan of already-saved rules.
+
+## Related
+
+- [`docs/runbooks/normalization-unified-policy.md`](runbooks/normalization-unified-policy.md) — `ECM_NORMALIZATION_UNIFIED_POLICY` flag, rollback switch.
+- [`docs/runbooks/normalization-canary-divergence.md`](runbooks/normalization-canary-divergence.md) — nightly canary and SLO-5.
+- [`docs/runbooks/duplicate-channels-unicode-suffix.md`](runbooks/duplicate-channels-unicode-suffix.md) — triage path for operator-reported duplicates.
+- [`docs/style_guide.md`](style_guide.md) — Regex section for rule-pattern hygiene. <!-- pending bd-eio04.8 -->
+- [`docs/sre/slos.md`](sre/slos.md#slo-5-normalization-correctness) — SLO-5 Normalization Correctness.
+- [`docs/api.md`](api.md#normalization) — full Normalization endpoint list.
+- [`docs/versioning.md`](versioning.md) — how to verify whether a given normalization fix is in your running build.
+- bd-eio04 — epic under which the parity contract, unified policy, canary, linter, and this documentation were built.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -16,6 +16,13 @@ Operational playbooks for on-call and incident response. Read during incidents, 
 |-|-|-|
 | [v0.16.0 Hard Rollback](./v0.16.0-rollback.md) | Post-release rollback of a tagged version across git, GitHub Release, and GHCR | 2026-04-20 (real incident) |
 | [NormalizationPolicy Unified Mode](./normalization-unified-policy.md) | `ECM_NORMALIZATION_UNIFIED_POLICY` — rollback switch for the bd-eio04.1 unified Unicode preprocessor (GH #104) | Not exercised |
+| [Normalization Canary Divergence](./normalization-canary-divergence.md) | Nightly canary detected Test Rules vs Auto Create output drift — SLO-5 breach, zero error budget | Not exercised |
+| [Duplicate Channels — Unicode Suffix](./duplicate-channels-unicode-suffix.md) | Manual triage for user-reported duplicate channels caused by Unicode-suffix divergence (ᴴᴰ / ² / ZWSP / NFD) | Not exercised |
+| [Request Timeouts, Concurrency, CPU Offload](./request-timeout.md) | 504 / 503 response patterns; `ECM_REQUEST_TIMEOUT_SECONDS` + `ECM_LIMIT_CONCURRENCY` + CPU pool tuning (bd-w3z4h) | Not exercised |
+| [HTTP Error Rate](./http_error_rate.md) | SLO-1 breach — 5xx rate elevated above budget | Not exercised |
+| [HTTP Latency](./http_latency.md) | SLO-2 breach — P95 latency elevated above budget | Not exercised |
+| [Readiness Availability](./readiness_availability.md) | Readiness check failing across sub-checks | Not exercised |
+| [Readiness Sub-check Latency](./readiness_subcheck_latency.md) | Individual readiness sub-check exceeding its latency budget | Not exercised |
 
 ## Adding a runbook
 

--- a/docs/runbooks/duplicate-channels-unicode-suffix.md
+++ b/docs/runbooks/duplicate-channels-unicode-suffix.md
@@ -1,0 +1,174 @@
+# Runbook: Duplicate Channels — Unicode Suffix Divergence
+
+> Two channels exist for the same logical network because one copy carries a Unicode suffix (ᴴᴰ, ᴿᴬᵂ, ², ³, ZWSP, ZWJ, NFD-decomposed accents) and the other does not. Normalization should have collapsed them into one; it did not. Triage via Test Rules, fix via Re-normalize Existing Channels.
+
+- **Severity**: P2
+- **Owner**: SRE (primary), Project Engineer (normalization-engine specialist, support)
+- **Last reviewed**: 2026-04-22
+- **Related beads**: `enhancedchannelmanager-eio04` (epic), `enhancedchannelmanager-eio04.10` (this runbook), `enhancedchannelmanager-eio04.1` (unified policy), GH-104
+
+## Alert / Trigger
+
+This runbook is **manually triggered**. There is no Prometheus alert on duplicate channels directly — dedupe is a correctness property, not a latency/error budget. Expect to reach this runbook via one of:
+
+- **User report** — "two copies of ESPN appeared after a refresh," "the channel list shows `RTL` and `RTL ᴿᴬᵂ` as separate entries," "we merged these last week, they came back."
+- **Auto-creation audit** — `ecm_auto_creation_channels_created_total{normalized="false"}` incremented unexpectedly for a rule that has a normalization group configured. Sampled INFO log under the same rule_id shows the raw names.
+- **Post-incident sweep** — after a normalization rule change lands, operator wants to know if any now-collapsible duplicates exist.
+- **Canary fired first** — if `ecm_normalization_canary_divergence_total` went non-zero, stop here and follow [`normalization-canary-divergence.md`](./normalization-canary-divergence.md) instead. The canary is the leading indicator; duplicates on disk are the lagging symptom.
+
+## Symptoms
+
+What the responder observes:
+
+- Two channel rows in the channels list for the same logical network. One carries a suffix, letter-superscript, numeric-superscript, ZWSP/ZWJ, or an NFD-decomposed accent; the other does not.
+- `channel_watch_stats` / `ecm_watch_sessions_*` cardinality shows both rows as distinct — viewer counts split, popularity rankings degrade, EPG matches may land on the wrong row.
+- Log signatures (grep `docker logs ecm-ecm-1`):
+  - `[AUTO-CREATE-EXEC]` lines show `Lookup 'X': not found` for a name that should have matched an existing channel.
+  - `[SAFE_REGEX]` WARN lines mentioning a `rule_id` imply the normalization rule's pattern timed out or failed to compile — the rule effectively did not run for that input.
+  - **Absence** of a normalization decision log line (`NORMALIZATION_DECISION_LOGGER`, sampled INFO) for the raw input under any rule_id means no rule matched.
+
+If the duplicates appeared *after* the bd-eio04.1 unified-policy cutover but *before* operator-driven Re-normalize Existing Channels, the duplicates are stale pre-fix data — see Resolution B.
+
+## Diagnosis
+
+Ordered, if/then. Do not skip steps — the wrong resolution for the wrong cause will mask the underlying bug.
+
+1. **Identify the duplicate pair.** Use the channels list search or query the DB:
+
+   ```bash
+   docker exec ecm-ecm-1 sqlite3 /config/journal.db \
+     "SELECT id, name FROM channels WHERE name LIKE '%ESPN%' ORDER BY name;"
+   ```
+
+   Note both `id` and exact `name` for each row. Copy the `name` bytes exactly — do not retype; Unicode differences are the root cause of the ticket and the human eye does not reliably distinguish `RTL` from `RTL` + U+200B.
+
+2. **Paste both raw names into Settings → Normalization → Test Rules.**
+
+   - If both inputs produce the **same output**, the normalization rule set is correct today — the duplicates are stale data from before the rule/policy change. Go to **Resolution B**.
+   - If the two inputs produce **different outputs**, a rule is missing or broken for this suffix class. Go to **Resolution A**.
+   - If Test Rules returns HTTP 5xx or the preview hangs, check the logs for `[SAFE_REGEX]` WARN on the rule_id. Go to **Resolution C**.
+
+3. **Check for `[SAFE_REGEX]` WARN in logs.**
+
+   ```bash
+   docker logs ecm-ecm-1 2>&1 | grep '\[SAFE_REGEX\]' | tail -20
+   ```
+
+   A WARN line that names a rule_id appearing in your Test Rules preview means the pattern is pathological (timeout, oversize, compile error). Go to **Resolution C** even if step 2 suggested A or B — fix the rule first, then re-diagnose.
+
+4. **Correlate with the canary.** If `ecm_normalization_canary_divergence_total` is non-zero for the same period, the divergence is between Test Rules and the auto-create executor — not between "correct rule" and "stale channel name." Stop this runbook and follow [`normalization-canary-divergence.md`](./normalization-canary-divergence.md).
+
+**Escalate** if:
+
+- Scope > 100 channels. Bulk rename/merge over that size warrants a postmortem and a staged rollout plan. Do not run Re-normalize Existing Channels against a set that large without PO authorization.
+- The duplicate pair differs by characters outside the known class (not a superscript, not a Cf code point, not an NFD accent). That is a new Unicode class — file a bead and attach the raw bytes before acting.
+- The duplicate rows are in use by an active Export Profile or a Channel Profile with downstream consumers. Fixing the duplication will change the channel ID that downstream references; the consumer must be coordinated.
+
+## Resolution
+
+Pick the resolution the diagnosis routed you to. Do not combine.
+
+### Resolution A — Normalization rule is missing or broken for this suffix class
+
+1. **Author or fix the rule.** Settings → Normalization → add a regex rule (or edit an existing one) that collapses the offending suffix. Follow the Regex section in [`docs/style_guide.md`](../style_guide.md) <!-- pending bd-eio04.8 — this doc is in-flight as of 2026-04-22; the linter enforces the same rules regardless --> for pattern hygiene. The write-time linter (`/api/normalization/lint-findings` + 422 on save) rejects bounded-repetition abuse, nested quantifiers, and lookbehind-lookahead combinations that trip ReDoS.
+
+2. **Test Rules preview — both inputs.** Paste both raw names again. Both must now produce the same output. If not, the rule is still wrong; iterate.
+
+3. **Dry-run Re-normalize Existing Channels.**
+
+   ```bash
+   curl -sS -X POST "http://localhost:6100/api/normalization/apply-to-channels?dry_run=true" \
+     -H "Authorization: Bearer $TOKEN" | jq '.channels_with_changes, .diffs[] | {channel_id, current_name, new_name, collision}'
+   ```
+
+   Or use the UI: Settings → Normalization Rules → **Apply to existing channels** → review the diff.
+
+4. **Review collisions.** For each row with `"collision": true`, the new normalized name matches another existing channel — choose `merge` to fold into that channel, not `rename`. `rename`-into-collision is rejected with HTTP 422 at execute time (bd-u9odj).
+
+5. **Execute with per-row actions.**
+
+   ```bash
+   curl -sS -X POST "http://localhost:6100/api/normalization/apply-to-channels?dry_run=false" \
+     -H "Authorization: Bearer $TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"actions":[{"channel_id": 42, "action": "merge", "target_channel_id": 17}, {"channel_id": 99, "action": "rename"}]}'
+   ```
+
+   Every rename/merge is written to the journal (`/api/journal`) with the rule_set_hash at execute time — undo path is journal-driven (see "Undo" in [`docs/normalization.md`](../normalization.md#re-normalize-existing-channels)).
+
+6. **Verify:**
+
+   - Test Rules: both raw inputs produce identical output.
+   - Channels list: only one row for the logical network.
+   - Logs: no new `[SAFE_REGEX]` WARN lines under this rule_id.
+   - `ecm_auto_creation_channels_created_total{normalized="false"}` rate returns to baseline.
+
+### Resolution B — Rules are correct, channel data is stale
+
+1. **Skip rule authoring.** The rules already collapse both inputs to the same output; the only work is to rewrite the stored names.
+
+2. **Dry-run, review, execute.** Identical procedure to Resolution A steps 3–5, but you expect every row's `current_name` to be an existing (pre-fix) variant and `new_name` to be the already-correct canonical form.
+
+3. **Scope-narrow via per-row actions.** For a targeted sweep, send only the `channel_id`s you want fixed in the `actions` array. Unspecified channels default to `skip` and are left alone.
+
+4. **Verify** — same four checks as Resolution A.
+
+### Resolution C — Rule pattern is pathological (`[SAFE_REGEX]` WARN)
+
+1. **Edit the offending rule's pattern** per the Regex section in [`docs/style_guide.md`](../style_guide.md) <!-- pending bd-eio04.8 -->. Common moves: replace nested quantifiers with character classes, replace bounded repetitions over 1000 with unbounded anchored matches, remove lookbehind with variable-length match.
+
+2. **Re-save the rule.** The write-time linter (bd-eio04.5 + bd-eio04.7) fires on save and rejects a still-pathological pattern with HTTP 422. If the save succeeds, the pattern passed the linter but may still be ReDoS-prone against exotic inputs — watch `[SAFE_REGEX]` WARN for another hour before declaring it fixed.
+
+3. **Re-run Test Rules** against both original inputs. Expect fast return and matching output.
+
+4. **Continue with Resolution B** — the rules are now correct; only the stored names need rewriting.
+
+### Verification (all resolutions)
+
+Paste-ready checklist:
+
+```bash
+# 1. Both raw inputs normalize to the same output
+curl -sS -X POST http://localhost:6100/api/normalization/test-batch \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"texts": ["<raw name A>", "<raw name B>"]}'
+# Expected: .results[*].normalized equal.
+
+# 2. Channels list shows one row for the logical network
+docker exec ecm-ecm-1 sqlite3 /config/journal.db \
+  "SELECT id, name FROM channels WHERE name LIKE '%ESPN%' ORDER BY name;"
+
+# 3. No new [SAFE_REGEX] WARN lines
+docker logs --since 5m ecm-ecm-1 2>&1 | grep '\[SAFE_REGEX\]'
+# Expected: empty.
+```
+
+If any step fails, **stop** and escalate — do not improvise a merge from the UI mid-runbook.
+
+## Escalation
+
+If the above does not resolve within **2 hours** of the initial user report:
+
+- Page the Project Engineer on-call rotation (or the engineer who last touched `backend/normalization_engine.py` per `git log`).
+- Provide: `trace_id` from the Test Rules preview request (returned in the `X-Request-ID` response header), the two raw names (copy-paste, not retyped), affected `channel_id`s, before/after names from the dry-run diff, and any `[SAFE_REGEX]` WARN log excerpts with the rule_id.
+- If the affected scope spans more than one M3U account / provider, also notify the PM — cross-provider dedupe usually needs a policy decision before execution.
+
+## Post-incident
+
+- [ ] **Mandatory**: add the offending input pair to `backend/tests/fixtures/unicode_fixtures.py` with `origin="runbook-YYYY-MM-DD"` and a `notes` field pointing to this runbook incident. Without this step, the same regression can slip back in.
+- [ ] Confirm the journal entry for each rename/merge is present (`/api/journal?category=normalization` or the UI Journal view). The journal is the undo path.
+- [ ] If this is the second Unicode-suffix incident in 30 days, file a bead to extend the linter and/or tighten the fixture bank — recurrence means the class is under-tested.
+- [ ] Update this runbook with any step that was unclear or missing. Reference the incident in the update commit.
+- [ ] If the user-reported scope was > 10 channels, post a brief note in the user communication channel explaining the one-time rewrite so downstream (Export Profiles, dashboards, dispatcharr consumers) don't see the reshape as a second outage.
+
+## References
+
+- [`docs/normalization.md`](../normalization.md) — user-facing guide to the rules engine, Test Rules / Auto-Create parity, and Re-normalize Existing Channels.
+- [`docs/runbooks/normalization-unified-policy.md`](./normalization-unified-policy.md) — the `ECM_NORMALIZATION_UNIFIED_POLICY` rollback switch.
+- [`docs/runbooks/normalization-canary-divergence.md`](./normalization-canary-divergence.md) — read this first if the canary fired before the user report.
+- [`docs/sre/slos.md`](../sre/slos.md#slo-5-normalization-correctness) — SLO-5 definition; duplicates are a correctness concern even if outside the SLI.
+- [`docs/api.md`](../api.md#normalization) — `POST /api/normalization/apply-to-channels`, `GET /api/normalization/lint-findings`.
+- `backend/normalization_engine.py` — `NormalizationPolicy`, `NormalizationEngine.normalize`, `NormalizationEngine.test_rule`.
+- `backend/routers/normalization.py` — apply-to-channels endpoint, lint-findings endpoint.
+- `backend/tests/fixtures/unicode_fixtures.py` — regression fixture bank.
+- Epic: `enhancedchannelmanager-eio04` — Normalization parity.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,99 @@
+# Versioning Scheme
+
+> How to read an ECM version string, map a dev-build number to a commit, and check whether a specific fix is in the build you are running.
+
+This page exists primarily for **external reporters** who want to verify that a fix they are tracking (a bead ID, a GitHub issue, a PR number) is included in the build they have deployed. If that is your situation, skip straight to [Checking whether a fix is in your build](#checking-whether-a-fix-is-in-your-build).
+
+## Format
+
+ECM versions follow this shape:
+
+```
+MAJOR.MINOR.PATCH-BUILD
+```
+
+- `MAJOR.MINOR.PATCH` — the target release. Until the target release is actually cut, this value is the **next planned release**, not a release that has already shipped. Example: `0.16.0-0051` means "dev tip aiming at the 0.16.0 cut, CI build #0051."
+- `BUILD` — a zero-padded, monotonically increasing CI build number. Four digits today (`0040`, `0051`, ...). Used on dev builds only. Release cuts drop the `-BUILD` suffix entirely (see [Cut Mechanics](shipping.md#release-workflow-merging-to-main)).
+
+The canonical version string lives in [`frontend/package.json`](../frontend/package.json) and is baked into the Docker image at build time via the `ECM_VERSION` build-arg. Every image tagged with a `-BUILD` suffix is a dev build; every image tagged `X.Y.Z` with no suffix is a promoted release.
+
+## Yanked release note — 0.16.0
+
+Version `0.16.0` was tagged and pushed to GHCR on 2026-04-20 and then **hard-rolled-back the same day** — the tag, GitHub Release, and GHCR image were all deleted before any external consumer pulled them. See [`docs/runbooks/v0.16.0-rollback.md`](runbooks/v0.16.0-rollback.md) for the full incident and [ADR-004](adr/ADR-004-release-cut-promotion-discipline.md) for the pre-cut gate that now blocks a repeat.
+
+Because of the rollback, the current dev stream is still on `0.16.0-NNNN`. Per PO decision (grooming 2026-04-22, bd-eio04.10), there is no `0.16.1` release cut planned — dev continues to increment `BUILD` until a full `0.17.0` cut. External users running `0.16.0-NNNN` images are on dev builds, not a promoted release; the `[Unreleased]` section of [`CHANGELOG.md`](../CHANGELOG.md) is the canonical list of fixes awaiting a cut.
+
+## Where to read the version
+
+Four places all show the same string:
+
+- **UI** — the footer (and About dialog) render `frontend/package.json` at build time.
+- **Docker image label** — `docker inspect ecm-ecm-1 --format '{{ index .Config.Labels "org.opencontainers.image.version" }}'`, or the GHCR tag itself.
+- **Build-arg inside the container** — `docker exec ecm-ecm-1 sh -c 'echo $ECM_VERSION'`.
+- **`package.json`** in the repo at the SHA the build was cut from.
+
+All four are populated from the same source; if they disagree, something has been hand-edited post-build and the image should be treated as suspect.
+
+## Checking whether a fix is in your build
+
+You have a bead ID or PR number, you have a running ECM container, and you want to know: is the fix in?
+
+### 1. Read the version you are running
+
+```bash
+docker exec ecm-ecm-1 sh -c 'echo $ECM_VERSION'
+# Example output: 0.16.0-0051
+```
+
+### 2. Map the build number to a commit
+
+Every dev build comes from exactly one commit on `dev`. The CI build workflow stamps the version onto the image, so the mapping is one-to-one, but it is not currently encoded in the image itself — you recover it from git by matching the build number against the version bump commit.
+
+The version bump lands in `frontend/package.json` at the time of the build, so:
+
+```bash
+# Clone or update a local copy of the repo, then:
+git fetch origin
+git log --all --oneline --follow -S '"version": "0.16.0-0051"' -- frontend/package.json
+# Expected: one commit, the one that set this version.
+```
+
+Alternative: if you know roughly when the build was cut, jump to the GitHub Actions run log. Each `build-amd64` run prints the resolved version in step "Extract version and set release channel" — the workflow run URL is the canonical audit trail.
+
+The commit SHA that sets `frontend/package.json` to your `BUILD` number is the tip of the tree your image was built from.
+
+### 3. Confirm the fix SHA is an ancestor
+
+Once you have the tip SHA (from step 2) and the fix SHA (from the bead, the merged PR, or the CHANGELOG entry):
+
+```bash
+git merge-base --is-ancestor <fix-sha> <tip-sha> && echo "FIX PRESENT" || echo "FIX ABSENT"
+```
+
+This is a pure `git` check — no need to rebuild or rerun anything. Exit code 0 means the fix is in the build; exit code 1 means it is not.
+
+### 4. (Cross-check) compare against CHANGELOG
+
+If the bead ID or PR number appears in the `[Unreleased]` section of [`CHANGELOG.md`](../CHANGELOG.md) at the tip SHA, the fix is in. If it appears in a versioned section (`## [0.X.Y]`), the fix shipped in that release and every subsequent build. The CHANGELOG is the intended-audience view; `git merge-base` is the authoritative check.
+
+## Worked example
+
+> "Does build `0.16.0-0040` include the fix for bd-eio04.1 (unified NormalizationPolicy, closes GH #104)?"
+
+1. **Build number → tip SHA.** `git log --all --oneline -S '"version": "0.16.0-0040"' -- frontend/package.json` returns one commit; call its SHA `abc1234`.
+2. **Fix SHA.** bd-eio04.1 landed in PR #114; the merge-commit SHA is listed in the bead's close comment (or `git log --grep='bd-eio04.1' --oneline`).
+3. **Ancestor check.** `git merge-base --is-ancestor <fix-sha> abc1234`. If the fix SHA was merged *before* the `0.16.0-0040` version bump, exit code 0 — fix present. If after, exit code 1 — fix absent.
+4. **Sanity check.** Does `CHANGELOG.md` at `abc1234` mention `bd-eio04.1` under `[Unreleased]`? If yes, consistent with "fix present." If no, either the fix post-dates the build or the CHANGELOG entry was missed at merge time (file a bead).
+
+## What this scheme does not guarantee
+
+- **Monotone feature presence across releases.** A feature visible in `0.16.0-0051` can be absent from a later promoted release if the PO explicitly decides to revert or defer. Always check against the target release's CHANGELOG, not the build stream.
+- **Reproducible binaries.** The `BUILD` number and commit SHA map is one-to-one, but the image bytes also depend on base-image digests and dependency resolver state at build time. For byte-identical reproducibility use the image digest (`docker inspect ... --format '{{ .Id }}'`), not the version string.
+- **External identification of a release.** `0.16.0-0051` is an internal dev-build identifier; only a tagged release like `0.17.0` is a stable external reference. Do not cite dev builds in external bug reports without also providing the commit SHA.
+
+## Related
+
+- [`CHANGELOG.md`](../CHANGELOG.md) — Keep-a-Changelog log of user-facing changes. `[Unreleased]` lists the fixes awaiting the next cut.
+- [`docs/shipping.md`](shipping.md) — mechanics of incrementing the build number (step 3) and cutting a release.
+- [`docs/adr/ADR-004-release-cut-promotion-discipline.md`](adr/ADR-004-release-cut-promotion-discipline.md) — why a release cut is a deliberate, gated act and what G1–G7 enforce.
+- [`docs/runbooks/v0.16.0-rollback.md`](runbooks/v0.16.0-rollback.md) — procedure that yanked 0.16.0.


### PR DESCRIPTION
## Summary

Closes the documentation gaps from GH #104 (reporter on `0.16.0-0040` had no way to verify fix inclusion). Ships last in the bd-eio04 epic — describes shipped behavior, not intended.

**New files:**
- `docs/normalization.md` (282 lines) — dual-audience guide. Test Rules vs Auto Create parity contract, NormalizationPolicy semantics, Unicode handling table, authoring rules, Re-normalize Existing Channels walkthrough, troubleshooting, developer reference.
- `docs/runbooks/duplicate-channels-unicode-suffix.md` (174 lines) — operator runbook following template. 5-step if/then Diagnosis → Resolution A/B/C → Post-incident adds the offending input to `unicode_fixtures.py`.
- `docs/versioning.md` (99 lines) — `0.16.0-NNNN` dev-build scheme, build-number → commit mapping, ancestor-check worked example for `.1` / GH #104, yanked-0.16.0 context.

**Modified:**
- `docs/api.md` — POST `/api/normalization/apply-to-channels` + 3 new `GET /*/lint-findings` rows.
- `docs/commands/analyze-rules.md` — Unicode-suffix callout.
- `docs/runbooks/README.md` — index now lists all 9 runbooks.
- `CLAUDE.md` — Reference Guides table updated with new docs.

## Style-guide cross-references

Links to `docs/style_guide.md#regex` (authored by `.8` in parallel) are wrapped in HTML-comment markers `<!-- pending bd-eio04.8 -->`. If `.8` ships first, the comments become removable in a tiny follow-up; if this ships first, the links already point at the final expected path.

## Screenshots

Two `placeholder —` references in `normalization.md` (Test Rules panel; Apply-to-Channels modal with rule-trace drawer expanded). This environment has no browser automation; maintainer to fill post-merge.

## Test plan

- [x] All internal links verified against existing paths (15 paths including SLO-5 anchor, runbooks, API anchors, code paths).
- [x] Code fences balanced.
- [x] Cross-reference sweep: pre-existing docs that mention normalization (`docs/architecture.md`, `project_architecture.md`, `testing.md`, `api.md`, `sre/slos.md`, 3 existing runbooks) remain factually accurate — no additional edits needed.
- [x] Docs-only PR — no CI test impact beyond lint/markdown checks.

## Sequence

Merge position: **4 of 4** (last in the epic — docs describe shipped behavior).