### PR TITLE
fix(settings): preserve mcp_api_key on partial POST (bd-vj8n9)

### DIFF
--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -367,6 +367,11 @@ async def update_settings(request: SettingsRequest):
     # Same for SMTP password - preserve existing if not provided
     smtp_password = request.smtp_password if request.smtp_password else current_settings.smtp_password
 
+    # MCP API key is never accepted on this endpoint (it has dedicated
+    # generate/revoke endpoints) — always preserve the stored value so a
+    # partial POST cannot silently revoke it (bd-vj8n9).
+    mcp_api_key = current_settings.mcp_api_key
+
     if request.auth_method not in ("password", "api_key"):
         raise HTTPException(
             status_code=400,
@@ -487,6 +492,9 @@ async def update_settings(request: SettingsRequest):
         auto_creation_excluded_terms=request.auto_creation_excluded_terms,
         auto_creation_excluded_groups=request.auto_creation_excluded_groups,
         auto_creation_exclude_auto_sync_groups=request.auto_creation_exclude_auto_sync_groups,
+        # MCP API key is preserved from current settings — see comment above
+        # where mcp_api_key is captured (bd-vj8n9).
+        mcp_api_key=mcp_api_key,
         telemetry_client_errors_enabled=request.telemetry_client_errors_enabled,
     )
     save_settings(new_settings)

--- a/backend/tests/routers/test_settings.py
+++ b/backend/tests/routers/test_settings.py
@@ -206,6 +206,69 @@ class TestUpdateSettings:
         assert response.status_code == 400
         assert "api key" in response.json()["detail"].lower()
 
+    @pytest.mark.asyncio
+    async def test_partial_update_preserves_mcp_api_key(self, async_client):
+        """bd-vj8n9: POST with a partial body must NOT clear the stored mcp_api_key.
+
+        Reproduction of the bug: SettingsRequest doesn't accept mcp_api_key, so
+        every POST that omits it would construct DispatcharrSettings(...) with
+        the field defaulting to "" and silently revoke the key.
+        """
+        current = _mock_settings(mcp_api_key="stored-mcp-key-abc123")
+        captured = {}
+
+        def capture_save(new_settings):
+            captured["mcp_api_key"] = new_settings.mcp_api_key
+
+        with patch("routers.settings.get_settings", return_value=current), \
+             patch("routers.settings.save_settings", side_effect=capture_save), \
+             patch("routers.settings.clear_settings_cache"), \
+             patch("routers.settings.reset_client"), \
+             patch("routers.settings.get_prober", return_value=None), \
+             patch("routers.settings.get_cache") as mock_cache:
+            mock_cache.return_value = MagicMock()
+            response = await async_client.post("/api/settings", json={
+                "url": current.url,
+                "username": current.username,
+                "telemetry_client_errors_enabled": False,
+            })
+
+        assert response.status_code == 200, response.json()
+        assert captured["mcp_api_key"] == "stored-mcp-key-abc123", (
+            "Partial POST cleared mcp_api_key — sensitive field not preserved"
+        )
+
+    @pytest.mark.asyncio
+    async def test_partial_update_preserves_smtp_password(self, async_client):
+        """bd-vj8n9: POST with a partial body must NOT clear the stored smtp_password.
+
+        Companion to mcp_api_key test — verifies the existing preserve-on-omit
+        contract for smtp_password still holds. Regression guard.
+        """
+        current = _mock_settings(smtp_password="stored-smtp-password-xyz")
+        captured = {}
+
+        def capture_save(new_settings):
+            captured["smtp_password"] = new_settings.smtp_password
+
+        with patch("routers.settings.get_settings", return_value=current), \
+             patch("routers.settings.save_settings", side_effect=capture_save), \
+             patch("routers.settings.clear_settings_cache"), \
+             patch("routers.settings.reset_client"), \
+             patch("routers.settings.get_prober", return_value=None), \
+             patch("routers.settings.get_cache") as mock_cache:
+            mock_cache.return_value = MagicMock()
+            response = await async_client.post("/api/settings", json={
+                "url": current.url,
+                "username": current.username,
+                "telemetry_client_errors_enabled": False,
+            })
+
+        assert response.status_code == 200, response.json()
+        assert captured["smtp_password"] == "stored-smtp-password-xyz", (
+            "Partial POST cleared smtp_password — sensitive field not preserved"
+        )
+
 
 class TestTestConnection:
     """Tests for POST /api/settings/test."""


### PR DESCRIPTION
## Summary

- POST /api/settings was silently revoking the stored `mcp_api_key` on every partial body. `SettingsRequest` doesn't expose `mcp_api_key` (it has dedicated generate/revoke endpoints), so `update_settings` was constructing `DispatcharrSettings` without it, defaulting the field to `""` and overwriting the stored key.
- Fix follows the existing preserve-on-omit pattern used for `password` / `api_key` / `smtp_password`: capture `mcp_api_key` from `current_settings` before building the new `DispatcharrSettings`, then pass it through.
- Audit: `mcp_api_key` is the only `DispatcharrSettings` field that `update_settings` was failing to round-trip. All other sensitive fields (`password`, `api_key`, `smtp_password`) already had explicit preserve logic.

## Test plan

- [x] Two new regression tests in `backend/tests/routers/test_settings.py` (mcp_api_key + smtp_password companion guard)
- [x] Full backend suite: 3118 passed (3116 baseline + 2 new), zero regressions
- [x] End-to-end verified against `ecm-ecm-1`: GET shows key configured → partial POST → GET still shows key configured, `/config/settings.json` retains the key on disk

Closes bd-vj8n9.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>