### PR TITLE
refactor: break SQLAlchemy / cloud_storage circular-import clusters (bd-wlvxh)

### DIFF
--- a/backend/cloud_storage/__init__.py
+++ b/backend/cloud_storage/__init__.py
@@ -2,11 +2,11 @@
 Cloud storage adapter framework for export distribution.
 Supports S3, Google Drive, OneDrive, and Dropbox.
 """
-from cloud_storage.base import (
+from cloud_storage.factory import get_adapter
+from cloud_storage.types import (
     CloudStorageAdapter,
-    UploadResult,
     ConnectionTestResult,
-    get_adapter,
+    UploadResult,
 )
 
 __all__ = [

--- a/backend/cloud_storage/dropbox_adapter.py
+++ b/backend/cloud_storage/dropbox_adapter.py
@@ -5,7 +5,7 @@ import logging
 import time
 from pathlib import Path
 
-from cloud_storage.base import CloudStorageAdapter, UploadResult, ConnectionTestResult
+from cloud_storage.types import CloudStorageAdapter, UploadResult, ConnectionTestResult
 
 logger = logging.getLogger(__name__)
 

--- a/backend/cloud_storage/factory.py
+++ b/backend/cloud_storage/factory.py
@@ -1,0 +1,42 @@
+"""
+Cloud storage adapter factory.
+
+One-way imports only: this module imports concrete adapters, but concrete
+adapters import from ``cloud_storage.types`` — never from here. See bead
+wlvxh for the topology rationale.
+"""
+import logging
+
+from cloud_storage.types import CloudStorageAdapter
+
+logger = logging.getLogger(__name__)
+
+
+def get_adapter(provider_type: str, credentials: dict) -> CloudStorageAdapter:
+    """Factory function to create the appropriate cloud storage adapter.
+
+    Args:
+        provider_type: One of "s3", "gdrive", "onedrive", "dropbox".
+        credentials: Provider-specific configuration dict.
+
+    Returns:
+        An instance of the appropriate CloudStorageAdapter subclass.
+
+    Raises:
+        ValueError: If the provider type is unknown.
+        ImportError: If required dependencies are not installed.
+    """
+    if provider_type == "s3":
+        from cloud_storage.s3_adapter import S3Adapter
+        return S3Adapter(credentials)
+    elif provider_type == "gdrive":
+        from cloud_storage.gdrive_adapter import GDriveAdapter
+        return GDriveAdapter(credentials)
+    elif provider_type == "onedrive":
+        from cloud_storage.onedrive_adapter import OneDriveAdapter
+        return OneDriveAdapter(credentials)
+    elif provider_type == "dropbox":
+        from cloud_storage.dropbox_adapter import DropboxAdapter
+        return DropboxAdapter(credentials)
+    else:
+        raise ValueError(f"Unknown cloud storage provider: {provider_type}")

--- a/backend/cloud_storage/gdrive_adapter.py
+++ b/backend/cloud_storage/gdrive_adapter.py
@@ -6,7 +6,7 @@ import logging
 import time
 from pathlib import Path
 
-from cloud_storage.base import CloudStorageAdapter, UploadResult, ConnectionTestResult
+from cloud_storage.types import CloudStorageAdapter, UploadResult, ConnectionTestResult
 
 logger = logging.getLogger(__name__)
 

--- a/backend/cloud_storage/onedrive_adapter.py
+++ b/backend/cloud_storage/onedrive_adapter.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import httpx
 
-from cloud_storage.base import CloudStorageAdapter, UploadResult, ConnectionTestResult
+from cloud_storage.types import CloudStorageAdapter, UploadResult, ConnectionTestResult
 
 logger = logging.getLogger(__name__)
 

--- a/backend/cloud_storage/s3_adapter.py
+++ b/backend/cloud_storage/s3_adapter.py
@@ -6,7 +6,7 @@ import logging
 import time
 from pathlib import Path
 
-from cloud_storage.base import CloudStorageAdapter, UploadResult, ConnectionTestResult
+from cloud_storage.types import CloudStorageAdapter, UploadResult, ConnectionTestResult
 
 logger = logging.getLogger(__name__)
 

--- a/backend/cloud_storage/types.py
+++ b/backend/cloud_storage/types.py
@@ -1,5 +1,10 @@
 """
 Abstract base class and data types for cloud storage adapters.
