### PR TITLE
fix(auto-creation): per-entity journal entries with batch_id for bulk-update (bd-91mcq)

### DIFF
--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -8,6 +8,7 @@ import json
 import logging
 import tarfile
 import time
+import uuid
 from datetime import datetime
 from typing import List, Optional
 
@@ -134,44 +135,72 @@ def _apply_merge_streams_remove_non_matching(actions: list, value: bool) -> list
     return out
 
 
-def _apply_rule_scalar_updates(rule, request: UpdateAutoCreationRuleRequest) -> None:
-    """Apply scalar columns from an update request (excluding conditions/actions body)."""
+def _apply_rule_scalar_updates(
+    rule, request: UpdateAutoCreationRuleRequest
+) -> dict:
+    """Apply scalar columns from an update request (excluding conditions/actions body).
+
+    Returns a diff dict of the form ``{field: {"before": old, "after": new}}``
+    for every scalar column whose value actually changed. Fields set to the
+    same value they already had are omitted so callers can avoid emitting
+    no-op journal entries (bd-91mcq).
+    """
+    diff: dict = {}
+
+    def _set(field: str, new_value) -> None:
+        """Assign attribute and record a diff entry if the value changed."""
+        old_value = getattr(rule, field)
+        if old_value != new_value:
+            diff[field] = {"before": old_value, "after": new_value}
+        setattr(rule, field, new_value)
+
     if request.name is not None:
-        rule.name = request.name
+        _set("name", request.name)
     if request.description is not None:
-        rule.description = request.description
+        _set("description", request.description)
     if request.enabled is not None:
-        rule.enabled = request.enabled
+        _set("enabled", request.enabled)
     if request.priority is not None:
-        rule.priority = request.priority
+        _set("priority", request.priority)
     if request.m3u_account_id is not None:
-        rule.m3u_account_id = request.m3u_account_id
+        _set("m3u_account_id", request.m3u_account_id)
     if request.target_group_id is not None:
-        rule.target_group_id = request.target_group_id
+        _set("target_group_id", request.target_group_id)
     if request.run_on_refresh is not None:
-        rule.run_on_refresh = request.run_on_refresh
+        _set("run_on_refresh", request.run_on_refresh)
     if request.stop_on_first_match is not None:
-        rule.stop_on_first_match = request.stop_on_first_match
+        _set("stop_on_first_match", request.stop_on_first_match)
     if request.sort_field is not None:
-        rule.sort_field = request.sort_field or None
+        _set("sort_field", request.sort_field or None)
     if request.sort_order is not None:
-        rule.sort_order = request.sort_order
+        _set("sort_order", request.sort_order)
     if request.probe_on_sort is not None:
-        rule.probe_on_sort = request.probe_on_sort
+        _set("probe_on_sort", request.probe_on_sort)
     if request.sort_regex is not None:
-        rule.sort_regex = request.sort_regex or None
+        _set("sort_regex", request.sort_regex or None)
     if request.stream_sort_field is not None:
-        rule.stream_sort_field = request.stream_sort_field or None
+        _set("stream_sort_field", request.stream_sort_field or None)
     if request.stream_sort_order is not None:
-        rule.stream_sort_order = request.stream_sort_order
+        _set("stream_sort_order", request.stream_sort_order)
     if request.normalization_group_ids is not None:
+        # NormalizationRuleGroup IDs go through a setter; diff by before/after
+        # of the serialized value to keep comparison simple.
+        before_norm = rule.normalization_group_ids
         rule.set_normalization_group_ids(request.normalization_group_ids)
+        after_norm = rule.normalization_group_ids
+        if before_norm != after_norm:
+            diff["normalization_group_ids"] = {
+                "before": before_norm,
+                "after": after_norm,
+            }
     if request.skip_struck_streams is not None:
-        rule.skip_struck_streams = request.skip_struck_streams
+        _set("skip_struck_streams", request.skip_struck_streams)
     if request.orphan_action is not None:
-        rule.orphan_action = request.orphan_action
+        _set("orphan_action", request.orphan_action)
     if getattr(request, "match_scope_target_group", None) is not None:
-        rule.match_scope_target_group = request.match_scope_target_group
+        _set("match_scope_target_group", request.match_scope_target_group)
+
+    return diff
 
 
 def _resolve_normalization_group_ids(rule_data: dict, session) -> str | None:
@@ -467,18 +496,28 @@ async def bulk_update_auto_creation_rules(request: BulkUpdateAutoCreationRulesRe
                 detail=f"Rules not found: {missing}",
             )
 
+        # Track per-rule diffs so we can emit per-entity journal entries with a
+        # shared batch_id after a successful commit (bd-91mcq). Matches the
+        # pattern at backend/routers/channels.py:800 (bulk channel renumber).
         updated: list = []
+        rule_diffs: list[tuple] = []  # (rule, scalar_diff, merge_streams_before, merge_streams_after)
         for rid in rule_ids:
             rule = rules_by_id[rid]
 
+            scalar_diff: dict = {}
             if payload:
-                _apply_rule_scalar_updates(rule, scalar_update)
+                scalar_diff = _apply_rule_scalar_updates(rule, scalar_update)
 
+            merge_before = None
+            merge_after = None
             if merge_streams_remove_non_matching is not None:
                 actions = rule.get_actions()
                 new_actions = _apply_merge_streams_remove_non_matching(
                     actions, merge_streams_remove_non_matching
                 )
+                if new_actions != actions:
+                    merge_before = actions
+                    merge_after = new_actions
                 rule.actions = json.dumps(new_actions)
 
             if mutated_rule_logic:
@@ -491,6 +530,7 @@ async def bulk_update_auto_creation_rules(request: BulkUpdateAutoCreationRulesRe
                         "errors": validation["errors"],
                     })
             updated.append(rule)
+            rule_diffs.append((rule, scalar_diff, merge_before, merge_after))
 
         session.commit()
         # No per-rule session.refresh() — attached instances already reflect
