### PR TITLE
feat(sre): ship cache-safe Cache-Control defaults on /assets and SPA index (bd-hl603)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1019,10 +1019,49 @@ async def shutdown_event():
 
 
 # Serve static files in production
+#
+# Cache-Control defaults (bd-hl603):
+#   /assets/*  -> "public, max-age=31536000, immutable"
+#       Vite emits content-hashed filenames in frontend/dist/assets/* (see
+#       frontend/vite.config.ts). The bytes at /assets/index-<hash>.js never
+#       change for that hash — a new build produces a new filename. They are
+#       eternal-cache-safe.
+#   /          -> "no-cache, must-revalidate"
+#   /index.html (served via the SPA fallback)
+#       The entry-point HTML references the hashed bundles by name. It MUST
+#       be revalidated on every load so a fresh deploy's bundle URLs are
+#       picked up. Without this, browsers / proxies that apply heuristic
+#       caching to HTML hand users a stale index.html pointing at a
+#       /assets/index-<old-hash>.js that has been removed from disk —
+#       producing 404s and the kind:"chunk_load" client-error spike that
+#       docs/runbooks/frontend_error_rate.md alerts on.
+#
+# Operator-facing cache-invalidation procedure:
+#   docs/runbooks/infra-cache-invalidation.md (companion runbook, covers
+#   reverse proxies and CDNs that may override or mask these defaults).
+ASSETS_CACHE_CONTROL = "public, max-age=31536000, immutable"
+INDEX_CACHE_CONTROL = "no-cache, must-revalidate"
+
+
+class ImmutableStaticFiles(StaticFiles):
+    """StaticFiles variant that stamps Cache-Control: immutable on every response.
+
+    Used for /assets/*, where Vite's content-hashed filenames make the bytes
+    at any given path immutable for the lifetime of that hash.
+    """
+
+    def file_response(self, *args, **kwargs):  # type: ignore[override]
+        response = super().file_response(*args, **kwargs)
+        response.headers["Cache-Control"] = ASSETS_CACHE_CONTROL
+        return response
+
+
 static_dir = os.path.join(os.path.dirname(__file__), "static")
 if os.path.exists(static_dir):
     app.mount(
-        "/assets", StaticFiles(directory=os.path.join(static_dir, "assets")), name="assets"
+        "/assets",
+        ImmutableStaticFiles(directory=os.path.join(static_dir, "assets")),
+        name="assets",
     )
     # Serve downloadable scripts (VLC protocol handlers, etc.)
     scripts_dir = os.path.join(static_dir, "scripts")
@@ -1054,10 +1093,17 @@ if os.path.exists(static_dir):
 
     @app.get("/{full_path:path}")
     async def serve_spa(full_path: str):
-        # Serve index.html for all non-API routes (SPA routing)
+        # Serve index.html for all non-API routes (SPA routing).
+        # Cache-Control: no-cache, must-revalidate ensures the browser always
+        # re-validates the entry-point HTML so it picks up the latest bundle
+        # hashes after a deploy. See bd-hl603 and the comment block above the
+        # static-file mounts.
         index_path = os.path.join(static_dir, "index.html")
         if os.path.exists(index_path):
-            return FileResponse(index_path)
+            return FileResponse(
+                index_path,
+                headers={"Cache-Control": INDEX_CACHE_CONTROL},
+            )
         return {"detail": "Frontend not built"}
 
 

