### PR TITLE
ci: retry docker push on transient GHCR failure (bd-42aai)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -380,7 +380,7 @@ jobs:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.digest.outputs.digest }}
 
     steps:
       - name: Checkout repository
@@ -418,8 +418,61 @@ jobs:
             echo "channel=latest" >> $GITHUB_OUTPUT
           fi
 
+      # Build + push with 2 retries on transient GHCR 50x during layer blob push.
+      # See bd-42aai: GHCR returned 502/504 with
+      # "error writing layer blob: failed to parse error response 50x" in a
+      # 30min window across 4 jobs, each needing manual rerun. Retries are
+      # scoped to this step only; build cache is reused across attempts.
       - name: Build and push (AMD64)
         id: build
+        uses: docker/build-push-action@v7
+        continue-on-error: true
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            ECM_VERSION=${{ steps.version.outputs.version }}
+            RELEASE_CHANNEL=${{ steps.version.outputs.channel }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=amd64
+          cache-to: type=gha,mode=max,scope=amd64
+
+      - name: Wait before retry 1 (AMD64)
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "::warning::Build/push attempt 1 failed (likely transient GHCR 50x). Sleeping 30s before retry."
+          sleep 30
+
+      - name: Build and push (AMD64) — retry 1
+        id: build_retry1
+        if: steps.build.outcome == 'failure'
+        uses: docker/build-push-action@v7
+        continue-on-error: true
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            ECM_VERSION=${{ steps.version.outputs.version }}
+            RELEASE_CHANNEL=${{ steps.version.outputs.channel }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=amd64
+          cache-to: type=gha,mode=max,scope=amd64
+
+      - name: Wait before retry 2 (AMD64)
+        if: steps.build.outcome == 'failure' && steps.build_retry1.outcome == 'failure'
+        run: |
+          echo "::warning::Build/push attempt 2 failed. Sleeping 60s before final retry."
+          sleep 60
+
+      - name: Build and push (AMD64) — retry 2
+        id: build_retry2
+        if: steps.build.outcome == 'failure' && steps.build_retry1.outcome == 'failure'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -433,6 +486,19 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           cache-from: type=gha,scope=amd64
           cache-to: type=gha,mode=max,scope=amd64
+
+      - name: Capture digest (AMD64)
+        id: digest
+        run: |
+          # Pick the digest from whichever attempt actually succeeded.
+          DIGEST="${{ steps.build.outputs.digest }}"
+          if [ -z "$DIGEST" ]; then DIGEST="${{ steps.build_retry1.outputs.digest }}"; fi
+          if [ -z "$DIGEST" ]; then DIGEST="${{ steps.build_retry2.outputs.digest }}"; fi
+          if [ -z "$DIGEST" ]; then
+            echo "::error::No digest produced by any build attempt"
+            exit 1
+          fi
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
   # Container vulnerability scanning with Trivy (loads image from build-amd64 cache)
   trivy-scan:
@@ -488,7 +554,7 @@ jobs:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.digest.outputs.digest }}
 
     steps:
       - name: Checkout repository
@@ -526,8 +592,58 @@ jobs:
             echo "channel=latest" >> $GITHUB_OUTPUT
           fi
 
+      # Build + push with 2 retries on transient GHCR 50x during layer blob push.
+      # See bd-42aai for the incident that motivated this.
       - name: Build and push (ARM64)
         id: build
+        uses: docker/build-push-action@v7
+        continue-on-error: true
+        with:
+          context: .
+          platforms: linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            ECM_VERSION=${{ steps.version.outputs.version }}
+            RELEASE_CHANNEL=${{ steps.version.outputs.channel }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=arm64
+          cache-to: type=gha,mode=max,scope=arm64
+
+      - name: Wait before retry 1 (ARM64)
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "::warning::Build/push attempt 1 failed (likely transient GHCR 50x). Sleeping 30s before retry."
+          sleep 30
+
+      - name: Build and push (ARM64) — retry 1
+        id: build_retry1
+        if: steps.build.outcome == 'failure'
+        uses: docker/build-push-action@v7
+        continue-on-error: true
+        with:
+          context: .
+          platforms: linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            ECM_VERSION=${{ steps.version.outputs.version }}
+            RELEASE_CHANNEL=${{ steps.version.outputs.channel }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=arm64
+          cache-to: type=gha,mode=max,scope=arm64
+
+      - name: Wait before retry 2 (ARM64)
+        if: steps.build.outcome == 'failure' && steps.build_retry1.outcome == 'failure'
+        run: |
+          echo "::warning::Build/push attempt 2 failed. Sleeping 60s before final retry."
+          sleep 60
+
+      - name: Build and push (ARM64) — retry 2
+        id: build_retry2
+        if: steps.build.outcome == 'failure' && steps.build_retry1.outcome == 'failure'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -541,6 +657,18 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           cache-from: type=gha,scope=arm64
           cache-to: type=gha,mode=max,scope=arm64
+
+      - name: Capture digest (ARM64)
+        id: digest
+        run: |
+          DIGEST="${{ steps.build.outputs.digest }}"
+          if [ -z "$DIGEST" ]; then DIGEST="${{ steps.build_retry1.outputs.digest }}"; fi
+          if [ -z "$DIGEST" ]; then DIGEST="${{ steps.build_retry2.outputs.digest }}"; fi
+          if [ -z "$DIGEST" ]; then
+            echo "::error::No digest produced by any build attempt"
+            exit 1
+          fi
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
   # Container vulnerability scanning with Trivy — ARM64 (loads image from build-arm64 cache)
   trivy-scan-arm64:
@@ -667,7 +795,7 @@ jobs:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.digest.outputs.digest }}
 
     steps:
       - name: Checkout repository
