### PR TITLE
chore: bump dev to 0.16.0-0059 after ship batch

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.16.0-0058",
+  "version": "0.16.0-0059",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Tag-stone version bump capturing the four merges from the standup ship batch:
- PR #171 (bd-d0pbr): ASGI regression runbook
- PR #172 (bd-wlvxh): cyclic-import refactor (15 CodeQL findings → 0)
- PR #173 (bd-i6a1m): frontend error telemetry Phase 1 per ADR-006
- PR #174 (bd-vjlzf): SPA-fallback API catch-all + stall-route prepend

Per docs/shipping.md §3 build-counter format (`0.X.Y-NNNN`).

## Why a PR (not direct push)
Dev branch protection requires 5 status checks + enforce_admins=true; direct push is no longer possible. Doc update tracked in a separate bead.

## Test plan
- [x] `npm run build` clean with new version
- [x] No code changes — only frontend/package.json line changed

🤖 Generated with Claude Code