### PR TITLE
feat(auto-creation): write-time FK validation for normalization_group_ids (bd-i75ax)

### DIFF
--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -225,6 +225,64 @@ def _resolve_normalization_group_ids(rule_data: dict, session) -> str | None:
     return None
 
 
+def _validate_normalization_group_ids(
+    submitted_ids: Optional[list[int]], session
+) -> None:
+    """bd-i75ax: Reject write requests that reference non-existent
+    NormalizationRuleGroup IDs.
+
+    Delta-on-write semantics: only the IDs the caller is *submitting* on this
+    request are validated. Already-stored values are left alone — a previously
+    valid stored ID whose group has since been deleted should not block an
+    unrelated PUT (e.g. renaming the rule). The startup audit (bd-i75ax)
+    confirmed zero stale IDs in production data; this guard prevents future
+    typos and copy-paste from the wrong environment.
+
+    Empty list and ``None`` are both valid (no normalization groups is a
+    legitimate state — it means normalization is disabled for the rule).
+
+    Raises:
+        HTTPException(422) with detail.invalid_normalization_group_ids listing
+        every offending ID, when any submitted ID is missing from
+        normalization_rule_groups.
+    """
+    if not submitted_ids:
+        # None or empty list — nothing to validate.
+        return
+
+    from models import NormalizationRuleGroup
+
+    # De-dup before query to keep the IN-list small; preserves order on report.
+    seen: set[int] = set()
+    unique_ids: list[int] = []
+    for gid in submitted_ids:
+        if gid not in seen:
+            seen.add(gid)
+            unique_ids.append(gid)
+
+    existing_rows = session.query(NormalizationRuleGroup.id).filter(
+        NormalizationRuleGroup.id.in_(unique_ids)
+    ).all()
+    existing_ids = {row[0] for row in existing_rows}
+
+    invalid_ids = [gid for gid in unique_ids if gid not in existing_ids]
+    if invalid_ids:
+        logger.warning(
+            "[AUTO-CREATE] Rejecting write — invalid normalization_group_ids: %s",
+            invalid_ids,
+        )
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": (
+                    "One or more normalization_group_ids do not exist in "
+                    "normalization_rule_groups"
+                ),
+                "invalid_normalization_group_ids": invalid_ids,
+            },
+        )
+
+
 # =============================================================================
 # Rule CRUD Endpoints
 # =============================================================================