--- a/backend/tests/integration/test_static_cache_headers.py
+++ b/backend/tests/integration/test_static_cache_headers.py
@@ -1,0 +1,126 @@
+"""Integration tests for Cache-Control defaults on /assets and SPA index.html.
+
+Bead: enhancedchannelmanager-hl603 — ECM should ship cache-safe defaults so
+operators don't inherit whatever heuristic their reverse proxy applies.
+
+Vite emits content-hashed filenames in frontend/dist/assets/* (see
+frontend/vite.config.ts), so /assets/* is eternal-cache-safe. index.html
+references those hashed bundles by name, so it must always re-validate or
+users hit a stale index.html pointing at a bundle URL that no longer exists
+on disk after a deploy (404 → kind:"chunk_load" client-error spike;
+docs/runbooks/frontend_error_rate.md).
+
+Companion runbook: docs/runbooks/infra-cache-invalidation.md
+"""
+import os
+
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.testclient import TestClient
+
+from main import (
+    ASSETS_CACHE_CONTROL,
+    INDEX_CACHE_CONTROL,
+    ImmutableStaticFiles,
+)
+
+
+def _build_static_tree(root):
+    """Mirror the runtime layout: <root>/assets/<bundle>.js + <root>/index.html."""
+    assets_dir = root / "assets"
+    assets_dir.mkdir()
+    bundle = assets_dir / "index-deadbeef.js"
+    bundle.write_text("console.log('hash-pinned bundle')\n")
+    index = root / "index.html"
+    index.write_text(
+        "<!doctype html><html><head>"
+        "<script src='/assets/index-deadbeef.js'></script>"
+        "</head><body></body></html>\n"
+    )
+    return bundle, index
+
+
+def _make_app(static_dir):
+    """Construct an isolated FastAPI app that wires the same mount + SPA fallback
+    pattern main.py uses, without depending on backend/static/ existing on disk
+    in CI."""
+    app = FastAPI()
+    app.mount(
+        "/assets",
+        ImmutableStaticFiles(directory=os.path.join(static_dir, "assets")),
+        name="assets",
+    )
+
+    @app.get("/{full_path:path}")
+    async def serve_spa(full_path: str):
+        index_path = os.path.join(static_dir, "index.html")
+        return FileResponse(
+            index_path,
+            headers={"Cache-Control": INDEX_CACHE_CONTROL},
+        )
+
+    return app
+
+
+class TestAssetsCacheHeader:
+    """/assets/* must advertise itself as immutable for one year."""
+
+    def test_assets_response_has_immutable_cache_control(self, tmp_path):
+        _build_static_tree(tmp_path)
+        client = TestClient(_make_app(str(tmp_path)))
+
+        resp = client.get("/assets/index-deadbeef.js")
+
+        assert resp.status_code == 200
+        assert resp.headers["cache-control"] == ASSETS_CACHE_CONTROL
+
+    def test_assets_cache_control_is_one_year_immutable(self):
+        """The constant itself encodes the policy — guard against drift."""
+        assert "public" in ASSETS_CACHE_CONTROL
+        assert "max-age=31536000" in ASSETS_CACHE_CONTROL  # 1 year in seconds
+        assert "immutable" in ASSETS_CACHE_CONTROL
+
+    def test_not_modified_response_preserves_cache_control(self, tmp_path):
+        """Starlette's NotModifiedResponse copies cache-control onto 304s,
+        so re-validations also carry the immutable directive forward."""
+        _build_static_tree(tmp_path)
+        client = TestClient(_make_app(str(tmp_path)))
+
+        first = client.get("/assets/index-deadbeef.js")
+        etag = first.headers.get("etag")
+        assert etag, "StaticFiles should emit ETag for revalidation"
+
+        second = client.get(
+            "/assets/index-deadbeef.js",
+            headers={"If-None-Match": etag},
+        )
+        assert second.status_code == 304
+        assert second.headers["cache-control"] == ASSETS_CACHE_CONTROL
+
+
+class TestIndexCacheHeader:
+    """The SPA entry point must always be re-validated."""
+
+    def test_spa_root_has_no_cache_must_revalidate(self, tmp_path):
+        _build_static_tree(tmp_path)
+        client = TestClient(_make_app(str(tmp_path)))
+
+        resp = client.get("/")
+
+        assert resp.status_code == 200
+        assert resp.headers["cache-control"] == INDEX_CACHE_CONTROL
+
+    def test_spa_arbitrary_path_has_no_cache_must_revalidate(self, tmp_path):
+        """SPA routes (/channels, /settings, etc.) are also entry-point HTML."""
+        _build_static_tree(tmp_path)
+        client = TestClient(_make_app(str(tmp_path)))
+
+        resp = client.get("/channels")
+
+        assert resp.status_code == 200
+        assert resp.headers["cache-control"] == INDEX_CACHE_CONTROL
+
+    def test_index_cache_control_forbids_caching_without_revalidation(self):
+        """The constant itself encodes the policy — guard against drift."""
+        assert "no-cache" in INDEX_CACHE_CONTROL
+        assert "must-revalidate" in INDEX_CACHE_CONTROL

