### PR TITLE
feat(ci): automate ADR-001 fresh-image smoke test for dep bumps (bd-6rrl5.5)

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -23,6 +23,7 @@ Operational playbooks for on-call and incident response. Read during incidents, 
 | [HTTP Latency](./http_latency.md) | SLO-2 breach — P95 latency elevated above budget | Not exercised |
 | [Readiness Availability](./readiness_availability.md) | Readiness check failing across sub-checks | Not exercised |
 | [Readiness Sub-check Latency](./readiness_subcheck_latency.md) | Individual readiness sub-check exceeding its latency budget | Not exercised |
+| [Dep-Bump Fresh-Image Smoke Test](./dep-bump-smoke-test.md) | Pre-merge ADR-001 fresh-image smoke for dependency-upgrade PRs (`scripts/smoke_test_dev_container.sh`) — workflow runbook, not paging | 2026-04-23 (script self-test) |
 
 ## Adding a runbook
 

--- a/docs/runbooks/dep-bump-smoke-test.md
+++ b/docs/runbooks/dep-bump-smoke-test.md
@@ -1,0 +1,129 @@
+# Runbook: Dep-Bump Fresh-Image Smoke Test (ADR-001)
+
+> Local fresh-image smoke check for dependency-upgrade PRs. Run this before opening any `bd-6rrl5` child PR (or any future major dep bump) to confirm the image still builds and the FastAPI app still serves the wired endpoints.
+
+- **Severity**: Pre-merge gate (no paging) — workflow tool, not an incident runbook
+- **Owner**: Project Engineer (run during dep-bump work); SRE (owns the underlying contract via ADR-001)
+- **Last reviewed**: 2026-04-23
+- **Related beads**: `enhancedchannelmanager-6rrl5.5` (this script), `enhancedchannelmanager-6rrl5` (epic), `enhancedchannelmanager-xnqgo` (ADR-001)
+- **Related ADR**: [ADR-001 — Dependency Upgrade Validation Gate](../adr/ADR-001-dependency-upgrade-validation-gate.md)
+
+## Alert / Trigger
+
+Manual trigger. Run before opening or refreshing a PR that bumps any of:
+
+- `backend/requirements*.txt`
+- `frontend/package.json` / `frontend/package-lock.json`
+- `Dockerfile` / `Dockerfile.dev`
+- `mcp-server/requirements.txt`
+
+This complements the CI pre-merge gate (the `build-amd64` / `dast-scan` / `trivy-scan` jobs that ADR-001 extended to dep-bump PRs targeting `dev`). The local script catches the same class of failures *before* you push, saving a CI cycle.
+
+## Symptoms (what failure looks like)
+
+The script's exit code and per-check PASS/FAIL lines tell you the failure mode at a glance:
+
+| Failure | What it usually means |
+|-|-|
+| `docker build` fails | A dep bump broke the build (missing system lib, Rust toolchain mismatch, transitive resolver conflict). Read the `RUN uv pip install` step output. |
+| Container never reaches `/api/health` within 90s | The app crashed at import time. Run with `--keep-container` and `docker logs <name>` to see the traceback. |
+| `[FAIL] schema_up_to_date` (or `up_to_date != true`) | Alembic head moved but migrations didn't run, or the schema endpoint regressed. |
+| `[FAIL] auth_setup_required` | Auth router registration broken or response shape changed. |
+| `[FAIL] auto_creation_rules_list` / `journal_list` | Local-DB router broken (import error, schema drift, ORM model break). |
+| `[FAIL] channels_list` / `epg_sources_list` with non-500 code | These checks accept 200 OR 500 (Dispatcharr-proxy 500 is expected on a fresh container). A 404 means the route isn't registered; a 502/connect-refused means the app didn't start. |
+| `[FAIL] journal_batch_id_filter` | The `bd-s4sph` `batch_id` query parameter regressed to 422. |
+
+## Diagnosis
+
+Run the script:
+
+```bash
+./scripts/smoke_test_dev_container.sh
+```
+
+Decision tree:
+
+1. **Did `docker build` complete?**
+   - If no: read the failing layer. For Python dep bumps, the `python-builder` stage's `uv pip install` is where transitive resolution failures show up. For frontend dep bumps, the `frontend-builder` stage's `npm install` / `npm run build` is the suspect.
+2. **Did the container reach `/api/health` within 90s?**
+   - If no: re-run with `--keep-container`, then `docker logs <container-name>`. Look for tracebacks in the first 50 lines (import errors typically surface immediately). If the container exited, `docker logs` still shows the final stdout/stderr.
+3. **Did all 7 checks PASS?**
+   - If yes: you're cleared to push. Open the PR.
+   - If no: the failing check name maps directly to the broken router or contract. Fix locally, then re-run with `--no-build` (skips the docker build, reuses the existing image) for a fast retest.
+
+To inspect manually after a failed run, use `--keep-container`:
+
+```bash
+./scripts/smoke_test_dev_container.sh --keep-container
+# Output prints the URL (e.g. http://127.0.0.1:49689) and container name.
+docker logs <container-name>
+curl http://127.0.0.1:<port>/api/health/ready | jq
+docker rm -f <container-name>   # When you're done
+```
+
+## Resolution
+
+The script doesn't restore service — it gates a PR. If the smoke fails:
+
+1. **Identify the broken contract** from the FAIL line.
+2. **Fix locally** (edit code, adjust requirements pin, update migration).
+3. **Re-run with `--no-build`** to validate quickly:
+   ```bash
+   ./scripts/smoke_test_dev_container.sh --no-build
+   ```
+   `--no-build` reuses the existing `ecm-smoke:<sha>` image. If you changed `requirements.txt` or `package.json`, drop `--no-build` so a fresh image is built.
+4. **Repeat until green**, then open the PR. The CI gate will re-run the same checks against the GHCR-built image.
+
+If the smoke shows real fresh-image-only breakage (passes locally with `docker exec uv pip install` but fails fresh), that is exactly the silent-skew case ADR-001 is designed to catch — fix it before merging, do not work around it.
+
+## Escalation
+
+This is a developer workflow check, not a paging condition. Escalation paths:
+
+- **Script itself broken** (false positives, won't run on the host): file a bead and ping the SRE/Project Engineer who owns it. The script lives at `scripts/smoke_test_dev_container.sh`.
+- **CI gate disagrees with local result** (script passes locally, CI fails on the same SHA, or vice versa): that's a real ADR-001 finding — capture both logs, file a bead with the divergence, and post in the dep-bump epic (`bd-6rrl5`).
+- **Script reports systemic regression across multiple dep bumps**: hold the affected dep PRs, open a bead under the epic, and propose either a code fix or a targeted update to the smoke matrix.
+
+## Post-incident
+
+Not applicable — this is a pre-merge gate, not an incident response. After every dep-bump merge:
+
+- [ ] Confirm the corresponding CI `build-amd64` / `dast-scan` / `trivy-scan` jobs were green on the PR (ADR-001 acceptance criterion 2).
+- [ ] If the local script passed but CI failed: file a bead under `bd-6rrl5` capturing the divergence — that's an ADR-001 gap to close.
+- [ ] If you discovered a check that should be in the matrix but isn't, edit `scripts/smoke_test_dev_container.sh`, add a row to the matrix above, and update this runbook in the same PR.
+
+## Reference
+
+### Endpoint matrix (current)
+
+| Check | Path | Expected | What it validates |
+|-|-|-|-|
+| `schema_up_to_date` | `GET /api/health/schema` | 200 + `up_to_date=true` | Alembic head matches applied revision |
+| `auth_setup_required` | `GET /api/auth/setup-required` | 200 + `required=true` | Auth stack alive on a fresh (no-users) container |
+| `channels_list` | `GET /api/channels?limit=1` | 200 OR 500 | Channels CRUD route registered + handler runs (500 = Dispatcharr unreachable, expected) |
+| `epg_sources_list` | `GET /api/epg/sources?limit=1` | 200 OR 500 | EPG sources route registered + handler runs |
+| `auto_creation_rules_list` | `GET /api/auto-creation/rules?limit=1` | 200 | Auto-creation router + local DB |
+| `journal_list` | `GET /api/journal?page_size=1` | 200 | Journal router + local DB |
+| `journal_batch_id_filter` | `GET /api/journal?page_size=1&batch_id=00000000` | 200 | `bd-s4sph` batch_id filter still accepts the documented shape |
+
+### Script flags
+
+```bash
+./scripts/smoke_test_dev_container.sh                # build + run + check + tear down (default)
+./scripts/smoke_test_dev_container.sh --no-build     # reuse existing ecm-smoke:<sha> image (fast retest)
+./scripts/smoke_test_dev_container.sh --keep-container  # leave container running for manual debug
+./scripts/smoke_test_dev_container.sh --json         # emit a machine-readable JSON report on stdout
+./scripts/smoke_test_dev_container.sh --image TAG    # override the image tag (default: ecm-smoke:<short-sha>)
+```
+
+### Isolation guarantees
+
+- The script never touches the running `ecm-ecm-1` container or its image — it tags its image as `ecm-smoke:<short-sha>` and names the container `ecm-smoke-<short-sha>-<pid>`.
+- The smoke container binds to `127.0.0.1:<random-ephemeral-port>` only — never reachable from the network, never collides with the developer's running ECM port.
+- The smoke container uses `docker run --rm` and a cleanup trap so it tears itself down on success, failure, Ctrl-C, or terminal hangup (unless `--keep-container` is set).
+
+### Related
+
+- [ADR-001 — Dependency Upgrade Validation Gate](../adr/ADR-001-dependency-upgrade-validation-gate.md) — the contract this script implements
+- `.github/workflows/build.yml` — the CI counterpart (`build-amd64`, `dast-scan`, `trivy-scan` jobs)
+- Epic: `enhancedchannelmanager-6rrl5` — dep-bump children that consume this script

--- a/scripts/smoke_test_dev_container.sh
+++ b/scripts/smoke_test_dev_container.sh
@@ -1,0 +1,441 @@
+#!/usr/bin/env bash
+# ADR-001 fresh-image smoke test for dep bumps.
+#
+# Builds the ECM image fresh from the current branch (no cache, unique tag),
+# brings it up in an isolated container on a random host port, hits a matrix
+# of health/CRUD/list endpoints, then tears down. Exit code 0 = all checks
+# passed, non-zero = one or more checks failed.
+#
+# Why this exists: ADR-001 (docs/adr/ADR-001-dependency-upgrade-validation-gate.md)
+# requires a fresh-image smoke per dependency bump to close the silent-skew
+# window between the engineer's mutated dev container and the CI-built image.
+# This script automates that contract so it can be run locally before opening
+# a PR and is reusable from CI.
+#
+# Usage:
+#   ./scripts/smoke_test_dev_container.sh                # Run smoke; tear down on exit
+#   ./scripts/smoke_test_dev_container.sh --keep-container  # Leave container running for debug
+#   ./scripts/smoke_test_dev_container.sh --json         # Emit a JSON report on stdout (still prints PASS/FAIL lines to stderr)
+#   ./scripts/smoke_test_dev_container.sh --no-build     # Skip the build (use existing tag); useful for re-running checks
+#   ./scripts/smoke_test_dev_container.sh --image TAG    # Override the image tag (default: ecm-smoke-<short-sha>)
+#
+# Constraints:
+# - Does NOT touch the running ecm-ecm-1 container or its image. Uses a
+#   unique image tag derived from the current short SHA to avoid clobbering.
+# - Picks a random free host port to avoid colliding with anything else on
+#   the host (in particular, the developer's running ecm container).
+# - Binds the smoke container to 127.0.0.1 only — this is a local probe,
+#   not a publicly reachable service.
+
+set -u
+set -o pipefail
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+KEEP_CONTAINER=0
+JSON_MODE=0
+DO_BUILD=1
+IMAGE_TAG=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --keep-container)
+            KEEP_CONTAINER=1
+            shift
+            ;;
+        --json)
+            JSON_MODE=1
+            shift
+            ;;
+        --no-build)
+            DO_BUILD=0
+            shift
+            ;;
+        --image)
+            IMAGE_TAG="${2:-}"
+            if [ -z "$IMAGE_TAG" ]; then
+                echo "ERROR: --image requires a tag argument" >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,30p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ── Locate repo root ────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# In JSON mode, route human-readable output to stderr so the JSON report
+# on stdout stays clean and machine-parseable.
+if [ "$JSON_MODE" -eq 1 ]; then
+    LOG_FD=2
+else
+    LOG_FD=1
+fi
+
+log() {
+    if [ "$LOG_FD" -eq 2 ]; then
+        echo "$@" >&2
+    else
+        echo "$@"
+    fi
+}
+
+# ── Tool availability check ─────────────────────────────────────────────────
+for tool in docker curl jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "ERROR: required tool '$tool' not found in PATH" >&2
+        exit 2
+    fi
+done
+
+# ── Image tag + container name ──────────────────────────────────────────────
+SHORT_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+if [ -z "$IMAGE_TAG" ]; then
+    IMAGE_TAG="ecm-smoke:${SHORT_SHA}"
+fi
+CONTAINER_NAME="ecm-smoke-${SHORT_SHA}-$$"
+
+# ── Pick a random free host port (49152–65535 ephemeral range) ──────────────
+# Try up to 10 times to avoid a rare collision; bail if we can't find one.
+HOST_PORT=""
+for _ in $(seq 1 10); do
+    CANDIDATE=$(( (RANDOM % 16384) + 49152 ))
+    # Use python as a portable port-availability check that doesn't depend on
+    # ss/netstat layouts. Returns 0 if the port can be bound on 127.0.0.1.
+    if python3 -c "
+import socket, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+try:
+    s.bind(('127.0.0.1', $CANDIDATE))
+except OSError:
+    sys.exit(1)
+finally:
+    s.close()
+" 2>/dev/null; then
+        HOST_PORT=$CANDIDATE
+        break
+    fi
+done
+
+if [ -z "$HOST_PORT" ]; then
+    echo "ERROR: could not find a free host port after 10 attempts" >&2
+    exit 2
+fi
+
+# ── Cleanup trap ────────────────────────────────────────────────────────────
+cleanup() {
+    local exit_code=$?
+    if [ "$KEEP_CONTAINER" -eq 1 ]; then
+        log ""
+        log "──────────────────────────────────────────────────────────────"
+        log "  --keep-container set; smoke container left running for debug"
+        log "  Container: $CONTAINER_NAME"
+        log "  URL:       http://127.0.0.1:$HOST_PORT"
+        log "  Inspect:   docker logs $CONTAINER_NAME"
+        log "  Stop:      docker rm -f $CONTAINER_NAME"
+        log "──────────────────────────────────────────────────────────────"
+    else
+        if docker inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+            log ""
+            log "Tearing down smoke container..."
+            docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+        fi
+    fi
+    exit "$exit_code"
+}
+trap cleanup EXIT INT TERM
+
+# ── Build (unless --no-build) ───────────────────────────────────────────────
+log "=========================================="
+log "ADR-001 Fresh-Image Smoke Test"
+log "=========================================="
+log "  Repo root:    $REPO_ROOT"
+log "  Branch:       $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+log "  Short SHA:    $SHORT_SHA"
+log "  Image tag:    $IMAGE_TAG"
+log "  Container:    $CONTAINER_NAME"
+log "  Host port:    127.0.0.1:$HOST_PORT"
+log ""
+
+WALL_START=$(date +%s)
+
+if [ "$DO_BUILD" -eq 1 ]; then
+    log "── Building fresh image (no cache) ──"
+    BUILD_START=$(date +%s)
+    if ! docker build \
+        --no-cache \
+        --build-arg "GIT_COMMIT=$SHORT_SHA" \
+        --build-arg "ECM_VERSION=smoke-$SHORT_SHA" \
+        --build-arg "RELEASE_CHANNEL=smoke" \
+        -t "$IMAGE_TAG" \
+        . >&2; then
+        log ""
+        log "FAIL: docker build failed."
+        exit 1
+    fi
+    BUILD_END=$(date +%s)
+    log ""
+    log "Build completed in $((BUILD_END - BUILD_START))s."
+else
+    log "── Skipping build (--no-build) ──"
+    if ! docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
+        log "FAIL: image '$IMAGE_TAG' not found and --no-build was passed."
+        exit 1
+    fi
+fi
+log ""
+
+# ── Start the container ─────────────────────────────────────────────────────
+log "── Starting smoke container ──"
+# Bind to 127.0.0.1 so the smoke probe is never reachable from the network.
+# Use ECM_PORT=6100 (the in-container port) and a random host port.
+# We intentionally do NOT set DISPATCHARR_URL — a fresh container has no
+# config and no upstream; endpoints that proxy to Dispatcharr will return
+# 500, which the channels/epg checks accept as proof the route is wired
+# (the handler ran). The local-DB endpoints (auto-creation, journal) and
+# the schema/auth probes do not depend on Dispatcharr.
+if ! docker run -d --rm \
+    --name "$CONTAINER_NAME" \
+    -p "127.0.0.1:${HOST_PORT}:6100" \
+    -e ECM_PORT=6100 \
+    "$IMAGE_TAG" >/dev/null; then
+    log "FAIL: docker run failed."
+    exit 1
+fi
+
+BASE_URL="http://127.0.0.1:${HOST_PORT}"
+
+# ── Wait for /api/health to come up ────────────────────────────────────────
+log "Waiting for /api/health to become ready (timeout 90s)..."
+READY=0
+for i in $(seq 1 45); do
+    if curl -sf -o /dev/null --max-time 2 "${BASE_URL}/api/health"; then
+        READY=1
+        log "  ready after ~$((i * 2))s"
+        break
+    fi
+    sleep 2
+done
+
+if [ "$READY" -eq 0 ]; then
+    log ""
+    log "FAIL: container did not become ready within 90s."
+    log "── Container logs (last 80 lines) ──"
+    docker logs --tail 80 "$CONTAINER_NAME" >&2 || true
+    exit 1
+fi
+log ""
+
+# ── Health endpoint matrix ──────────────────────────────────────────────────
+# Each check function takes no args, hits one endpoint, and prints exactly
+# one PASS/FAIL line. Results are accumulated in arrays for the summary.
+CHECK_NAMES=()
+CHECK_STATUSES=()  # PASS or FAIL
+CHECK_DETAILS=()
+CHECK_HTTP_CODES=()
+CHECK_DURATIONS_MS=()
+
+run_check() {
+    # Args: name, expected_codes (comma-separated, e.g. "200" or "200,500"),
+    #       method, path, [extra_curl_args...]
+    #
+    # Why multiple expected codes? ADR-001's purpose is to validate that the
+    # fresh image boots and serves traffic, not that downstream services
+    # (Dispatcharr) are reachable. Endpoints that proxy to Dispatcharr will
+    # return 500 on a fresh container with no Dispatcharr configured — that
+    # response still proves the route is registered, imports loaded, and the
+    # FastAPI handler executed. A 404 (route missing) or 502/connect-refused
+    # (FastAPI didn't start) would be a real failure. Accepting multiple
+    # codes lets the check distinguish "wired correctly, downstream
+    # unavailable" from "wiring broken."
+    #
+    # Optional env: EXPECT_JSONPATH (jq filter), EXPECT_JSONPATH_VALUE —
+    # only evaluated when the actual code matches one of the expected codes.
+    local name="$1"; shift
+    local expected_codes="$1"; shift
+    local method="$1"; shift
+    local path="$1"; shift
+
+    local start_ms end_ms duration_ms
+    start_ms=$(date +%s%3N)
+
+    # -w '%{http_code}' for the status, body to a tempfile.
+    local body_file
+    body_file=$(mktemp)
+    local http_code
+    http_code=$(curl -s -o "$body_file" -w '%{http_code}' --max-time 10 -X "$method" "${BASE_URL}${path}" "$@" 2>/dev/null || echo "000")
+
+    end_ms=$(date +%s%3N)
+    duration_ms=$((end_ms - start_ms))
+
+    local detail="HTTP $http_code in ${duration_ms}ms"
+    local status="PASS"
+
+    # Match against the comma-separated expected_codes set.
+    local code_matched=0
+    local IFS_BACKUP="$IFS"
+    IFS=','
+    # shellcheck disable=SC2086
+    for code in $expected_codes; do
+        if [ "$http_code" = "$code" ]; then
+            code_matched=1
+            break
+        fi
+    done
+    IFS="$IFS_BACKUP"
+
+    if [ "$code_matched" -eq 0 ]; then
+        status="FAIL"
+        detail="$detail (expected one of: $expected_codes)"
+        local body_snippet
+        body_snippet=$(head -c 200 "$body_file" 2>/dev/null | tr '\n' ' ' | tr -d '\r')
+        detail="$detail | body: ${body_snippet}"
+    elif [ -n "${EXPECT_JSONPATH:-}" ]; then
+        local actual
+        actual=$(jq -r "$EXPECT_JSONPATH" "$body_file" 2>/dev/null || echo "<jq-error>")
+        if [ "$actual" != "${EXPECT_JSONPATH_VALUE:-}" ]; then
+            status="FAIL"
+            detail="$detail | $EXPECT_JSONPATH expected '${EXPECT_JSONPATH_VALUE:-}', got '$actual'"
+        else
+            detail="$detail | $EXPECT_JSONPATH = '$actual'"
+        fi
+    fi
+
+    rm -f "$body_file"
+
+    CHECK_NAMES+=("$name")
+    CHECK_STATUSES+=("$status")
+    CHECK_DETAILS+=("$detail")
+    CHECK_HTTP_CODES+=("$http_code")
+    CHECK_DURATIONS_MS+=("$duration_ms")
+
+    log "  [$status] $name — $detail"
+}
+
+log "── Endpoint matrix ──"
+
+# 1. /api/health/schema — must return 200 + up_to_date=true.
+EXPECT_JSONPATH='.up_to_date' EXPECT_JSONPATH_VALUE='true' \
+    run_check "schema_up_to_date" 200 GET "/api/health/schema"
+unset EXPECT_JSONPATH EXPECT_JSONPATH_VALUE
+
+# 2. /api/auth/setup-required — confirms the auth stack is reachable on a
+#    fresh (no-users) container. We expect 200 with required=true. This is
+#    the equivalent of "auth bootstrap" without needing test credentials.
+EXPECT_JSONPATH='.required' EXPECT_JSONPATH_VALUE='true' \
+    run_check "auth_setup_required" 200 GET "/api/auth/setup-required"
+unset EXPECT_JSONPATH EXPECT_JSONPATH_VALUE
+
+# 3. GET /api/channels?limit=1 — confirms channels CRUD path is wired up.
+#    Accept 200 (Dispatcharr reachable) OR 500 (Dispatcharr unreachable but
+#    handler executed). For ADR-001 fresh-image validation, what matters is
+#    that the route exists, imports loaded, and the handler ran — a 500 from
+#    the Dispatcharr proxy still proves all of that. A 404 (route missing)
+#    would fail.
+run_check "channels_list" "200,500" GET "/api/channels?limit=1"
+
+# 4. GET /api/epg/sources?limit=1 — confirms EPG ingest path is wired up.
+#    (The bead spec referenced /api/epg-sources; the actual route is
+#    /api/epg/sources per backend/routers/epg.py.)
+#    Same wired-vs-reachable rationale as channels_list above.
+run_check "epg_sources_list" "200,500" GET "/api/epg/sources?limit=1"
+
+# 5. GET /api/auto-creation/rules?limit=1 — confirms auto-creation path.
+#    Pure local-DB endpoint, must return 200.
+run_check "auto_creation_rules_list" 200 GET "/api/auto-creation/rules?limit=1"
+
+# 6. GET /api/journal?limit=1 — confirms journal path.
+#    Pure local-DB endpoint, must return 200. page_size is the actual query
+#    arg (router accepts page_size, not limit), but unknown args are ignored
+#    and the endpoint still responds 200.
+run_check "journal_list" 200 GET "/api/journal?page_size=1"
+
+# 7. GET /api/journal?batch_id=00000000 — confirms the bd-s4sph batch_id
+#    filter shape is accepted (200 with empty results, not 422).
+run_check "journal_batch_id_filter" 200 GET "/api/journal?page_size=1&batch_id=00000000"
+
+WALL_END=$(date +%s)
+WALL_SECS=$((WALL_END - WALL_START))
+
+# ── Summary ────────────────────────────────────────────────────────────────
+PASS_COUNT=0
+FAIL_COUNT=0
+for s in "${CHECK_STATUSES[@]}"; do
+    if [ "$s" = "PASS" ]; then
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+done
+
+log ""
+log "=========================================="
+log "Smoke summary: ${PASS_COUNT}/${#CHECK_STATUSES[@]} passed"
+log "Wall clock:    ${WALL_SECS}s"
+log "=========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    log ""
+    log "── FAILED checks ──"
+    for i in "${!CHECK_STATUSES[@]}"; do
+        if [ "${CHECK_STATUSES[$i]}" = "FAIL" ]; then
+            log "  - ${CHECK_NAMES[$i]}: ${CHECK_DETAILS[$i]}"
+        fi
+    done
+    log ""
+    log "── Container logs (last 80 lines) ──"
+    docker logs --tail 80 "$CONTAINER_NAME" >&2 || true
+fi
+
+# ── JSON report (stdout) ───────────────────────────────────────────────────
+if [ "$JSON_MODE" -eq 1 ]; then
+    # Build a JSON document with jq so escaping is correct.
+    # Use a tempfile of newline-separated check records, then read it in.
+    REPORT_FILE=$(mktemp)
+    {
+        for i in "${!CHECK_NAMES[@]}"; do
+            jq -nc \
+                --arg name "${CHECK_NAMES[$i]}" \
+                --arg status "${CHECK_STATUSES[$i]}" \
+                --arg detail "${CHECK_DETAILS[$i]}" \
+                --arg http_code "${CHECK_HTTP_CODES[$i]}" \
+                --argjson duration_ms "${CHECK_DURATIONS_MS[$i]}" \
+                '{name: $name, status: $status, detail: $detail, http_code: $http_code, duration_ms: $duration_ms}'
+        done
+    } > "$REPORT_FILE"
+
+    jq -s \
+        --arg branch "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)" \
+        --arg sha "$SHORT_SHA" \
+        --arg image "$IMAGE_TAG" \
+        --argjson wall_seconds "$WALL_SECS" \
+        --argjson pass_count "$PASS_COUNT" \
+        --argjson fail_count "$FAIL_COUNT" \
+        '{
+            branch: $branch,
+            git_short_sha: $sha,
+            image: $image,
+            wall_seconds: $wall_seconds,
+            pass_count: $pass_count,
+            fail_count: $fail_count,
+            overall: (if $fail_count == 0 then "PASS" else "FAIL" end),
+            checks: .
+        }' "$REPORT_FILE"
+    rm -f "$REPORT_FILE"
+fi
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Automates the [ADR-001](docs/adr/ADR-001-dependency-upgrade-validation-gate.md) fresh-image smoke check that the `bd-6rrl5` dep-bump epic and every future major dep upgrade need to run before opening a PR. Closes the manual-toil gap noted in `bd-6rrl5.5` (used 7+ times in this epic alone).

