### PR TITLE
deps(frontend): @dnd-kit/sortable 8 → 10 (bd-zqmv1)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "enhanced-channel-manager",
-  "version": "0.16.0-0052",
+  "version": "0.16.0-0059",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "enhanced-channel-manager",
-      "version": "0.16.0-0052",
+      "version": "0.16.0-0059",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
-        "@dnd-kit/sortable": "8.0.0",
+        "@dnd-kit/sortable": "10.0.0",
         "@dnd-kit/utilities": "3.2.2",
         "mpegts.js": "1.8.0",
         "react": "18.3.1",
@@ -524,16 +524,16 @@
       }
     },
     "node_modules/@dnd-kit/sortable": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
-      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
-        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/core": "^6.3.0",
         "react": ">=16.8.0"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "6.3.1",
-    "@dnd-kit/sortable": "8.0.0",
+    "@dnd-kit/sortable": "10.0.0",
     "@dnd-kit/utilities": "3.2.2",
     "mpegts.js": "1.8.0",
     "react": "18.3.1",


### PR DESCRIPTION
## [bd-zqmv1] @dnd-kit/sortable 8 → 10

### What
Bumps `@dnd-kit/sortable` two majors (8.0.0 → 10.0.0). No companion `@dnd-kit/core` bump needed — sortable@10 peer-deps `^6.3.0`, satisfied by the pinned 6.3.1.

### Why
Part of the deferred major-bump epic (bd-6rrl5). Held back from v0.16.0-0035.

### API impact
None. The hook surface in use across the codebase is backwards-compatible across v8-v10:
- `useSortable({ id, disabled })` → `{ attributes, listeners, setNodeRef, transform, transition, isDragging }`
- `DndContext` + `SortableContext` + `verticalListSortingStrategy`
- `arrayMove`, `sortableKeyboardCoordinates`
- `useSensor` / `useSensors` with `PointerSensor` / `KeyboardSensor`

Affected components (touched only via dependency, no source edits):
ChannelListItem, ChannelDetail, ChannelsPane, StreamListItem, SubstitutionPairsEditor, EPGManagerTab, SettingsTab, NormalizationEngineSection.

### How to Test
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (0 warnings)
- [x] `npm test` — 1177/1177 pass
- [x] `npm run build` — succeeds
- [ ] Manual smoke: drag-reorder channels in edit mode, drag-reorder streams in channel detail, drag-reorder normalization rules

### Deployment
- Frontend dependency-only change. No backend, no infra, no DB.
- Rollback: revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)