--- a/docs/runbooks/infra-cache-invalidation.md
+++ b/docs/runbooks/infra-cache-invalidation.md
@@ -59,10 +59,13 @@ Browser-side invalidation (per the [Dep-Bump Frontend Regression runbook](./dep-
 ### What ECM emits today
 
 - ECM serves static assets via FastAPI's [`StaticFiles`](https://fastapi.tiangolo.com/reference/staticfiles/) mount (`backend/main.py`, `/assets` and the SPA fallback).
-- **ECM does not set `Cache-Control` headers on `/assets/*` or `/index.html`.** Starlette's default `StaticFiles` emits `ETag` and `Last-Modified` only. This means each upstream cache decides its own TTL according to its own heuristics — which is why "why is this still cached?" varies by operator.
+- **ECM ships cache-safe `Cache-Control` defaults** (bd-hl603):
+  - `/assets/*` → `Cache-Control: public, max-age=31536000, immutable` — Vite's content-hashed filenames make each path eternal-cache-safe.
+  - `/` and the SPA fallback (which serves `index.html`) → `Cache-Control: no-cache, must-revalidate` — the entry-point HTML must always be revalidated so a fresh deploy's bundle URLs are picked up.
+- The headers above ride on top of Starlette's default `ETag` + `Last-Modified`. A correctly-configured downstream cache will honor them and you will not need this runbook for routine deploys. **This runbook still matters when** a reverse proxy or CDN strips, overrides, or pre-dates these headers — which is common with default Cloudflare configurations, nginx `proxy_cache` blocks that ignore origin `Cache-Control`, or any cache that was warmed before the bd-hl603 release.
 - **ECM ships no service worker.** Confirmed in `frontend/vite.config.ts` (no `vite-plugin-pwa`, no `workbox-*`). Any service-worker-induced caching seen in the wild is either a reverse proxy injecting one or a stale SW from a much older ECM build — treat as anomalous.
 
-Operators who want more predictable cache behavior should set `Cache-Control: no-cache` on `/` and `/index.html` and `Cache-Control: public, max-age=31536000, immutable` on `/assets/*` at their proxy. That configuration is the operator's call — ECM does not enforce it. See the per-proxy sections below for copy-pasteable snippets.
+Operators whose proxy ignores upstream `Cache-Control` (or who want belt-and-suspenders consistency at the edge) can apply the same policy at the proxy itself: `Cache-Control: no-cache` on `/` and `/index.html`, `Cache-Control: public, max-age=31536000, immutable` on `/assets/*`. See the per-proxy sections below for copy-pasteable snippets.
 
 ## Diagnosis
 


### PR DESCRIPTION
## Summary

Bead [`enhancedchannelmanager-hl603`](https://github.com/MotWakorb/enhancedchannelmanager) — ship Cache-Control defaults so ECM is a safe default citizen instead of inheriting whatever heuristic the operator's reverse proxy chooses.

- `/assets/*` now responds with `Cache-Control: public, max-age=31536000, immutable`. Vite emits content-hashed bundle filenames, so each path is eternal-cache-safe.
- `/` and the SPA fallback (which serves `index.html`) now respond with `Cache-Control: no-cache, must-revalidate`. The entry-point HTML must always be revalidated so a fresh deploy's bundle URLs are picked up. Without this, downstream caches serve a stale `index.html` pointing at a `/assets/index-<old-hash>.js` that has been removed from disk on deploy → 404 → `kind:"chunk_load"` client errors (alerted on per `docs/runbooks/frontend_error_rate.md`).
- The `/api/*` JSON 404 catch-all (vjlzf) is preserved unchanged.

## Implementation notes

- New `ImmutableStaticFiles` subclass stamps the immutable header on every `/assets/*` response, including the 304 NotModified revalidation path (Starlette's `NotModifiedResponse` preserves `cache-control` from the underlying response).
- The SPA fallback passes `headers={"Cache-Control": ...}` to `FileResponse`.
- `docs/runbooks/infra-cache-invalidation.md` is updated so the "What ECM emits today" section reflects the new defaults and reframes the runbook as the response for proxies that strip or pre-date them.

## Live verification (container)

```
$ /assets/index-<hash>.js → cache-control: public, max-age=31536000, immutable
$ /                       → cache-control: no-cache, must-revalidate
```

## Test plan

- [x] New integration tests `backend/tests/integration/test_static_cache_headers.py` (6 tests) cover:
  - `/assets/*` immutable header on 200
  - `/assets/*` immutable header preserved on 304 revalidation
  - SPA `/` no-cache + must-revalidate
  - SPA arbitrary path (e.g. `/channels`) no-cache + must-revalidate
  - Constant-drift guards on `ASSETS_CACHE_CONTROL` and `INDEX_CACHE_CONTROL`
- [x] Full backend suite: 3122 passed, 0 failed (+6 from this PR)
- [x] Live container verification of both response headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)