### PR TITLE
ci: sentinel workflow to satisfy required checks on doc-only PRs (bd-2gfil)

### DIFF
--- a/.github/workflows/docs-only-pass.yml
+++ b/.github/workflows/docs-only-pass.yml
@@ -1,0 +1,107 @@
+# Sentinel workflow that satisfies branch-protection required check-runs
+# on PRs that touch ONLY paths the main CI workflows skip.
+#
+# ─── Why this exists ──────────────────────────────────────────────────
+# `dev` and `main` branch protection require these 5 status checks:
+#   - Backend Tests                              (test.yml: backend)
+#   - Frontend Tests                             (test.yml: frontend)
+#   - Semgrep Lint                               (test.yml: semgrep-lint)
+#   - CodeQL Analysis (python)                   (build.yml: codeql-analysis matrix)
+#   - CodeQL Analysis (javascript-typescript)    (build.yml: codeql-analysis matrix)
+#
+# build.yml ignores `**.md` and `.beads/**`. test.yml (PR trigger) ignores
+# `.beads/**`. So a PR touching only `**.md` produces no CodeQL check-runs —
+# the required checks never report — and the PR is unmergeable. A PR
+# touching only `.beads/**` produces no check-runs at all and is doubly
+# blocked. See bd-pf82j (PR #139, the api.md backfill that surfaced this).
+#
+# ─── How this satisfies branch protection ─────────────────────────────
+# This workflow's `paths:` filter is the strict complement of build.yml's
+# `paths-ignore`: it triggers ONLY when every changed file matches one of
+# those skipped globs. Each job's `name:` matches a required check name
+# exactly, so GitHub records a successful check-run for each name and
+# branch protection is satisfied.
+#
+# ─── Mixed-PR safety ──────────────────────────────────────────────────
+# GitHub triggers a workflow when ANY changed file matches its `paths`
+# filter (and none-of-the-paths-match for `paths-ignore`). So a PR that
+# touches both `docs/api.md` and `backend/foo.py` will:
+#   - Trigger this sentinel (because of the .md file)
+#   - Trigger build.yml + test.yml (because of the .py file)
+# Both workflows produce check-runs with the same names. Branch protection
+# requires every same-named check-run to succeed, so the real CI's
+# CodeQL/Backend/Frontend/Semgrep results still gate the merge. The
+# sentinel cannot mask a real failure — it can only fill in for the
+# absence of a real run.
+#
+# ─── Doc-only / beads-only PR ────────────────────────────────────────
+# Only this sentinel runs. Each job is a no-op `exit 0`. All 5 required
+# check-runs report success. PR becomes mergeable.
+#
+# ─── Code-only PR ────────────────────────────────────────────────────
+# This sentinel does NOT run (no changed file matches `paths`). build.yml
+# and test.yml run normally and produce the required check-runs. No
+# regression to the existing CI flow.
+name: Docs-Only Sentinel CI
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+    # MUST stay in sync with the union of `paths-ignore` lists in
+    # build.yml and test.yml. Adding a new ignored glob there without
+    # mirroring it here re-opens the chicken-and-egg gap.
+    paths:
+      - '**.md'
+      - '.beads/**'
+  pull_request:
+    branches:
+      - main
+      - dev
+    paths:
+      - '**.md'
+      - '.beads/**'
+
+# Names below MUST match the required status check names byte-for-byte.
+# Matrix-generated names from build.yml's codeql-analysis job take the
+# form "<job name> (<matrix value>)" — that's where the
+# "CodeQL Analysis (python)" / "(javascript-typescript)" names come from.
+jobs:
+  backend-tests:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Doc-only PR — main CI skipped per paths-ignore in test.yml
+        run: echo "Doc-only / beads-only change. Real Backend Tests would run if any non-doc file changed."
+
+  frontend-tests:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Doc-only PR — main CI skipped per paths-ignore in test.yml
+        run: echo "Doc-only / beads-only change. Real Frontend Tests would run if any non-doc file changed."
+
+  semgrep-lint:
+    name: Semgrep Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Doc-only PR — main CI skipped per paths-ignore in test.yml
+        run: echo "Doc-only / beads-only change. Real Semgrep Lint would run if any non-doc file changed."
+
+  codeql-analysis:
+    # Mirrors the matrix in build.yml's `codeql-analysis` job so the
+    # check-run names render as "CodeQL Analysis (python)" and
+    # "CodeQL Analysis (javascript-typescript)" — matching the names
+    # required by branch protection.
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript-typescript', 'python']
+    steps:
+      - name: Doc-only PR — main CI skipped per paths-ignore in build.yml
+        run: |
+          echo "Doc-only / beads-only change for language=${{ matrix.language }}."
+          echo "Real CodeQL Analysis would run if any non-doc file changed."


### PR DESCRIPTION
## Summary

Adds `.github/workflows/docs-only-pass.yml` — a sentinel workflow that emits success check-runs matching every required branch-protection check on PRs that touch only doc-equivalent paths.

## Root cause (chicken-and-egg)

`dev` branch protection requires 5 checks:

- `Backend Tests`
- `Frontend Tests`
- `Semgrep Lint`
- `CodeQL Analysis (python)`
- `CodeQL Analysis (javascript-typescript)`

