### PR TITLE
fix(security): route auto_creation_schema write-time regex validation through safe_regex (bd-ltjyx)

### DIFF
--- a/backend/auto_creation_schema.py
+++ b/backend/auto_creation_schema.py
@@ -11,6 +11,8 @@ from typing import Any, Optional, Union
 import re
 import json
 
+import safe_regex
+
 logger = logging.getLogger(__name__)
 
 
@@ -160,12 +162,14 @@ class Condition:
                 ConditionType.TVG_ID_MATCHES,
                 ConditionType.CHANNEL_EXISTS_MATCHING,
             ):
-                # TODO(enhancedchannelmanager-ltjyx): migrate write-time syntax validation
-                # to safe_regex.compile so length cap + compile-error surface match
-                # regex_lint.py (bd-eio04.7).
+                # bd-ltjyx: route write-time syntax validation through
+                # safe_regex.compile. SafeRegexError covers both
+                # PatternTooLongError (length cap) and wrapped regex
+                # syntax errors, mirroring the runtime path used by
+                # auto_creation_evaluator (bd-eio04.15).
                 try:
-                    re.compile(self.value)  # nosemgrep: no-bare-re-on-dynamic-pattern
-                except re.error as e:
+                    safe_regex.compile(self.value)
+                except safe_regex.SafeRegexError as e:
                     errors.append(f"Invalid regex pattern for {self.type}: {e}")
 
         elif cond_type in (ConditionType.QUALITY_MIN, ConditionType.QUALITY_MAX, ConditionType.CHANNEL_HAS_STREAMS, ConditionType.HAS_AUDIO_TRACKS):
@@ -487,10 +491,13 @@ class Action:
                     if not pattern or not isinstance(pattern, str):
                         errors.append(f"set_variable with mode '{mode}' requires a 'pattern'")
                     else:
-                        # TODO(enhancedchannelmanager-ltjyx): migrate to safe_regex.compile.
+                        # bd-ltjyx: route through safe_regex.compile so the
+                        # length cap and compile-error surface match the
+                        # runtime path that actually executes this pattern
+                        # (auto_creation_executor._execute_set_variable).
                         try:
-                            re.compile(pattern)  # nosemgrep: no-bare-re-on-dynamic-pattern
-                        except re.error as e:
+                            safe_regex.compile(pattern)
+                        except safe_regex.SafeRegexError as e:
                             errors.append(f"Invalid regex pattern for set_variable: {e}")
                     if mode == "regex_replace":
                         replacement = self.params.get("replacement")
@@ -515,10 +522,12 @@ class Action:
             if not isinstance(pattern, str):
                 errors.append("name_transform_pattern must be a string")
             else:
-                # TODO(enhancedchannelmanager-ltjyx): migrate to safe_regex.compile.
+                # bd-ltjyx: route through safe_regex.compile so the length
+                # cap and compile-error surface match the runtime path
+                # (auto_creation_executor._apply_name_transform).
                 try:
-                    re.compile(pattern)  # nosemgrep: no-bare-re-on-dynamic-pattern
-                except re.error as e:
+                    safe_regex.compile(pattern)
+                except safe_regex.SafeRegexError as e:
                     errors.append(f"Invalid name_transform_pattern: {e}")
             # replacement is optional (defaults to empty string), but must be string if present
             if replacement is not None and not isinstance(replacement, str):

--- a/backend/tests/unit/test_auto_creation_schema.py
+++ b/backend/tests/unit/test_auto_creation_schema.py
@@ -848,3 +848,137 @@ class TestActionTypes:
         assert ActionType.SET_VARIABLE.value == "set_variable"
         assert ActionType.SKIP.value == "skip"
         assert ActionType.STOP_PROCESSING.value == "stop_processing"
