### PR TITLE
fix(backend): /api catch-all 404 + stall-test route prepend (bd-vjlzf)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1036,6 +1036,21 @@ if os.path.exists(static_dir):
             "/docs", StaticFiles(directory=docs_dir, html=True), name="docs"
         )
 
+    # Any /api/* path not claimed by a registered router returns JSON 404.
+    # Without this the SPA catch-all below would serve index.html for GET
+    # /api/<unknown> (200) and 405 for other methods, masking proper API
+    # error semantics and breaking path-injection tests where URL-encoded
+    # slashes decode into multi-segment paths that the typed {filename}
+    # param cannot match. Registered before the SPA so real routers
+    # (registered earlier via include_router) still win by match order.
+    @app.api_route(
+        "/api/{full_path:path}",
+        methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],
+        include_in_schema=False,
+    )
+    async def api_not_found(full_path: str):
+        raise HTTPException(status_code=404, detail="Not Found")
+
     @app.get("/{full_path:path}")
     async def serve_spa(full_path: str):
         # Serve index.html for all non-API routes (SPA routing)

--- a/backend/tests/integration/test_event_loop_responsiveness.py
+++ b/backend/tests/integration/test_event_loop_responsiveness.py
@@ -180,13 +180,28 @@ class TestRequestTimeoutMiddleware:
 
         monkeypatch.setattr(main_module, "_REQUEST_TIMEOUT_SECONDS", 0.2)
 
-        # Register a deliberately slow route on the app for this test
+        # Register a deliberately slow route on the app for this test.
+        # When backend/static/ exists (container) main.py registers an
+        # /api/{full_path:path} 404 catch-all and a /{full_path:path} SPA
+        # handler. Appending via @app.get puts the stall route AFTER those
+        # catch-alls, so starlette matches the catch-all first and the
+        # stall handler never runs. Prepending via
+        # app.router.routes.insert(0, ...) keeps this test deterministic
+        # regardless of static-dir presence.
         from main import app
+        from fastapi.routing import APIRoute
 
-        @app.get("/api/_test_stall_for_timeout", include_in_schema=False)
         async def _stall_route():
             await asyncio.sleep(1.0)
             return {"unreachable": True}
+
+        stall_route = APIRoute(
+            "/api/_test_stall_for_timeout",
+            _stall_route,
+            methods=["GET"],
+            include_in_schema=False,
+        )
+        app.router.routes.insert(0, stall_route)
 
         try:
             response = await async_client.get("/api/_test_stall_for_timeout")
@@ -195,8 +210,8 @@ class TestRequestTimeoutMiddleware:
             assert body["detail"] == "Gateway Timeout"
         finally:
             # Remove the test route so it doesn't leak to other tests
-            app.routes[:] = [
-                r for r in app.routes
+            app.router.routes[:] = [
+                r for r in app.router.routes
                 if getattr(r, "path", None) != "/api/_test_stall_for_timeout"
             ]
 
@@ -220,11 +235,22 @@ class TestRequestTimeoutMiddleware:
         monkeypatch.setattr(main_module, "_REQUEST_TIMEOUT_SECONDS", 0.2)
 
         from main import app
+        from fastapi.routing import APIRoute
 
-        @app.get("/api/auto-creation/_test_stall_enfsy", include_in_schema=False)
         async def _stall_route():
             await asyncio.sleep(1.0)
             return {"unreachable": True}
+
+        # Prepend so the stall route wins over the /api/{full_path:path}
+        # 404 catch-all and the SPA catch-all that main.py registers when
+        # backend/static/ exists.
+        stall_route = APIRoute(
+            "/api/auto-creation/_test_stall_enfsy",
+            _stall_route,
+            methods=["GET"],
+            include_in_schema=False,
+        )
+        app.router.routes.insert(0, stall_route)
 
         try:
             response = await async_client.get("/api/auto-creation/_test_stall_enfsy")
@@ -233,7 +259,7 @@ class TestRequestTimeoutMiddleware:
                 "timeout middleware (bd-enfsy removed the exempt prefix)."
             )
         finally:
-            app.routes[:] = [
-                r for r in app.routes
+            app.router.routes[:] = [
+                r for r in app.router.routes
                 if getattr(r, "path", None) != "/api/auto-creation/_test_stall_enfsy"
             ]


### PR DESCRIPTION
## Summary
Fixes container-deterministic test failures caused by the SPA catch-all eating URL-encoded path-injection requests and dynamically-registered stall routes.

## Changes
- `backend/main.py`: new `/api/{full_path:path}` JSON 404 handler registered before the SPA catch-all. Real routers still win by order; only unclaimed `/api/*` sees 404. Improves API error semantics (no more SPA 200 for unknown API routes).
- `backend/tests/integration/test_event_loop_responsiveness.py`: stall-route registration uses `app.router.routes.insert(0, APIRoute(...))` to win over both catch-alls. Same pattern applied to `test_slow_handler_returns_504` and `test_auto_creation_crud_subject_to_timeout`. Teardown uses `app.router.routes` (writable list) instead of `app.routes` (property alias).

## Test plan
- [x] Pre-fix baseline in `ecm-ecm-1`: 25 failed, 2934 passed
- [x] Post-fix: 11 failed, 2971 passed (-14 targeted failures cleared)
- [x] Path-injection tests (`TestSavedBackupsPathInjection` + `TestExportPathInjection`) return 400/404/422 as expected
- [x] Stall-route tests return 504 from timeout middleware
- [ ] Remaining 11 failures are pre-existing test drift unrelated to SPA (journal `batch_id` kwarg, auto-creation 202-vs-200, mcp status sanitization, tags metadata) — will be filed as a separate bead

## Unblocks
- Clears the baseline gate on PR #170 (ASGI triplet bead `6rrl5.1`/`6rrl5.2`)

Closes bd-vjlzf

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>