### PR TITLE
ci: ensure backend requirements.txt installed before pytest; surface silent test skips (bd-s8kq3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,17 @@ jobs:
           # pin them here so the CI command is self-documenting.
           pip install pytest pytest-asyncio pytest-cov httpx
 
+      - name: Verify required test deps are importable (bd-s8kq3)
+        working-directory: backend
+        # Fast-fail guard: if the install step above silently failed to
+        # bring in a required test dep (alembic for migration tests,
+        # hypothesis for property-based tests), surface a clear "install
+        # gap" error here BEFORE pytest runs. Without this, missing deps
+        # manifest as cryptic collection errors mid-suite, or — worse —
+        # silent skips that let CI pass green on a degraded suite.
+        # See bd-s8kq3 for the silent-skip → install-gap audit.
+        run: python scripts/verify_test_deps.py
+
       - name: Prepare CI SQLite database
         working-directory: backend
         run: |

--- a/backend/scripts/verify_test_deps.py
+++ b/backend/scripts/verify_test_deps.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Verify that test-required Python packages are importable.
+
+This is a CI fast-fail guard (bd-s8kq3). The backend test suite requires
+several packages from `backend/requirements.txt` that, if missing, would
+otherwise cause:
+
+  - silent skips (e.g. `pytest.importorskip("hypothesis")` returning a
+    "skipped" line that CI treats as success)
+  - cryptic mid-suite collection errors (bare `import hypothesis`
+    failing during test collection on one specific file)
+
+By verifying these imports BEFORE pytest runs, an install-gap surfaces
+as a clear, single-line error with actionable remediation, instead of
+being buried in pytest output.
+
+Usage (from `backend/`):
+
+    python scripts/verify_test_deps.py
+
+Exits 0 if all required packages import cleanly; exits 1 with a
+diagnostic to stderr otherwise.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+
+# Packages required by the backend test suite. Each is pinned in
+# `backend/requirements.in` (and resolved into `requirements.txt`).
+# When you add a hard test dependency that, if absent, would cause a
+# silent skip or mid-suite collection error, add it here.
+REQUIRED_TEST_DEPS = [
+    "alembic",          # tests/unit/test_alembic_baseline.py + safe_regex migration tests
+    "hypothesis",       # property-based tests (test_regex_lint_property, safe_regex migration tests)
+    "pytest",
+    "pytest_asyncio",
+    "httpx",
+]
+
+
+def main() -> int:
+    missing: list[str] = []
+    for mod in REQUIRED_TEST_DEPS:
+        try:
+            importlib.import_module(mod)
+        except ImportError as e:
+            missing.append(f"{mod} ({e})")
+
+    if missing:
+        print("FATAL: required test dependencies missing:", file=sys.stderr)
+        for m in missing:
+            print(f"  - {m}", file=sys.stderr)
+        print(
+            "\nThe backend test suite REQUIRES these packages. They are "
+            "pinned in backend/requirements.txt. The 'Install dependencies' "
+            "step in CI (or your local `pip install -r requirements.txt`) "
+            "must have failed silently. See bd-s8kq3.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "All required test deps importable: "
+        + ", ".join(REQUIRED_TEST_DEPS)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/unit/test_dummy_epg_engine.py
+++ b/backend/tests/unit/test_dummy_epg_engine.py
@@ -867,54 +867,57 @@ def test_extract_groups_date_pattern_adversarial_keeps_title_within_budget():
 # ---------------------------------------------------------------------------
 # Property-based equivalence: for benign (pattern, text) pairs, safe_regex
 # migrated sites produce the same result as the prior stdlib-re behavior.
+#
+# ``hypothesis`` is a hard requirement (pinned in backend/requirements.in
+# + requirements.txt). We import it directly rather than guarding with
+# ``try/except ImportError`` so a missing install (e.g. CI didn't install
+# backend/requirements.txt) surfaces as a loud collection error instead
+# of silently dropping these property tests — see bd-s8kq3 for the
+# install-gap policy.
 # ---------------------------------------------------------------------------
 
-try:
-    from hypothesis import given, settings, strategies as st
-    _HAS_HYPOTHESIS = True
-except ImportError:  # pragma: no cover
-    _HAS_HYPOTHESIS = False
+import re as _re_stdlib
+
+from hypothesis import given, settings, strategies as st
+
+# Benign patterns: simple literal + alternation that neither stdlib re
+# nor the regex library will treat pathologically. Keep the alphabet
+# tiny so patterns and texts exercise the same characters reliably.
+_BENIGN_PATTERNS = st.sampled_from([
+    r"foo", r"\d+", r"[a-z]+", r"ab?c", r"^hello", r"world$",
+    r"(?P<w>\w+)", r"a(b|c)d", r"x{1,3}y",
+])
+_BENIGN_TEXTS = st.text(alphabet="abcdefghijxyz 0123456789", min_size=0, max_size=64)
 
 
-if _HAS_HYPOTHESIS:
-    import re as _re_stdlib
+@given(pattern=_BENIGN_PATTERNS, text=_BENIGN_TEXTS)
+@settings(max_examples=50, deadline=1000)
+def test_apply_substitutions_benign_equivalence(pattern, text):
+    """For benign patterns, apply_substitutions produces the same string
+    as the prior stdlib re.sub behavior."""
+    try:
+        expected = _re_stdlib.sub(pattern, "REPL", text)
+    except _re_stdlib.error:
+        # Skip patterns stdlib rejects — migration behavior on invalid
+        # patterns (no-op) is covered by the explicit tests above.
+        return
+    pairs = [{"find": pattern, "replace": "REPL", "is_regex": True, "enabled": True}]
+    actual, _steps = apply_substitutions(text, pairs)
+    assert actual == expected
 
-    # Benign patterns: simple literal + alternation that neither stdlib re
-    # nor the regex library will treat pathologically. Keep the alphabet
-    # tiny so patterns and texts exercise the same characters reliably.
-    _BENIGN_PATTERNS = st.sampled_from([
-        r"foo", r"\d+", r"[a-z]+", r"ab?c", r"^hello", r"world$",
-        r"(?P<w>\w+)", r"a(b|c)d", r"x{1,3}y",
-    ])
-    _BENIGN_TEXTS = st.text(alphabet="abcdefghijxyz 0123456789", min_size=0, max_size=64)
 
-    @given(pattern=_BENIGN_PATTERNS, text=_BENIGN_TEXTS)
-    @settings(max_examples=50, deadline=1000)
-    def test_apply_substitutions_benign_equivalence(pattern, text):
-        """For benign patterns, apply_substitutions produces the same string
-        as the prior stdlib re.sub behavior."""
-        try:
-            expected = _re_stdlib.sub(pattern, "REPL", text)
-        except _re_stdlib.error:
-            # Skip patterns stdlib rejects — migration behavior on invalid
-            # patterns (no-op) is covered by the explicit tests above.
-            return
-        pairs = [{"find": pattern, "replace": "REPL", "is_regex": True, "enabled": True}]
-        actual, _steps = apply_substitutions(text, pairs)
-        assert actual == expected
-
-    @given(pattern=_BENIGN_PATTERNS, text=_BENIGN_TEXTS)
-    @settings(max_examples=50, deadline=1000)
-    def test_extract_groups_title_benign_equivalence(pattern, text):
-        """For benign title patterns, extract_groups behaves the same way
-        as stdlib re.search: match -> dict, no match -> None."""
-        try:
-            expected_match = _re_stdlib.search(pattern, text)
-        except _re_stdlib.error:
-            return
-        groups = extract_groups(text, pattern)
-        if expected_match is None:
-            assert groups is None
-        else:
-            assert groups is not None
-            assert groups == dict(expected_match.groupdict())
+@given(pattern=_BENIGN_PATTERNS, text=_BENIGN_TEXTS)
+@settings(max_examples=50, deadline=1000)
+def test_extract_groups_title_benign_equivalence(pattern, text):
+    """For benign title patterns, extract_groups behaves the same way
+    as stdlib re.search: match -> dict, no match -> None."""
+    try:
+        expected_match = _re_stdlib.search(pattern, text)
+    except _re_stdlib.error:
+        return
+    groups = extract_groups(text, pattern)
+    if expected_match is None:
+        assert groups is None
+    else:
+        assert groups is not None
+        assert groups == dict(expected_match.groupdict())

--- a/backend/tests/unit/test_regex_lint_property.py
+++ b/backend/tests/unit/test_regex_lint_property.py
@@ -9,22 +9,17 @@ named groups, and simple branches — covering the shapes that dominate
 the real production corpus without ever composing a nested-unbounded
 quantifier.
 
-Skipped cleanly if ``hypothesis`` is not installed. The hand-curated
-sweep in :mod:`test_regex_lint.TestBenignSmokeSweep` runs unconditionally
-and is the minimum guaranteed coverage.
+``hypothesis`` is a hard requirement (pinned in backend/requirements.in
++ requirements.txt). This module imports it directly rather than via
+``pytest.importorskip`` so a missing install (e.g. CI didn't install
+backend/requirements.txt) surfaces as a loud collection error instead
+of a silent skip — see bd-s8kq3 for the install-gap policy.
 """
 from __future__ import annotations
 
-import pytest
+from hypothesis import given, settings, strategies as st
 
-hypothesis = pytest.importorskip(
-    "hypothesis",
-    reason="hypothesis not installed; hand-curated sweep in test_regex_lint covers the minimum",
-)
-
-from hypothesis import given, settings, strategies as st  # noqa: E402
-
-from regex_lint import lint_pattern  # noqa: E402
+from regex_lint import lint_pattern
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

bd-s8kq3 — silent-skip / install-gap audit for the backend test suite.

The CI test workflow (`.github/workflows/test.yml`) already runs
`pip install -r backend/requirements.txt` before pytest, and both
`alembic` and `hypothesis` are pinned hard requirements in
`backend/requirements.in` + `requirements.txt`. The install step is
not the gap.

The gap is two test modules that masked the contract by treating
`hypothesis` as optional, so a future requirements-install regression
would silently drop tests instead of failing CI.

## Changes

**Audit findings (silent-skip patterns in `backend/tests/`):**

- `tests/unit/test_regex_lint_property.py` — `pytest.importorskip("hypothesis")` → MASK (fixed)
- `tests/unit/test_dummy_epg_engine.py` — `try: from hypothesis import …; except ImportError` guard around property tests → MASK (fixed)
- `tests/e2e/conftest.py` — `pytestmark = pytest.mark.skipif(not _container_reachable())` → LEGITIMATE (E2E requires a live container; workflow already passes `--ignore=tests/e2e`)
- `tests/e2e/conftest.py::skip_if_not_api()` — runtime SPA-vs-API content-type guard → LEGITIMATE
- `tests/routers/test_backup.py` — `pytest.skip("Symlinks not supported in this environment")` → LEGITIMATE (OS filesystem capability guard, not a dep mask)

**Fixes:**

- Convert the two MASK sites to bare `from hypothesis import …` so a
  missing install raises a loud collection error (pytest exit 2),
  not a silent SKIPPED line buried in summary output.
- Add `backend/scripts/verify_test_deps.py` — a fast-fail CI guard
  that imports the test-required packages BEFORE pytest runs, so
  install gaps surface as a single clear FATAL with remediation,
  not as cryptic mid-suite collection failures across N files.
- Wire the guard into `.github/workflows/test.yml` as a step between
  Install dependencies and Prepare CI SQLite database.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — YAML parses cleanly.
- [x] Fresh `uv venv` + `uv pip install -r backend/requirements.txt`:
      `3022 passed in 65s` (`-m "not slow" --ignore=tests/e2e`, no regressions).
- [x] Fresh `uv venv` WITHOUT hypothesis: `python scripts/verify_test_deps.py` exits 1 with `FATAL: required test dependencies missing: hypothesis`.
- [x] Fresh `uv venv` WITHOUT hypothesis: `pytest tests/unit/test_regex_lint_property.py` now exits 2 (collection error) instead of returning a single SKIPPED line.
- [x] Fresh `uv venv` WITH all deps: targeted run of `test_alembic_baseline.py`, `test_auto_creation_safe_regex_migration.py`, `test_normalization_safe_regex_migration.py`, `test_regex_lint_property.py`, `test_dummy_epg_engine.py` — `163 passed`.
- [ ] CI run on this PR completes the `Verify required test deps are importable (bd-s8kq3)` step + full pytest suite.

## Notes

No new follow-up beads needed — the audit covered all
`importorskip`/`except ImportError` sites under `backend/tests/`, and
each was either fixed (the two MASK sites) or classified as legitimate
(E2E live-container guard, OS symlink-capability guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)