### PR TITLE
fix(auto-creation): /run → 202+poll background pattern + restore 30s timeout (bd-enfsy)

### DIFF
--- a/backend/auto_creation_engine.py
+++ b/backend/auto_creation_engine.py
@@ -80,7 +80,8 @@ class AutoCreationEngine:
         dry_run: bool = False,
         triggered_by: str = "manual",
         m3u_account_ids: list[int] = None,
-        rule_ids: list[int] = None
+        rule_ids: list[int] = None,
+        execution_id: int | None = None,
     ) -> dict:
         """
         Run the full auto-creation pipeline.
@@ -90,12 +91,19 @@ class AutoCreationEngine:
             triggered_by: How the pipeline was triggered (manual, scheduled, m3u_refresh)
             m3u_account_ids: Optional list of M3U account IDs to process (None = all)
             rule_ids: Optional list of rule IDs to run (None = all enabled)
+            execution_id: Optional pre-created execution record id. When the
+                router enqueues a background task (bd-enfsy 202+poll pattern)
+                it creates an AutoCreationExecution(status="running") up front
+                so it can return the id to the caller immediately. Passing the
+                id here lets the engine reuse that record instead of creating a
+                second one — the row stays in "running" while work proceeds and
+                is finalized to "completed" / "failed" by this method.
 
         Returns:
             Dict with execution summary and results
         """
         started_at = datetime.utcnow()
-        logger.info("[AUTO-CREATE-ENGINE] Starting auto-creation pipeline (dry_run=%s, triggered_by=%s)", dry_run, triggered_by)
+        logger.info("[AUTO-CREATE-ENGINE] Starting auto-creation pipeline (dry_run=%s, triggered_by=%s, execution_id=%s)", dry_run, triggered_by, execution_id)
 
         # Load existing channels and groups
         await self._load_existing_data()
@@ -104,6 +112,11 @@ class AutoCreationEngine:
         rules = await self._load_rules(rule_ids)
         if not rules:
             logger.info("[AUTO-CREATE-ENGINE] No enabled rules found")
+            # If a pre-created execution exists, mark it completed so it does
+            # not stay in "running" forever (otherwise the frontend poll would
+            # spin indefinitely on a no-op run).
+            if execution_id is not None:
+                await self._finalize_no_op_execution(execution_id)
             return {
                 "success": True,
                 "message": "No enabled rules to process",
@@ -134,11 +147,29 @@ class AutoCreationEngine:
         # Apply global exclusion filters
         streams, exclusion_log = await self._apply_global_filters(streams)
 
-        # Create execution record
-        execution = await self._create_execution(
-            mode="dry_run" if dry_run else "execute",
-            triggered_by=triggered_by
-        )
+        # Reuse pre-created execution record (bd-enfsy 202+poll path) when
+        # the router has supplied an id; otherwise create one ourselves
+        # (synchronous /tasks/scheduled path remains unchanged).
+        if execution_id is not None:
+            execution = await self._load_execution(execution_id)
+            if execution is None:
+                # The pre-created row was deleted between enqueue and run —
+                # fall back to creating a fresh one so the run still records
+                # something sensible.
+                logger.warning(
+                    "[AUTO-CREATE-ENGINE] execution_id=%s not found at run time; "
+                    "creating a new execution record",
+                    execution_id,
+                )
+                execution = await self._create_execution(
+                    mode="dry_run" if dry_run else "execute",
+                    triggered_by=triggered_by,
+                )
+        else:
+            execution = await self._create_execution(
+                mode="dry_run" if dry_run else "execute",
+                triggered_by=triggered_by
+            )
 
         # Process streams through rules
         results = await self._process_streams(streams, rules, execution, dry_run)
@@ -199,7 +230,8 @@ class AutoCreationEngine:
         self,
         rule_id: int,
         dry_run: bool = False,
-        triggered_by: str = "manual"
+        triggered_by: str = "manual",
+        execution_id: int | None = None,
     ) -> dict:
         """
         Run a specific rule.
@@ -208,6 +240,9 @@ class AutoCreationEngine:
             rule_id: ID of the rule to run
             dry_run: If True, only simulate changes
             triggered_by: How the rule was triggered
+            execution_id: Optional pre-created execution record id, threaded
+                through to ``run_pipeline`` (see its docstring for the
+                bd-enfsy 202+poll background-task pattern).
 
         Returns:
             Dict with execution summary
@@ -215,7 +250,8 @@ class AutoCreationEngine:
         return await self.run_pipeline(
             dry_run=dry_run,
             triggered_by=triggered_by,
-            rule_ids=[rule_id]
+            rule_ids=[rule_id],
+            execution_id=execution_id,
         )
 
     async def rollback_execution(self, execution_id: int, rolled_back_by: str = "manual") -> dict:
@@ -2171,6 +2207,41 @@ class AutoCreationEngine:
             session.commit()
             session.refresh(execution)
             return execution
+        finally:
+            session.close()
+
+    async def _load_execution(self, execution_id: int) -> AutoCreationExecution | None:
+        """Load an existing execution record by id (bd-enfsy: reuses the row
+        the router pre-created when enqueuing background work)."""
+        session = get_session()
+        try:
+            execution = session.query(AutoCreationExecution).filter(
+                AutoCreationExecution.id == execution_id
+            ).first()
+            if execution is not None:
+                # Detach so it can be mutated outside this session and saved
+                # via _save_execution(merge) like a freshly-created one.
+                session.expunge(execution)
+            return execution
+        finally:
+            session.close()
+
+    async def _finalize_no_op_execution(self, execution_id: int) -> None:
+        """Mark a pre-created execution as completed when there's no work to do
+        (e.g. no enabled rules). Without this the row would remain in
+        ``status="running"`` forever and the frontend poller would spin."""
+        session = get_session()
+        try:
+            execution = session.query(AutoCreationExecution).filter(
+                AutoCreationExecution.id == execution_id
+            ).first()
+            if execution is None:
+                return
+            now = datetime.utcnow()
+            execution.completed_at = now
+            execution.duration_seconds = (now - execution.started_at).total_seconds() if execution.started_at else 0.0
+            execution.status = "completed"
+            session.commit()
         finally:
             session.close()
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -348,7 +348,12 @@ _TIMEOUT_EXEMPT_PREFIXES = (
     "/api/ffmpeg/",            # long-running ffmpeg jobs
     "/api/tasks/",             # task triggering / status
     "/api/backup/",            # backup/restore can be large
-    "/api/auto-creation/",     # pipeline runs can exceed 30s on large catalogs
+    # Note: /api/auto-creation/ was previously exempt as a hotfix (bd-zv6pi)
+    # for synchronous /run handlers that could exceed the 30s budget. As of
+    # bd-enfsy those handlers are now 202+poll background tasks (the
+    # supervisor lives in routers/auto_creation.py), so the prefix is back
+    # under the timeout — every CRUD and the now-fast enqueue must respect
+    # the budget.
 )
 
 

--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -3,6 +3,7 @@ Auto-creation router — auto-creation pipeline CRUD, execution, import/export, 
 
 Extracted from main.py (Phase 3 of v0.13.0 backend refactor).
 """
