### PR TITLE
chore: bump to v0.16.0-0056 for bd-tvlxz items 3+5 ceremony

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.16.0-0055",
+  "version": "0.16.0-0056",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Version bump for the bd-tvlxz follow-ups shipped in PR #147. CHANGELOG entries already added under `[Unreleased]` Added + Changed (release.md PR template + G1b semantics paragraph).

| Bead | Status | PR |
|------|--------|-----|
| bd-tvlxz | Closed | items 1+2 in PR #97; items 3-6 in PR #147 |
| bd-kgjci | Verified substantially complete; left in_progress until canary (bd-41tn1) closes | n/a — already shipped via prior PRs #96 + #98 + #108 |

## Test plan

- [x] `frontend/package.json` bumped to `0.16.0-0056`
- [x] `npm run build` succeeds
- [x] CHANGELOG entries for bd-tvlxz already present in `[Unreleased]` (no further edits needed in this PR)