+
+Split out from the historical ``cloud_storage.base`` module so concrete
+adapters can depend on the ABC + dataclasses without forming an import
+cycle with the factory (which imports the concrete adapters). See bead
+wlvxh for context.
 """
 import logging
 from abc import ABC, abstractmethod
@@ -69,33 +74,3 @@ class CloudStorageAdapter(ABC):
         Returns:
             List of file names/paths.
         """
-
-
-def get_adapter(provider_type: str, credentials: dict) -> CloudStorageAdapter:
-    """Factory function to create the appropriate cloud storage adapter.
-
-    Args:
-        provider_type: One of "s3", "gdrive", "onedrive", "dropbox".
-        credentials: Provider-specific configuration dict.
-
-    Returns:
-        An instance of the appropriate CloudStorageAdapter subclass.
-
-    Raises:
-        ValueError: If the provider type is unknown.
-        ImportError: If required dependencies are not installed.
-    """
-    if provider_type == "s3":
-        from cloud_storage.s3_adapter import S3Adapter
-        return S3Adapter(credentials)
-    elif provider_type == "gdrive":
-        from cloud_storage.gdrive_adapter import GDriveAdapter
-        return GDriveAdapter(credentials)
-    elif provider_type == "onedrive":
-        from cloud_storage.onedrive_adapter import OneDriveAdapter
-        return OneDriveAdapter(credentials)
-    elif provider_type == "dropbox":
-        from cloud_storage.dropbox_adapter import DropboxAdapter
-        return DropboxAdapter(credentials)
-    else:
-        raise ValueError(f"Unknown cloud storage provider: {provider_type}")

--- a/backend/database.py
+++ b/backend/database.py
@@ -6,10 +6,15 @@ import logging
 from pathlib import Path
 from sqlalchemy import create_engine, event, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from config import CONFIG_DIR
+# ``Base`` lives in a standalone module (``db_base``) so model modules can
+# import it without cycling through ``database`` itself. Re-exported below
+# so existing ``from database import Base`` call sites keep working. See
+# bead wlvxh.
+from db_base import Base
 
 logger = logging.getLogger(__name__)
 
@@ -19,9 +24,6 @@ JOURNAL_DB_FILE = CONFIG_DIR / "journal.db"
 # Alembic config location. Bead bd-c5wf5 introduced Alembic as the migration
 # system; see ``docs/database_migrations.md``.
 ALEMBIC_INI_PATH = Path(__file__).resolve().parent / "alembic.ini"
-
-# SQLAlchemy Base for model declarations
-Base = declarative_base()
 
 # Engine and session factory (initialized on startup)
 _engine = None

--- a/backend/db_base.py
+++ b/backend/db_base.py
@@ -1,0 +1,18 @@
+"""
+SQLAlchemy ``Base`` for ORM model declarations.
+
+Split out from ``database`` so model modules (``models``, ``export_models``,
+etc.) can import ``Base`` without forming an import cycle with
+``database.init_db`` (which imports the model modules to register their
+tables). See bead wlvxh for the topology rationale.
+
+Everything else — engine, session factory, migrations, init hooks —
+stays in ``database.py``. ``database`` re-exports ``Base`` so existing
+``from database import Base`` call sites (e.g. ``ffmpeg_builder``) keep
+working without a sweeping rewrite.
+"""
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+__all__ = ["Base"]

--- a/backend/export_models.py
+++ b/backend/export_models.py
@@ -6,7 +6,7 @@ import json
 import logging
 from datetime import datetime
 from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, ForeignKey, Index
