### PR TITLE
security(normalization): opt-in Unicode confusables fold (bd-sc5s4)

### DIFF
--- a/backend/normalization_engine.py
+++ b/backend/normalization_engine.py
@@ -36,6 +36,17 @@ ECM_NORMALIZATION_UNIFIED_POLICY (default: "true")
     carve-outs, no NFC, no Cf-stripping) without re-deploying. Intended
     as a one-pull-request rollback switch; remove once the new policy
     has soaked in production.
+
+ECM_NORMALIZATION_CONFUSABLES_FOLD (default: "false", bd-sc5s4)
+    Opt-in. When "true" (or "1"/"yes"/"on"), the policy applies a
+    Unicode-TR39-style confusables fold AFTER NFC + Cf-stripping +
+    superscript conversion. Cyrillic/Greek/math/fullwidth look-alikes
+    fold to their Latin/ASCII visual equivalents, which makes
+    homoglyph-disguised inputs (e.g. Cyrillic 'а' U+0430 vs Latin 'a'
+    U+0061) compare equal. Off by default because the fold is
+    aggressive and can collapse characters that some operators want
+    distinct (Greek 'Ω' Ohm sign vs Latin 'O', math italics, etc.).
+    Filed under the homoglyph attack threat — see docs/normalization.md.
 """
 import os
 import re
@@ -74,6 +85,12 @@ def _unified_policy_enabled() -> bool:
     """Parse ECM_NORMALIZATION_UNIFIED_POLICY. Default-on."""
     raw = os.environ.get("ECM_NORMALIZATION_UNIFIED_POLICY", "true")
     return raw.strip().lower() not in {"false", "0", "no", "off"}
+
+
+def _confusables_fold_enabled() -> bool:
+    """Parse ECM_NORMALIZATION_CONFUSABLES_FOLD. Default-OFF (opt-in, bd-sc5s4)."""
+    raw = os.environ.get("ECM_NORMALIZATION_CONFUSABLES_FOLD", "false")
+    return raw.strip().lower() in {"true", "1", "yes", "on"}
 
 
 # Cf code points stripped by the unified policy. Intentionally narrow: we
@@ -185,6 +202,144 @@ NUMERIC_SUPERSCRIPTS = {
 SUPERSCRIPT_MAP = {**LETTER_SUPERSCRIPTS, **NUMERIC_SUPERSCRIPTS}
 
 
+# -----------------------------------------------------------------------------
+# Confusables fold (bd-sc5s4) — Unicode TR39 skeleton-style mapping for the
+# most common homoglyph attack pairs. NOT the full TR39 confusables.txt
+# table (~6000 entries); a curated subset covering the realistic threat:
+#
+#   * Cyrillic letters that share a glyph with Latin (А/а/В/Е/е/К/М/...).
+#   * Greek capitals that share a glyph with Latin (Α/Β/Ε/Ζ/Η/Ι/Κ/Μ/Ν/Ο/...).
+#   * Mathematical alphanumeric symbols (𝐀-𝐳, 𝟎-𝟗, etc.) — bulk-folded
+#     by NFKC, but fullwidth/halfwidth Latin (Ａ-ｚ, ０-９) is kept here
+#     explicitly so we don't have to invoke NFKC and lose the
+#     ligature/Roman-numeral preservation that the unified policy
+#     intentionally guards via NFC-not-NFKC.
+#   * Common digit/letter look-alikes are NOT folded by default (O/0,
+#     I/1/l) — those collisions cause more false positives than they
+#     prevent attacks, and the bead description flags them as
+#     speculative. Operators who want them can layer a normalization
+#     rule of their own.
+#
+# Sources cross-referenced:
+#   * Unicode TR39 confusables.txt (Latin-target rows).
+#   * unicode-security.org/confusables.html.
+# Curated for IPTV channel name surfaces — covers the alphabets most
+# likely to appear in M3U feeds (Cyrillic, Greek, fullwidth CJK forms).
+# -----------------------------------------------------------------------------
+
+CONFUSABLES_MAP: dict[str, str] = {
+    # Cyrillic uppercase that look like Latin uppercase
+    'А': 'A',  # А CYRILLIC CAPITAL A
+    'В': 'B',  # В CYRILLIC CAPITAL VE
+    'С': 'C',  # С CYRILLIC CAPITAL ES
+    'Е': 'E',  # Е CYRILLIC CAPITAL IE
+    'Н': 'H',  # Н CYRILLIC CAPITAL EN
+    'І': 'I',  # І CYRILLIC CAPITAL BYELORUSSIAN-UKRAINIAN I
+    'Ј': 'J',  # Ј CYRILLIC CAPITAL JE
+    'К': 'K',  # К CYRILLIC CAPITAL KA
+    'М': 'M',  # М CYRILLIC CAPITAL EM
+    'О': 'O',  # О CYRILLIC CAPITAL O
+    'Р': 'P',  # Р CYRILLIC CAPITAL ER
+    'Ѕ': 'S',  # Ѕ CYRILLIC CAPITAL DZE
+    'Т': 'T',  # Т CYRILLIC CAPITAL TE
+    'Х': 'X',  # Х CYRILLIC CAPITAL HA
+    'У': 'Y',  # У CYRILLIC CAPITAL U (looks like Latin Y)
+    # Cyrillic lowercase that look like Latin lowercase
+    'а': 'a',  # а CYRILLIC SMALL A
+    'с': 'c',  # с CYRILLIC SMALL ES
+    'е': 'e',  # е CYRILLIC SMALL IE
+    'һ': 'h',  # һ CYRILLIC SMALL SHHA
+    'і': 'i',  # і CYRILLIC SMALL BYELORUSSIAN-UKRAINIAN I
+    'ј': 'j',  # ј CYRILLIC SMALL JE
+    'о': 'o',  # о CYRILLIC SMALL O
+    'р': 'p',  # р CYRILLIC SMALL ER
+    'ѕ': 's',  # ѕ CYRILLIC SMALL DZE
+    'х': 'x',  # х CYRILLIC SMALL HA
+    'у': 'y',  # у CYRILLIC SMALL U (looks like Latin y)
+    # Greek capitals that look like Latin capitals
+    'Α': 'A',  # Α GREEK CAPITAL ALPHA
+    'Β': 'B',  # Β GREEK CAPITAL BETA
+    'Ε': 'E',  # Ε GREEK CAPITAL EPSILON
+    'Ζ': 'Z',  # Ζ GREEK CAPITAL ZETA
+    'Η': 'H',  # Η GREEK CAPITAL ETA
+    'Ι': 'I',  # Ι GREEK CAPITAL IOTA
+    'Κ': 'K',  # Κ GREEK CAPITAL KAPPA
+    'Μ': 'M',  # Μ GREEK CAPITAL MU
+    'Ν': 'N',  # Ν GREEK CAPITAL NU
+    'Ο': 'O',  # Ο GREEK CAPITAL OMICRON
+    'Ρ': 'P',  # Ρ GREEK CAPITAL RHO
+    'Τ': 'T',  # Τ GREEK CAPITAL TAU
+    'Υ': 'Y',  # Υ GREEK CAPITAL UPSILON
+    'Χ': 'X',  # Χ GREEK CAPITAL CHI
+    # Greek lowercase that resemble Latin lowercase (common subset)
+    'ο': 'o',  # ο GREEK SMALL OMICRON
+    'ρ': 'p',  # ρ GREEK SMALL RHO (descender, but commonly substituted)
+    'υ': 'u',  # υ GREEK SMALL UPSILON
+    # Math italic / sans-serif Latin (Mathematical Alphanumeric Symbols block).
+    # NFKC would do this in bulk but also collapses ligatures/fullwidth which
+    # the unified policy intentionally preserves. Listed individually below
+    # for the math-italic block (U+1D400 - U+1D7FF) range so we can be
+    # surgical. Programmatic build: each block is 26 letters, then the next
+    # block starts. We hand-roll the most common attack-relevant ones.
+    '\U0001d400': 'A', '\U0001d401': 'B', '\U0001d402': 'C', '\U0001d403': 'D',
+    '\U0001d404': 'E', '\U0001d405': 'F', '\U0001d406': 'G', '\U0001d407': 'H',
+    '\U0001d408': 'I', '\U0001d409': 'J', '\U0001d40a': 'K', '\U0001d40b': 'L',
+    '\U0001d40c': 'M', '\U0001d40d': 'N', '\U0001d40e': 'O', '\U0001d40f': 'P',
+    '\U0001d410': 'Q', '\U0001d411': 'R', '\U0001d412': 'S', '\U0001d413': 'T',
+    '\U0001d414': 'U', '\U0001d415': 'V', '\U0001d416': 'W', '\U0001d417': 'X',
+    '\U0001d418': 'Y', '\U0001d419': 'Z',
+    # Math italic lowercase (U+1D44E onward — note U+1D455 is reserved)
+    '\U0001d44e': 'a', '\U0001d44f': 'b', '\U0001d450': 'c', '\U0001d451': 'd',
+    '\U0001d452': 'e', '\U0001d453': 'f', '\U0001d454': 'g',
+    '\U0001d456': 'i', '\U0001d457': 'j', '\U0001d458': 'k', '\U0001d459': 'l',
+    '\U0001d45a': 'm', '\U0001d45b': 'n', '\U0001d45c': 'o', '\U0001d45d': 'p',
+    '\U0001d45e': 'q', '\U0001d45f': 'r', '\U0001d460': 's', '\U0001d461': 't',
+    '\U0001d462': 'u', '\U0001d463': 'v', '\U0001d464': 'w', '\U0001d465': 'x',
+    '\U0001d466': 'y', '\U0001d467': 'z',
+    # Math digits 0-9 (Mathematical Bold Digits block U+1D7CE-U+1D7D7)
+    '\U0001d7ce': '0', '\U0001d7cf': '1', '\U0001d7d0': '2', '\U0001d7d1': '3',
+    '\U0001d7d2': '4', '\U0001d7d3': '5', '\U0001d7d4': '6', '\U0001d7d5': '7',
+    '\U0001d7d6': '8', '\U0001d7d7': '9',
+    # Fullwidth Latin (NFKC would also fold these, but doing it explicitly
+    # lets us keep NFC and only fold the fullwidth letters/digits, not
+    # ligatures / Roman numerals / squared-character compatibility forms).
+    'Ａ': 'A', 'Ｂ': 'B', 'Ｃ': 'C', 'Ｄ': 'D', 'Ｅ': 'E',
+    'Ｆ': 'F', 'Ｇ': 'G', 'Ｈ': 'H', 'Ｉ': 'I', 'Ｊ': 'J',
+    'Ｋ': 'K', 'Ｌ': 'L', 'Ｍ': 'M', 'Ｎ': 'N', 'Ｏ': 'O',
+    'Ｐ': 'P', 'Ｑ': 'Q', 'Ｒ': 'R', 'Ｓ': 'S', 'Ｔ': 'T',
+    'Ｕ': 'U', 'Ｖ': 'V', 'Ｗ': 'W', 'Ｘ': 'X', 'Ｙ': 'Y',
+    'Ｚ': 'Z',
+    'ａ': 'a', 'ｂ': 'b', 'ｃ': 'c', 'ｄ': 'd', 'ｅ': 'e',
+    'ｆ': 'f', 'ｇ': 'g', 'ｈ': 'h', 'ｉ': 'i', 'ｊ': 'j',
+    'ｋ': 'k', 'ｌ': 'l', 'ｍ': 'm', 'ｎ': 'n', 'ｏ': 'o',
+    'ｐ': 'p', 'ｑ': 'q', 'ｒ': 'r', 'ｓ': 's', 'ｔ': 't',
+    'ｕ': 'u', 'ｖ': 'v', 'ｗ': 'w', 'ｘ': 'x', 'ｙ': 'y',
+    'ｚ': 'z',
+    '０': '0', '１': '1', '２': '2', '３': '3', '４': '4',
+    '５': '5', '６': '6', '７': '7', '８': '8', '９': '9',
+}
+
+
+def fold_confusables(text: str) -> str:
+    """
+    Map Unicode confusables (homoglyphs) to their canonical Latin/ASCII form.
+
+    Subset of Unicode TR39 confusables.txt focused on the realistic
+    homoglyph-attack surface for IPTV channel names: Cyrillic, Greek,
+    math italic, fullwidth. Pure ASCII strings are returned unchanged
+    (fast-path bail-out), preserving the regression contract for ASCII
+    callers.
+
+    bd-sc5s4. Opt-in via ECM_NORMALIZATION_CONFUSABLES_FOLD; not invoked
+    by the default policy.
+    """
+    if not text:
+        return text
+    if text.isascii():
+        return text
+    return ''.join(CONFUSABLES_MAP.get(ch, ch) for ch in text)
+
+
 def convert_superscripts(text: str) -> str:
     """
     Convert Unicode superscript characters to their ASCII equivalents.
