### PR TITLE
fix(auto-creation): skip validate_rule on scalars-only bulk updates (bd-z7xqy)

### DIFF
--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -429,6 +429,13 @@ async def bulk_update_auto_creation_rules(request: BulkUpdateAutoCreationRulesRe
     # accept conditions/actions, so only sort_regex can carry a pattern.
     _lint_auto_creation_rule_request(None, None, scalar_update.sort_regex)
 
+    # Only mutations that touch rule logic (conditions/actions) need post-update
+    # schema validation. Scalars-only bulk edits (enabled, priority, sort fields,
+    # …) must not be blocked by pre-existing schema drift in untouched rows
+    # (bd-z7xqy). Bulk-update does not accept raw conditions/actions, so today
+    # the only logic mutation is merge_streams_remove_non_matching.
+    mutated_rule_logic = merge_streams_remove_non_matching is not None
+
     session = get_session()
     try:
         updated: list = []
@@ -447,14 +454,15 @@ async def bulk_update_auto_creation_rules(request: BulkUpdateAutoCreationRulesRe
                 )
                 rule.actions = json.dumps(new_actions)
 
-            conditions = rule.get_conditions()
-            actions = rule.get_actions()
-            validation = validate_rule(conditions, actions)
-            if not validation["valid"]:
-                raise HTTPException(status_code=400, detail={
-                    "message": f"Invalid rule configuration for rule id={rid}",
-                    "errors": validation["errors"],
-                })
+            if mutated_rule_logic:
+                conditions = rule.get_conditions()
+                actions = rule.get_actions()
+                validation = validate_rule(conditions, actions)
+                if not validation["valid"]:
+                    raise HTTPException(status_code=400, detail={
+                        "message": f"Invalid rule configuration for rule id={rid}",
+                        "errors": validation["errors"],
+                    })
             updated.append(rule)
 
         session.commit()

--- a/backend/tests/routers/test_auto_creation.py
+++ b/backend/tests/routers/test_auto_creation.py
@@ -289,6 +289,79 @@ class TestBulkUpdateAutoCreationRules:
         acts = json.loads(rule.actions)
         assert acts[0]["remove_non_matching"] is True
 
+    @pytest.mark.asyncio
+    async def test_scalars_only_update_skips_validate_on_drifted_rule(
+        self, async_client, test_session
+    ):
+        """bd-z7xqy: Scalar-only bulk edits must succeed even when the stored
+        rule's conditions/actions fail validate_rule (schema drift / legacy data).
+
+        Uses the real validate_rule — no mock — to prove the handler no longer
+        gates scalar-only updates on post-update schema validation.
+        """
+        rule = _create_rule(
+            test_session,
+            name="DriftedScalar",
+            enabled=False,
+            conditions=json.dumps([]),  # validate_rule rejects empty conditions
+        )
+
+        with patch("routers.auto_creation.journal"):
+            response = await async_client.post(
+                "/api/auto-creation/rules/bulk-update",
+                json={"rule_ids": [rule.id], "enabled": True},
+            )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["updated_count"] == 1
+
+        test_session.expire_all()
+        refreshed = test_session.query(AutoCreationRule).get(rule.id)
+        assert refreshed.enabled is True
+
+    @pytest.mark.asyncio
+    async def test_merge_streams_payload_still_validates_drifted_rule(
+        self, async_client, test_session
+    ):
+        """bd-z7xqy: When the bulk payload touches rule logic
+        (merge_streams_remove_non_matching), validate_rule must still gate
+        the change and the transaction must roll back on failure.
+        """
+        merge_action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "match_by": "tvg_id",
+            "remove_non_matching": False,
+        }
+        original_actions = json.dumps([merge_action])
+        rule = _create_rule(
+            test_session,
+            name="DriftedMerge",
+            conditions=json.dumps([]),  # drift: empty conditions fail validate_rule
+            actions=original_actions,
+        )
+
+        with patch("routers.auto_creation.journal"):
+            response = await async_client.post(
+                "/api/auto-creation/rules/bulk-update",
+                json={
+                    "rule_ids": [rule.id],
+                    "merge_streams_remove_non_matching": True,
+                },
+            )
+
+        assert response.status_code == 400, response.text
+        detail = response.json()["detail"]
+        # detail is a dict with {"message": "...", "errors": [...]}
+        message = detail["message"] if isinstance(detail, dict) else str(detail)
+        assert "Invalid rule configuration" in message
+
+        # Rollback: actions JSON must be unchanged.
+        test_session.expire_all()
+        refreshed = test_session.query(AutoCreationRule).get(rule.id)
+        assert json.loads(refreshed.actions) == [merge_action]
+
 
 class TestDeleteAutoCreationRule:
     """Tests for DELETE /api/auto-creation/rules/{rule_id}."""


### PR DESCRIPTION
## Summary
Bulk-update of auto-creation rules ran `validate_rule` on every touched row post-update, even when the payload only mutated scalar columns. Any row whose stored `conditions`/`actions` were already invalid (legacy schema drift, empty arrays) would 400 the entire batch and roll it back — from a scalar-only edit that never touched rule logic.

Gate the validation on a `mutated_rule_logic` flag that's only set when the payload actually changes conditions/actions (today: `merge_streams_remove_non_matching`). Scalars-only bulk edits skip the check; logic-mutating edits still validate and roll back on failure.

## Context
- Tracks bead `enhancedchannelmanager-z7xqy` (P2). Raised during review of PR #99 (auto-creation bulk edit, merged as `c9e5bf78`). Regex-lint fix-forward in #127 (`832baaec`) addressed a different branch of the same handler.
- Prod DB audit: 3 rules, 0 currently invalid — this was latent, not live. PO approved option (b): scope to bulk only, leave single-rule PUT alone.

## Implementation
- `backend/routers/auto_creation.py`: compute `mutated_rule_logic = merge_streams_remove_non_matching is not None` before the per-row loop; wrap the `validate_rule` block in `if mutated_rule_logic:`.
- Bulk-update does not accept raw `conditions`/`actions` today, so the guard reduces to the merge-streams path. Future logic-mutating bulk fields must flip the same flag.

## TDD Evidence
Tests added first, run against unchanged code, then patch applied:
- `test_scalars_only_update_skips_validate_on_drifted_rule` — **failed** before patch (400 `"Rule must have at least one condition"`), **passes** after.
- `test_merge_streams_payload_still_validates_drifted_rule` — **passed** before and after (unchanged behavior for logic mutations).

Both use the real `validate_rule` — no mock — so the handler's actual gating is under test.

## Test plan
- [x] `pytest tests/routers/test_auto_creation.py::TestBulkUpdateAutoCreationRules::test_scalars_only_update_skips_validate_on_drifted_rule -v` — passes
- [x] `pytest tests/routers/test_auto_creation.py::TestBulkUpdateAutoCreationRules::test_merge_streams_payload_still_validates_drifted_rule -v` — passes
- [x] `pytest tests/routers/test_auto_creation.py tests/routers/test_regex_lint_integration.py` — 67 passed

Generated with Claude Code.