-from database import Base
+from db_base import Base
 
 logger = logging.getLogger(__name__)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, date
 from sqlalchemy import Column, Integer, BigInteger, String, Text, Boolean, DateTime, Date, Float, Index, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import relationship
-from database import Base
+from db_base import Base
 
 logger = logging.getLogger(__name__)
 

--- a/backend/publish_pipeline.py
+++ b/backend/publish_pipeline.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
-from cloud_storage.base import get_adapter
+from cloud_storage import get_adapter
 from cloud_storage.crypto import decrypt_credentials
 from database import get_session
 from export_manager import ExportManager

--- a/backend/routers/export.py
+++ b/backend/routers/export.py
@@ -12,7 +12,7 @@ from typing import Literal, Optional
 from fastapi import APIRouter, HTTPException, Response
 from pydantic import BaseModel, field_validator
 
-from cloud_storage.base import get_adapter
+from cloud_storage import get_adapter
 from cloud_storage.crypto import encrypt_credentials, decrypt_credentials
 from cloud_storage.onedrive_adapter import _validate_tenant_id, _validate_drive_id
 from database import get_session

--- a/backend/tests/test_cloud_storage.py
+++ b/backend/tests/test_cloud_storage.py
@@ -5,7 +5,7 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from cloud_storage.base import get_adapter, ConnectionTestResult
+from cloud_storage import get_adapter, ConnectionTestResult
 from cloud_storage.crypto import encrypt_credentials, decrypt_credentials, reset_key_cache
 
 

--- a/backend/tests/test_export_integration.py
+++ b/backend/tests/test_export_integration.py
@@ -300,7 +300,7 @@ class TestCloudTargetIntegration:
     @patch("routers.export.get_adapter")
     async def test_test_connection_inline(self, mock_get_adapter, async_client):
         """Inline connection test should use provided credentials."""
-        from cloud_storage.base import ConnectionTestResult
+        from cloud_storage import ConnectionTestResult
         mock_adapter = AsyncMock()
         mock_adapter.test_connection.return_value = ConnectionTestResult(
             success=True, message="Connected", provider_info={"bucket": "test"}


### PR DESCRIPTION
## Summary
Breaks the two SQLAlchemy / cloud_storage circular-import clusters CodeQL flags as 15 `py/cyclic-import` findings.

## Changes
**Cluster A — cloud_storage (8 findings):**
- Split `cloud_storage/base.py` into `types.py` (ABC + dataclasses) and `factory.py` (`get_adapter()`). Deleted `base.py` — no shim (a shim reintroduces the cycle).
- Concrete adapters import from `cloud_storage.types`. External callers (`publish_pipeline`, `routers/export`, 3 tests) now import from `cloud_storage` package root.
- `cloud_storage/__init__.py` re-exports the public surface unchanged.

**Cluster B — SQLAlchemy Base (7 findings):**
- Extracted `Base = declarative_base()` into new `backend/db_base.py`.
- `database.py` imports Base from `db_base` and re-exports, so existing `from database import Base` callers keep working.
- `models.py` and `export_models.py` now import Base from `db_base` directly.

## Test plan
- [x] 15 `py/cyclic-import` CodeQL findings → 0
- [x] Import-isolation smoke: `database.Base is db_base.Base is models.Base is export_models.Base`
- [x] Full backend suite: 0 new failures (delta from dev baseline)

## Unblocks
- `enhancedchannelmanager-0i2vt.4` (SyncTarget/CloudTarget Fernet-encrypted credential models)
- `enhancedchannelmanager-skqln.2` (session_telemetry Alembic migration — autogenerate needs a clean Base import graph)

Rebased onto latest `origin/dev` (was at 878d6d09; now 4013efbf after conflict resolution — three import-line conflicts in `publish_pipeline.py`, `tests/test_cloud_storage.py`, `tests/test_publish_pipeline.py` resolved by taking dev's dead-import cleanup + refactor's new `cloud_storage` package-root import path).

🤖 Generated with Claude Code