@@ -236,9 +391,19 @@ class NormalizationPolicy:
             entry point. When False, fall back to the pre-bd-eio04.1
             behavior (superscript conversion only, no NFC, no
             Cf-stripping) so operators have a rollback switch.
+        confusables_fold: When True (opt-in, gated by
+            ECM_NORMALIZATION_CONFUSABLES_FOLD env var, bd-sc5s4),
+            apply a curated Unicode-TR39-style homoglyph fold AFTER
+            NFC + Cf-stripping + superscripts. Folds Cyrillic/Greek/
+            math-italic/fullwidth look-alikes to Latin/ASCII so
+            disguised inputs (Cyrillic 'а' vs Latin 'a') compare equal.
+            Off by default — aggressive, can collapse intentionally
+            distinct characters. Has no effect when unified_enabled is
+            False (the legacy rollback path is byte-for-byte preserved).
     """
 
     unified_enabled: bool = True
+    confusables_fold: bool = False
 
     def apply_to_text(self, text: str) -> str:
         """
@@ -248,10 +413,13 @@ class NormalizationPolicy:
             1. NFC canonicalize.
             2. Strip whitelisted Cf code points (ZWSP/ZWNJ/ZWJ/BOM).
             3. Convert superscripts to ASCII (letters AND numerics).
