### PR TITLE
fix(security): lint sort_regex in auto-creation bulk-update (bd-k41e0)

### DIFF
--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -425,6 +425,10 @@ async def bulk_update_auto_creation_rules(request: BulkUpdateAutoCreationRulesRe
 
     scalar_update = UpdateAutoCreationRuleRequest(**payload) if payload else UpdateAutoCreationRuleRequest()
 
+    # Lint sort_regex (bd-eio04.7) before any DB work. Bulk-update does not
+    # accept conditions/actions, so only sort_regex can carry a pattern.
+    _lint_auto_creation_rule_request(None, None, scalar_update.sort_regex)
+
     session = get_session()
     try:
         updated: list = []

--- a/backend/tests/routers/test_regex_lint_integration.py
+++ b/backend/tests/routers/test_regex_lint_integration.py
@@ -293,6 +293,43 @@ class TestAutoCreationUpdateRuleLinting:
         assert response.status_code == 422
 
 
+class TestAutoCreationBulkUpdateRuleLinting:
+    """Regression-lock: bulk-update must call the same regex linter as PUT."""
+
+    @pytest.mark.asyncio
+    async def test_bulk_update_rejects_evil_sort_regex(
+        self, async_client, test_session
+    ):
+        rule = AutoCreationRule(
+            name="Bulk lint target",
+            conditions=json.dumps(
+                [{"type": "stream_name_contains", "value": "ESPN"}]
+            ),
+            actions=json.dumps(
+                [{"type": "create_channel", "name_template": "{stream_name}"}]
+            ),
+            sort_field="stream_name_regex",
+        )
+        test_session.add(rule)
+        test_session.commit()
+        test_session.refresh(rule)
+        rule_id = rule.id
+
+        response = await async_client.post(
+            "/api/auto-creation/rules/bulk-update",
+            json={"rule_ids": [rule_id], "sort_regex": EVIL_PATTERN},
+        )
+        assert response.status_code == 422
+        err = response.json()["detail"]["error"]
+        assert err["details"][0]["field"] == "sort_regex"
+        assert err["details"][0]["code"] == "REGEX_NESTED_QUANTIFIER"
+
+        # Defense in depth: the rule's sort_regex must not have been written.
+        test_session.expire_all()
+        refreshed = test_session.query(AutoCreationRule).get(rule_id)
+        assert refreshed.sort_regex is None
+
+
 # =========================================================================
 # Dummy-EPG router.
 # =========================================================================


### PR DESCRIPTION
## Summary
- Calls `_lint_auto_creation_rule_request(None, None, scalar_update.sort_regex)` once in `bulk_update_auto_creation_rules` before any DB work, so the bulk path rejects catastrophic-backtracking patterns on `sort_regex` the same way the single-rule `PUT /api/auto-creation/rules/{id}` already does.
- Adds `TestAutoCreationBulkUpdateRuleLinting.test_bulk_update_rejects_evil_sort_regex` mirroring the existing `test_put_rejects_evil_pattern` — POSTs `EVIL_PATTERN` via bulk-update, asserts 422 with `field=sort_regex` + `code=REGEX_NESTED_QUANTIFIER`, and verifies the rule row was not mutated.

## Context
PR #99 (merged in `c9e5bf78`) introduced `BulkUpdateAutoCreationRulesRequest` which inherits `sort_regex` from `UpdateAutoCreationRuleRequest` and applies it via `_apply_rule_scalar_updates`. The single-rule PUT has called `_lint_auto_creation_rule_request` since bd-eio04.7 to close the ReDoS surface on user-supplied patterns. The bulk endpoint did not — a single request could plant a pathological pattern on up to 500 rules that the PUT would have rejected.

Bead: `enhancedchannelmanager-k41e0` (P1).

## Test plan
- [x] `cd backend && python -m pytest tests/routers/test_regex_lint_integration.py tests/routers/test_auto_creation.py --no-header -p no:warnings --no-cov` → 65 passed
- [ ] CI: Backend Tests, Frontend Tests, Semgrep, CodeQL (python + js-ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)