### PR TITLE
deps(frontend): TypeScript 5.9 → 6.0 (bd-v28b8)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,7 +30,7 @@
         "globals": "17.5.0",
         "jsdom": "24.1.3",
         "msw": "2.13.4",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "typescript-eslint": "8.58.2",
         "vite": "7.3.2",
         "vitest": "4.1.4"
@@ -5982,9 +5982,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "globals": "17.5.0",
     "jsdom": "24.1.3",
     "msw": "2.13.4",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "typescript-eslint": "8.58.2",
     "vite": "7.3.2",
     "vitest": "4.1.4"


### PR DESCRIPTION
## Summary
TypeScript 5.9.3 → 6.0.3 (chain head of v0.16.0 major dep-bump epic, bd-v28b8).

## Verification
- npm typecheck: clean
- npm run lint: clean
- npm test: 1177/1177 tests pass (50 files)
- npm run build: clean

## Type-error fixes
None required. TS 6.0 strict-mode defaults already mirror our existing `tsconfig.json` (`strict`, `noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`). No deprecated flags in use.

## Notes
- Frontend-only — backend untouched.
- React 18 / @types/react 18 left unchanged (React 19 lives in sibling bead `bd-in620`).
- Closes bead `enhancedchannelmanager-v28b8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)