+            4. (opt-in, bd-sc5s4) Fold confusables to Latin/ASCII.
 
         Under unified_enabled=False, only step (3) runs, via the legacy
         preserve_numeric=False path — this matches pre-bd-eio04.1
-        default behavior.
+        default behavior. The confusables fold is intentionally
+        suppressed on the legacy path so the rollback switch retains
+        its byte-for-byte semantic.
         """
         if not text:
             return text
@@ -261,17 +429,24 @@ class NormalizationPolicy:
                 text = ''.join(
                     ch for ch in text if ch not in _STRIPPED_CF_CODEPOINTS
                 )
-            return ''.join(SUPERSCRIPT_MAP.get(ch, ch) for ch in text)
+            text = ''.join(SUPERSCRIPT_MAP.get(ch, ch) for ch in text)
+            if self.confusables_fold:
+                text = fold_confusables(text)
+            return text
         # Legacy fallback path — behavior prior to bd-eio04.1. Keeps
         # superscript conversion (bd-yui1k behavior with
-        # preserve_numeric=False) but NO NFC, NO Cf-stripping.
+        # preserve_numeric=False) but NO NFC, NO Cf-stripping, and NO
+        # confusables fold (rollback switch preserves prior bytes).
         return ''.join(SUPERSCRIPT_MAP.get(ch, ch) for ch in text)
 
 
 # Process-wide canonical policy instance. Both code paths read this. The
 # instance is created at module load so the env-var feature flag is
 # latched once; to change, restart the container.
-_DEFAULT_POLICY = NormalizationPolicy(unified_enabled=_unified_policy_enabled())
+_DEFAULT_POLICY = NormalizationPolicy(
+    unified_enabled=_unified_policy_enabled(),
+    confusables_fold=_confusables_fold_enabled(),
+)
 
 
 def get_default_policy() -> NormalizationPolicy:
@@ -280,12 +455,16 @@ def get_default_policy() -> NormalizationPolicy:
 
 
 def _reset_default_policy_for_tests() -> NormalizationPolicy:
-    """Re-read the ECM_NORMALIZATION_UNIFIED_POLICY env var and refresh the
-    singleton. ONLY for tests — production toggles the flag via container
-    restart, not at runtime.
+    """Re-read the ECM_NORMALIZATION_UNIFIED_POLICY and
+    ECM_NORMALIZATION_CONFUSABLES_FOLD env vars and refresh the singleton.
+    ONLY for tests — production toggles the flags via container restart,
+    not at runtime.
     """
     global _DEFAULT_POLICY