@@ -694,8 +822,50 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
 
+      # Build + push with 2 retries on transient GHCR 50x during layer blob push.
+      # See bd-42aai for the incident that motivated this.
       - name: Build and push MCP (AMD64)
         id: build
+        uses: docker/build-push-action@v7
+        continue-on-error: true
+        with:
+          context: ./mcp-server
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=mcp-amd64
+          cache-to: type=gha,mode=max,scope=mcp-amd64
+
+      - name: Wait before MCP retry 1 (AMD64)
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "::warning::MCP build/push attempt 1 failed (likely transient GHCR 50x). Sleeping 30s before retry."
+          sleep 30
+
+      - name: Build and push MCP (AMD64) — retry 1
+        id: build_retry1
+        if: steps.build.outcome == 'failure'
+        uses: docker/build-push-action@v7
+        continue-on-error: true
+        with:
+          context: ./mcp-server
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=mcp-amd64
+          cache-to: type=gha,mode=max,scope=mcp-amd64
+
+      - name: Wait before MCP retry 2 (AMD64)
+        if: steps.build.outcome == 'failure' && steps.build_retry1.outcome == 'failure'
+        run: |
+          echo "::warning::MCP build/push attempt 2 failed. Sleeping 60s before final retry."
+          sleep 60
+
+      - name: Build and push MCP (AMD64) — retry 2
+        id: build_retry2
+        if: steps.build.outcome == 'failure' && steps.build_retry1.outcome == 'failure'
         uses: docker/build-push-action@v7
         with:
           context: ./mcp-server
@@ -706,6 +876,18 @@ jobs:
           cache-from: type=gha,scope=mcp-amd64
           cache-to: type=gha,mode=max,scope=mcp-amd64
 
+      - name: Capture MCP digest (AMD64)
+        id: digest
+        run: |
+          DIGEST="${{ steps.build.outputs.digest }}"
+          if [ -z "$DIGEST" ]; then DIGEST="${{ steps.build_retry1.outputs.digest }}"; fi
+          if [ -z "$DIGEST" ]; then DIGEST="${{ steps.build_retry2.outputs.digest }}"; fi
+          if [ -z "$DIGEST" ]; then
+            echo "::error::No digest produced by any MCP build attempt"
+            exit 1
+          fi
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
   build-mcp-arm64:
     name: Build MCP Image (ARM64)
     runs-on: ubuntu-24.04-arm
@@ -715,7 +897,7 @@ jobs:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.digest.outputs.digest }}
 
     steps:
       - name: Checkout repository
@@ -742,8 +924,50 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
 
+      # Build + push with 2 retries on transient GHCR 50x during layer blob push.
+      # See bd-42aai for the incident that motivated this.
       - name: Build and push MCP (ARM64)
         id: build
+        uses: docker/build-push-action@v7
+        continue-on-error: true
+        with:
+          context: ./mcp-server
+          platforms: linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=mcp-arm64
+          cache-to: type=gha,mode=max,scope=mcp-arm64
+
+      - name: Wait before MCP retry 1 (ARM64)
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "::warning::MCP build/push attempt 1 failed (likely transient GHCR 50x). Sleeping 30s before retry."
+          sleep 30
+
+      - name: Build and push MCP (ARM64) — retry 1
+        id: build_retry1
+        if: steps.build.outcome == 'failure'
+        uses: docker/build-push-action@v7
+        continue-on-error: true
+        with:
+          context: ./mcp-server
+          platforms: linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=mcp-arm64
+          cache-to: type=gha,mode=max,scope=mcp-arm64
+
+      - name: Wait before MCP retry 2 (ARM64)
+        if: steps.build.outcome == 'failure' && steps.build_retry1.outcome == 'failure'
+        run: |
+          echo "::warning::MCP build/push attempt 2 failed. Sleeping 60s before final retry."
+          sleep 60
+
+      - name: Build and push MCP (ARM64) — retry 2
+        id: build_retry2
+        if: steps.build.outcome == 'failure' && steps.build_retry1.outcome == 'failure'
         uses: docker/build-push-action@v7
         with:
           context: ./mcp-server
