### PR TITLE
feat(auto-creation): extend normalization_group_ids FK validation to POST /rules (bd-j5p4k)

### DIFF
--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -392,6 +392,14 @@ async def create_auto_creation_rule(request: CreateAutoCreationRuleRequest):
 
         session = get_session()
         try:
+            # bd-j5p4k: write-time FK validation for normalization_group_ids.
+            # Run BEFORE the DB insert so a bad ID can't create a partially
+            # populated row. Mirrors the PUT/bulk-update guard added in
+            # bd-i75ax — same delta-on-write semantics, same 422 shape.
+            _validate_normalization_group_ids(
+                request.normalization_group_ids, session
+            )
+
             # Auto-assign priority: if requested priority already taken, append at end
             existing_priorities = [r.priority for r in session.query(AutoCreationRule).all()]
             if existing_priorities and request.priority in existing_priorities:

--- a/backend/tests/routers/test_auto_creation.py
+++ b/backend/tests/routers/test_auto_creation.py
@@ -155,6 +155,96 @@ class TestCreateAutoCreationRule:
 
         assert response.status_code == 400
 
+    @pytest.mark.asyncio
+    async def test_accepts_valid_normalization_group_ids(
+        self, async_client, test_session
+    ):
+        """bd-j5p4k: POST accepts normalization_group_ids that all exist.
+
+        Mirrors the PUT/bulk-update validation added in bd-i75ax to close
+        the symmetric write-time gap on the create endpoint.
+        """
+        g1 = _create_normalization_group(test_session, name="Group A")
+        g2 = _create_normalization_group(test_session, name="Group B")
+
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post("/api/auto-creation/rules", json={
+                "name": "WithNorm",
+                "conditions": [{"type": "stream_name_contains", "value": "CNN"}],
+                "actions": [{"type": "create_channel", "name_template": "{stream_name}"}],
+                "normalization_group_ids": [g1.id, g2.id],
+            })
+
+        assert response.status_code == 200, response.text
+        assert sorted(response.json()["normalization_group_ids"]) == sorted([g1.id, g2.id])
+
+    @pytest.mark.asyncio
+    async def test_accepts_empty_normalization_group_ids(
+        self, async_client
+    ):
+        """bd-j5p4k: POST accepts an empty normalization_group_ids list
+        (no normalization groups is a legitimate state)."""
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post("/api/auto-creation/rules", json={
+                "name": "EmptyNorm",
+                "conditions": [{"type": "stream_name_contains", "value": "CNN"}],
+                "actions": [{"type": "create_channel", "name_template": "{stream_name}"}],
+                "normalization_group_ids": [],
+            })
+
+        assert response.status_code == 200, response.text
+        assert response.json()["normalization_group_ids"] == []
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_normalization_group_id(
+        self, async_client, test_session
+    ):
+        """bd-j5p4k: POST returns 422 when a submitted ID is not in
+        normalization_rule_groups, and the error names the offending ID."""
+        g1 = _create_normalization_group(test_session, name="Group Real")
+        missing_id = 999999
+
+        response = await async_client.post("/api/auto-creation/rules", json={
+            "name": "BadNorm",
+            "conditions": [{"type": "stream_name_contains", "value": "CNN"}],
+            "actions": [{"type": "create_channel", "name_template": "{stream_name}"}],
+            "normalization_group_ids": [g1.id, missing_id],
+        })
+
+        assert response.status_code == 422, response.text
+        body = response.text
+        assert str(missing_id) in body
+        detail = response.json().get("detail")
+        assert detail is not None
+        if isinstance(detail, dict):
+            offending = detail.get("invalid_normalization_group_ids") or detail.get("offending_ids") or []
+            assert missing_id in offending
+            assert g1.id not in offending
+
+    @pytest.mark.asyncio
+    async def test_rejects_lists_all_invalid_normalization_group_ids(
+        self, async_client, test_session
+    ):
+        """bd-j5p4k: When multiple submitted IDs are missing on POST, all are listed."""
+        g1 = _create_normalization_group(test_session, name="Real Group")
+        bad_a, bad_b, bad_c = 700001, 700002, 700003
+
+        response = await async_client.post("/api/auto-creation/rules", json={
+            "name": "MultiBadNorm",
+            "conditions": [{"type": "stream_name_contains", "value": "CNN"}],
+            "actions": [{"type": "create_channel", "name_template": "{stream_name}"}],
+            "normalization_group_ids": [g1.id, bad_a, bad_b, bad_c],
+        })
+
+        assert response.status_code == 422, response.text
+        detail = response.json().get("detail")
+        assert isinstance(detail, dict)
+        offending = detail.get("invalid_normalization_group_ids") or detail.get("offending_ids") or []
+        assert sorted(offending) == sorted([bad_a, bad_b, bad_c])
+        assert g1.id not in offending
+
 
 class TestUpdateAutoCreationRule:
     """Tests for PUT /api/auto-creation/rules/{rule_id}."""


### PR DESCRIPTION
## Summary

Closes the symmetric write-time validation gap left by bd-i75ax (PR #145), which wired write-time FK validation for `normalization_group_ids` into PUT `/api/auto-creation/rules/{id}` and POST `/api/auto-creation/rules/bulk-update` but explicitly left POST `/api/auto-creation/rules` (create) out of scope. This bead reuses the already-merged `_validate_normalization_group_ids` helper and calls it from the create handler between payload validation and the DB insert. Same delta-on-write semantics, same HTTP 422 response shape (`detail.invalid_normalization_group_ids` lists every offending ID). Previously a typo or stale ID at create time would silently persist and surface later as a confusing "no normalization happened" symptom.

All three rule write paths now validate `normalization_group_ids` consistently:

- POST `/rules` (create) — this change
- PUT `/rules/{id}` (update) — bd-i75ax
- POST `/rules/bulk-update` (bulk) — bd-i75ax

## Test cases (4 new, on `TestCreateAutoCreationRule`)

- `test_accepts_valid_normalization_group_ids` — POST with all-existing IDs returns 200 and persists them
- `test_accepts_empty_normalization_group_ids` — POST with `[]` returns 200 (legitimate "normalization disabled" state)
- `test_rejects_missing_normalization_group_id` — POST with one non-existent ID returns 422; offending ID is named, valid ID is not
- `test_rejects_lists_all_invalid_normalization_group_ids` — POST with multiple non-existent IDs returns 422 listing all of them

## Test plan

- [x] Backend suite green: `python -m pytest tests/ --tb=short --no-header -p no:warnings` -> 3096 passed
- [x] Targeted suite green: `python -m pytest tests/routers/test_auto_creation.py` -> 67 passed (4 new + 63 pre-existing)
- [x] Helper reused — no duplication, no new validation code paths

Bead: enhancedchannelmanager-j5p4k
Symmetry rationale: bd-i75ax (PR #145)

Generated with Claude Code