-    _DEFAULT_POLICY = NormalizationPolicy(unified_enabled=_unified_policy_enabled())
+    _DEFAULT_POLICY = NormalizationPolicy(
+        unified_enabled=_unified_policy_enabled(),
+        confusables_fold=_confusables_fold_enabled(),
+    )
     return _DEFAULT_POLICY
 
 

--- a/backend/tests/unit/test_normalization_confusables.py
+++ b/backend/tests/unit/test_normalization_confusables.py
@@ -1,0 +1,271 @@
+"""
+Unicode confusables / homoglyph fold tests (bd-sc5s4).
+
+Covers the opt-in ECM_NORMALIZATION_CONFUSABLES_FOLD flag on
+NormalizationPolicy. The fold maps a curated subset of Unicode TR39
+confusables (Cyrillic, Greek, math italic, fullwidth) to Latin/ASCII so
+homoglyph-disguised inputs (e.g. an attacker-registered 'chаnnel' with
+Cyrillic 'а' U+0430) compare equal to the legitimate 'channel'.
+
+Layout:
+    * Default-off regression: with the fold disabled (default), Cyrillic
+      look-alikes stay distinct from Latin (the prior behavior).
+    * Default-off ASCII regression: ASCII-only inputs are byte-identical
+      with and without the fold, on every code path.
+    * Fold-on positive cases: at least one pair from each script class
+      called out in the bead — Cyrillic, Greek, math symbols, fullwidth,
+      decomposed combining marks (combining marks are handled by NFC,
+      not the fold, so we assert the combined NFC + fold pipeline).
+    * Engine integration: when the fold is on, a rule pattern typed in
+      Latin matches an input typed in Cyrillic homoglyphs.
+"""
+from __future__ import annotations
+
+import unicodedata
+
+import pytest
+
+from normalization_engine import (
+    CONFUSABLES_MAP,
+    NormalizationPolicy,
+    _confusables_fold_enabled,
+    fold_confusables,
+)
+
+
+# =============================================================================
+# fold_confusables() unit behavior
+# =============================================================================
+
+
+class TestFoldConfusablesUnit:
+    """Direct tests of fold_confusables() — no policy context."""
+
+    def test_empty_string_returns_empty(self):
+        assert fold_confusables("") == ""
+
+    def test_pure_ascii_unchanged(self):
+        """ASCII-only fast path: same object semantics not required, but
+        the value must be byte-identical."""
+        for s in ("ESPN HD", "Fox News", "channel123", "ABC-1080p"):
+            assert fold_confusables(s) == s
+
+    def test_cyrillic_lowercase_maps_to_latin(self):
+        # 'chаnnel' with U+0430 Cyrillic 'а' should fold to 'channel'.
+        attacker = "chаnnel"
+        assert attacker != "channel"  # they really are different code points
+        assert fold_confusables(attacker) == "channel"
+
+    def test_cyrillic_uppercase_maps_to_latin(self):
+        # 'ЕSPN' with U+0415 Cyrillic 'Е' should fold to 'ESPN'.
+        attacker = "ЕSPN"
+        assert fold_confusables(attacker) == "ESPN"
+
+    def test_greek_uppercase_maps_to_latin(self):
+        # 'ΑBC' with U+0391 Greek 'Α' (Alpha) should fold to 'ABC'.
+        attacker = "ΑBC"
+        assert fold_confusables(attacker) == "ABC"
+
+    def test_math_italic_letter_maps_to_latin(self):
+        # U+1D44E MATHEMATICAL ITALIC SMALL A.
+        attacker = "channel\U0001d44e"
+        assert fold_confusables(attacker) == "channela"
+
+    def test_math_bold_digit_maps_to_ascii(self):
+        # U+1D7CE MATHEMATICAL BOLD DIGIT ZERO.
+        attacker = "channel\U0001d7ce"
+        assert fold_confusables(attacker) == "channel0"
+
+    def test_fullwidth_letter_maps_to_ascii(self):
+        # U+FF21 FULLWIDTH LATIN CAPITAL LETTER A.
+        attacker = "ＡBC"
+        assert fold_confusables(attacker) == "ABC"
+
+    def test_fullwidth_digit_maps_to_ascii(self):
+        # U+FF11 FULLWIDTH DIGIT ONE.
+        attacker = "ESPN１"
+        assert fold_confusables(attacker) == "ESPN1"
+
+
+# =============================================================================
+# Confusables map sanity — no entry is a no-op (would indicate a typo).
+# =============================================================================
+
+
+class TestConfusablesMapSanity:
+    def test_no_entry_maps_to_itself(self):
+        """A confusable that maps to its own bytes is a copy-paste typo
+        in the map (the source and target are the same character)."""
+        for src, tgt in CONFUSABLES_MAP.items():
+            assert src != tgt, f"map entry {src!r} ({hex(ord(src))}) -> itself"
+
+    def test_all_targets_are_ascii(self):
+        """The fold is a TO-ASCII fold by design. A non-ASCII target is
+        a bug — it would mean the fold leaves you in the same situation
+        you started in."""
+        for src, tgt in CONFUSABLES_MAP.items():
+            assert tgt.isascii(), f"map entry {src!r} -> non-ASCII {tgt!r}"
+
+
+# =============================================================================
+# Policy integration — opt-in semantic and ordering with NFC + Cf-strip
+# =============================================================================
+
+
+class TestPolicyConfusablesFoldDisabled:
+    """Default behavior: fold is OFF. Cyrillic stays distinct from Latin."""
+
+    def test_default_policy_does_not_fold_cyrillic(self):
+        policy = NormalizationPolicy(unified_enabled=True, confusables_fold=False)
+        attacker = "chаnnel"  # Cyrillic 'а'
+        assert policy.apply_to_text(attacker) == attacker
+        assert policy.apply_to_text(attacker) != "channel"
+
+    def test_default_policy_ascii_unchanged(self):
+        policy = NormalizationPolicy(unified_enabled=True, confusables_fold=False)
+        assert policy.apply_to_text("ESPN HD") == "ESPN HD"
+
+    def test_default_policy_default_constructor(self):
+        """The dataclass default keeps confusables OFF (opt-in)."""
+        policy = NormalizationPolicy()
+        assert policy.confusables_fold is False
+
+
+class TestPolicyConfusablesFoldEnabled:
+    """confusables_fold=True: bead's required pair classes all collapse."""
+
+    def test_cyrillic_pair_folds(self):
+        """Pair class 1 — Cyrillic. 'chаnnel' (U+0430) -> 'channel'."""
+        policy = NormalizationPolicy(unified_enabled=True, confusables_fold=True)
+        assert policy.apply_to_text("chаnnel") == "channel"
+
+    def test_greek_pair_folds(self):
+        """Pair class 2 — Greek. 'ΑΒC' (Α=U+0391, Β=U+0392) -> 'ABC'."""
+        policy = NormalizationPolicy(unified_enabled=True, confusables_fold=True)
+        assert policy.apply_to_text("ΑΒC") == "ABC"
+
+    def test_math_symbol_pair_folds(self):
+        """Pair class 3 — math italic / math bold."""
+        policy = NormalizationPolicy(unified_enabled=True, confusables_fold=True)
+        # MATHEMATICAL ITALIC SMALL A + B + C
+        assert policy.apply_to_text("\U0001d44e\U0001d44f\U0001d450") == "abc"
+
+    def test_fullwidth_pair_folds(self):
+        """Pair class 4 — fullwidth Latin / digits."""
+        policy = NormalizationPolicy(unified_enabled=True, confusables_fold=True)
+        assert policy.apply_to_text("ＡＢＣ１") == "ABC1"
+
+    def test_decomposed_combining_marks_collapse_via_nfc_then_fold(self):
+        """Pair class 5 — decomposed combining marks. NFC handles the
+        decomposition step; the fold is a no-op for ASCII letters but
+        the combined output must match a pre-composed reference."""
+        policy = NormalizationPolicy(unified_enabled=True, confusables_fold=True)
+        nfd = unicodedata.normalize("NFD", "Café")  # e + U+0301
+        out = policy.apply_to_text(nfd)
+        # NFC re-composition produces 'Café' with U+00E9; the fold
+        # leaves U+00E9 alone (not in CONFUSABLES_MAP — accented Latin
+        # is intentional content, not a confusable). The combining mark
+        # MUST be gone.
+        assert "́" not in out
+        assert out == unicodedata.normalize("NFC", "Café")
+
+    def test_ascii_only_input_unchanged_when_fold_enabled(self):
+        """Regression contract from the bead: opt-in must not perturb
+        ASCII-only inputs. Same output enabled or disabled."""
+        on = NormalizationPolicy(unified_enabled=True, confusables_fold=True)
+        off = NormalizationPolicy(unified_enabled=True, confusables_fold=False)
+        for s in ("ESPN HD", "Fox News 1080p", "channel-123", "[US] ABC"):
+            assert on.apply_to_text(s) == off.apply_to_text(s) == s
+
+
+class TestPolicyConfusablesFoldLegacyInteraction:
+    """confusables_fold has NO effect when unified_enabled=False —
+    rollback switch keeps its byte-for-byte semantic."""
+
+    def test_legacy_policy_ignores_fold_flag(self):
+        legacy_with_fold = NormalizationPolicy(
+            unified_enabled=False, confusables_fold=True
+        )
+        # Cyrillic 'а' must NOT fold under legacy, even with the flag on.
+        attacker = "chаnnel"
+        assert legacy_with_fold.apply_to_text(attacker) == attacker
+
+
+# =============================================================================
+# Env-var parsing — opt-in semantic
+# =============================================================================
+
+
+class TestConfusablesFoldEnvVar:
+    def test_default_off(self, monkeypatch):
+        monkeypatch.delenv("ECM_NORMALIZATION_CONFUSABLES_FOLD", raising=False)
+        assert _confusables_fold_enabled() is False
+
+    def test_truthy_values_enable(self, monkeypatch):
+        for raw in ("true", "True", "TRUE", "1", "yes", "on"):
+            monkeypatch.setenv("ECM_NORMALIZATION_CONFUSABLES_FOLD", raw)
+            assert _confusables_fold_enabled() is True, f"truthy {raw!r}"
+
+    def test_falsy_values_disable(self, monkeypatch):
+        for raw in ("false", "False", "FALSE", "0", "no", "off", ""):
+            monkeypatch.setenv("ECM_NORMALIZATION_CONFUSABLES_FOLD", raw)
+            assert _confusables_fold_enabled() is False, f"falsy {raw!r}"
+
+
+# =============================================================================
+# Engine-level integration — pattern in Latin matches input in Cyrillic.
+# This is the security property the fold delivers: with the flag on, a
+# rule typed by an operator in Latin catches inputs that an attacker
+# disguised in Cyrillic.
+# =============================================================================
+
+
+class TestEngineIntegrationConfusablesFold:
+    """Rules use the policy via _match_single_condition. A 'contains'
+    rule typed in Latin should match an input typed in Cyrillic when
+    the fold is enabled."""
+
+    def test_pattern_latin_matches_cyrillic_input_when_fold_on(self, monkeypatch):
+        # Set the env BEFORE importing the engine so the singleton picks
+        # up the value. We then explicitly call the test-only refresh.
+        monkeypatch.setenv("ECM_NORMALIZATION_CONFUSABLES_FOLD", "true")
+        from normalization_engine import (
+            NormalizationEngine,
+            _reset_default_policy_for_tests,
+            get_default_policy,
+        )
+
+        _reset_default_policy_for_tests()
+        try:
+            assert get_default_policy().confusables_fold is True
+
+            engine = NormalizationEngine(db=None)
+            # Pattern is plain Latin 'channel'; input has Cyrillic 'а'.
+            attacker_input = "Sky chаnnel HD"
+            match = engine._match_single_condition(
+                attacker_input, "contains", "channel", case_sensitive=False
+            )
+            assert match.matched is True
+        finally:
+            monkeypatch.delenv("ECM_NORMALIZATION_CONFUSABLES_FOLD", raising=False)
+            _reset_default_policy_for_tests()
+
+    def test_pattern_latin_does_not_match_cyrillic_input_when_fold_off(self):
+        """Default behavior (fold off): Latin pattern does NOT match
+        Cyrillic-disguised input. This is the regression baseline — we
+        must not change pre-bd-sc5s4 default semantics."""
+        from normalization_engine import (
+            NormalizationEngine,
+            _reset_default_policy_for_tests,
+            get_default_policy,
+        )
+
+        _reset_default_policy_for_tests()
+        assert get_default_policy().confusables_fold is False
+
+        engine = NormalizationEngine(db=None)
+        attacker_input = "Sky chаnnel HD"
+        match = engine._match_single_condition(
+            attacker_input, "contains", "channel", case_sensitive=False
+        )
+        assert match.matched is False

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -61,8 +61,37 @@ Before any user-authored rule runs, a **policy** preprocesses the input. The pol
 1. **NFC canonicalization.** NFD-decomposed input (`e` + U+0301) collapses to pre-composed form (`é` = U+00E9). NFC, *not* NFKC — ligatures (`ﬁ`), fullwidth digits (`１`), and Roman-numeral compatibility forms are preserved because users who typed them intended them.
 2. **Cf-whitelist stripping.** `U+200B` ZWSP, `U+200C` ZWNJ, `U+200D` ZWJ, and `U+FEFF` BOM are removed. RTL/LTR bidi marks (`U+200F`, `U+202E`) are **preserved** — some right-to-left channel names need them.
 3. **Full superscript conversion.** Letter-superscripts (`ᴴᴰ` → `HD`, `ᴿᴬᵂ` → `RAW`) and numeric-superscripts (`²` → `2`, `⁶⁰` → `60`) both convert to ASCII. Both, always.