@@ -402,6 +460,14 @@ async def update_auto_creation_rule(rule_id: int, request: UpdateAutoCreationRul
             if not rule:
                 raise HTTPException(status_code=404, detail="Rule not found")
 
+            # bd-i75ax: write-time FK validation for normalization_group_ids.
+            # Run BEFORE mutation so a bad ID can't leave partial scalar
+            # changes on the row. Only validates IDs the caller submitted
+            # (delta-on-write — does not re-check stored values).
+            _validate_normalization_group_ids(
+                request.normalization_group_ids, session
+            )
+
             _apply_rule_scalar_updates(rule, request)
 
             # Validate and update conditions/actions if provided
@@ -502,6 +568,16 @@ async def bulk_update_auto_creation_rules(request: BulkUpdateAutoCreationRulesRe
                 status_code=404,
                 detail=f"Rules not found: {missing}",
             )
+
+        # bd-i75ax: write-time FK validation for normalization_group_ids.
+        # Validate the SUBMITTED ids once (they're applied identically to
+        # every rule in scope), before any mutation. A bad ID must roll back
+        # the entire bulk-update — not leave half the rules updated and the
+        # other half rejected. Delta-on-write: stored values on rules in
+        # scope are not re-checked.
+        _validate_normalization_group_ids(
+            scalar_update.normalization_group_ids, session
+        )
 
         # Track per-rule diffs so we can emit per-entity journal entries with a
         # shared batch_id after a successful commit (bd-91mcq). Matches the

--- a/backend/tests/routers/test_auto_creation.py
+++ b/backend/tests/routers/test_auto_creation.py
@@ -11,7 +11,25 @@ import pytest
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from models import AutoCreationRule, AutoCreationExecution
+from models import AutoCreationRule, AutoCreationExecution, NormalizationRuleGroup
+
+
+def _create_normalization_group(session, **overrides):
+    """Helper to create a NormalizationRuleGroup."""
+    defaults = {
+        "name": "Test Group",
+        "enabled": True,
+        "priority": 0,
+        "is_builtin": False,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+    }
+    defaults.update(overrides)
+    group = NormalizationRuleGroup(**defaults)
+    session.add(group)
+    session.commit()
+    session.refresh(group)
+    return group
 
 
 def _create_rule(session, **overrides):
@@ -166,6 +184,122 @@ class TestUpdateAutoCreationRule:
             )
 
         assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_accepts_valid_normalization_group_ids(
+        self, async_client, test_session
+    ):
+        """bd-i75ax: PUT accepts normalization_group_ids that all exist."""
+        rule = _create_rule(test_session, name="WithNorm")
+        g1 = _create_normalization_group(test_session, name="Group A")
+        g2 = _create_normalization_group(test_session, name="Group B")
+
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.put(
+                f"/api/auto-creation/rules/{rule.id}",
+                json={"normalization_group_ids": [g1.id, g2.id]},
+            )
+
+        assert response.status_code == 200, response.text
+        assert sorted(response.json()["normalization_group_ids"]) == sorted([g1.id, g2.id])
+
+    @pytest.mark.asyncio
+    async def test_accepts_empty_normalization_group_ids(
+        self, async_client, test_session
+    ):
+        """bd-i75ax: PUT accepts an empty normalization_group_ids list (disables normalization)."""
+        rule = _create_rule(test_session, name="EmptyNorm")
+        # Pre-populate with valid IDs to verify empty clears them
+        g1 = _create_normalization_group(test_session, name="Group X")
+        rule.set_normalization_group_ids([g1.id])
+        test_session.commit()
+
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.put(
+                f"/api/auto-creation/rules/{rule.id}",
+                json={"normalization_group_ids": []},
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["normalization_group_ids"] == []
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_normalization_group_id(
+        self, async_client, test_session
+    ):
+        """bd-i75ax: PUT returns 422 when a submitted ID is not in normalization_rule_groups,
+        and the error names the offending ID."""
+        rule = _create_rule(test_session, name="BadNorm")
+        g1 = _create_normalization_group(test_session, name="Group Real")
+        missing_id = 999999
+
+        response = await async_client.put(
+            f"/api/auto-creation/rules/{rule.id}",
+            json={"normalization_group_ids": [g1.id, missing_id]},
+        )
+
+        assert response.status_code == 422, response.text
+        body = response.text
+        assert str(missing_id) in body
+        # Sanity: the valid id should not be in the offending list
+        # (we look for the structured field rather than substring to avoid
+        # false-positive overlap with rule_id or other numbers in the error)
+        detail = response.json().get("detail")
+        assert detail is not None
+        # detail may be a dict with an offending list; assert structure carries it
+        if isinstance(detail, dict):
+            offending = detail.get("invalid_normalization_group_ids") or detail.get("offending_ids") or []
+            assert missing_id in offending
+            assert g1.id not in offending
+
+    @pytest.mark.asyncio
+    async def test_rejects_lists_all_invalid_normalization_group_ids(
+        self, async_client, test_session
+    ):
+        """bd-i75ax: When multiple submitted IDs are missing, all are listed."""
+        rule = _create_rule(test_session, name="MultiBadNorm")
+        g1 = _create_normalization_group(test_session, name="Real Group")
+        bad_a, bad_b, bad_c = 700001, 700002, 700003
+
+        response = await async_client.put(
+            f"/api/auto-creation/rules/{rule.id}",
+            json={"normalization_group_ids": [g1.id, bad_a, bad_b, bad_c]},
+        )
+
+        assert response.status_code == 422, response.text
+        detail = response.json().get("detail")
+        assert isinstance(detail, dict)
+        offending = detail.get("invalid_normalization_group_ids") or detail.get("offending_ids") or []
+        assert sorted(offending) == sorted([bad_a, bad_b, bad_c])
+        assert g1.id not in offending
+
+    @pytest.mark.asyncio
+    async def test_does_not_validate_when_normalization_group_ids_omitted(
+        self, async_client, test_session
+    ):
+        """bd-i75ax delta-on-write: PUT requests that don't include
+        normalization_group_ids must not re-validate the existing stored value.
+        This preserves backward-compat with rules whose stored IDs reference
+        groups that have since been deleted."""
+        rule = _create_rule(test_session, name="StaleStored")
+        # Simulate a stale stored id (group was deleted out from under us)
+        stale_id = 999998
+        rule.set_normalization_group_ids([stale_id])
+        test_session.commit()
+
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            # Update an unrelated field — must succeed even though stored
+            # normalization_group_ids reference a missing group.
+            response = await async_client.put(
+                f"/api/auto-creation/rules/{rule.id}",
+                json={"name": "Renamed"},
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["name"] == "Renamed"
 
 
 class TestBulkUpdateAutoCreationRules:
@@ -546,6 +680,125 @@ class TestBulkUpdateAutoCreationRules:
         assert response.status_code == 404
         # Zero log_entry calls on the rollback path.
         assert mock_journal.log_entry.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_accepts_valid_normalization_group_ids(
+        self, async_client, test_session
+    ):
+        """bd-i75ax: bulk-update accepts normalization_group_ids that all exist."""
+        r1 = _create_rule(test_session, name="BulkNormA")
+        r2 = _create_rule(test_session, name="BulkNormB")
+        g1 = _create_normalization_group(test_session, name="Bulk Group A")
+        g2 = _create_normalization_group(test_session, name="Bulk Group B")
+
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post(
+                "/api/auto-creation/rules/bulk-update",
+                json={
+                    "rule_ids": [r1.id, r2.id],
+                    "normalization_group_ids": [g1.id, g2.id],
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["updated_count"] == 2
+        test_session.expire_all()
+        for rid in (r1.id, r2.id):
+            refreshed = test_session.query(AutoCreationRule).get(rid)
+            assert sorted(refreshed.get_normalization_group_ids()) == sorted([g1.id, g2.id])
+
+    @pytest.mark.asyncio
+    async def test_accepts_empty_normalization_group_ids(
+        self, async_client, test_session
+    ):
+        """bd-i75ax: bulk-update accepts empty normalization_group_ids list."""
+        r1 = _create_rule(test_session, name="BulkEmptyNorm")
+        # Pre-populate so empty actually clears something
+        g1 = _create_normalization_group(test_session, name="Bulk Pre Group")
+        r1.set_normalization_group_ids([g1.id])
+        test_session.commit()
+
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post(
+                "/api/auto-creation/rules/bulk-update",
+                json={
+                    "rule_ids": [r1.id],
+                    "normalization_group_ids": [],
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        test_session.expire_all()
+        refreshed = test_session.query(AutoCreationRule).get(r1.id)
+        assert refreshed.get_normalization_group_ids() == []
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_normalization_group_id(
+        self, async_client, test_session
+    ):
+        """bd-i75ax: bulk-update returns 422 with offending IDs named when any
+        submitted ID is missing from normalization_rule_groups, and rolls back
+        (no rule is mutated)."""
+        r1 = _create_rule(test_session, name="BulkBadNormA", enabled=False)
+        r2 = _create_rule(test_session, name="BulkBadNormB", enabled=False)
+        g1 = _create_normalization_group(test_session, name="Bulk Real Group")
+        bad_a = 800001
+        bad_b = 800002
+
+        mock_journal = MagicMock()
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal", mock_journal):
+            response = await async_client.post(
+                "/api/auto-creation/rules/bulk-update",
+                json={
+                    "rule_ids": [r1.id, r2.id],
+                    "normalization_group_ids": [g1.id, bad_a, bad_b],
+                    # Try a scalar update too — must not be applied on rollback
+                    "enabled": True,
+                },
+            )
+
+        assert response.status_code == 422, response.text
+        detail = response.json().get("detail")
+        assert isinstance(detail, dict)
+        offending = detail.get("invalid_normalization_group_ids") or detail.get("offending_ids") or []
+        assert sorted(offending) == sorted([bad_a, bad_b])
+        assert g1.id not in offending
+
+        # No journal entries should be written on the validation failure path.
+        assert mock_journal.log_entry.call_count == 0
+
+        # Sanity: scalar update must not have been persisted.
+        test_session.expire_all()
+        for rid in (r1.id, r2.id):
+            refreshed = test_session.query(AutoCreationRule).get(rid)
+            assert refreshed.enabled is False, f"rule id={rid} was mutated despite 422"
+
+    @pytest.mark.asyncio
+    async def test_does_not_validate_when_normalization_group_ids_omitted(
+        self, async_client, test_session
+    ):
+        """bd-i75ax delta-on-write: bulk-update requests that don't include
+        normalization_group_ids must not re-validate stored values, even if
+        any rule in scope has stale stored IDs."""
+        r1 = _create_rule(test_session, name="BulkStale", enabled=False)
+        # Simulate a stale stored id
+        r1.set_normalization_group_ids([999997])
+        test_session.commit()
+
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post(
+                "/api/auto-creation/rules/bulk-update",
+                json={"rule_ids": [r1.id], "enabled": True},
+            )
+
+        assert response.status_code == 200, response.text
+        test_session.expire_all()
+        refreshed = test_session.query(AutoCreationRule).get(r1.id)
+        assert refreshed.enabled is True
 
 
 class TestDeleteAutoCreationRule:


### PR DESCRIPTION
## Summary

Both `PUT /api/auto-creation/rules/{id}` and `POST /api/auto-creation/rules/bulk-update` accept a `normalization_group_ids` JSON list, but neither verified the IDs exist in `normalization_rule_groups`. A typo, copy-paste from a different environment, or stale ID stored garbage; failure surfaced later as silent "no normalization happened" with no clear error. This PR rejects bad IDs at write-time with HTTP 422 and names every offending ID in the error detail.

## Stale-data audit (run BEFORE writing the validation)

Audited the live container DB to scope migration safety:

```
Valid normalization_rule_group IDs: [1, 2, 3, 4, 5, 6, 7, 8] (8 rows)
Auto-creation rules with normalization_group_ids set: 1
  rule id=3 name='USA Entertainment': clean (ids=[1, 2, 3, 4, 5, 7, 6, 8])
Stale or unparseable references: 0
```

Result: clean. Straightforward write-time validation is safe — no backfill needed, no read-path impact.

## Validation approach

Helper `_validate_normalization_group_ids(submitted_ids, session)` lives in `backend/routers/auto_creation.py` next to the existing `_resolve_normalization_group_ids` for cohesion. It runs a single `IN (...)` query (de-duped first) and raises `HTTPException(422, detail={"message": ..., "invalid_normalization_group_ids": [...]})` listing every offending ID.

Why a router-level helper rather than a Pydantic `model_validator`:
- Pydantic validators with DB lookups couple request models to a session — anti-pattern, breaks model reusability and unit-testability of the schema layer.
- Service-layer abstraction would have been gold-plating for a 30-line check used by exactly two endpoints.

Why **delta-on-write** semantics (only validate IDs the caller is *submitting*, not stored values):
- Preserves backward-compat: if a `NormalizationRuleGroup` is deleted later out from under existing rules, an unrelated PUT (rename, toggle enabled) must still succeed. Tests cover this case explicitly.
- Audit shows zero stale data today, but a startup or migration that re-validates stored values would be a hidden footgun the day someone deletes a group.

Why **before mutation**:
- `PUT`: validation sits between the rule lookup and `_apply_rule_scalar_updates` so a bad ID can't leave partial scalar changes on the row.
- `bulk-update`: validation sits after the rules-by-id fetch but before the per-rule mutation loop. Submitted IDs are validated once (they apply identically to every rule in scope) and a single 422 rolls back the whole batch.

## Endpoints touched

- `PUT /api/auto-creation/rules/{rule_id}` — `update_auto_creation_rule`
- `POST /api/auto-creation/rules/bulk-update` — `bulk_update_auto_creation_rules`

`POST /api/auto-creation/rules` (create) is **not** in scope per the bead. If desired, that endpoint can be wired up the same way in a follow-up — current behavior already wraps the IDs in JSON without validation, so the same gap exists there.

## Backward-compat

- Empty list and omitted field both treated as no-op (no normalization groups is a valid state).
- Stored stale IDs on a row are not re-validated when the caller doesn't submit the field — explicit test guards this.

## Tests (TDD — written first, all initially red on the rejection cases)

`backend/tests/routers/test_auto_creation.py` — 9 new tests:

PUT:
- `test_accepts_valid_normalization_group_ids`
- `test_accepts_empty_normalization_group_ids`
- `test_rejects_missing_normalization_group_id`
- `test_rejects_lists_all_invalid_normalization_group_ids`
- `test_does_not_validate_when_normalization_group_ids_omitted` (delta-on-write guard)

bulk-update:
- `test_accepts_valid_normalization_group_ids`
- `test_accepts_empty_normalization_group_ids`
- `test_rejects_missing_normalization_group_id` (also asserts zero journal entries on rollback path and that scalar updates were not persisted)
- `test_does_not_validate_when_normalization_group_ids_omitted` (delta-on-write guard)

## Test plan

- [x] `pytest tests/routers/test_auto_creation.py` — 63 passed
- [x] `pytest tests/integration/test_api_auto_creation.py` — 25 passed
- [x] Full backend suite — 3088 passed in 111.79s
- [ ] Manual smoke: `curl -X PUT .../rules/{id} -d '{"normalization_group_ids": [99999]}'` returns 422 with `invalid_normalization_group_ids: [99999]`
- [ ] Manual smoke: `curl -X POST .../rules/bulk-update -d '{"rule_ids": [...], "normalization_group_ids": [valid, 99999]}'` returns 422; verify no rule mutated

Bead: enhancedchannelmanager-i75ax