@@ -753,6 +977,18 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           cache-from: type=gha,scope=mcp-arm64
           cache-to: type=gha,mode=max,scope=mcp-arm64
+
+      - name: Capture MCP digest (ARM64)
+        id: digest
+        run: |
+          DIGEST="${{ steps.build.outputs.digest }}"
+          if [ -z "$DIGEST" ]; then DIGEST="${{ steps.build_retry1.outputs.digest }}"; fi
+          if [ -z "$DIGEST" ]; then DIGEST="${{ steps.build_retry2.outputs.digest }}"; fi
+          if [ -z "$DIGEST" ]; then
+            echo "::error::No digest produced by any MCP build attempt"
+            exit 1
+          fi
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
   merge-mcp-manifests:
     name: Create MCP Multi-Arch Manifest


### PR DESCRIPTION
## Summary

Wrap the four `docker/build-push-action` push steps in `.github/workflows/build.yml` with a 3-attempt native YAML retry pattern to tolerate transient GHCR 502/504 failures during layer blob push. No new action dependencies.

Scope: main AMD64 + main ARM64 + MCP AMD64 + MCP ARM64. The Load-from-cache steps, Trivy, DAST, CodeQL, and tests are NOT wrapped — retrying those would mask real flakes.

References bead `enhancedchannelmanager-42aai`.

## Context

In a ~30min window on 2026-04-23, GHCR returned 50x four separate times across different docker-push jobs:

| # | Job | Error | Run |
|-|-|-|-|
| 1 | Build Docker Image (AMD64) | 504 | PR #99 initial |
| 2 | Build Docker Image (ARM64) | 504 | PR #99 initial |
| 3 | Build MCP Image (AMD64) | 504 | PR #99 close/reopen rerun |
| 4 | Build MCP Image (ARM64) | 502 | dev post-merge CI |

Error signature on every failure:

```
ERROR: failed to parse error response 50x: <!DOCTYPE html>
ERROR: failed to build: failed to solve: error writing layer blob: ...
```

All four were during the layer blob upload phase. Each manual re-run succeeded first try, confirming transient GHCR-side infra issue, not a code defect.

## Design

- `docker/build-push-action@v7` has **no** native retry input (verified against the v7 README). Retry is implemented in YAML.
- Pattern per push step (x4):
  1. First attempt: `continue-on-error: true`
  2. `Wait 30s` step gated on `steps.build.outcome == 'failure'`
  3. Second attempt: `continue-on-error: true`, same gate
  4. `Wait 60s` step gated on both prior failures
  5. Third attempt (final): no `continue-on-error` — its failure propagates and fails the job
  6. `Capture digest` step picks the first non-empty `digest` output from the three attempts; job-level `outputs.digest` now references this capture step instead of `steps.build.outputs.digest`. Preserves the contract consumed by `merge-manifests` / `merge-mcp-manifests`.
- Backoff: 30s -> 60s (exponential-ish, in spec).
- Build cache (`type=gha`) is shared across attempts — retries re-use layers and effectively become "just push" operations.
- No new action deps — keeps the supply-chain surface unchanged for CI image build.

## Test plan

- [x] YAML validity: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"` -> `YAML OK`
- [x] Structure audit: each of the four push jobs has 3 build attempts, `continue-on-error` set correctly per attempt (true, true, false), digest capture step present, job `outputs.digest` points at capture step.
- [x] On a clean CI run with no transient: only `steps.build` runs — behavior identical to pre-change (the retry steps short-circuit via their `if:` guards).
- [ ] End-to-end retry is **unverified** by this PR — no way to replay a 50x from GHCR on demand. Retry path will be exercised the next time GHCR burps. Validated by observation: tracking rerun-needed count over the next 2 weeks (acceptance metric on the bead).

## Rollback

If retry ever masks a real failure or breaks the digest contract, revert this single commit — it only touches `.github/workflows/build.yml` and leaves the first attempt semantically identical to the pre-change step.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>