+4. **(Opt-in)** **Confusables fold** — see [Confusables fold](#confusables-fold-opt-in-bd-sc5s4) below. Off by default; enable when homoglyph attacks are part of your threat model.
 
 The policy is a [frozen dataclass](#developer-reference) applied at the same call site by Test Rules, Auto Create, and Re-normalize Existing Channels. It is not extensible from rule configuration — if you need a different Unicode preprocessing step, file a bead.
+
+### Confusables fold (opt-in, bd-sc5s4)
+
+Unicode contains many characters that render identically across scripts but occupy distinct code points — for example, Cyrillic `а` (U+0430) and Latin `a` (U+0061) look the same on screen but are byte-distinct. An attacker can register a stream named `chаnnel` (with a Cyrillic `а`) that visually matches a legitimate `channel`, defeating dedup, rule matching, and auto-creation collision detection.
+
+ECM ships with an opt-in **confusables fold** that maps a curated subset of Unicode TR39 confusables to Latin/ASCII *after* NFC + Cf-strip + superscript conversion. The fold is **off by default** because it is aggressive — it collapses characters that some operators want kept distinct (e.g. Greek alphabet channels, math-italic letters used as branding).
+
+**Enable it** by setting `ECM_NORMALIZATION_CONFUSABLES_FOLD=true` and restarting the container. Once on, the fold applies uniformly to Test Rules, Auto Create, and Re-normalize Existing Channels — the parity contract is preserved.
+
+**What gets folded** (curated subset, not the full ~6000-entry TR39 table):
+
+| Class | Example input | After fold |
+|-|-|-|
+| Cyrillic look-alikes | `chаnnel` (а=U+0430) | `channel` |
+| Greek capitals | `ΑBC` (Α=U+0391) | `ABC` |
+| Math italic letters | `\U0001D44E` MATHEMATICAL ITALIC SMALL A | `a` |
+| Math bold digits | `\U0001D7CE` MATHEMATICAL BOLD DIGIT ZERO | `0` |
+| Fullwidth Latin | `ＡＢＣ１` | `ABC1` |
+
+**What does NOT fold** (intentionally):
+
+- Accented Latin letters (`é`, `ñ`, `ü`) — these are content, not confusables.
+- Digit/letter look-alikes O/0, I/1/l — these collide more often than they prevent attacks.
+- The full TR39 6000-entry table — operators who need broader coverage should layer their own normalization rules or file a bead.
+
+**Rollback semantic**: with `ECM_NORMALIZATION_UNIFIED_POLICY=false` (legacy rollback path), the confusables fold is suppressed unconditionally — the rollback switch retains its byte-for-byte semantic. To use the fold, the unified policy must also be enabled (which is the default).
+
+**When to enable**: enable only if (a) you have evidence of homoglyph-based collisions in your feed, or (b) you operate a multi-tenant deployment where stream names come from untrusted sources. For single-operator / trusted-feed deployments the default-off behavior is correct — the false-positive risk (collapsing a legitimate Cyrillic channel name into Latin) outweighs the attack surface.
 
 ### Letter vs numeric superscripts — both now strip
 
@@ -183,7 +212,7 @@ The execute call takes an `actions[]` array keyed by `channel_id`. Only the chan
 Work this checklist in order:
 
 1. **NFC mismatch.** Is the input NFD-decomposed and your pattern composed (or vice versa)? The policy NFCs the input before rules run, but if your *pattern* was typed with composed characters and an older input had NFD, they now match; if your pattern has NFD and the input is now NFC (post-policy), they no longer match. Recompose the pattern.
-2. **Homoglyph.** Cyrillic `А` (U+0410) and Latin `A` (U+0041) render identically. The policy does not normalize homoglyphs. Copy the exact bytes from the raw input into your pattern.
+2. **Homoglyph.** Cyrillic `А` (U+0410) and Latin `A` (U+0041) render identically. The default policy does NOT normalize homoglyphs — copy the exact bytes from the raw input into your pattern, OR enable the [confusables fold](#confusables-fold-opt-in-bd-sc5s4) (`ECM_NORMALIZATION_CONFUSABLES_FOLD=true`) so Cyrillic / Greek / math / fullwidth look-alikes collapse to Latin/ASCII before matching.
 3. **Cf code point you didn't see.** `​` (ZWSP) is invisible. If the policy strips it, your pattern against `RTL HD` won't see the `​` that was in the raw input — which is correct behavior — but if you're testing against a pre-policy byte stream, the pattern will miss. Always use Test Rules (which applies the policy) for debugging, not raw-byte regex checks.
 4. **Rule ordering.** Does an earlier rule in the pipeline already transform the input away from what your pattern expects? The Test Rules trace drawer shows the intermediate values; read it top-down.
 5. **Regex timeout.** Check logs for `[SAFE_REGEX]` WARN mentioning your rule_id. If present, the pattern is timing out on this input — rewrite per style guide.
@@ -226,14 +255,17 @@ Dashboard metrics to watch during a normalization incident:
 ```python
 @dataclass(frozen=True)
 class NormalizationPolicy:
-    unified_enabled: bool = True   # latched at module load from ECM_NORMALIZATION_UNIFIED_POLICY
+    unified_enabled: bool = True       # latched from ECM_NORMALIZATION_UNIFIED_POLICY
+    confusables_fold: bool = False     # latched from ECM_NORMALIZATION_CONFUSABLES_FOLD (bd-sc5s4)
 
     def apply_to_text(self, text: str) -> str:
         # Under unified_enabled=True:
         #   1. NFC canonicalize
         #   2. strip whitelisted Cf code points
         #   3. convert superscripts (letters + numerics)
+        #   4. (opt-in) confusables fold (Cyrillic/Greek/math/fullwidth -> ASCII)
         # Under unified_enabled=False: only step 3 (legacy behavior)
+        # The confusables fold is suppressed under legacy regardless of the flag.
 ```
 
 The instance is process-global. Read it via `get_default_policy()`; mutate it via the env var + container restart. There is no per-request override.


### PR DESCRIPTION
## Summary

- Adds opt-in homoglyph defense to `NormalizationPolicy` via `ECM_NORMALIZATION_CONFUSABLES_FOLD=true` (default off — aggressive, collapses intentionally distinct characters when on).
- When enabled, folds Cyrillic / Greek / math italic / fullwidth confusables to Latin/ASCII after the existing NFC + Cf-strip + superscript pipeline, so `chаnnel` (Cyrillic U+0430) compares equal to `channel`.
- Fold is suppressed under the legacy `ECM_NORMALIZATION_UNIFIED_POLICY=false` rollback path so the rollback switch keeps its byte-for-byte semantic.
- Curated TR39 subset (not the full ~6000-entry table); deliberately excludes O/0 and I/1/l look-alikes (false-positive prone). Operators wanting wider coverage can layer normalization rules.

## Test plan

- [x] 26 new tests in `backend/tests/unit/test_normalization_confusables.py` covering: 5 confusable pair classes (Cyrillic, Greek, math, fullwidth, decomposed combining), ASCII regression with and without the flag, legacy-path suppression, env-var parsing, map sanity (no self-mappings, all targets ASCII), engine-level integration (Latin pattern matches Cyrillic input when fold on, doesn't when off).
- [x] All 257 existing normalization tests pass — no parity-contract drift.
- [x] Full backend suite: 3144 passed.
- [ ] Operator follow-up: enable in deployments where homoglyph attacks are part of the threat model.

Closes bd-sc5s4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)