+import asyncio
 import io
 import json
 import logging
@@ -14,7 +15,7 @@ from typing import List, Optional
 
 import journal
 from fastapi import APIRouter, Body, HTTPException
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 from pydantic import BaseModel, Field, model_validator
 from starlette.responses import StreamingResponse
 
@@ -27,6 +28,12 @@ from regex_lint import (
     lint_pattern,
     violations_to_http_detail,
 )
+
+# Strong references to in-flight background pipeline tasks (bd-enfsy). Without
+# this set, asyncio only weakly references created tasks and the GC could
+# cancel them mid-run — fire-and-forget without supervision is a known
+# footgun. Tasks remove themselves on completion via the done callback below.
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
 
 logger = logging.getLogger(__name__)
 
@@ -740,54 +747,209 @@ async def duplicate_auto_creation_rule(rule_id: int):
 # =============================================================================
 
 
-@router.post("/run")
+async def _ensure_engine():
+    """Get the auto-creation engine, initializing it if necessary."""
+    from auto_creation_engine import get_auto_creation_engine, init_auto_creation_engine
+
+    engine = get_auto_creation_engine()
+    if not engine:
+        client = get_client()
+        engine = await init_auto_creation_engine(client)
+    return engine
+
+
+def _create_pending_execution(
+    *,
+    mode: str,
+    triggered_by: str,
+    rule_id: int | None = None,
+    rule_name: str | None = None,
+) -> int:
+    """Create a status='running' execution row up front (bd-enfsy 202+poll).
+
+    Returns the new execution id so the caller can return it in the 202
+    response and the background task can finalize the same row when work
+    completes.
+    """
+    from models import AutoCreationExecution
+
+    session = get_session()
+    try:
+        execution = AutoCreationExecution(
+            mode=mode,
+            triggered_by=triggered_by,
+            started_at=datetime.utcnow(),
+            status="running",
+            rule_id=rule_id,
+            rule_name=rule_name,
+        )
+        session.add(execution)
+        session.commit()
+        session.refresh(execution)
+        return execution.id
+    finally:
+        session.close()
+
+
+def _mark_execution_failed(execution_id: int, error: BaseException) -> None:
+    """Mark a pre-created execution as failed and capture the error message."""
+    from models import AutoCreationExecution
+
+    session = get_session()
+    try:
+        execution = session.query(AutoCreationExecution).filter(
+            AutoCreationExecution.id == execution_id
+        ).first()
+        if execution is None:
+            logger.warning(
+                "[AUTO-CREATE] Cannot mark execution %s failed — row was deleted",
+                execution_id,
+            )
+            return
+        # Only finalize if still running (don't clobber a completed/rolled_back row)
+        if execution.status == "running":
+            now = datetime.utcnow()
+            execution.completed_at = now
+            execution.duration_seconds = (
+                (now - execution.started_at).total_seconds()
+                if execution.started_at else 0.0
+            )
+            execution.status = "failed"
+            execution.error_message = f"{type(error).__name__}: {error}"
+            session.commit()
+    finally:
+        session.close()
+
+
+def _supervise_background_pipeline(coro, *, execution_id: int, label: str) -> asyncio.Task:
+    """Schedule a coroutine as a supervised background task.
+
+    Wraps the coroutine in a try/except so any failure is captured to the
+    pre-created execution row (status='failed' + error_message) — no silent
+    fire-and-forget. Holds a strong reference to the task so the GC cannot
+    cancel it mid-run.
+    """
+    async def _runner():
+        try:
+            await coro
+            logger.info("[AUTO-CREATE] Background %s execution=%s completed", label, execution_id)
+        except asyncio.CancelledError:
+            logger.warning("[AUTO-CREATE] Background %s execution=%s cancelled", label, execution_id)
+            _mark_execution_failed(execution_id, RuntimeError("Background task cancelled"))
+            raise
+        except Exception as e:  # noqa: BLE001 — supervisor must catch broadly
+            logger.exception(
+                "[AUTO-CREATE] Background %s execution=%s failed: %s",
+                label, execution_id, e,
+            )
+            _mark_execution_failed(execution_id, e)
+
+    task = asyncio.create_task(_runner(), name=f"auto-creation-{label}-exec-{execution_id}")
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+    return task
+
+
+@router.post("/run", status_code=202)
 async def run_auto_creation_pipeline(request: RunPipelineRequest):
-    """Run the auto-creation pipeline."""
+    """Enqueue an auto-creation pipeline run and return immediately (bd-enfsy).
+
+    Pipeline runs on large catalogs can take minutes — running them inside the
+    request coroutine pinned an HTTP worker for the duration and forced us to
+    exempt this prefix from the 30s request-timeout middleware (bd-zv6pi). We
+    now pre-create the execution row, return its id, and run the pipeline in
+    a supervised background task. Clients poll
+    ``GET /api/auto-creation/executions/{id}`` until ``status`` is terminal
+    (``completed`` / ``failed`` / ``rolled_back``).
+    """
     logger.debug("[AUTO-CREATE] POST /run - dry_run=%s", request.dry_run)
     try:
-        from auto_creation_engine import get_auto_creation_engine, init_auto_creation_engine
-
-        # Get or initialize engine
-        engine = get_auto_creation_engine()
-        if not engine:
-            client = get_client()
-            engine = await init_auto_creation_engine(client)
-
-        result = await engine.run_pipeline(
-            dry_run=request.dry_run,
+        engine = await _ensure_engine()
+        execution_id = _create_pending_execution(
+            mode="dry_run" if request.dry_run else "execute",
             triggered_by="api",
-            m3u_account_ids=request.m3u_account_ids,
-            rule_ids=request.rule_ids
         )
-
-        return result
+        _supervise_background_pipeline(
+            engine.run_pipeline(
+                dry_run=request.dry_run,
+                triggered_by="api",
+                m3u_account_ids=request.m3u_account_ids,
+                rule_ids=request.rule_ids,
+                execution_id=execution_id,
+            ),
+            execution_id=execution_id,
+            label="run_pipeline",
+        )
+        return JSONResponse(
+            status_code=202,
+            content={
+                "execution_id": execution_id,
+                "status": "running",
+                "message": "Pipeline started; poll /api/auto-creation/executions/{id} for status",
+            },
+        )
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.exception("[AUTO-CREATE] Failed to run auto-creation pipeline: %s", e)
+        logger.exception("[AUTO-CREATE] Failed to enqueue auto-creation pipeline: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/rules/{rule_id}/run")
+@router.post("/rules/{rule_id}/run", status_code=202)
 async def run_auto_creation_rule(rule_id: int, dry_run: bool = False):
-    """Run a specific auto-creation rule."""
+    """Enqueue a single-rule auto-creation run and return immediately (bd-enfsy).
+
+    See ``run_auto_creation_pipeline`` for the 202 + poll contract.
+    """
     logger.debug("[AUTO-CREATE] POST /rules/%s/run - dry_run=%s", rule_id, dry_run)
     try:
-        from auto_creation_engine import get_auto_creation_engine, init_auto_creation_engine
+        engine = await _ensure_engine()
+        # Verify the rule exists before enqueuing — otherwise the pre-created
+        # execution row violates the rule_id FK constraint and the caller would
+        # see a 500 instead of a clean 404. Capture the name so the execution
+        # row keeps it for display even if the rule is later deleted (matches
+        # the engine's pre-existing behavior).
+        from models import AutoCreationRule
+        session = get_session()
+        try:
+            rule = session.query(AutoCreationRule).filter(
+                AutoCreationRule.id == rule_id
+            ).first()
+            if rule is None:
+                raise HTTPException(status_code=404, detail="Rule not found")
+            rule_name = rule.name
+        finally:
+            session.close()
 
-        # Get or initialize engine
-        engine = get_auto_creation_engine()
-        if not engine:
-            client = get_client()
-            engine = await init_auto_creation_engine(client)
-
-        result = await engine.run_rule(
+        execution_id = _create_pending_execution(
+            mode="dry_run" if dry_run else "execute",
+            triggered_by="api",
             rule_id=rule_id,
-            dry_run=dry_run,
-            triggered_by="api"
+            rule_name=rule_name,
         )
-
-        return result
+        _supervise_background_pipeline(
+            engine.run_rule(
+                rule_id=rule_id,
+                dry_run=dry_run,
+                triggered_by="api",
+                execution_id=execution_id,
+            ),
+            execution_id=execution_id,
+            label="run_rule",
+        )
+        return JSONResponse(
+            status_code=202,
+            content={
+                "execution_id": execution_id,
+                "status": "running",
+                "rule_id": rule_id,
+                "message": "Rule run started; poll /api/auto-creation/executions/{id} for status",
+            },
+        )
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.exception("[AUTO-CREATE] Failed to run auto-creation rule %s: %s", rule_id, e)
+        logger.exception("[AUTO-CREATE] Failed to enqueue auto-creation rule %s: %s", rule_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/backend/tests/integration/test_event_loop_responsiveness.py
+++ b/backend/tests/integration/test_event_loop_responsiveness.py
@@ -199,3 +199,41 @@ class TestRequestTimeoutMiddleware:
                 r for r in app.routes
                 if getattr(r, "path", None) != "/api/_test_stall_for_timeout"
             ]
+
+    def test_auto_creation_no_longer_exempt(self):
+        """bd-enfsy: now that /run uses background-task pattern, /api/auto-creation/
+        must NOT be in the exempt prefix list — defense-in-depth restored."""
+        import main as main_module
+
+        assert "/api/auto-creation/" not in main_module._TIMEOUT_EXEMPT_PREFIXES, (
+            "bd-enfsy: /api/auto-creation/ should be removed from "
+            "_TIMEOUT_EXEMPT_PREFIXES once /run is converted to 202 + poll. "
+            "If you re-added it, you've broken the operational defense-in-depth."
+        )
+
+    @pytest.mark.asyncio
+    async def test_auto_creation_crud_subject_to_timeout(self, async_client, test_session, monkeypatch):
+        """bd-enfsy: A pathologically slow auto-creation CRUD handler must now
+        be cut off by the timeout middleware (was previously bypassed)."""
+        import main as main_module
+
+        monkeypatch.setattr(main_module, "_REQUEST_TIMEOUT_SECONDS", 0.2)
+
+        from main import app
+
+        @app.get("/api/auto-creation/_test_stall_enfsy", include_in_schema=False)
+        async def _stall_route():
+            await asyncio.sleep(1.0)
+            return {"unreachable": True}
+
+        try:
+            response = await async_client.get("/api/auto-creation/_test_stall_enfsy")
+            assert response.status_code == 504, (
+                "Auto-creation endpoint should now be subject to the request "
+                "timeout middleware (bd-enfsy removed the exempt prefix)."
+            )
+        finally:
+            app.routes[:] = [
+                r for r in app.routes
+                if getattr(r, "path", None) != "/api/auto-creation/_test_stall_enfsy"
+            ]

--- a/backend/tests/routers/test_auto_creation.py
+++ b/backend/tests/routers/test_auto_creation.py
@@ -637,62 +637,193 @@ class TestDuplicateAutoCreationRule:
 
 
 class TestRunAutoCreationPipeline:
-    """Tests for POST /api/auto-creation/run."""
+    """Tests for POST /api/auto-creation/run (background-task pattern, bd-enfsy)."""
 
     @pytest.mark.asyncio
-    async def test_runs_pipeline(self, async_client):
-        """Runs the auto-creation pipeline."""
+    async def test_returns_202_with_execution_id(self, async_client, test_session):
+        """POST /run enqueues work and returns 202 + execution_id immediately."""
+        # Use an Event so the background task blocks until the assertion runs,
+        # so we can observe the "running" status before the engine completes.
+        import asyncio as _asyncio
+        gate = _asyncio.Event()
+
+        async def slow_run_pipeline(*args, **kwargs):
+            await gate.wait()
+            return {"success": True, "execution_id": kwargs.get("execution_id")}
+
         mock_engine = AsyncMock()
-        mock_engine.run_pipeline.return_value = {
-            "status": "completed",
-            "streams_matched": 10,
-            "channels_created": 5,
-        }
+        mock_engine.run_pipeline = AsyncMock(side_effect=slow_run_pipeline)
 
         with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine):
-            response = await async_client.post("/api/auto-creation/run", json={
-                "dry_run": False,
-            })
+            response = await async_client.post("/api/auto-creation/run", json={"dry_run": False})
 
-        assert response.status_code == 200
-        assert response.json()["channels_created"] == 5
-        mock_engine.run_pipeline.assert_called_once_with(
-            dry_run=False, triggered_by="api", m3u_account_ids=None, rule_ids=None,
-        )
+        assert response.status_code == 202, response.text
+        body = response.json()
+        assert "execution_id" in body
+        assert body["status"] == "running"
+        execution_id = body["execution_id"]
+
+        # Execution row should already exist with status="running"
+        from models import AutoCreationExecution
+        exe = test_session.query(AutoCreationExecution).filter_by(id=execution_id).first()
+        assert exe is not None
+        assert exe.status == "running"
+        assert exe.mode == "execute"
+        assert exe.triggered_by == "api"
+
+        # Release the background task
+        gate.set()
+        # Yield so the background task can complete (drain it)
+        for _ in range(20):
+            await _asyncio.sleep(0)
+        # Engine call must have been issued with execution_id binding
+        mock_engine.run_pipeline.assert_called()
+        call_kwargs = mock_engine.run_pipeline.call_args.kwargs
+        assert call_kwargs["dry_run"] is False
+        assert call_kwargs["triggered_by"] == "api"
+        assert call_kwargs["execution_id"] == execution_id
 
     @pytest.mark.asyncio
-    async def test_dry_run(self, async_client):
-        """Runs pipeline in dry-run mode."""
+    async def test_dry_run_creates_dry_run_execution(self, async_client, test_session):
+        """dry_run=True must create execution with mode='dry_run'."""
         mock_engine = AsyncMock()
-        mock_engine.run_pipeline.return_value = {"status": "dry_run"}
+        mock_engine.run_pipeline = AsyncMock(return_value={"success": True})
 
         with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine):
