### PR TITLE
fix(auto-creation): reject conditions/actions in bulk-update payload (bd-gjoe5)

### DIFF
--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -14,7 +14,7 @@ from typing import List, Optional
 import journal
 from fastapi import APIRouter, Body, HTTPException
 from fastapi.responses import PlainTextResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from starlette.responses import StreamingResponse
 
 from concurrency import run_cpu_bound
@@ -90,6 +90,21 @@ class BulkUpdateAutoCreationRulesRequest(UpdateAutoCreationRuleRequest):
 
     rule_ids: List[int] = Field(..., min_length=1, max_length=500)
     merge_streams_remove_non_matching: Optional[bool] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_conditions_and_actions(cls, data):
+        """bd-gjoe5: Bulk-update inherits conditions/actions from the single-rule
+        update request, but the handler does not apply them — silently dropping
+        them is the wrong default for an API contract. Reject the request so
+        callers route conditions/actions edits through PUT /rules/{id} instead.
+        """
+        if isinstance(data, dict) and ("conditions" in data or "actions" in data):
+            raise ValueError(
+                "conditions and actions are not supported in bulk-update; "
+                "use PUT /rules/{id}"
+            )
+        return data
 
 
 class RunPipelineRequest(BaseModel):

--- a/backend/tests/routers/test_auto_creation.py
+++ b/backend/tests/routers/test_auto_creation.py
@@ -362,6 +362,59 @@ class TestBulkUpdateAutoCreationRules:
         refreshed = test_session.query(AutoCreationRule).get(rule.id)
         assert json.loads(refreshed.actions) == [merge_action]
 
+    @pytest.mark.asyncio
+    async def test_rejects_conditions_in_payload(self, async_client, test_session):
+        """bd-gjoe5: conditions is not supported in bulk-update; silent-drop
+        is the wrong default for an API contract. Must reject (4xx) and name
+        the offending field in the error message.
+        """
+        r = _create_rule(test_session, name="RejectCond", enabled=True)
+        response = await async_client.post(
+            "/api/auto-creation/rules/bulk-update",
+            json={
+                "rule_ids": [r.id],
+                "conditions": [{"type": "stream_name_contains", "value": "X"}],
+            },
+        )
+        assert response.status_code in (400, 422), response.text
+        body = response.text.lower()
+        assert "conditions" in body
+
+    @pytest.mark.asyncio
+    async def test_rejects_actions_in_payload(self, async_client, test_session):
+        """bd-gjoe5: actions is not supported in bulk-update."""
+        r = _create_rule(test_session, name="RejectActs", enabled=True)
+        response = await async_client.post(
+            "/api/auto-creation/rules/bulk-update",
+            json={
+                "rule_ids": [r.id],
+                "actions": [{"type": "create_channel", "name_template": "{stream_name}"}],
+            },
+        )
+        assert response.status_code in (400, 422), response.text
+        body = response.text.lower()
+        assert "actions" in body
+
+    @pytest.mark.asyncio
+    async def test_scalars_only_update_still_succeeds(self, async_client, test_session):
+        """bd-gjoe5 regression guard: scalars-only bulk updates must still
+        return 200 after the conditions/actions rejection is added.
+        """
+        r = _create_rule(test_session, name="ScalarsOnly", enabled=False)
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post(
+                "/api/auto-creation/rules/bulk-update",
+                json={"rule_ids": [r.id], "enabled": True, "priority": 5},
+            )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["updated_count"] == 1
+        test_session.expire_all()
+        refreshed = test_session.query(AutoCreationRule).get(r.id)
+        assert refreshed.enabled is True
+        assert refreshed.priority == 5
+
 
 class TestDeleteAutoCreationRule:
     """Tests for DELETE /api/auto-creation/rules/{rule_id}."""


### PR DESCRIPTION
## Summary

- Add a Pydantic `model_validator(mode=\"before\")` on `BulkUpdateAutoCreationRulesRequest` that rejects either `conditions` or `actions` at request-parse time with 422.
- Error: `\"conditions and actions are not supported in bulk-update; use PUT /rules/{id}\"`.
- Single-rule `PUT /rules/{id}` is unchanged and still accepts both fields.

## Context

Bead: `enhancedchannelmanager-gjoe5` (P3).

PR #99 introduced `POST /api/auto-creation/rules/bulk-update`. `BulkUpdateAutoCreationRulesRequest` inherits from `UpdateAutoCreationRuleRequest`, which includes `Optional[list] conditions` and `Optional[list] actions`. The bulk handler never reads or applies these fields, so a caller sending

```json
{\"rule_ids\": [1, 2], \"conditions\": [...], \"actions\": [...]}
```

received **200 OK with the conditions/actions payload silently dropped**. Silent data-loss is the wrong default for an API contract — a caller who thought they were editing rule logic gets no signal that nothing happened. Fail loudly and point them at the correct endpoint.

### Why a `model_validator` instead of a handler guard?

The validator fires at request-parse time (before the handler runs), matches the existing 422 contract on this endpoint (see `test_rejects_empty_rule_ids`), inspects the raw payload dict so it catches `{\"conditions\": null}` and `{\"conditions\": []}` equally (both equal \"caller sent this field\"), and centralizes the rule on the model so any future endpoint that reuses `BulkUpdateAutoCreationRulesRequest` inherits the protection.

## Test plan

- [x] TDD red: `test_rejects_conditions_in_payload` + `test_rejects_actions_in_payload` fail on dev tip (200 OK with silent drop) — confirmed before fix
- [x] TDD green: both tests pass after the validator is added
- [x] Regression guard: `test_scalars_only_update_still_succeeds` passes both before and after (scalars-only bulk updates still 200)
- [x] `tests/routers/test_auto_creation.py tests/routers/test_regex_lint_integration.py` — **70 passed**
- [x] `tests/routers/test_auto_creation.py` — **46 passed** (includes single-rule PUT tests that send conditions/actions — still 200)