### PR TITLE
perf(auto-creation): single-query fetch in bulk-update (bd-bh1hh)

### DIFF
--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -438,11 +438,23 @@ async def bulk_update_auto_creation_rules(request: BulkUpdateAutoCreationRulesRe
 
     session = get_session()
     try:
+        # Single SELECT ... WHERE id IN (...) instead of N per-id queries
+        # (bd-bh1hh: avoid N+1 — at max_length=500 this collapses 500 round
+        # trips into 1).
+        rules_by_id = {
+            r.id: r for r in session.query(AutoCreationRule)
+            .filter(AutoCreationRule.id.in_(rule_ids)).all()
+        }
+        missing = [rid for rid in rule_ids if rid not in rules_by_id]
+        if missing:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Rules not found: {missing}",
+            )
+
         updated: list = []
         for rid in rule_ids:
-            rule = session.query(AutoCreationRule).filter(AutoCreationRule.id == rid).first()
-            if not rule:
-                raise HTTPException(status_code=404, detail=f"Rule not found: {rid}")
+            rule = rules_by_id[rid]
 
             if payload:
                 _apply_rule_scalar_updates(rule, scalar_update)
@@ -466,8 +478,12 @@ async def bulk_update_auto_creation_rules(request: BulkUpdateAutoCreationRulesRe
             updated.append(rule)
 
         session.commit()
-        for rule in updated:
-            session.refresh(rule)
+        # No per-rule session.refresh() — attached instances already reflect
+        # the committed values. AutoCreationRule has no server_default or DB
+        # triggers on the columns written here; updated_at uses a Python-side
+        # onupdate callable which SQLAlchemy applies during flush, so it is
+        # populated on the in-memory instance before to_dict() reads it.
+        # (bd-bh1hh: drops another N SELECTs per bulk request.)
 
         names = ", ".join(r.name for r in updated[:5])
         if len(updated) > 5:

--- a/backend/tests/routers/test_auto_creation.py
+++ b/backend/tests/routers/test_auto_creation.py
@@ -264,6 +264,32 @@ class TestBulkUpdateAutoCreationRules:
         assert test_session.query(AutoCreationRule).get(r3.id).enabled is True
 
     @pytest.mark.asyncio
+    async def test_reports_all_missing_ids(self, async_client, test_session):
+        """bd-bh1hh: When multiple rule_ids are missing, the 404 body mentions
+        every missing id (not just the first one encountered). This is a visible
+        API change from the original loop-and-fail-fast behavior.
+        """
+        r1 = _create_rule(test_session, name="BulkMiss1", enabled=True)
+        r2 = _create_rule(test_session, name="BulkMiss2", enabled=True)
+
+        missing_a = 99999
+        missing_b = 99998
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post(
+                "/api/auto-creation/rules/bulk-update",
+                json={
+                    "rule_ids": [r1.id, missing_a, r2.id, missing_b],
+                    "enabled": False,
+                },
+            )
+
+        assert response.status_code == 404
+        detail = str(response.json()["detail"])
+        assert str(missing_a) in detail
+        assert str(missing_b) in detail
+
+    @pytest.mark.asyncio
     async def test_sets_merge_streams_remove_non_matching(self, async_client, test_session):
         """Updates remove_non_matching on all merge_streams actions."""
         merge_action = {


### PR DESCRIPTION
## Summary

- Replace the two N+1 loops in `bulk_update_auto_creation_rules` with a single `SELECT ... WHERE id IN (...)` fetch.
- Drop the per-rule `session.refresh()` loop that ran after commit.
- At the `max_length=500` cap, query count drops from ~1000 to 1 for the fetch.

## Context

`bulk_update_auto_creation_rules` (`backend/routers/auto_creation.py`) previously issued one `.filter(AutoCreationRule.id == rid).first()` per id, then one `session.refresh(rule)` per id post-commit. At N=500 that is ~1000 round trips per request. This was flagged as a non-blocking follow-up in the original PR #99 review and tracked as bead `enhancedchannelmanager-bh1hh`.

**Why dropping `session.refresh()` is safe.** Inspected `models.AutoCreationRule`: no column written by `_apply_rule_scalar_updates` (or by `rule.actions = json.dumps(...)`) has a `server_default`, DB-side trigger, or computed-column attached. The only auto-populated column in the model is `updated_at`, which uses a **Python-side** `onupdate=datetime.utcnow` callable — SQLAlchemy applies Python-side `onupdate` values during flush, so the attribute is populated on the attached instance before `to_dict()` reads it. No refresh required.

## Behavior change (explicit callout)

The current code raises 404 with `detail=f"Rule not found: {rid}"` on the **first** missing id encountered in the loop. The refactor now reports **all** missing ids in a single 404:

- Before: `{"detail": "Rule not found: 42"}`
- After:  `{"detail": "Rules not found: [42, 57]"}`

This is strictly more useful for operators but is an observable API change — any caller that string-matches on the old single-id message will need to adapt.

## Test plan

- [x] New test `test_reports_all_missing_ids` verifies both missing ids appear in the 404 body. Confirmed red against current code (matches `99999` only, misses `99998`), green after refactor.
- [x] Existing regression locks remain green:
  - `test_rolls_back_when_any_rule_id_missing` — 404 + all pre-existing rules' `enabled` unchanged.
  - `test_updates_multiple_rules` — happy-path bulk toggle of multiple rules returns 200 with `updated_count` correct and persisted changes.
  - `test_accepts_exactly_500_rule_ids` — 500-id batch succeeds.
  - `test_sets_merge_streams_remove_non_matching` — nested-JSON action mutation still commits.
  - `test_scalars_only_update_skips_validate_on_drifted_rule` / `test_merge_streams_payload_still_validates_drifted_rule` — bd-z7xqy invariants preserved.
- [x] `backend/tests/routers/test_auto_creation.py` + `test_regex_lint_integration.py`: **68 passed** post-change.
- [x] Full backend sweep: **2949 passed, 1 skipped**. 8 pre-existing alembic/schema-version failures confirmed on clean `origin/dev` HEAD — unrelated to this change.

Bead: `enhancedchannelmanager-bh1hh`

Coordination note: two other engineers are working on `backend/routers/auto_creation.py` in parallel (`gjoe5` bulk reject conditions/actions; `91mcq` audit-trail journal entries). This change is contained to the fetch pattern inside the handler body and doesn't touch validation, journal, or the request model — expect a straightforward rebase if either lands first.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>