-            response = await async_client.post("/api/auto-creation/run", json={
-                "dry_run": True,
-            })
+            response = await async_client.post("/api/auto-creation/run", json={"dry_run": True})
 
-        assert response.status_code == 200
-        mock_engine.run_pipeline.assert_called_once_with(
-            dry_run=True, triggered_by="api", m3u_account_ids=None, rule_ids=None,
-        )
+        assert response.status_code == 202
+        execution_id = response.json()["execution_id"]
+        from models import AutoCreationExecution
+        exe = test_session.query(AutoCreationExecution).filter_by(id=execution_id).first()
+        assert exe is not None
+        assert exe.mode == "dry_run"
+
+    @pytest.mark.asyncio
+    async def test_background_task_failure_marks_execution_failed(self, async_client, test_session):
+        """If the engine raises, the background supervisor marks the execution failed."""
+        import asyncio as _asyncio
+
+        async def boom(*args, **kwargs):
+            raise RuntimeError("engine exploded")
+
+        mock_engine = AsyncMock()
+        mock_engine.run_pipeline = AsyncMock(side_effect=boom)
+
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine):
+            response = await async_client.post("/api/auto-creation/run", json={"dry_run": False})
+
+        assert response.status_code == 202
+        execution_id = response.json()["execution_id"]
+
+        # Yield to let the background task run
+        for _ in range(50):
+            await _asyncio.sleep(0)
+
+        from models import AutoCreationExecution
+        # Use a fresh query to pick up the supervised handler's commit
+        test_session.expire_all()
+        exe = test_session.query(AutoCreationExecution).filter_by(id=execution_id).first()
+        assert exe is not None
+        assert exe.status == "failed"
+        assert exe.error_message and "engine exploded" in exe.error_message
+
+    @pytest.mark.asyncio
+    async def test_enqueue_completes_within_timeout_budget(self, async_client, test_session):
+        """The handler itself must return fast (well under the 30s timeout) — the
+        whole point of bd-enfsy is to make /run not synchronous."""
+        import asyncio as _asyncio
+        import time as _time
+        gate = _asyncio.Event()
+
+        async def slow(*args, **kwargs):
+            await gate.wait()
+            return {"success": True}
+
+        mock_engine = AsyncMock()
+        mock_engine.run_pipeline = AsyncMock(side_effect=slow)
+
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine):
+            start = _time.monotonic()
+            response = await async_client.post("/api/auto-creation/run", json={"dry_run": False})
+            elapsed = _time.monotonic() - start
+
+        # Must enqueue and return well under 30s — even with a worker stuck in the engine
+        assert response.status_code == 202
+        assert elapsed < 5.0, f"enqueue took {elapsed:.2f}s — handler is not actually async-enqueuing"
+
+        gate.set()
+        for _ in range(20):
+            await _asyncio.sleep(0)
 
 
 class TestRunAutoCreationRule:
-    """Tests for POST /api/auto-creation/rules/{rule_id}/run."""
+    """Tests for POST /api/auto-creation/rules/{rule_id}/run (background-task pattern)."""
 
     @pytest.mark.asyncio
-    async def test_runs_single_rule(self, async_client):
-        """Runs a specific auto-creation rule."""
+    async def test_returns_202_and_invokes_run_rule_with_execution_id(self, async_client, test_session):
+        """POST /rules/{id}/run returns 202 + execution_id, runs in background."""
+        import asyncio as _asyncio
+        rule = _create_rule(test_session, name="Sports")
         mock_engine = AsyncMock()
-        mock_engine.run_rule.return_value = {"status": "completed"}
+        mock_engine.run_rule = AsyncMock(return_value={"success": True})
 
         with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine):
-            response = await async_client.post("/api/auto-creation/rules/42/run")
+            response = await async_client.post(f"/api/auto-creation/rules/{rule.id}/run")
 
-        assert response.status_code == 200
-        mock_engine.run_rule.assert_called_once_with(
-            rule_id=42, dry_run=False, triggered_by="api",
-        )
+        assert response.status_code == 202, response.text
+        body = response.json()
+        assert "execution_id" in body
+        assert body["status"] == "running"
+        assert body["rule_id"] == rule.id
+        execution_id = body["execution_id"]
+
+        # Yield to let background task run
+        for _ in range(20):
+            await _asyncio.sleep(0)
+
+        mock_engine.run_rule.assert_called()
+        call_kwargs = mock_engine.run_rule.call_args.kwargs
+        assert call_kwargs["rule_id"] == rule.id
+        assert call_kwargs["dry_run"] is False
+        assert call_kwargs["triggered_by"] == "api"
+        assert call_kwargs["execution_id"] == execution_id
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_unknown_rule(self, async_client):
+        """Pre-validation rejects unknown rule_id with a clean 404 (so the
+        FK-constrained execution row is never even attempted)."""
+        response = await async_client.post("/api/auto-creation/rules/99999/run")
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_rule_run_failure_marks_execution_failed(self, async_client, test_session):
+        """Background failure on per-rule run is captured to the execution record."""
+        import asyncio as _asyncio
+        rule = _create_rule(test_session, name="BoomRule")
+
+        async def boom(*args, **kwargs):
+            raise ValueError("rule borked")
+
+        mock_engine = AsyncMock()
+        mock_engine.run_rule = AsyncMock(side_effect=boom)
+
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine):
+            response = await async_client.post(f"/api/auto-creation/rules/{rule.id}/run")
+
+        assert response.status_code == 202
+        execution_id = response.json()["execution_id"]
+
+        for _ in range(50):
+            await _asyncio.sleep(0)
+
+        from models import AutoCreationExecution
+        test_session.expire_all()
+        exe = test_session.query(AutoCreationExecution).filter_by(id=execution_id).first()
+        assert exe is not None
+        assert exe.status == "failed"
+        assert exe.error_message and "rule borked" in exe.error_message
+        assert exe.rule_id == rule.id
 
 
 class TestGetExecutions:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "enhanced-channel-manager",