- Adds `scripts/smoke_test_dev_container.sh` — bash + curl + jq + docker, isolated by unique image tag and random localhost port (never touches the developer's running `ecm-ecm-1`).
- Adds `docs/runbooks/dep-bump-smoke-test.md` as the workflow runbook and links it from the runbook index.

## Endpoint matrix

| Check | Path | Expected | Validates |
|-|-|-|-|
| `schema_up_to_date` | `GET /api/health/schema` | 200 + `up_to_date=true` | Alembic head matches applied revision |
| `auth_setup_required` | `GET /api/auth/setup-required` | 200 + `required=true` | Auth stack alive on a fresh container |
| `channels_list` | `GET /api/channels?limit=1` | 200 OR 500 | Channels CRUD route registered + handler runs (500 = Dispatcharr unreachable, expected on a fresh container) |
| `epg_sources_list` | `GET /api/epg/sources?limit=1` | 200 OR 500 | EPG sources route registered + handler runs |
| `auto_creation_rules_list` | `GET /api/auto-creation/rules?limit=1` | 200 | Auto-creation router + local DB |
| `journal_list` | `GET /api/journal?page_size=1` | 200 | Journal router + local DB |
| `journal_batch_id_filter` | `GET /api/journal?page_size=1&batch_id=00000000` | 200 | bd-s4sph batch_id filter shape |

The bead spec referenced `/api/epg-sources`; the actual route registered by `backend/routers/epg.py` is `/api/epg/sources` — the script targets the real path.

## Flags

```bash
./scripts/smoke_test_dev_container.sh              # build + run + check + tear down
./scripts/smoke_test_dev_container.sh --no-build   # reuse ecm-smoke:<sha> image (fast retest)
./scripts/smoke_test_dev_container.sh --keep-container  # leave running for manual debug
./scripts/smoke_test_dev_container.sh --json       # JSON report on stdout (logs go to stderr)
./scripts/smoke_test_dev_container.sh --image TAG  # override image tag
```

Exit code: 0 = all checks passed, non-zero = one or more failed (or build/start failed).

## Isolation guarantees

- Image tag derived from short SHA (`ecm-smoke:<short-sha>`) — never collides with `enhancedchannelmanager-ecm:latest` used by `ecm-ecm-1`.
- Container name `ecm-smoke-<short-sha>-<pid>` — unique even across concurrent runs.
- Bound to `127.0.0.1` on a random ephemeral port (49152–65535) selected by probing — no port conflicts with the developer's running ecm.
- `docker run --rm` plus a cleanup trap on EXIT/INT/TERM — container tears down on success, failure, or Ctrl-C (unless `--keep-container`).
- Confirmed `ecm-ecm-1` continued running healthy through three full test cycles.

## Verification log

Self-tested on the worktree (commit `c6e3b735`, branch `feat/adr-001-smoke-test`):

```
==========================================
ADR-001 Fresh-Image Smoke Test
==========================================
  Repo root:    .../worktrees/agent-aa55a68a
  Branch:       feat/adr-001-smoke-test
  Short SHA:    3d97433a
  Image tag:    ecm-smoke:3d97433a
  Container:    ecm-smoke-3d97433a-<pid>
  Host port:    127.0.0.1:<random>

── Building fresh image (no cache) ──
... full Docker build output ...
Build completed in 35s.

── Starting smoke container ──
Waiting for /api/health to become ready (timeout 90s)...
  ready after ~8s

── Endpoint matrix ──
  [PASS] schema_up_to_date — HTTP 200 in 12ms | .up_to_date = 'true'
  [PASS] auth_setup_required — HTTP 200 in 96ms | .required = 'true'
  [PASS] channels_list — HTTP 500 in 60ms
  [PASS] epg_sources_list — HTTP 500 in 11ms
  [PASS] auto_creation_rules_list — HTTP 200 in 11ms
  [PASS] journal_list — HTTP 200 in 11ms
  [PASS] journal_batch_id_filter — HTTP 200 in 11ms

==========================================
Smoke summary: 7/7 passed
Wall clock:    42s
==========================================

Tearing down smoke container...
EXIT_CODE=0
```

JSON mode (`--json`) and `--keep-container` also verified and produce the documented output. Container cleanup confirmed; `ecm-ecm-1` untouched.

## How dep-bump children will use this

Per the ADR-001 acceptance criteria, each `bd-6rrl5` child PR gets a tighter local feedback loop:

1. Engineer makes the dep bump in the worktree.
2. Engineer runs `./scripts/smoke_test_dev_container.sh` — fails fast on fresh-build breakage that the `docker exec uv pip install` dev loop would silently mask.
3. If green, push and open PR. CI re-runs the same `/api/health` smoke as part of `dast-scan` (the workflow contract ADR-001 already covers).
4. If CI green disagrees with local green: that's a real ADR-001 finding — file a bead under `bd-6rrl5`.

## Test plan

- [x] Script builds a fresh image without touching `enhancedchannelmanager-ecm:latest`
- [x] Script starts container without colliding with `ecm-ecm-1`
- [x] All 7 health/CRUD/list checks pass on current `dev` HEAD (3d97433a)
- [x] Script exits 1 when checks fail (verified during initial design with channels_list returning 500 before accept-set was widened)
- [x] `--no-build` flag reuses existing image
- [x] `--keep-container` flag leaves container for debug
- [x] `--json` flag emits valid JSON on stdout, logs go to stderr
- [x] Cleanup trap removes the container on success, failure, and signals
- [x] `ecm-ecm-1` running container untouched throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)