### PR TITLE
feat(observability): expose container source SHA + add deploy-freshness check (bd-h0wfu)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -396,6 +396,10 @@ AUTH_EXEMPT_PATHS = {
     "/api/health/ready",
     # Schema version — public so DBAS restore/sync can gate on revision
     "/api/health/schema",
+    # Build identity — public so operators can detect container drift from
+    # origin/dev (bd-h0wfu) without authenticating. Echoes the same env
+    # vars baked into the image at Docker build time. No subsystem access.
+    "/api/version",
     # Auth flow (must be public by definition)
     "/api/auth/login",
     "/api/auth/refresh",

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -259,6 +259,32 @@ _NORMALIZATION_LATENCY_BUCKETS = (
 def _build_metrics(registry: CollectorRegistry) -> Dict[str, Any]:
     """Instantiate the ECM metric set against ``registry``."""
     return {
+        # ----------------------------------------------------------------
+        # Build identity (bd-h0wfu).
+        #
+        # ``ecm_app_info`` is the canonical Prometheus "info" pattern — a
+        # gauge stuck at 1.0 whose ONLY purpose is to carry build-identity
+        # labels (``version``, ``git_sha``, ``release_channel``). Operators
+        # use it to answer "what is the running container actually built
+        # from?" without having to parse JSON from /api/health, which is a
+        # recurring source of fake "test failure" beads where the real
+        # cause is container drift from origin/dev.
+        #
+        # Cardinality: bounded — each running container has exactly one
+        # (version, git_sha, release_channel) tuple for its lifetime. A
+        # fresh container build produces a single new time series.
+        # ``install_metrics`` sets the gauge to 1.0 with the labels read
+        # from the build-time environment (GIT_COMMIT, ECM_VERSION,
+        # RELEASE_CHANNEL — all baked into the image by Dockerfile ARGs).
+        # ----------------------------------------------------------------
+        "app_info": Gauge(
+            "ecm_app_info",
+            "Build identity of the running container. Labels carry the "
+            "version, git SHA, and release channel baked in at image-build "
+            "time. Value is always 1.0 — query the labels, not the value.",
+            ["version", "git_sha", "release_channel"],
+            registry=registry,
+        ),
         "http_requests_total": Counter(
             "ecm_http_requests_total",
             "Count of HTTP requests processed, labeled by method, route "
@@ -402,7 +428,42 @@ def install_metrics(registry: Optional[CollectorRegistry] = None) -> Dict[str, A
     if REGISTRY is None:
         REGISTRY = registry or CollectorRegistry()
         _METRICS = _build_metrics(REGISTRY)
+        _publish_app_info()
     return _METRICS
+
+
+def _publish_app_info() -> None:
+    """Stamp the build-identity labels onto ``ecm_app_info`` (bd-h0wfu).
+
+    Reads the same env vars that ``/api/health`` and ``/api/version`` echo
+    so operators see the same SHA in three places — Prometheus, the JSON
+    health probe, and the dedicated version endpoint. All three are
+    populated from Dockerfile build ARGs, so a fresh image build mints a
+    new (version, git_sha) time series and stale containers are
+    immediately distinguishable from the running ``origin/dev`` HEAD.
+
+    Defensive: never raises. If prometheus-client is missing or the env
+    vars are absent, the gauge is simply not stamped — better than taking
+    down app startup over an observability nicety.
+    """
+    if not _METRICS:
+        return
+    try:
+        gauge = _METRICS.get("app_info")
+        if gauge is None:
+            return
+        version = os.environ.get("ECM_VERSION", "unknown")
+        git_sha = os.environ.get("GIT_COMMIT", "unknown")
+        release_channel = os.environ.get("RELEASE_CHANNEL", "latest")
+        gauge.labels(
+            version=version,
+            git_sha=git_sha,
+            release_channel=release_channel,
+        ).set(1.0)
+    except Exception:  # pragma: no cover — observability must not break startup
+        logging.getLogger(__name__).debug(
+            "[OBSERVABILITY] Failed to publish ecm_app_info gauge", exc_info=True
+        )
 
 
 def get_metric(name: str) -> Any:

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -223,6 +223,35 @@ async def health_check():
     }
 
 
+@router.get("/api/version")
+async def version_endpoint() -> dict:
+    """Report the build identity of the running container (bd-h0wfu).
+
+    Dedicated, ultra-cheap endpoint whose ONLY job is to answer "what
+    SHA is this container running?". Same fields as ``/api/health`` but
+    without the ``status``/``service`` envelope, so operators can pipe
+    it through ``jq -r .git_commit`` and compare against
+    ``git rev-parse origin/dev`` to detect deploy drift in a one-liner::
+
+        curl -s http://localhost:6100/api/version | jq -r .git_commit
+
+    Why a separate endpoint instead of just reusing /api/health? The
+    health endpoint is the Dockerfile HEALTHCHECK target — its
+    semantics are "am I alive?" and downstream tooling parses its
+    response shape. Adding a dedicated /api/version keeps the
+    drift-check path discoverable by name and lets us evolve the
+    health response independently if we ever need to.
+
+    Public endpoint (see ``main.AUTH_EXEMPT_PATHS``): no auth, no rate
+    limit, no subsystem probing. Three env-var reads — that's it.
+    """
+    return {
+        "version": os.environ.get("ECM_VERSION", "unknown"),
+        "git_commit": os.environ.get("GIT_COMMIT", "unknown"),
+        "release_channel": os.environ.get("RELEASE_CHANNEL", "latest"),
+    }
+
+
 @router.get("/api/health/ready")
 async def readiness_check(response: Response) -> dict:
     """Rich readiness check — verifies DB, Dispatcharr, and ffprobe.

--- a/backend/tests/routers/test_health.py
+++ b/backend/tests/routers/test_health.py
@@ -48,6 +48,53 @@ class TestHealthCheck:
             assert data["git_commit"] == "abc123"
 
 
+class TestVersionEndpoint:
+    """Tests for GET /api/version (bd-h0wfu).
+
+    The endpoint is the canonical "what SHA is this container running?"
+    probe used by operators to detect drift between ``ecm-ecm-1`` and
+    ``origin/dev`` before triaging fake test-failure beads.
+    """
+
+    @pytest.mark.asyncio
+    async def test_version_returns_200(self, async_client):
+        """GET /api/version returns 200 with build identity fields."""
+        response = await async_client.get("/api/version")
+        assert response.status_code == 200
+        data = response.json()
+        assert "version" in data
+        assert "git_commit" in data
+        assert "release_channel" in data
+
+    @pytest.mark.asyncio
+    async def test_version_reads_env_vars(self, async_client):
+        """GET /api/version surfaces ECM_VERSION / GIT_COMMIT / RELEASE_CHANNEL."""
+        with patch.dict("os.environ", {
+            "ECM_VERSION": "9.9.9",
+            "RELEASE_CHANNEL": "edge",
+            "GIT_COMMIT": "deadbeef",
+        }):
+            response = await async_client.get("/api/version")
+            data = response.json()
+            assert data["version"] == "9.9.9"
+            assert data["git_commit"] == "deadbeef"
+            assert data["release_channel"] == "edge"
+
+    @pytest.mark.asyncio
+    async def test_version_falls_back_to_unknown(self, async_client):
+        """Missing env vars produce 'unknown' / 'latest' defaults, never 500."""
+        # Wipe the relevant env vars so the defaults take effect.
+        with patch.dict("os.environ", {}, clear=False) as _env:
+            for key in ("ECM_VERSION", "GIT_COMMIT", "RELEASE_CHANNEL"):
+                _env.pop(key, None)
+            response = await async_client.get("/api/version")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["version"] == "unknown"
+            assert data["git_commit"] == "unknown"
+            assert data["release_channel"] == "latest"
+
+
 class TestSchemaVersionEndpoint:
     """Tests for GET /api/health/schema (bd-c5wf5)."""
 

--- a/backend/tests/unit/test_observability.py
+++ b/backend/tests/unit/test_observability.py
@@ -134,6 +134,8 @@ class TestMetrics:
         assert "http_request_duration_seconds" in metrics
         assert "health_ready_ok" in metrics
         assert "health_ready_check_duration_seconds" in metrics
+        # bd-h0wfu: build identity gauge must also be installed.
+        assert "app_info" in metrics
 
     def test_install_metrics_is_idempotent(self):
         first = observability.install_metrics()
@@ -172,3 +174,52 @@ class TestMetrics:
         assert gauge._value.get() == 1.0
         gauge.set(0)
         assert gauge._value.get() == 0.0
+
+
+class TestAppInfoGauge:
+    """Tests for the ``ecm_app_info`` build-identity gauge (bd-h0wfu).
+
+    The gauge follows the standard Prometheus "info" pattern: value is
+    always 1.0; the meaningful payload is in the labels. Operators query
+    the labels (``version``, ``git_sha``, ``release_channel``) to detect
+    when the running container has drifted from ``origin/dev`` HEAD.
+    """
+
+    def test_app_info_is_published_with_env_labels(self, monkeypatch):
+        """install_metrics stamps ecm_app_info with env-var labels."""
+        monkeypatch.setenv("ECM_VERSION", "0.16.0-test")
+        monkeypatch.setenv("GIT_COMMIT", "cafebabe1234")
+        monkeypatch.setenv("RELEASE_CHANNEL", "dev")
+
+        observability.install_metrics()
+        body = observability.render_metrics().decode("utf-8")
+
+        assert "# HELP ecm_app_info" in body
+        assert "# TYPE ecm_app_info gauge" in body
+        assert 'version="0.16.0-test"' in body
+        assert 'git_sha="cafebabe1234"' in body
+        assert 'release_channel="dev"' in body
+
+    def test_app_info_falls_back_to_unknown(self, monkeypatch):
+        """Missing env vars resolve to 'unknown' / 'latest', never crash."""
+        monkeypatch.delenv("ECM_VERSION", raising=False)
+        monkeypatch.delenv("GIT_COMMIT", raising=False)
+        monkeypatch.delenv("RELEASE_CHANNEL", raising=False)
+
+        observability.install_metrics()
+        body = observability.render_metrics().decode("utf-8")
+
+        assert 'version="unknown"' in body
+        assert 'git_sha="unknown"' in body
+        assert 'release_channel="latest"' in body
+
+    def test_app_info_value_is_one(self, monkeypatch):
+        """The info-pattern gauge is always 1.0 — labels carry the payload."""
+        monkeypatch.setenv("ECM_VERSION", "v")
+        monkeypatch.setenv("GIT_COMMIT", "g")
+        monkeypatch.setenv("RELEASE_CHANNEL", "r")
+
+        observability.install_metrics()
+        gauge = observability.get_metric("app_info")
+        sample = gauge.labels(version="v", git_sha="g", release_channel="r")
+        assert sample._value.get() == 1.0

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -197,6 +197,63 @@ Do **not** lower the threshold in the config.
 - **Frontend tests**: MANDATORY for any frontend code changes
 - **E2E tests**: Run on merge to main only (CI/CD pipeline)
 
+## Container Freshness Check
+
+**Before triaging any "test failure" bead that reports failures from
+`ecm-ecm-1`, verify the container is actually running current `dev`
+HEAD.** This pattern (engineer files a "tests failing on dev" bead;
+investigation reveals tests pass locally and the container is stale)
+recurred enough times — beads `5dug8`, `0gcu9`, others — that it
+deserves its own check (bd-h0wfu).
+
+The container reports its source SHA in two places, populated from
+Docker build args at image-build time (`Dockerfile`: `ARG GIT_COMMIT`):
+
+```bash
+# Method A — JSON endpoint (no auth required, /api/version is exempt)
+curl -s http://localhost:6100/api/version | jq -r .git_commit
+
+# Method B — Prometheus metric label
+curl -s http://localhost:6100/metrics | grep ecm_app_info
+# ecm_app_info{git_sha="<sha>",release_channel="latest",version="<ver>"} 1.0
+```
+
+Compare against `origin/dev`:
+
+```bash
+git fetch origin dev
+git rev-parse origin/dev
+```
+
+**If the SHAs match**, the container is current — investigate the test
+failure as real. **If they don't match**, the container is stale; redeploy
+current dev HEAD before triaging:
+
+```bash
+# Backend
+docker cp backend/main.py ecm-ecm-1:/app/main.py
+docker cp backend/routers/. ecm-ecm-1:/app/routers/
+docker restart ecm-ecm-1
+
+# Frontend
+cd frontend && npm run build
+docker exec ecm-ecm-1 sh -c 'rm -rf /app/static/assets/*'
+docker cp dist/. ecm-ecm-1:/app/static/
+```
+
+Re-run the failing tests. If they now pass, the bead was deploy drift,
+not a code defect — close it without filing a code bead. The
+container-first development workflow (per `CLAUDE.md`) means agents
+`docker cp` specific files when iterating, so the shared `ecm-ecm-1`
+container can lag origin/dev when nobody re-deploys after a merge to
+`dev`. The freshness check above is a one-line cure for the entire
+class of fake test-failure beads.
+
+The same SHA labels also drive container-drift dashboards in Grafana —
+`max by (git_sha) (ecm_app_info)` shows the running build identity, and
+an alert can fire when it diverges from the `origin/dev` SHA published by
+the build pipeline.
+
 ## Quality Gate Commands
 
 ```bash


### PR DESCRIPTION
## Summary

- Add `/api/version` endpoint and `ecm_app_info` Prometheus gauge that surface the running container's build identity (version + git SHA + release channel). Both populate from existing Dockerfile build ARGs — no build-pipeline changes needed.
- Add a "Container Freshness Check" section to `docs/testing.md` pointing engineers to verify the container matches `origin/dev` HEAD **before** triaging failing-test beads on `ecm-ecm-1`.

This drains the recurring pattern (beads `5dug8`, `0gcu9`, others) where engineers file fake test-failure beads against `dev` HEAD when the actual root cause is that `ecm-ecm-1` is running a stale `docker cp`-deployed snapshot from someone else's iteration.

## Implementation

**`/api/version`** (new, in `routers/health.py`): Returns `{version, git_commit, release_channel}` from env vars. Auth-exempt. Distinct from `/api/health` so the drift-check path is discoverable by name and pipes cleanly through `jq -r .git_commit`.

**`ecm_app_info`** (new gauge, in `observability.py`): Standard Prometheus "info" pattern — value always `1.0`, payload carried in labels (`version`, `git_sha`, `release_channel`). Stamped by `install_metrics()` from the same env vars. Bounded cardinality — exactly one time series per running container. Drives `max by (git_sha) (ecm_app_info)` dashboards for container-drift alerting (future bead).

**`docs/testing.md`** gains a "Container Freshness Check" section between "When to Run Tests" and "Quality Gate Commands" with the two probe commands (curl `/api/version`, grep `/metrics`) and the redeploy snippet to apply when SHAs diverge.

## Test plan

- [x] `tests/routers/test_health.py::TestVersionEndpoint` — 3 new tests covering: returns 200 with build-identity fields, reads env vars, falls back to `unknown`/`latest` when env vars are missing.
- [x] `tests/unit/test_observability.py::TestAppInfoGauge` — 3 new tests covering: gauge stamped with env labels, falls back to `unknown`/`latest`, value is always `1.0` (info-pattern invariant).
- [x] Existing `test_install_metrics_creates_required_series` extended to assert `app_info` is registered.
- [x] Verified end-to-end on `ecm-ecm-1`:
  - `curl /api/version` → returns the running container's git SHA (matches `f243dde8` here)
  - `curl /metrics | grep ecm_app_info` → returns `ecm_app_info{git_sha="f243dde8…",release_channel="dev",version="0.16.0-0060"} 1.0`
- [x] Full backend suite: `3093 passed in 103.19s` (60.70% coverage, above 56% gate).

## Bead

`enhancedchannelmanager-h0wfu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)