-  "version": "0.16.0-0051",
+  "version": "0.16.0-0052",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "enhanced-channel-manager",
-      "version": "0.16.0-0051",
+      "version": "0.16.0-0052",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/sortable": "8.0.0",

--- a/frontend/src/components/autoCreation/AutoCreationTab.tsx
+++ b/frontend/src/components/autoCreation/AutoCreationTab.tsx
@@ -357,25 +357,39 @@ export function AutoCreationTab() {
 
   const handleRun = useCallback(async (dryRun: boolean = false, ruleIds?: number[]) => {
     try {
+      // bd-enfsy: runPipelineApi now polls the backend until the execution
+      // reaches a terminal status, then resolves with the AutoCreationExecution
+      // row. Orphan-reconciliation counters (channels_removed / channels_moved)
+      // are derived from results during the run but not persisted on the row,
+      // so the success message only quotes the persisted channels_created
+      // figure now. Detail-level orphan counts are still visible via the
+      // Execution History pane (which fetches the full execution).
       const response = await runPipelineApi({ dryRun, ruleIds });
 
       if (response) {
         const created = response.channels_created ?? 0;
-        const removed = response.channels_removed ?? 0;
-        const moved = response.channels_moved ?? 0;
-        const orphanParts: string[] = [];
-        if (removed > 0) orphanParts.push(`removed ${removed} orphan${removed !== 1 ? 's' : ''}`);
-        if (moved > 0) orphanParts.push(`moved ${moved} orphan${moved !== 1 ? 's' : ''}`);
-        const orphanSuffix = orphanParts.length > 0 ? `, ${orphanParts.join(', ')}` : '';
-        const msg = dryRun
-          ? `Dry run complete - Would create ${created} channel${created !== 1 ? 's' : ''}${orphanSuffix ? `, would remove ${removed} orphan${removed !== 1 ? 's' : ''}` : ''}`
-          : `Execution complete - Created ${created} channel${created !== 1 ? 's' : ''}${orphanSuffix}`;
-        notifications.success(msg, 'Auto-Creation');
-        // Refresh executions list and rule stats (match counts)
+        const status = response.status;
+        const succeeded = status === 'completed';
+        const msg = succeeded
+          ? (dryRun
+            ? `Dry run complete - Would create ${created} channel${created !== 1 ? 's' : ''}`
+            : `Execution complete - Created ${created} channel${created !== 1 ? 's' : ''}`)
+          : `Pipeline ${status}`;
+        if (succeeded) {
+          notifications.success(msg, 'Auto-Creation');
+        } else {
+          notifications.error(
+            response.error_message || msg,
+            'Auto-Creation',
+          );
+        }
+        // Refresh executions list and rule stats (match counts). The hook
+        // already refetches executions in its finally block, but rule stats
+        // (last_run_at / match_count) live on a separate endpoint.
         await fetchExecutions();
         await fetchRules();
         // Notify other panes to refresh (channels/groups may have changed)
-        if (!dryRun) {
+        if (!dryRun && succeeded) {
           window.dispatchEvent(new CustomEvent('channels-changed'));
         }
       }

--- a/frontend/src/hooks/useAutoCreationExecution.test.ts
+++ b/frontend/src/hooks/useAutoCreationExecution.test.ts
@@ -158,7 +158,10 @@ describe('useAutoCreationExecution', () => {
   });
 
   describe('runPipeline', () => {
-    it('runs the pipeline in execute mode', async () => {
+    // bd-enfsy: contract is now POST returns 202 + execution_id and the hook
+    // polls GET /executions/{id} until terminal. The hook resolves with the
+    // terminal AutoCreationExecution row (or undefined on error/timeout).
+    it('runs the pipeline in execute mode and resolves to terminal execution', async () => {
       const { result } = renderHook(() => useAutoCreationExecution());
 
       let response: RunPipelineResponse | undefined;
@@ -167,7 +170,7 @@ describe('useAutoCreationExecution', () => {
       });
 
       expect(response).toBeDefined();
-      expect(response!.success).toBe(true);
+      expect(response!.status).toBe('completed');
       expect(response!.mode).toBe('execute');
     });
 
@@ -180,9 +183,8 @@ describe('useAutoCreationExecution', () => {
       });
 
       expect(response).toBeDefined();
-      expect(response!.success).toBe(true);
+      expect(response!.status).toBe('completed');
       expect(response!.mode).toBe('dry_run');
-      expect(response!.dry_run_results).toBeDefined();
     });
 
     it('supports filtering by rule IDs', async () => {
@@ -197,7 +199,7 @@ describe('useAutoCreationExecution', () => {
       });
 
       expect(response).toBeDefined();
-      expect(response!.success).toBe(true);
+      expect(response!.status).toBe('completed');
     });
 
     it('sets isRunning true during execution', async () => {
@@ -218,11 +220,8 @@ describe('useAutoCreationExecution', () => {
         await result.current.runPipeline({ dryRun: false });
       });
 
-      // Fetch to see the new execution
-      await act(async () => {
-        await result.current.fetchExecutions();
-      });
-
+      // bd-enfsy: the hook now refetches in finally — no need for a separate
+      // fetchExecutions() call. The list should contain the new execution.
       expect(result.current.executions.length).toBeGreaterThan(0);
     });
 
@@ -239,6 +238,89 @@ describe('useAutoCreationExecution', () => {
       expect(response!.channels_created).toBeDefined();
       expect(response!.channels_updated).toBeDefined();
       expect(response!.groups_created).toBeDefined();
+    });
+
+    it('refetches executions in finally block on POST error (bd-enfsy)', async () => {
+      // The 202 enqueue itself fails — list should still be refetched so the
+      // user sees fresh state without needing to reload the browser.
+      mockDataStore.autoCreationExecutions.push(
+        createMockAutoCreationExecution({ status: 'completed' })
+      );
+      server.use(
+        http.post('/api/auto-creation/run', () => {
+          return new HttpResponse(
+            JSON.stringify({ detail: 'enqueue exploded' }),
+            { status: 500 }
+          );
+        })
+      );
+
+      const { result } = renderHook(() => useAutoCreationExecution());
+
+      let response: RunPipelineResponse | undefined;
+      await act(async () => {
+        response = await result.current.runPipeline({ dryRun: false });
+      });
+
+      // Hook surfaces the error and returns undefined…
+      expect(response).toBeUndefined();
+      expect(result.current.error).toBeTruthy();
+      // …but the executions list must have been refreshed in the finally
+      // block (bd-enfsy: previously refetch only happened in the try path).
+      expect(result.current.executions.length).toBe(1);
+    });
+
+    it('updates the execution list incrementally during polling (bd-enfsy)', async () => {
+      // First execution row starts as 'running' so the poller observes a
+      // non-terminal status, then flips to 'completed' on the second poll.
+      const { result } = renderHook(() => useAutoCreationExecution());
+
+      let pollCount = 0;
+      let assignedExecutionId = 0;
+      // Override the run handler to enqueue a 'running' execution
+      server.use(
+        http.post('/api/auto-creation/run', () => {
+          const exe = createMockAutoCreationExecution({
+            status: 'running',
+            mode: 'execute',
+          });
+          mockDataStore.autoCreationExecutions.unshift(exe);
+          assignedExecutionId = exe.id;
+          return HttpResponse.json(
+            { execution_id: exe.id, status: 'running', message: 'started' },
+            { status: 202 }
+          );
+        }),
+        http.get('/api/auto-creation/executions/:id', ({ params }) => {
+          const id = parseInt(params.id as string);
+          const exe = mockDataStore.autoCreationExecutions.find(e => e.id === id);
+          if (!exe) {
+            return HttpResponse.json({ detail: 'not found' }, { status: 404 });
+          }
+          pollCount += 1;
+          // Flip to 'completed' on the second poll
+          if (pollCount >= 2 && exe.status === 'running') {
+            exe.status = 'completed';
+            exe.channels_created = 7;
+          }
+          return HttpResponse.json(exe);
+        })
+      );
+
+      let response: RunPipelineResponse | undefined;
+      await act(async () => {
+        response = await result.current.runPipeline({ dryRun: false });
+      });
+
+      expect(response).toBeDefined();
+      expect(response!.status).toBe('completed');
+      expect(response!.channels_created).toBe(7);
+      // Poller hit the endpoint at least twice (once saw running, once completed).
+      expect(pollCount).toBeGreaterThanOrEqual(2);
+      // Execution list contains the spliced-in row from the polling updates.
+      const inList = result.current.executions.find(e => e.id === assignedExecutionId);
+      expect(inList).toBeDefined();
+      expect(inList!.status).toBe('completed');
     });
   });
 

--- a/frontend/src/hooks/useAutoCreationExecution.ts
+++ b/frontend/src/hooks/useAutoCreationExecution.ts
@@ -12,6 +12,10 @@ import type {
 } from '../types/autoCreation';
 import * as api from '../services/autoCreationApi';
 
+// ExecutionStatus is referenced both at value-position (the TERMINAL list
+// inside pollExecutionUntilTerminal) and at type-position; keeping a single
+// type-only import is fine because TS erases the array element type at runtime.
+
 export interface UseAutoCreationExecutionOptions {
   /** Auto-refresh interval in milliseconds (0 to disable) */
   autoRefreshInterval?: number;
@@ -114,27 +118,103 @@ export function useAutoCreationExecution(
     }
   }, []);
 
+  /**
+   * Poll the executions endpoint until the run reaches a terminal status
+   * (bd-enfsy: 202 + poll background-task pattern). On every poll we also
+   * splice the latest snapshot into the executions list so the UI updates
+   * incrementally without waiting for the final fetchExecutions() call.
+   *
+   * Cancellation: callers (or component unmount) can abort the polling by
+   * passing an AbortSignal — we honor it both before each fetch and inside
+   * the inter-poll sleep.
+   */
+  const pollExecutionUntilTerminal = useCallback(async (
+    executionId: number,
+    signal?: AbortSignal,
+  ): Promise<AutoCreationExecution | undefined> => {
+    // Tunables — small and steady; backend status writes are cheap GETs.
+    const POLL_INTERVAL_MS = 1000;
+    const MAX_POLL_DURATION_MS = 30 * 60 * 1000; // 30 minutes safety cap
+    const TERMINAL: ExecutionStatus[] = ['completed', 'failed', 'rolled_back'];
+    const startedAt = Date.now();
+
+    while (true) {
+      if (signal?.aborted) return undefined;
+      let snapshot: AutoCreationExecution | undefined;
+      try {
+        snapshot = await api.getAutoCreationExecution(executionId);
+      } catch {
+        // Transient fetch failure — fall through to retry until cap.
+        snapshot = undefined;
+      }
+      if (snapshot) {
+        // Splice into list so the UI sees the row update without a full refetch.
+        setExecutions(prev => {
+          const idx = prev.findIndex(e => e.id === snapshot!.id);
+          if (idx === -1) return [snapshot!, ...prev];
+          const next = prev.slice();
+          next[idx] = snapshot!;
+          return next;
+        });
+        if (TERMINAL.includes(snapshot.status)) {
+          return snapshot;
+        }
+      }
+      if (Date.now() - startedAt > MAX_POLL_DURATION_MS) {
+        // Safety break — return the last snapshot we have (status still
+        // 'running' / 'pending'); caller can surface a stale-poll warning.
+        return snapshot;
+      }
+      await new Promise<void>((resolve) => {
+        const t = window.setTimeout(resolve, POLL_INTERVAL_MS);
+        signal?.addEventListener('abort', () => {
+          window.clearTimeout(t);
+          resolve();
+        }, { once: true });
+      });
+    }
+  }, []);
+
   const runPipeline = useCallback(async (options?: {
     dryRun?: boolean;
     ruleIds?: number[];
   }): Promise<RunPipelineResponse | undefined> => {
     setIsRunning(true);
     setError(null);
+    let pipelineError: string | null = null;
     try {
-      const response = await api.runAutoCreationPipeline({
+      // bd-enfsy: backend returns 202 with execution_id and runs the pipeline
+      // in a supervised background task. Poll until terminal so the caller
+      // (and the existing isRunning UI flag) still sees a "done" signal.
+      const enqueued = await api.runAutoCreationPipeline({
         dryRun: options?.dryRun,
         ruleIds: options?.ruleIds,
       });
-      // Refresh executions to include the new one
-      await fetchExecutions();
-      return response;
+      const terminal = await pollExecutionUntilTerminal(enqueued.execution_id);
+      return terminal;
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to run pipeline');
+      pipelineError = err instanceof Error ? err.message : 'Failed to run pipeline';
+      setError(pipelineError);
       return undefined;
     } finally {
+      // Always refetch — both on success and on error — so the UI list is
+      // never stale after a POST attempt (bd-enfsy fix: previously only
+      // refetched inside the try block, leaving the list stale on 504/500
+      // until the user manually reloaded the browser). fetchExecutions
+      // internally clears the hook's error state, so re-apply our pipeline
+      // error after the refresh succeeds — otherwise the user's visible
+      // error message disappears the instant the refetch completes.
+      try {
+        await fetchExecutions();
+      } catch {
+        // Ignore: already in finally, don't shadow the original error.
+      }
+      if (pipelineError) {
+        setError(pipelineError);
+      }
       setIsRunning(false);
     }
-  }, [fetchExecutions]);
+  }, [fetchExecutions, pollExecutionUntilTerminal]);
 
   const rollback = useCallback(async (id: number): Promise<RollbackResponse | undefined> => {
     setError(null);

--- a/frontend/src/services/autoCreationApi.test.ts
+++ b/frontend/src/services/autoCreationApi.test.ts
@@ -312,54 +312,41 @@ describe('Auto-Creation API Service', () => {
   // ===========================================================================
 
   describe('runAutoCreationPipeline', () => {
-    it('runs pipeline in execute mode', async () => {
-      // API uses { dryRun: boolean } which maps to { dry_run: boolean } in the request body
+    // bd-enfsy: POST returns 202 + { execution_id, status: 'running' } now —
+    // pipeline runs in a supervised background task and the caller polls
+    // GET /executions/{id} until status is terminal.
+    it('enqueues pipeline in execute mode and returns execution_id', async () => {
       const result = await runAutoCreationPipeline({ dryRun: false });
 
-      expect(result.success).toBe(true);
       expect(result.execution_id).toBeDefined();
-      expect(result.mode).toBe('execute');
-      expect(result.streams_evaluated).toBeGreaterThanOrEqual(0);
+      expect(result.status).toBe('running');
     });
 
-    it('runs pipeline in dry-run mode', async () => {
+    it('enqueues pipeline in dry-run mode', async () => {
       const result = await runAutoCreationPipeline({ dryRun: true });
 
-      expect(result.success).toBe(true);
-      expect(result.mode).toBe('dry_run');
-      expect(result.dry_run_results).toBeDefined();
+      expect(result.execution_id).toBeDefined();
+      expect(result.status).toBe('running');
     });
 
-    it('can run specific rules', async () => {
+    it('can enqueue specific rules', async () => {
       let capturedBody: { rule_ids?: number[] } = {};
       server.use(
         http.post('/api/auto-creation/run', async ({ request }) => {
           capturedBody = await request.json() as { rule_ids?: number[] };
-          return HttpResponse.json({
-            success: true,
-            execution_id: 1,
-            mode: 'execute',
-            duration_seconds: 1.0,
-            streams_evaluated: 10,
-            streams_matched: 5,
-            channels_created: 2,
-            channels_updated: 1,
-            groups_created: 0,
-            streams_merged: 2,
-            streams_skipped: 0,
-            created_entities: [],
-            modified_entities: [],
-          });
+          return HttpResponse.json(
+            { execution_id: 1, status: 'running', message: 'started' },
+            { status: 202 }
+          );
         })
       );
 
-      // API uses ruleIds which maps to rule_ids in the request body
       await runAutoCreationPipeline({ ruleIds: [1, 2, 3] });
 
       expect(capturedBody.rule_ids).toEqual([1, 2, 3]);
     });
 
-    it('handles pipeline errors', async () => {
+    it('handles pipeline enqueue errors', async () => {
       server.use(
         http.post('/api/auto-creation/run', () => {
           return HttpResponse.json(

--- a/frontend/src/services/autoCreationApi.ts
+++ b/frontend/src/services/autoCreationApi.ts
@@ -13,7 +13,7 @@ import type {
   ExecutionsListResponse,
   AutoCreationExecution,
   ValidationResult,
-  RunPipelineResponse,
+  RunPipelineEnqueuedResponse,
   RollbackResponse,
   SchemaResponse,
   ConditionSchema,
@@ -150,19 +150,39 @@ export async function getTemplateVariables(): Promise<TemplateVariableSchema[]> 
 // =============================================================================
 
 /**
- * Run the auto-creation pipeline.
+ * Enqueue an auto-creation pipeline run (bd-enfsy: 202+poll background-task pattern).
+ *
+ * The handler now returns ``202 Accepted`` with ``{ execution_id, status: 'running' }``
+ * after queuing the work. Callers (see ``useAutoCreationExecution.runPipeline``)
+ * are expected to poll ``getAutoCreationExecution(execution_id)`` until
+ * ``status`` is terminal (``completed`` / ``failed`` / ``rolled_back``).
  */
 export async function runAutoCreationPipeline(options?: {
   dryRun?: boolean;
   ruleIds?: number[];
-}): Promise<RunPipelineResponse> {
-  return fetchJson<RunPipelineResponse>(`${API_BASE}/auto-creation/run`, {
+}): Promise<RunPipelineEnqueuedResponse> {
+  return fetchJson<RunPipelineEnqueuedResponse>(`${API_BASE}/auto-creation/run`, {
     method: 'POST',
     body: JSON.stringify({
       dry_run: options?.dryRun ?? false,
       rule_ids: options?.ruleIds,
     }),
   });
+}
+
+/**
+ * Enqueue a single-rule auto-creation run (bd-enfsy 202+poll, see
+ * ``runAutoCreationPipeline`` for the contract).
+ */
+export async function runAutoCreationRule(
+  ruleId: number,
+  options?: { dryRun?: boolean }
+): Promise<RunPipelineEnqueuedResponse> {
+  const query = buildQuery({ dry_run: options?.dryRun });
+  return fetchJson<RunPipelineEnqueuedResponse>(
+    `${API_BASE}/auto-creation/rules/${ruleId}/run${query}`,
+    { method: 'POST' }
+  );
 }
 
 /**

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -1014,6 +1014,10 @@ export const handlers = [
   }),
 
   http.post(`${API_BASE}/auto-creation/run`, async ({ request }) => {
+    // bd-enfsy: 202 + poll background-task pattern. We mirror the backend by
+    // creating an execution with status='completed' immediately (so the
+    // poller's first GET sees a terminal status — the fastest possible
+    // poll path) and returning 202 + execution_id.
     const data = await request.json() as { dry_run?: boolean; rule_ids?: number[] }
     const dryRun = data.dry_run ?? false
     const execution = createMockAutoCreationExecution({
@@ -1024,25 +1028,41 @@ export const handlers = [
       streams_matched: 5,
       streams_evaluated: 100,
     })
-    if (!dryRun) {
-      mockDataStore.autoCreationExecutions.unshift(execution)
-    }
-    return HttpResponse.json({
-      success: true,
-      execution_id: execution.id,
-      mode: execution.mode,
-      duration_seconds: execution.duration_seconds,
-      streams_evaluated: execution.streams_evaluated,
-      streams_matched: execution.streams_matched,
-      channels_created: execution.channels_created,
-      channels_updated: execution.channels_updated,
-      groups_created: execution.groups_created,
-      streams_merged: execution.streams_merged,
-      streams_skipped: execution.streams_skipped,
-      created_entities: execution.created_entities,
-      modified_entities: execution.modified_entities,
-      dry_run_results: dryRun ? [] : undefined,
+    // Always store so the GET /executions/{id} poll target can find it.
+    mockDataStore.autoCreationExecutions.unshift(execution)
+    return HttpResponse.json(
+      {
+        execution_id: execution.id,
+        status: 'running',
+        message: 'Pipeline started; poll /api/auto-creation/executions/{id} for status',
+      },
+      { status: 202 }
+    )
+  }),
+
+  http.post(`${API_BASE}/auto-creation/rules/:ruleId/run`, async ({ params, request }) => {
+    // bd-enfsy: 202 + poll for the per-rule run too.
+    const ruleId = parseInt(params.ruleId as string)
+    const url = new URL(request.url)
+    const dryRun = url.searchParams.get('dry_run') === 'true'
+    const execution = createMockAutoCreationExecution({
+      mode: dryRun ? 'dry_run' : 'execute',
+      triggered_by: 'manual',
+      status: 'completed',
+      channels_created: dryRun ? 0 : 1,
+      streams_matched: 1,
+      streams_evaluated: 5,
     })
+    mockDataStore.autoCreationExecutions.unshift(execution)
+    return HttpResponse.json(
+      {
+        execution_id: execution.id,
+        status: 'running',
+        rule_id: ruleId,
+        message: 'Rule run started; poll /api/auto-creation/executions/{id} for status',
+      },
+      { status: 202 }
+    )
   }),
 
   http.post(`${API_BASE}/auto-creation/executions/:id/rollback`, ({ params }) => {

--- a/frontend/src/types/autoCreation.ts
+++ b/frontend/src/types/autoCreation.ts
@@ -419,32 +419,26 @@ export interface ValidationResult {
   warnings?: string[];
 }
 
-export interface RunPipelineResponse {
-  success: boolean;
+/**
+ * 202-Accepted response from POST /api/auto-creation/run and
+ * POST /api/auto-creation/rules/{id}/run (bd-enfsy: background-task pattern).
+ *
+ * Pipeline runs are now enqueued and the caller polls
+ * GET /api/auto-creation/executions/{id} until status is terminal.
+ */
+export interface RunPipelineEnqueuedResponse {
   execution_id: number;
-  mode: ExecutionMode;
-  duration_seconds: number;
-  streams_evaluated: number;
-  streams_matched: number;
-  channels_created: number;
-  channels_updated: number;
-  groups_created: number;
-  streams_merged: number;
-  streams_skipped: number;
-  streams_excluded: number;
-  streams_removed: number;
-  channels_removed: number;
-  channels_moved: number;
-  created_entities: CreatedEntity[];
-  modified_entities: ModifiedEntity[];
-  dry_run_results?: DryRunResult[];
-  conflicts?: {
-    stream_id: number;
-    stream_name: string;
-    winning_rule_id: number;
-    losing_rule_ids: number[];
-  }[];
+  status: 'running';
+  rule_id?: number;
+  message: string;
 }
+
+/**
+ * Result returned by the polling-based ``runPipeline`` hook helper —
+ * the terminal AutoCreationExecution row once polling resolves, or
+ * ``undefined`` if the request errored out before completion.
+ */
+export type RunPipelineResponse = AutoCreationExecution;
 
 export interface RollbackResponse {
   success: boolean;


### PR DESCRIPTION
## Summary

- bd-zv6pi hotfix exempted `/api/auto-creation/` from the 30s request-timeout middleware so long-running rule executions wouldn't 504 — but that removed defense-in-depth on every endpoint under that prefix. SRE flagged at standup as YELLOW-escalating-to-RED.
- Converts `POST /run` and `POST /rules/{id}/run` to 202+poll: handler pre-creates the `AutoCreationExecution(status="running")` row, returns `{execution_id, status, ...}` immediately, and dispatches the engine call as a **supervised** background task (`asyncio.create_task` + strong-ref set + done-callback for GC safety + wrapping try/except that marks the row `failed` with `error_message` so failures are observable, not lost).
- Removes `/api/auto-creation/` from `_TIMEOUT_EXEMPT_PREFIXES` in `backend/main.py` — defense-in-depth restored. Two new `test_event_loop_responsiveness` tests guard against regression of the exempt list.
- Frontend `useAutoCreationExecution.runPipeline` now enqueues → polls every 1s (30-min cap, AbortSignal-aware) → resolves with the terminal row. Splices snapshots into `executions` state for incremental UI.
- `fetchExecutions()` moved to `finally` block so list refreshes on both success and error. Pipeline error captured to local var and re-applied after refetch (otherwise `setError(null)` clobbered it; caught by a test).
- Per-rule endpoint now pre-validates rule existence (404 instead of FK-violation 500).

## Out of scope

- ReDoS hardening (parallel work via bd-ltjyx + bd-3u6p0). This change relocates worker pinning from HTTP worker to background-task worker but does not eliminate it. Security regex hardening must land alongside.

## Test plan

- [x] Backend: replaced `TestRunAutoCreationPipeline` / `TestRunAutoCreationRule` with new tests covering 202 + execution_id contract, status="running" pre-creation, dry_run mode tag, supervised failure capture (status="failed" + error_message), enqueue completes fast (under-5s with stuck engine), 404 on unknown rule
- [x] Backend: new `test_event_loop_responsiveness::test_auto_creation_no_longer_exempt` (asserts prefix gone from `_TIMEOUT_EXEMPT_PREFIXES`) and `test_auto_creation_crud_subject_to_timeout` (registers a slow `/api/auto-creation/_test_*` route; confirms 504)
- [x] Frontend: contract updates in handlers.ts; new tests for finally-block error handling and incremental list updates during polling
- [x] Backend: 3044 passed (~62s)
- [x] Frontend: 1142 passed (48 files, ~6s); `npm run build` succeeds; `tsc --noEmit` clean
- [ ] Container smoke after merge — verify a real bulk-update UI flow against ecm-ecm-1