But `.github/workflows/build.yml` (the workflow that produces both CodeQL Analysis check-runs) is configured with:

```yaml
paths-ignore:
  - '.beads/**'
  - '**.md'
```

So a PR touching only Markdown files (e.g. PR #139, the `bd-pf82j` `docs/api.md` backfill) triggers zero build.yml runs. The two CodeQL check-runs never report. Branch protection waits forever. The PR is unmergeable without admin override.

`test.yml` also ignores `.beads/**` on `pull_request`, so a `.beads/**`-only PR has the same problem on all 5 checks.

## Approach

Bead `enhancedchannelmanager-2gfil` listed three engineering options:

- **(a)** Drop `**.md` from `paths-ignore` — full CI on every doc PR. Correct but slow.
- **(b)** Sentinel workflow on the complementary `paths:` filter that emits success check-runs with the required names. Preserves CI economy. **Chosen.**
- **(c)** `dorny/paths-filter` inside the existing workflows. More invasive, harder to reason about.

## Path-filter design

The sentinel's `paths:` is the strict complement of the union of `paths-ignore` lists in the main workflows:

```yaml
paths:
  - '**.md'
  - '.beads/**'
```

GitHub triggers a workflow if ANY changed file matches `paths`. So:

| PR shape | build.yml / test.yml | docs-only-pass.yml | Outcome |
|---|---|---|---|
| Only `**.md` and/or `.beads/**` | Skipped (every changed file matches `paths-ignore`) | Triggers (every changed file matches `paths`) | All 5 required checks satisfied by sentinel — mergeable |
| Only code (`.py`, `.ts`, etc.) | Triggers normally | Does NOT trigger (no changed file matches `paths`) | Real CI runs as before — no regression |
| Mixed (docs + code) | Triggers (because of code file) | Triggers (because of doc file) | Both produce same-named check-runs; **both must succeed** for branch protection. Sentinel cannot mask a real CI failure |

## Mixed-PR safety

This is the most important safety property. When two workflows produce check-runs with the same name on the same SHA, GitHub's branch protection treats each as an independent required check — every same-named check-run must succeed. So a mixed PR's CodeQL Analysis (python) check-runs include both:

1. The sentinel's no-op (always passes)
2. The real build.yml CodeQL run (gates the PR on actual findings)

If real CodeQL fails, branch protection blocks the merge regardless of the sentinel. The sentinel can only fill in for the **absence** of a real run, never override one.

## Required check-run names — exact match

| Source | Workflow | Job `name:` | Check-run name |
|---|---|---|---|
| Real | test.yml | `Backend Tests` | `Backend Tests` |
| Real | test.yml | `Frontend Tests` | `Frontend Tests` |
| Real | test.yml | `Semgrep Lint` | `Semgrep Lint` |
| Real | build.yml (matrix) | `CodeQL Analysis` + `language: python` | `CodeQL Analysis (python)` |
| Real | build.yml (matrix) | `CodeQL Analysis` + `language: javascript-typescript` | `CodeQL Analysis (javascript-typescript)` |
| Sentinel | docs-only-pass.yml | `Backend Tests` | `Backend Tests` |
| Sentinel | docs-only-pass.yml | `Frontend Tests` | `Frontend Tests` |
| Sentinel | docs-only-pass.yml | `Semgrep Lint` | `Semgrep Lint` |
| Sentinel | docs-only-pass.yml (matrix) | `CodeQL Analysis` + `language: python` | `CodeQL Analysis (python)` |
| Sentinel | docs-only-pass.yml (matrix) | `CodeQL Analysis` + `language: javascript-typescript` | `CodeQL Analysis (javascript-typescript)` |

Verified by parsing the generated YAML through PyYAML and expanding the matrix.

## Verification

- [x] `actionlint v1.7.4` runs clean against the new workflow file (the unrelated findings in `build.yml` for `ubuntu-24.04-arm` and `normalization-canary.yml` for Slack action inputs predate this change).
- [x] PyYAML parse confirms the workflow loads and the matrix expands to the two required CodeQL check-run names.
- [x] PR #139's only changed file (`docs/api.md`) matches `**.md` → sentinel will trigger, build.yml will continue to skip → required CodeQL checks satisfied → PR #139 becomes mergeable once this lands.
- [x] This PR itself touches `.github/workflows/docs-only-pass.yml`, which is NOT in `paths-ignore`, so the real CI workflows run normally and gate this merge — the sentinel does not gate itself.

## Test plan

- [ ] Confirm the real build.yml + test.yml runs trigger for this PR (since `.github/workflows/docs-only-pass.yml` is not a doc path) and all 5 required checks report from the real workflows.
- [ ] After merge to `dev`, retrigger PR #139's checks (close + reopen, or push an empty commit) and verify the sentinel produces the 2 missing CodeQL check-runs as success → PR #139 becomes mergeable.
- [ ] Optional follow-up smoke test: open a throwaway PR touching only `CHANGELOG.md` and confirm only the sentinel workflow triggers, all 5 required checks come from the sentinel, and the PR is mergeable.

## Bead

Closes the implementation work for `enhancedchannelmanager-2gfil`. Unblocks `enhancedchannelmanager-pf82j` (PR #139).

🤖 Generated with [Claude Code](https://claude.com/claude-code)