@@ -500,16 +540,48 @@ async def bulk_update_auto_creation_rules(request: BulkUpdateAutoCreationRulesRe
         # populated on the in-memory instance before to_dict() reads it.
         # (bd-bh1hh: drops another N SELECTs per bulk request.)
 
-        names = ", ".join(r.name for r in updated[:5])
-        if len(updated) > 5:
-            names += ", …"
-        journal.log_entry(
-            category="auto_creation",
-            action_type="update",
-            entity_id=0,
-            entity_name="bulk",
-            description=f"Bulk-updated {len(updated)} auto-creation rule(s): {names}",
-        )
+        # Emit one journal entry per rule that actually changed, all sharing
+        # the same batch_id so forensics can group them. Skip rules where no
+        # scalar column and no merge-streams action changed (bulk-toggle to
+        # the existing value is a no-op).
+        batch_id = str(uuid.uuid4())[:8]
+        for rule, scalar_diff, merge_before, merge_after in rule_diffs:
+            if not scalar_diff and merge_before is None:
+                continue
+
+            description_parts = [
+                f"{field}: {entry['before']} -> {entry['after']}"
+                for field, entry in scalar_diff.items()
+            ]
+            if merge_before is not None:
+                description_parts.append(
+                    "merge_streams.remove_non_matching -> "
+                    f"{merge_streams_remove_non_matching}"
+                )
+            description = (
+                f"Bulk-updated rule '{rule.name}': " + ", ".join(description_parts)
+            )
+
+            before_value = {
+                field: entry["before"] for field, entry in scalar_diff.items()
+            }
+            after_value = {
+                field: entry["after"] for field, entry in scalar_diff.items()
+            }
+            if merge_before is not None:
+                before_value["actions"] = merge_before
+                after_value["actions"] = merge_after
+
+            journal.log_entry(
+                category="auto_creation",
+                action_type="bulk_update",
+                entity_id=rule.id,
+                entity_name=rule.name,
+                description=description,
+                before_value=before_value,
+                after_value=after_value,
+                batch_id=batch_id,
+            )
 
         return {"rules": [r.to_dict() for r in updated], "updated_count": len(updated)}
     except HTTPException:

--- a/backend/tests/routers/test_auto_creation.py
+++ b/backend/tests/routers/test_auto_creation.py
@@ -9,7 +9,7 @@ Mocks: auto_creation_engine, auto_creation_schema, get_client(), get_session().
 import json
 import pytest
 from datetime import datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from models import AutoCreationRule, AutoCreationExecution
 
@@ -440,6 +440,112 @@ class TestBulkUpdateAutoCreationRules:
         refreshed = test_session.query(AutoCreationRule).get(r.id)
         assert refreshed.enabled is True
         assert refreshed.priority == 5
+
+    @pytest.mark.asyncio
+    async def test_emits_per_entity_journal_entries_with_shared_batch_id(
+        self, async_client, test_session
+    ):
+        """bd-91mcq: Bulk-update must emit one journal entry per mutated rule,
+        each with entity_id=rule.id, and all sharing the same batch_id.
+
+        Matches the pattern in backend/routers/channels.py:800 (bulk channel
+        renumber) — per-entity forensics over a single summary entry.
+        """
+        r1 = _create_rule(test_session, name="JournalA", enabled=False)
+        r2 = _create_rule(test_session, name="JournalB", enabled=False)
+        r3 = _create_rule(test_session, name="JournalC", enabled=False)
+
+        mock_journal = MagicMock()
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal", mock_journal):
+            response = await async_client.post(
+                "/api/auto-creation/rules/bulk-update",
+                json={"rule_ids": [r1.id, r2.id, r3.id], "enabled": True},
+            )
+
+        assert response.status_code == 200, response.text
+
+        # One log_entry call per rule mutated.
+        assert mock_journal.log_entry.call_count == 3
+
+        # Collect entity_ids and batch_ids from each call.
+        call_entity_ids = []
+        call_batch_ids = []
+        for call in mock_journal.log_entry.call_args_list:
+            kwargs = call.kwargs
+            call_entity_ids.append(kwargs["entity_id"])
+            call_batch_ids.append(kwargs["batch_id"])
+
+        # Each entity_id matches one of the seeded rules, all distinct.
+        assert sorted(call_entity_ids) == sorted([r1.id, r2.id, r3.id])
+
+        # All three calls share the same batch_id (grouping).
+        assert len(set(call_batch_ids)) == 1
+        assert call_batch_ids[0] is not None and call_batch_ids[0] != ""
+
+    @pytest.mark.asyncio
+    async def test_journal_description_reflects_scalar_diff(
+        self, async_client, test_session
+    ):
+        """bd-91mcq: Journal description must show the before→after diff of
+        changed scalar fields (e.g. 'enabled: False → True, priority: 3 → 5').
+        """
+        rule = _create_rule(
+            test_session, name="DiffRule", enabled=False, priority=3
+        )
+
+        mock_journal = MagicMock()
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal", mock_journal):
+            response = await async_client.post(
+                "/api/auto-creation/rules/bulk-update",
+                json={"rule_ids": [rule.id], "enabled": True, "priority": 5},
+            )
+
+        assert response.status_code == 200, response.text
+        assert mock_journal.log_entry.call_count == 1
+
+        call = mock_journal.log_entry.call_args
+        description = call.kwargs["description"]
+        # Description must reflect both transitions.
+        assert "enabled" in description
+        assert "priority" in description
+        assert "False" in description and "True" in description
+        assert "3" in description and "5" in description
+
+        # before/after also capture the diff, mirroring channels.py pattern.
+        before = call.kwargs.get("before_value") or {}
+        after = call.kwargs.get("after_value") or {}
+        assert before.get("enabled") is False
+        assert after.get("enabled") is True
+        assert before.get("priority") == 3
+        assert after.get("priority") == 5
+
+    @pytest.mark.asyncio
+    async def test_no_journal_entries_when_rollback(
+        self, async_client, test_session
+    ):
+        """bd-91mcq: On rollback path (missing rule id triggers 404), no
+        journal entries must be emitted.
+        """
+        r1 = _create_rule(test_session, name="NoJournalRB1", enabled=True)
+        r2 = _create_rule(test_session, name="NoJournalRB2", enabled=True)
+        missing_id = 999999
+
+        mock_journal = MagicMock()
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal", mock_journal):
+            response = await async_client.post(
+                "/api/auto-creation/rules/bulk-update",
+                json={
+                    "rule_ids": [r1.id, r2.id, missing_id],
+                    "enabled": False,
+                },
+            )
+
+        assert response.status_code == 404
+        # Zero log_entry calls on the rollback path.
+        assert mock_journal.log_entry.call_count == 0
 
 
 class TestDeleteAutoCreationRule:


### PR DESCRIPTION
## Summary

- Bulk-update of auto-creation rules now emits one journal entry per mutated rule (entity_id=rule.id, action_type=bulk_update), all sharing a single batch_id for grouping.
- Description captures the scalar diff (e.g. `enabled: False -> True, priority: 3 -> 5`); before_value and after_value JSON capture the same data structurally. Rules touched with no column change are skipped.
- Matches the established pattern at `backend/routers/channels.py:800` (bulk channel renumber).

## Context

Bead: `enhancedchannelmanager-91mcq`

Before this PR, `bulk_update_auto_creation_rules` wrote a single summary journal row with `entity_id=0`, `entity_name="bulk"`, and a first-five-names description. Forensics queries like "what did bulk-update do to rule 47 at 14:32?" returned nothing, because there was no row tied to rule 47.

The journal schema already supports this forensic pattern — `JournalEntry.batch_id` (`backend/models.py:31`) and `journal.log_entry(batch_id=...)` (`backend/journal.py:26`) are both in place. Channels already use them at `backend/routers/channels.py:800-870` for bulk number assignment. This PR wires auto-creation bulk-update into the same pattern.

### Implementation notes

- `_apply_rule_scalar_updates` now returns a diff dict `{field: {"before": old, "after": new}}` instead of `None`. Existing single-rule callers ignore the return value (backward compatible).
- Journal writes happen **after** `session.commit()`, so on the rollback path (missing id, validation fail) zero entries are emitted.
- The summary entry with `entity_id=0`/`entity_name="bulk"` is fully replaced — it served no separate purpose and actively obscured which rows changed.

## Test plan

- [x] `python -m pytest backend/tests/routers/test_auto_creation.py -v --no-header -p no:warnings --no-cov` — **13 passed** (10 existing + 3 new).
- [x] `python -m pytest backend/tests/routers/test_auto_creation.py backend/tests/routers/test_regex_lint_integration.py --no-header -p no:warnings --no-cov` — **70 passed**.
- [x] Full backend sweep: **2950 passed**, 9 pre-existing failures (all in alembic baseline / schema-version tests — verified pre-existing on dev tip `92f044ca`, unrelated to this change).

### New tests

1. `test_emits_per_entity_journal_entries_with_shared_batch_id` — 3 rules bulk-toggled; `journal.log_entry` called exactly 3 times with distinct `entity_id`s and a shared `batch_id`.
2. `test_journal_description_reflects_scalar_diff` — `enabled: False -> True, priority: 3 -> 5` appears in description and the before/after payloads carry the structured data.
3. `test_no_journal_entries_when_rollback` — bulk-update with a missing id returns 404 and emits zero journal rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)