### PR TITLE
fix(journal): batch_id + entity composite indexes + 90d retention (bd-dmu8w)

### DIFF
--- a/backend/alembic/versions/20260423_1100_0004_journal_batch_and_entity_indexes.py
+++ b/backend/alembic/versions/20260423_1100_0004_journal_batch_and_entity_indexes.py
@@ -1,0 +1,65 @@
+"""journal_batch_and_entity_indexes
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-04-23 11:00:00.000000
+
+Adds two indexes to ``journal_entries`` to back forensic queries that
+became hot paths after bd-91mcq landed per-entity journal rows for
+bulk auto-creation operations:
+
+* ``idx_journal_batch_id`` — single-column on ``batch_id``. Powers
+  "show me batch X" lookups. Without this index, the query full-scans
+  the table. Bulk auto-creation amplifies row growth N-fold per run,
+  so scan cost was growing with table size.
+* ``idx_journal_entity`` — composite on ``(category, entity_id,
+  timestamp DESC)``. Powers "history for this entity" lookups
+  (``WHERE category=? AND entity_id=? ORDER BY timestamp DESC``).
+  Leading columns are the equality filters; trailing ``timestamp DESC``
+  lets SQLite serve the order-by from the index without a separate
+  sort step.
+
+Both indexes are non-unique. Reversal drops both.
+
+DB-engineer note: SQLite ``CREATE INDEX`` is not concurrent (no
+``CONCURRENTLY`` clause exists in the SQLite dialect), and the
+journal_entries table is a write-light, append-mostly workload, so
+build cost is acceptable. Postgres would need ``CONCURRENTLY`` if
+this project ever ports off SQLite.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0004'
+down_revision: Union[str, Sequence[str], None] = '0003'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add idx_journal_batch_id and idx_journal_entity to journal_entries."""
+    with op.batch_alter_table('journal_entries', schema=None) as batch_op:
+        batch_op.create_index(
+            'idx_journal_batch_id',
+            ['batch_id'],
+            unique=False,
+        )
+        # The descending sort on ``timestamp`` is encoded via literal_column
+        # (matching the baseline's idx_journal_timestamp pattern) so SQLAlchemy
+        # emits ``CREATE INDEX ... (category, entity_id, timestamp DESC)``.
+        batch_op.create_index(
+            'idx_journal_entity',
+            ['category', 'entity_id', sa.literal_column('timestamp DESC')],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Drop both indexes added in ``upgrade()``."""
+    with op.batch_alter_table('journal_entries', schema=None) as batch_op:
+        batch_op.drop_index('idx_journal_entity')
+        batch_op.drop_index('idx_journal_batch_id')

--- a/backend/models.py
+++ b/backend/models.py
@@ -30,11 +30,26 @@ class JournalEntry(Base):
     user_initiated = Column(Boolean, default=True, nullable=False)  # Manual vs automatic
     batch_id = Column(String(50), nullable=True)  # Groups related changes
 
-    # Indexes for common queries
+    # Indexes for common queries.
+    #
+    # bd-dmu8w added the next two on top of the bd-91mcq per-entity audit work:
+    #
+    # * ``idx_journal_batch_id`` — single-column on ``batch_id``. Forensic
+    #   "show me everything in batch X" queries (auto-creation bulk runs)
+    #   used to full-scan; bulk operations now amplify row growth N-fold,
+    #   making the scan cost grow with table size.
+    # * ``idx_journal_entity`` — composite ``(category, entity_id, timestamp DESC)``
+    #   for the "history for this entity" access pattern (e.g.
+    #   ``WHERE category='channel' AND entity_id=42 ORDER BY timestamp DESC``).
+    #   Leading columns are the equality filters; the trailing
+    #   ``timestamp DESC`` lets SQLite serve newest-first ranges from the
+    #   index without an additional sort.
     __table_args__ = (
         Index("idx_journal_timestamp", timestamp.desc()),
         Index("idx_journal_category", category),
         Index("idx_journal_action_type", action_type),
+        Index("idx_journal_batch_id", batch_id),
+        Index("idx_journal_entity", category, entity_id, timestamp.desc()),
     )
 
     def to_dict(self) -> dict:

--- a/backend/tasks/cleanup.py
+++ b/backend/tasks/cleanup.py
@@ -27,8 +27,14 @@ class CleanupTask(TaskScheduler):
     Configuration options (stored in task config JSON):
     - probe_history_days: Keep probe history for this many days (default: 30)
     - task_history_days: Keep task execution history for this many days (default: 30)
-    - journal_days: Keep journal entries for this many days (default: 30)
+    - journal_days: Keep journal entries for this many days (default: 90)
     - vacuum_db: Run VACUUM after cleanup (default: True)
+
+    Retention rationale (bd-dmu8w): the journal default is 90 days because
+    bulk auto-creation now produces per-entity rows (bd-91mcq), amplifying
+    journal growth N-fold per run. 90 days is the documented hot-retention
+    window and matches ``journal.purge_old_entries``' own default. Operators
+    who need a longer audit trail should override this via the task config.
     """
 
     task_id = "cleanup"
@@ -47,7 +53,9 @@ class CleanupTask(TaskScheduler):
         # Task-specific config - retention periods in days
         self.probe_history_days: int = 30
         self.task_history_days: int = 30
-        self.journal_days: int = 30
+        # bd-dmu8w: 90 days hot retention for journal entries.
+        # See class docstring for rationale.
+        self.journal_days: int = 90
         self.vacuum_db: bool = True
 
     def get_config(self) -> dict:

--- a/backend/tests/unit/test_journal_indexes_and_retention.py
+++ b/backend/tests/unit/test_journal_indexes_and_retention.py
@@ -1,0 +1,421 @@
+"""Tests for journal_entries indexes and retention policy (bd-dmu8w).
+
+After bd-91mcq landed per-entity journal rows with a shared ``batch_id``
+for bulk auto-creation operations, two latent gaps surfaced:
+
+1. ``journal_entries.batch_id`` had no index → forensic
+   "show me batch X" queries full-scan.
+2. No composite ``(category, entity_id, timestamp DESC)`` index →
+   "history for rule N" queries full-scan.
+3. The ``CleanupTask`` default ``journal_days`` retention was 30, but
+   bulk operations now amplify row growth N-fold; the documented hot
+   retention is 90 days.
+
+This module covers all three gaps in one place so a future regression
+that drops an index or shortens the default retention without thought
+is caught immediately.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, text
+
+
+# ---------------------------------------------------------------------------
+# Index existence tests (model + migration must agree)
+# ---------------------------------------------------------------------------
+
+
+class TestJournalEntryIndexes:
+    """The JournalEntry SQLAlchemy model must declare the new indexes.
+
+    These tests inspect ``JournalEntry.__table__.indexes`` so the model
+    stays in sync with the Alembic migration. If autogenerate ever drops
+    one of these from the declarative side, this test fires before the
+    drift test does.
+    """
+
+    def test_batch_id_index_declared_on_model(self):
+        from models import JournalEntry
+
+        index_names = {idx.name for idx in JournalEntry.__table__.indexes}
+        assert "idx_journal_batch_id" in index_names, (
+            f"idx_journal_batch_id missing from JournalEntry model "
+            f"(found: {sorted(index_names)})"
+        )
+
+    def test_batch_id_index_is_single_column_on_batch_id(self):
+        from models import JournalEntry
+
+        idx = next(
+            (i for i in JournalEntry.__table__.indexes if i.name == "idx_journal_batch_id"),
+            None,
+        )
+        assert idx is not None
+        cols = [c.name for c in idx.columns]
+        assert cols == ["batch_id"], (
+            f"idx_journal_batch_id should index exactly ['batch_id'], got {cols}"
+        )
+
+    def test_entity_composite_index_declared_on_model(self):
+        from models import JournalEntry
+
+        index_names = {idx.name for idx in JournalEntry.__table__.indexes}
+        assert "idx_journal_entity" in index_names, (
+            f"idx_journal_entity missing from JournalEntry model "
+            f"(found: {sorted(index_names)})"
+        )
+
+    def test_entity_composite_index_columns(self):
+        """Composite must order ``category, entity_id, timestamp`` so that
+        the leading-column rule covers ``WHERE category=? AND entity_id=?
+        ORDER BY timestamp DESC`` queries — the "history for rule N" path."""
+        from models import JournalEntry
+
+        idx = next(
+            (i for i in JournalEntry.__table__.indexes if i.name == "idx_journal_entity"),
+            None,
+        )
+        assert idx is not None
+        cols = [c.name for c in idx.columns]
+        # SQLAlchemy reports the column expression's name; descending order
+        # is encoded on the expression, not the column name.
+        assert cols == ["category", "entity_id", "timestamp"], (
+            f"idx_journal_entity should index ['category', 'entity_id', 'timestamp'], got {cols}"
+        )
+
+
+class TestJournalEntryIndexesInDatabase:
+    """SQLite must actually carry the indexes after metadata.create_all."""
+
+    def test_batch_id_index_present_in_sqlite(self, test_engine):
+        with test_engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='index' AND tbl_name='journal_entries'"
+                )
+            ).fetchall()
+        names = {r[0] for r in rows}
+        assert "idx_journal_batch_id" in names, (
+            f"idx_journal_batch_id missing from sqlite_master indexes "
+            f"(found: {sorted(names)})"
+        )
+
+    def test_entity_composite_index_present_in_sqlite(self, test_engine):
+        with test_engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='index' AND tbl_name='journal_entries'"
+                )
+            ).fetchall()
+        names = {r[0] for r in rows}
+        assert "idx_journal_entity" in names, (
+            f"idx_journal_entity missing from sqlite_master indexes "
+            f"(found: {sorted(names)})"
+        )
+
+    def test_batch_id_query_uses_index(self, test_engine):
+        """EXPLAIN QUERY PLAN must report SEARCH using ``idx_journal_batch_id``
+        for a batch_id equality lookup. If SQLite picks SCAN, the index is
+        either missing or unusable for this access pattern."""
+        with test_engine.connect() as conn:
+            plan = conn.execute(
+                text(
+                    "EXPLAIN QUERY PLAN "
+                    "SELECT id FROM journal_entries WHERE batch_id = 'b1'"
+                )
+            ).fetchall()
+        plan_text = " | ".join(str(row) for row in plan)
+        assert "idx_journal_batch_id" in plan_text, (
+            f"Expected query plan to use idx_journal_batch_id, got: {plan_text}"
+        )
+
+    def test_entity_history_query_uses_composite_index(self, test_engine):
+        """EXPLAIN QUERY PLAN must report SEARCH using ``idx_journal_entity``
+        for the history-for-rule access pattern (``category = ? AND entity_id = ?``)."""
+        with test_engine.connect() as conn:
+            plan = conn.execute(
+                text(
+                    "EXPLAIN QUERY PLAN "
+                    "SELECT id FROM journal_entries "
+                    "WHERE category = 'channel' AND entity_id = 42 "
+                    "ORDER BY timestamp DESC"
+                )
+            ).fetchall()
+        plan_text = " | ".join(str(row) for row in plan)
+        assert "idx_journal_entity" in plan_text, (
+            f"Expected query plan to use idx_journal_entity, got: {plan_text}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Migration tests — the new revision must apply cleanly on a fresh DB and
+# on a DB pre-populated with journal rows from the baseline schema.
+# ---------------------------------------------------------------------------
+
+
+def _make_alembic_config(db_url: str):
+    import database
+    from alembic.config import Config
+
+    ini_path = Path(database.ALEMBIC_INI_PATH)
+    assert ini_path.exists(), f"alembic.ini missing at {ini_path}"
+    cfg = Config(str(ini_path))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    return cfg
+
+
+def _journal_index_names(engine) -> set[str]:
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND tbl_name='journal_entries'"
+            )
+        ).fetchall()
+    return {r[0] for r in rows}
+
+
+class TestJournalIndexMigration:
+    """Revision must add the two new indexes and round-trip cleanly."""
+
+    def test_upgrade_head_creates_both_indexes_on_fresh_db(self, tmp_path):
+        from alembic import command
+
+        db_file = tmp_path / "fresh.db"
+        db_url = f"sqlite:///{db_file}"
+        cfg = _make_alembic_config(db_url)
+
+        command.upgrade(cfg, "head")
+
+        engine = create_engine(db_url)
+        try:
+            names = _journal_index_names(engine)
+        finally:
+            engine.dispose()
+
+        assert "idx_journal_batch_id" in names, (
+            f"Expected idx_journal_batch_id after upgrade head; got {sorted(names)}"
+        )
+        assert "idx_journal_entity" in names, (
+            f"Expected idx_journal_entity after upgrade head; got {sorted(names)}"
+        )
+
+    def test_upgrade_preserves_existing_journal_rows(self, tmp_path):
+        """Pre-populate journal_entries before applying the new revision and
+        confirm row count + values survive the migration. Index creation
+        must not lose data."""
+        from alembic import command
+
+        db_file = tmp_path / "prepop.db"
+        db_url = f"sqlite:///{db_file}"
+        cfg = _make_alembic_config(db_url)
+
+        # First, upgrade to the revision *before* the new index migration.
+        # We use a constant marker so future migrations don't break this
+        # test — we always step to the prior head, insert rows, then
+        # complete the upgrade.
+        command.upgrade(cfg, "0003")
+
+        engine = create_engine(db_url)
+        try:
+            with engine.begin() as conn:
+                for i in range(50):
+                    conn.execute(
+                        text(
+                            "INSERT INTO journal_entries "
+                            "(timestamp, category, action_type, entity_id, "
+                            " entity_name, description, user_initiated, batch_id) "
+                            "VALUES (:ts, :cat, :act, :eid, :ename, :desc, :ui, :bid)"
+                        ),
+                        {
+                            "ts": datetime.utcnow().isoformat(),
+                            "cat": "channel",
+                            "act": "create",
+                            "eid": i,
+                            "ename": f"channel-{i}",
+                            "desc": f"created channel {i}",
+                            "ui": False,
+                            "bid": f"batch-{i // 10}",
+                        },
+                    )
+        finally:
+            engine.dispose()
+
+        # Now apply the new revision (and any newer ones).
+        command.upgrade(cfg, "head")
+
+        engine = create_engine(db_url)
+        try:
+            with engine.connect() as conn:
+                count = conn.execute(
+                    text("SELECT COUNT(*) FROM journal_entries")
+                ).scalar()
+            names = _journal_index_names(engine)
+        finally:
+            engine.dispose()
+
+        assert count == 50, f"Row count changed across migration: expected 50, got {count}"
+        assert "idx_journal_batch_id" in names
+        assert "idx_journal_entity" in names
+
+    def test_downgrade_drops_indexes(self, tmp_path):
+        """Round-trip safety: ``alembic downgrade -1`` must remove both
+        indexes so a re-upgrade is idempotent."""
+        from alembic import command
+
+        db_file = tmp_path / "rt.db"
+        db_url = f"sqlite:///{db_file}"
+        cfg = _make_alembic_config(db_url)
+
+        command.upgrade(cfg, "head")
+
+        engine = create_engine(db_url)
+        try:
+            after_up = _journal_index_names(engine)
+        finally:
+            engine.dispose()
+        assert "idx_journal_batch_id" in after_up
+        assert "idx_journal_entity" in after_up
+
+        command.downgrade(cfg, "-1")
+
+        engine = create_engine(db_url)
+        try:
+            after_down = _journal_index_names(engine)
+        finally:
+            engine.dispose()
+        assert "idx_journal_batch_id" not in after_down, (
+            f"downgrade left idx_journal_batch_id behind: {sorted(after_down)}"
+        )
+        assert "idx_journal_entity" not in after_down, (
+            f"downgrade left idx_journal_entity behind: {sorted(after_down)}"
+        )
+
+        # Re-upgrade must restore both.
+        command.upgrade(cfg, "head")
+        engine = create_engine(db_url)
+        try:
+            after_reup = _journal_index_names(engine)
+        finally:
+            engine.dispose()
+        assert "idx_journal_batch_id" in after_reup
+        assert "idx_journal_entity" in after_reup
+
+
+# ---------------------------------------------------------------------------
+# Retention policy tests — CleanupTask must default to 90-day journal
+# retention (per bd-dmu8w) and prune correctly.
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupTaskJournalRetentionDefault:
+    """The default journal retention must be 90 days (hot retention).
+
+    Bulk auto-creation can produce thousands of journal rows per run.
+    Keeping the documented 90-day window matches ``journal.purge_old_entries``
+    and prevents silent table bloat from a too-conservative default.
+    """
+
+    def test_default_journal_days_is_90(self):
+        from tasks.cleanup import CleanupTask
+
+        task = CleanupTask()
+        assert task.journal_days == 90, (
+            f"CleanupTask.journal_days default must be 90 days "
+            f"(got {task.journal_days}). bd-dmu8w aligns the cleanup task "
+            f"with journal.purge_old_entries default and the documented "
+            f"hot-retention window."
+        )
+
+    def test_get_config_reports_journal_days(self):
+        from tasks.cleanup import CleanupTask
+
+        cfg = CleanupTask().get_config()
+        assert cfg["journal_days"] == 90
+
+
+class TestCleanupTaskPrunesJournalEntries:
+    """End-to-end: running the cleanup task removes rows older than the
+    configured threshold and keeps fresher rows untouched."""
+
+    @pytest.mark.asyncio
+    async def test_prunes_only_rows_older_than_threshold(self, test_session, test_engine):
+        from tests.fixtures.factories import create_journal_entry
+        from models import JournalEntry
+
+        now = datetime.utcnow()
+        # Older than threshold (should be deleted)
+        create_journal_entry(test_session, timestamp=now - timedelta(days=100))
+        create_journal_entry(test_session, timestamp=now - timedelta(days=120))
+        # Within threshold (should be kept)
+        create_journal_entry(test_session, timestamp=now - timedelta(days=10))
+        create_journal_entry(test_session, timestamp=now - timedelta(days=89))
+        create_journal_entry(test_session, timestamp=now)
+
+        from tasks.cleanup import CleanupTask
+        task = CleanupTask()
+        # Force vacuum off — VACUUM cannot run inside the test transaction
+        # context and is irrelevant to the prune assertion.
+        task.vacuum_db = False
+
+        # Patch get_session inside the task module so the task uses the
+        # in-memory test DB.
+        with patch("tasks.cleanup.get_session", return_value=test_session):
+            result = await task.execute()
+
+        assert result.success, f"Cleanup task should succeed: {result.message}"
+
+        # Re-query through the same session: only the 3 in-window rows remain.
+        remaining = test_session.query(JournalEntry).all()
+        remaining_ages_days = sorted(
+            int((now - r.timestamp).total_seconds() // 86400) for r in remaining
+        )
+        assert len(remaining) == 3, (
+            f"Expected 3 rows within 90-day window after prune, got "
+            f"{len(remaining)} (ages: {remaining_ages_days})"
+        )
+        for age in remaining_ages_days:
+            assert age <= 89, (
+                f"Row with age {age}d survived prune but should have been "
+                f"deleted (threshold = 90d)"
+            )
+
+    @pytest.mark.asyncio
+    async def test_keeps_rows_when_journal_is_empty(self, test_session, test_engine):
+        from tasks.cleanup import CleanupTask
+        task = CleanupTask()
+        task.vacuum_db = False
+
+        with patch("tasks.cleanup.get_session", return_value=test_session):
+            result = await task.execute()
+
+        assert result.success
+        # No rows existed; deleted count should be 0.
+        deleted = result.details.get("deleted", {})
+        assert deleted.get("journal_entries", 0) == 0
+
+
+class TestCleanupTaskRegistration:
+    """The cleanup task must be discoverable via the task registry so the
+    scheduler actually runs it. Regressions here would silently disable
+    journal pruning."""
+
+    def test_cleanup_task_is_registered(self):
+        # Importing the package triggers @register_task side effects.
+        import tasks  # noqa: F401
+        from task_registry import get_registry
+
+        registry = get_registry()
+        cleanup = registry.get_task_class("cleanup")
+        assert cleanup is not None, (
+            "CleanupTask must be registered under task_id='cleanup' so the "
+            "scheduler can run journal retention. Check tasks/__init__.py "
+            "imports cleanup and the @register_task decorator is intact."
+        )


### PR DESCRIPTION
## Summary

- bd-91mcq shipped per-entity journal entries with shared `batch_id` for bulk auto-creation operations, but `journal_entries` had no index on `batch_id` and no composite for entity-history queries — both forensic queries would full-scan as journal volume grew (DBA flagged at standup 2026-04-23).
- Adds two indexes via Alembic migration `0004_journal_batch_and_entity_indexes` (SQLite via `op.batch_alter_table` matching baseline pattern; `timestamp DESC` encoded with `sa.literal_column`):
  - `idx_journal_batch_id` on `(batch_id)`
  - `idx_journal_entity` on `(category, entity_id, timestamp DESC)` — note: bd description used generic "entity_type"; actual JournalEntry column is `category` (channel/epg/m3u). Composite verified against `journal.py` and `auto_creation_executor.py` call sites.
- Raises `CleanupTask.journal_days` default from 30 → 90, aligning with `journal.purge_old_entries`'s existing 90-day default. CleanupTask was already wired into the scheduler — no integration changes needed.
- Mirrors indexes in the SQLAlchemy model (`backend/models.py` JournalEntry `__table_args__`) so model + migration stay in sync; drift test confirms.

## Test plan

- [x] 16 new unit tests in `backend/tests/unit/test_journal_indexes_and_retention.py` covering: model `__table_args__` declarations, `sqlite_master` index presence after `metadata.create_all`, `EXPLAIN QUERY PLAN` confirming SQLite uses indexes for batch-id + entity-history queries, fresh-DB Alembic upgrade, pre-populated 50-row migration, downgrade/upgrade round-trip, retention default + prune behavior + empty-journal handling, task-registry discoverability
- [x] Existing alembic baseline + journal tests: 36 passed (drift test confirms model + migration agree)
- [x] Full backend suite: 2922 passed, 1 skipped in 52s
- [x] Direct CLI: `alembic upgrade head` → `downgrade -1` → `upgrade head` round-trip clean against fresh SQLite DB; `sqlite_master` confirms both indexes with expected DDL
- [ ] Container smoke after merge

## Backlog flagged during this work
- bd-mzm3j: `hypothesis` not installed → `test_auto_creation_safe_regex_migration.py` and `test_normalization_safe_regex_migration.py` fail collection (pre-existing on dev)
- bd-s8kq3: CI gap — alembic-dependent tests silently skip if `requirements.txt` not installed pre-test (surfaced because uv refused to install alembic without a venv during this work)