### PR TITLE
refactor(settings): hoist discord_pattern to module-level _DISCORD_WEBHOOK_RE constant (bd-4mab3)

### DIFF
--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -4,6 +4,7 @@ Settings router — Dispatcharr connection, preferences, and service management 
 Extracted from main.py (Phase 2 of v0.13.0 backend refactor).
 """
 import logging
+import re
 import secrets
 from typing import Optional
 
@@ -19,6 +20,13 @@ from bandwidth_tracker import BandwidthTracker, get_tracker, set_tracker
 from services.notification_service import create_notification_internal, update_notification_internal, delete_notifications_by_source_internal
 
 logger = logging.getLogger(__name__)
+
+# Discord webhook URL prefix — accepts the canonical discord.com host, the legacy
+# discordapp.com host, and the canary/ptb subdomains. Anchored to the start so
+# only well-formed webhook URLs are admitted by the test-discord endpoint.
+_DISCORD_WEBHOOK_RE = re.compile(
+    r"^https://(discord\.com|discordapp\.com|canary\.discord\.com|ptb\.discord\.com)/api/webhooks/"
+)
 
 router = APIRouter(prefix="/api/settings", tags=["Settings"])
 
@@ -783,11 +791,7 @@ async def test_discord_webhook(request: DiscordTestRequest):
         return {"success": False, "message": "Webhook URL is required"}
 
     # Validate URL format - accept discord.com, discordapp.com, and variants (canary, ptb)
-    # TODO(enhancedchannelmanager-4mab3): promote to module-level _DISCORD_WEBHOOK_RE
-    # constant to match the ECM style guide convention.
-    import re
-    discord_pattern = r'^https://(discord\.com|discordapp\.com|canary\.discord\.com|ptb\.discord\.com)/api/webhooks/'
-    if not re.match(discord_pattern, webhook_url):  # nosemgrep: no-bare-re-on-dynamic-pattern
+    if not _DISCORD_WEBHOOK_RE.match(webhook_url):
         return {"success": False, "message": "Invalid Discord webhook URL format"}
 
     try:


### PR DESCRIPTION
## Summary

Hoist the Discord webhook URL validation regex out of `test_discord_webhook` and into a pre-compiled module-level constant `_DISCORD_WEBHOOK_RE` in `backend/routers/settings.py`, matching the existing project convention (`epg_matching.py`, `stream_normalization.py`, `obfuscate.py`, etc.). The pattern is now compiled once at import time, the function-local `import re` is removed, and the `nosemgrep: no-bare-re-on-dynamic-pattern` annotation is no longer needed since the regex literal is no longer assigned to a local variable. This closes the Semgrep-flagged style debt from `bd-eio04.8` without any change to validation semantics.

## Before / After

- **Before**: `backend/routers/settings.py:785-790` — inline `discord_pattern = r'...'` string variable, function-local `import re`, `re.match(discord_pattern, webhook_url)` with nosemgrep suppression and a TODO comment referencing this bead.
- **After**: `backend/routers/settings.py:24-29` — module-level `_DISCORD_WEBHOOK_RE = re.compile(r"...")` with explanatory comment; `backend/routers/settings.py:794` — call site uses `_DISCORD_WEBHOOK_RE.match(webhook_url)`.

## Behavior unchanged

- Pure refactor: regex source, anchoring, alternation, and trailing `/api/webhooks/` path are byte-identical.
- Parity verified manually across all four accepted hosts (`discord.com`, `discordapp.com`, `canary.discord.com`, `ptb.discord.com`) and rejection cases (empty string, non-Discord host, `http://`, wrong path).
- Full backend test suite passes: **3092 passed in 119s**, including the two `TestTestDiscord` cases that exercise the validation branch (`test_rejects_empty_url`, `test_rejects_invalid_url`).

## Test plan

- [x] `pytest tests/routers/test_settings.py` — 30 passed
- [x] `pytest tests/` — 3092 passed, coverage 60.20% (gate: 56%)
- [x] Manual parity check confirming `re.match(old_literal, x) == _DISCORD_WEBHOOK_RE.match(x)` for representative inputs

Closes enhancedchannelmanager-4mab3.