+
+
+class TestSafeRegexMigrationWriteTimeValidation:
+    """
+    bd-ltjyx — write-time regex validation for user-supplied patterns must
+    route through ``safe_regex.compile`` instead of bare ``re.compile``.
+
+    This locks two behaviors that bare ``re.compile`` did NOT enforce:
+
+    1. Patterns longer than ``safe_regex.DEFAULT_MAX_PATTERN_LEN`` (500
+       chars) must be rejected at validation time. Bare ``re.compile``
+       would happily compile a 50,000-char pattern; ``safe_regex.compile``
+       caps it.
+    2. The error surfaced for syntactically invalid patterns must remain
+       backward-compatible — existing UI and API contracts assert the
+       string ``"Invalid regex"`` (or ``"Invalid name_transform_pattern"``)
+       appears in the validation error. ``safe_regex.SafeRegexError`` is
+       wrapped, not re-raised, so the user-facing message stays stable.
+    """
+
+    # safe_regex.DEFAULT_MAX_PATTERN_LEN is 500 — anything past that must
+    # be rejected at write time.
+    OVERSIZE_PATTERN = "a" * 600
+
+    # ----- Site 1: Condition regex types (auto_creation_schema.py:167) -----
+
+    def test_oversize_pattern_rejected_for_stream_name_matches(self):
+        """Oversize pattern must be rejected at validation time."""
+        cond = Condition(type="stream_name_matches", value=self.OVERSIZE_PATTERN)
+        errors = cond.validate()
+        assert len(errors) > 0
+        assert "Invalid regex" in errors[0]
+
+    def test_oversize_pattern_rejected_for_channel_exists_matching(self):
+        cond = Condition(type="channel_exists_matching", value=self.OVERSIZE_PATTERN)
+        errors = cond.validate()
+        assert len(errors) > 0
+        assert "Invalid regex" in errors[0]
+
+    def test_oversize_pattern_rejected_for_stream_group_matches(self):
+        cond = Condition(type="stream_group_matches", value=self.OVERSIZE_PATTERN)
+        errors = cond.validate()
+        assert len(errors) > 0
+        assert "Invalid regex" in errors[0]
+
+    def test_oversize_pattern_rejected_for_tvg_id_matches(self):
+        cond = Condition(type="tvg_id_matches", value=self.OVERSIZE_PATTERN)
+        errors = cond.validate()
+        assert len(errors) > 0
+        assert "Invalid regex" in errors[0]
+
+    # ----- Site 2: set_variable pattern (auto_creation_schema.py:492) -----
+
+    def test_oversize_pattern_rejected_for_set_variable_regex_extract(self):
+        action = Action(
+            type="set_variable",
+            params={
+                "variable_name": "v",
+                "variable_mode": "regex_extract",
+                "source_field": "stream_name",
+                "pattern": self.OVERSIZE_PATTERN,
+            },
+        )
+        errors = action.validate()
+        assert len(errors) > 0
+        assert "Invalid regex" in errors[0]
+
+    def test_oversize_pattern_rejected_for_set_variable_regex_replace(self):
+        action = Action(
+            type="set_variable",
+            params={
+                "variable_name": "v",
+                "variable_mode": "regex_replace",
+                "source_field": "stream_name",
+                "pattern": self.OVERSIZE_PATTERN,
+                "replacement": "",
+            },
+        )
+        errors = action.validate()
+        assert len(errors) > 0
+        assert "Invalid regex" in errors[0]
+
+    # ----- Site 3: name_transform_pattern (auto_creation_schema.py:520) -----
+
+    def test_oversize_pattern_rejected_for_name_transform(self):
+        action = Action(
+            type="create_channel",
+            params={
+                "name_template": "test",
+                "name_transform_pattern": self.OVERSIZE_PATTERN,
+            },
+        )
+        errors = action.validate()
+        assert len(errors) > 0
+        # Existing contract: error message names the field.
+        assert "name_transform_pattern" in errors[0]
+
+    # ----- Boundary check: pattern at exactly the cap is still accepted ---
+
+    def test_pattern_at_max_length_is_accepted_for_condition(self):
+        """Patterns exactly at the 500-char cap are still valid (boundary)."""
+        # Use a literal string (no metacharacters) so the only thing under
+        # test is the length cap, not regex syntax.
+        at_cap = "a" * 500
+        cond = Condition(type="stream_name_matches", value=at_cap)
+        errors = cond.validate()
+        assert errors == []
+
+    def test_pattern_at_max_length_is_accepted_for_set_variable(self):
+        at_cap = "a" * 500
+        action = Action(
+            type="set_variable",
+            params={
+                "variable_name": "v",
+                "variable_mode": "regex_extract",
+                "source_field": "stream_name",
+                "pattern": at_cap,
+            },
+        )
+        errors = action.validate()
+        assert errors == []
+
+    def test_pattern_at_max_length_is_accepted_for_name_transform(self):
+        at_cap = "a" * 500
+        action = Action(
+            type="create_channel",
+            params={
+                "name_template": "test",
+                "name_transform_pattern": at_cap,
+                "name_transform_replacement": "",
+            },
+        )
+        errors = action.validate()
+        assert errors == []


### PR DESCRIPTION
## Summary

- Migrates three write-time `re.compile(<user_input>)` sites in `backend/auto_creation_schema.py` to `safe_regex.compile`. These validate user-controlled regex from auto-creation rule definitions.
- Sites: condition regex validation (L171), set_variable pattern validation (L499), name_transform_pattern validation (L529). Bead cited L164/L488/L515; actual lines drifted (file trumps bead per brief).
- Removes all 3 `# nosemgrep: no-bare-re-on-dynamic-pattern` annotations + their `TODO(enhancedchannelmanager-ltjyx)` markers.
- Updates exception handling: `except re.error` → `except safe_regex.SafeRegexError` (covers both `PatternTooLongError` and wrapped `regex.error`).
- Per Security Engineer's standup finding (2026-04-23) — closes the second of the two ReDoS-exposed paths flagged after bd-91mcq's auto-creation bulk merges. Sister bead bd-3u6p0 (m3u_digest) is in PR #135.

## Backward compatibility
- Error messages preserve `"Invalid regex"` and `"Invalid name_transform_pattern"` substrings asserted by existing tests at L141, L587, L765 — UI/API contract unchanged.
- `re` import retained: `re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', var_name)` at L479 uses a raw-string literal and is exempt from the Semgrep rule.

## Test plan

- [x] New `TestSafeRegexMigrationWriteTimeValidation` — 10 tests covering oversize-pattern rejection at all three sites + boundary-at-cap acceptance
- [x] TDD evidence: 7 oversize tests failed pre-migration, all 10 pass post-migration
- [x] `tests/unit/test_auto_creation_schema.py`: 94/94 pass (84 baseline + 10 new)
- [x] `tests/unit/test_auto_creation_safe_regex_migration.py`: 37/37 pass (hypothesis was already installed in this worktree — note bd-mzm3j tracks the broader CI install gap)
- [x] Backend full suite: 3048 passed in 111s; coverage 60% (above 56% gate)
- [x] Semgrep `no-bare-re-on-dynamic-pattern`: 0 findings on `auto_creation_schema.py` and 0 across `backend/`