### PR TITLE
chore: bump dev to 0.16.0-0060 after dep-bump batch

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.16.0-0059",
+  "version": "0.16.0-0060",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Tag-stone bump capturing the v0.16.0 major dep-bump epic completion + ADR-001 cadence change.

## Batch Captured (PRs merged to dev)
- PR #183 (bd-lx1gf): jsdom 24 → 29
- PR #184 (bd-hlcgj): vite 7 → 8 + plugin-react 5 → 6
- PR #185 (bd-zqmv1): @dnd-kit/sortable 8 → 10
- PR #186 (bd-v28b8): TypeScript 5.9 → 6.0
- PR #187 (bd-c7txa): ADR-001 cadence-rule excision
- PR #188 (bd-in620): React 19 ecosystem (react/react-dom/@types/react/@testing-library/react 16)
- PR #189 (bd-5x6n7): eslint 9 → 10 + typescript-eslint compat

## Diff
`frontend/package.json` version bump only: `0.16.0-0059` → `0.16.0-0060`.

## Validation
`cd frontend && npm run build` — clean (built in 2.99s).