### PR TITLE
feat(observability): ecm_session_starts_total + dedup_set_size for SLO-6 denominator (bd-arp3o)

### DIFF
--- a/backend/observability.py
+++ b/backend/observability.py
@@ -414,6 +414,36 @@ def _build_metrics(registry: CollectorRegistry) -> Dict[str, Any]:
             buckets=(128, 256, 512, 1024, 2048, 4096, 8192),
             registry=registry,
         ),
+        # ----------------------------------------------------------------
+        # Session lifecycle (bd-arp3o, spike bd-1tl01).
+        #
+        # ``session_starts_total`` is the SLO-6 denominator — number of
+        # unique frontend sessions that POSTed /api/session-start. The
+        # counter has NO labels (per ADR-006 §9 cardinality posture); the
+        # session_id itself never becomes a label and is never logged.
+        # The router maintains an in-memory dedup set keyed by session_id
+        # (TTL=24h) so a hard-refresh inside the same tab cannot
+        # double-count a single browser session.
+        #
+        # ``session_dedup_set_size`` exposes the dedup set's current
+        # cardinality so SRE can spot a leaking pruner — a slowly-growing
+        # gauge means the lazy reaper has regressed and the in-memory
+        # set is accumulating stale entries past their TTL.
+        # ----------------------------------------------------------------
+        "session_starts_total": Counter(
+            "ecm_session_starts_total",
+            "Count of unique frontend sessions observed via "
+            "POST /api/session-start. SLO-6 SLI denominator. "
+            "No labels — session_id is in-memory dedup state, never a label.",
+            registry=registry,
+        ),
+        "session_dedup_set_size": Gauge(
+            "ecm_session_dedup_set_size",
+            "Current size of the in-memory session-id dedup set. Steady "
+            "state ~= sessions seen in the last 24h. A monotonically "
+            "growing value indicates the lazy TTL reaper has regressed.",
+            registry=registry,
+        ),
     }
 
 

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -28,6 +28,7 @@ from routers.export import router as export_router
 from routers.backup import router as backup_router
 from routers.lookup_tables import router as lookup_tables_router
 from routers.client_errors import router as client_errors_router
+from routers.session_starts import router as session_starts_router
 
 all_routers = [
     tasks_router,
@@ -55,4 +56,5 @@ all_routers = [
     backup_router,
     lookup_tables_router,
     client_errors_router,
+    session_starts_router,
 ]

--- a/backend/routers/session_starts.py
+++ b/backend/routers/session_starts.py
@@ -1,0 +1,256 @@
+"""
+Session-start router — SLO-6 denominator counter ingest.
+
+Implements bead ``enhancedchannelmanager-arp3o`` per the spike decision
+recorded in ``docs/sre/spike-slo-6-session-semantics.md`` (bd-1tl01).
+
+Contract:
+
+  POST /api/session-start
+
+The frontend generates a SubtleCrypto-backed UUIDv4 once per
+``sessionStorage`` lifetime and POSTs it here. The backend deduplicates
+via an in-memory set with 24h TTL — only first-seen ``session_id``
+values increment ``ecm_session_starts_total``. Re-submission inside the
+TTL returns 200 with no metric bump.
+
+Architecture anchors from the spike doc:
+
+  * The counter has no labels (cardinality posture from ADR-006 §9).
+  * ``session_id`` is **never** logged, **never** returned in a
+    response, **never** written to the database. The dedup set lives
+    only in-memory and dies with the process — same lifecycle as the
+    Prometheus counter state itself.
+  * A second metric — ``ecm_session_dedup_set_size`` (Gauge) — exposes
+    the dedup set's current cardinality so SRE can spot pruner leaks.
+  * Auth posture matches ``/api/client-errors`` (JWT-required when auth
+    is enabled). The spike defers the pre-auth-coverage question to a
+    separate ADR-006 amendment if the PO chooses to expand coverage.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import time
+from threading import Lock
+from typing import Dict
+
+from fastapi import APIRouter, HTTPException, Request, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field, field_validator
+
+from observability import get_metric
+
+logger = logging.getLogger("ecm.session_start")
+
+router = APIRouter(prefix="/api/session-start", tags=["Observability"])
+
+
+# ---------------------------------------------------------------------------
+# Payload caps + dedup TTL (from spike §6.2)
+# ---------------------------------------------------------------------------
+# A UUIDv4 string is 36 chars. We cap incoming raw body at 256 bytes so a
+# malformed/oversized body cannot inflate the dedup set's per-entry cost.
+MAX_REQUEST_BYTES = 256
+MAX_SESSION_ID_CHARS = 36
+
+# Dedup TTL — entries older than this are pruned at the next request.
+# Spike §6.2 specifies 24 hours: long enough that a tab left open
+# overnight isn't double-counted on the morning refresh, short enough
+# that the in-memory set's steady-state size is bounded by daily session
+# volume.
+DEDUP_TTL_SECONDS = 24 * 60 * 60  # 24 hours
+
+# UUIDv4 regex: 8-4-4-4-12 hex with version=4 nibble and variant in {8,9,a,b}.
+# Stricter than a generic UUID regex so the endpoint matches the
+# SubtleCrypto-generated value the frontend sends and rejects anything
+# else (a v1 UUID, a hash, or a free-form string).
+_UUID_V4_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schema
+# ---------------------------------------------------------------------------
+class SessionStartPayload(BaseModel):
+    """Single-field payload for the session-start ingest.
+
+    Field allowlist (deny-by-default) — matches the spike's data-minimization
+    posture: nothing about the user, the browser, or the page is sent here.
+    The session_id alone is enough to deduplicate.
+    """
+
+    session_id: str = Field(..., max_length=MAX_SESSION_ID_CHARS)
+
+    model_config = {
+        "extra": "forbid",  # Reject unknown fields (deny-by-default allowlist).
+    }
+
+    @field_validator("session_id")
+    @classmethod
+    def _uuid_v4(cls, v: str) -> str:
+        """session_id MUST be a UUIDv4 — reject anything else with 422."""
+        if not _UUID_V4_RE.fullmatch(v or ""):
+            raise ValueError("session_id must be a UUIDv4 string")
+        return v.lower()
+
+
+# ---------------------------------------------------------------------------
+# In-memory dedup set
+# ---------------------------------------------------------------------------
+# Map session_id -> expiry_timestamp (monotonic seconds). A dict (not a
+# set) lets us prune lazily by comparing expiry to ``now`` without
+# tracking a separate parallel structure. Memory cost per entry is the
+# 36-char UUID + a float — well under 100 bytes including dict overhead.
+#
+# Spike §6.2 specifies "lazy prune at request time" — we sweep expired
+# entries on every POST. Sweep cost is O(active_entries); at the SLO-6
+# §11 evaluation gate (~50 sessions/day → ~50 entries) this is
+# negligible. At pathological scale (10k sessions in 24h) the sweep is
+# still microseconds — and a leak there would be visible via the
+# ``ecm_session_dedup_set_size`` gauge before it became a real problem.
+_dedup: Dict[str, float] = {}
+_dedup_lock = Lock()
+
+
+def _prune_expired(now: float) -> None:
+    """Drop dedup entries whose TTL has elapsed.
+
+    Caller MUST hold ``_dedup_lock``. Pure side-effect: mutates ``_dedup``
+    in place. Cheap O(active_entries) sweep — runs on every request so
+    the set never grows unboundedly between scrapes.
+    """
+    expired = [sid for sid, expiry in _dedup.items() if expiry <= now]
+    for sid in expired:
+        _dedup.pop(sid, None)
+
+
+def _publish_dedup_size() -> None:
+    """Mirror the dedup set's current size onto the gauge.
+
+    Defensive: never raises. If prometheus-client isn't available the
+    gauge .set() call is a no-op via the metric stub layer.
+    """
+    try:
+        get_metric("session_dedup_set_size").set(float(len(_dedup)))
+    except Exception:  # pragma: no cover — observability must not break the sink
+        logger.debug("[SESSION-START] gauge update failed for dedup_set_size")
+
+
+def _bump_session_counter() -> None:
+    """Increment ``ecm_session_starts_total``.
+
+    Defensive: a metric emit failure must never break the endpoint —
+    the SLO denominator is best-effort, not a transactional guarantee.
+    """
+    try:
+        get_metric("session_starts_total").inc()
+    except Exception:  # pragma: no cover
+        logger.debug("[SESSION-START] counter emit failed")
+
+
+def _reset_dedup_for_tests() -> None:
+    """Clear the in-memory dedup state. Tests only."""
+    with _dedup_lock:
+        _dedup.clear()
+    _publish_dedup_size()
+
+
+# ---------------------------------------------------------------------------
+# Route handler
+# ---------------------------------------------------------------------------
+@router.post("", include_in_schema=True)
+async def post_session_start(request: Request) -> JSONResponse:
+    """Ingest a single session-start beacon.
+
+    Contract:
+      * 200 with ``{"deduplicated": false}`` on first sighting (counter +1).
+      * 200 with ``{"deduplicated": true}`` on a re-submission inside TTL
+        (no counter bump).
+      * 401 when auth is enabled and the JWT is missing/invalid (handled
+        by the global ``auth_middleware`` in main.py before this handler).
+      * 413 when the raw body exceeds ``MAX_REQUEST_BYTES``.
+      * 422 when the payload fails Pydantic validation (e.g. non-UUIDv4).
+
+    The endpoint honors the same operator toggle as ``/api/client-errors``
+    — when ``settings.telemetry_client_errors_enabled`` is False, the
+    handler short-circuits with 200 + ``{"deduplicated": false}`` and
+    does NOT bump the counter. This matches the frontend's gate (one
+    operator toggle controls both telemetry surfaces, per spike §6.1).
+
+    The ``session_id`` is NEVER logged. NEVER returned. NEVER persisted.
+    """
+    # ---- Settings gate ------------------------------------------------------
+    # Same lazy import pattern as routers/client_errors.py to avoid a
+    # top-level config import loop in tests that stub get_settings().
+    try:
+        from config import get_settings
+        if not get_settings().telemetry_client_errors_enabled:
+            return JSONResponse(
+                status_code=status.HTTP_200_OK,
+                content={"deduplicated": False},
+            )
+    except Exception:  # pragma: no cover — settings subsystem misconfigured
+        logger.debug("[SESSION-START] Could not read telemetry setting; proceeding")
+
+    # ---- Size check (before parsing body) -----------------------------------
+    raw_body = await request.body()
+    body_size = len(raw_body)
+    if body_size > MAX_REQUEST_BYTES:
+        logger.warning(
+            "[SESSION-START] Dropped oversized payload bytes=%d cap=%d",
+            body_size, MAX_REQUEST_BYTES,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Payload too large",
+        )
+
+    # ---- Schema validation --------------------------------------------------
+    try:
+        import json
+        parsed = json.loads(raw_body)
+        payload = SessionStartPayload.model_validate(parsed)
+    except Exception as exc:
+        # Log the validation failure (NOT the body — could contain a
+        # candidate session_id we don't want in logs even when invalid).
+        logger.info("[SESSION-START] Dropped invalid payload: %s", type(exc).__name__)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Invalid payload",
+        )
+
+    # ---- Dedup check + counter bump ----------------------------------------
+    now = time.monotonic()
+    with _dedup_lock:
+        _prune_expired(now)
+        if payload.session_id in _dedup:
+            # Refresh the expiry so a long-lived tab that re-submits at
+            # the 23h mark doesn't fall out of the dedup window 1h
+            # later. Without this, the tab would be re-counted at 24h
+            # exactly because of timing rather than because it's a real
+            # new session.
+            _dedup[payload.session_id] = now + DEDUP_TTL_SECONDS
+            _publish_dedup_size()
+            return JSONResponse(
+                status_code=status.HTTP_200_OK,
+                content={"deduplicated": True},
+            )
+        _dedup[payload.session_id] = now + DEDUP_TTL_SECONDS
+
+    # First sighting — bump the counter. Done OUTSIDE the lock because
+    # the counter has its own internal lock and we don't want to hold the
+    # dedup lock across a metrics call.
+    _bump_session_counter()
+    _publish_dedup_size()
+
+    # NEVER log the session_id. The audit message is intentionally
+    # cardinality-free.
+    logger.debug("[SESSION-START] Counted new session")
+
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={"deduplicated": False},
+    )

--- a/backend/tests/routers/test_session_starts.py
+++ b/backend/tests/routers/test_session_starts.py
@@ -1,0 +1,350 @@
+"""
+Tests for the session-start router (bd-arp3o, spike bd-1tl01).
+
+Covers happy path, idempotent dedup, TTL expiry, schema validation,
+size cap, and Prometheus counter / gauge emission.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+def _valid_session_id() -> str:
+    """Return a fresh UUIDv4 string."""
+    return str(uuid.uuid4())
+
+
+def _reset_session_state() -> None:
+    """Clear dedup state between tests."""
+    from routers import session_starts as ss
+    ss._reset_dedup_for_tests()
+
+
+def _get_metric_sample(metric_name: str, **labels) -> float:
+    """Return the sample value for ``metric_name`` with ``labels``."""
+    from observability import REGISTRY
+    if REGISTRY is None:
+        return 0.0
+    for metric in REGISTRY.collect():
+        for sample in metric.samples:
+            if sample.name != metric_name:
+                continue
+            if all(sample.labels.get(k) == v for k, v in labels.items()):
+                return float(sample.value)
+    return 0.0
+
+
+@pytest.fixture(autouse=True)
+def _reset_between_tests():
+    """Clear session-start in-memory state before every test in this module."""
+    _reset_session_state()
+    yield
+    _reset_session_state()
+
+
+# ---------------------------------------------------------------------------
+# Happy path — counter increment, dedup contract
+# ---------------------------------------------------------------------------
+class TestHappyPath:
+
+    @pytest.mark.asyncio
+    async def test_first_sighting_returns_200_not_deduplicated(self, async_client):
+        sid = _valid_session_id()
+        response = await async_client.post(
+            "/api/session-start", json={"session_id": sid}
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body == {"deduplicated": False}
+
+    @pytest.mark.asyncio
+    async def test_first_sighting_increments_counter(self, async_client):
+        before = _get_metric_sample("ecm_session_starts_total")
+        sid = _valid_session_id()
+        response = await async_client.post(
+            "/api/session-start", json={"session_id": sid}
+        )
+        assert response.status_code == 200
+        after = _get_metric_sample("ecm_session_starts_total")
+        assert after - before == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Dedup — same session_id twice in TTL = no double-count
+# ---------------------------------------------------------------------------
+class TestDedup:
+
+    @pytest.mark.asyncio
+    async def test_same_session_id_twice_returns_deduplicated(self, async_client):
+        sid = _valid_session_id()
+        first = await async_client.post(
+            "/api/session-start", json={"session_id": sid}
+        )
+        assert first.status_code == 200
+        assert first.json() == {"deduplicated": False}
+
+        second = await async_client.post(
+            "/api/session-start", json={"session_id": sid}
+        )
+        assert second.status_code == 200
+        assert second.json() == {"deduplicated": True}
+
+    @pytest.mark.asyncio
+    async def test_same_session_id_twice_only_one_counter_increment(self, async_client):
+        sid = _valid_session_id()
+        before = _get_metric_sample("ecm_session_starts_total")
+        await async_client.post("/api/session-start", json={"session_id": sid})
+        await async_client.post("/api/session-start", json={"session_id": sid})
+        await async_client.post("/api/session-start", json={"session_id": sid})
+        after = _get_metric_sample("ecm_session_starts_total")
+        # Three POSTs of the same session_id → exactly one counter bump.
+        assert after - before == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_two_different_session_ids_two_increments(self, async_client):
+        before = _get_metric_sample("ecm_session_starts_total")
+        await async_client.post(
+            "/api/session-start", json={"session_id": _valid_session_id()}
+        )
+        await async_client.post(
+            "/api/session-start", json={"session_id": _valid_session_id()}
+        )
+        after = _get_metric_sample("ecm_session_starts_total")
+        assert after - before == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# TTL expiry — same session_id after TTL = re-counted
+# ---------------------------------------------------------------------------
+class TestTTLExpiry:
+
+    @pytest.mark.asyncio
+    async def test_dedup_entry_expires_after_ttl(self, async_client, monkeypatch):
+        """After 24h, a previously-seen session_id is treated as new again."""
+        from routers import session_starts as ss
+
+        # Anchor monotonic time at a known starting value.
+        fake_now = [1000.0]
+
+        def fake_monotonic() -> float:
+            return fake_now[0]
+
+        monkeypatch.setattr(ss.time, "monotonic", fake_monotonic)
+
+        sid = _valid_session_id()
+        before = _get_metric_sample("ecm_session_starts_total")
+
+        # First sighting at t=1000 → counts (+1).
+        first = await async_client.post(
+            "/api/session-start", json={"session_id": sid}
+        )
+        assert first.json() == {"deduplicated": False}
+
+        # Advance time past the TTL boundary (24h + 1s).
+        fake_now[0] += ss.DEDUP_TTL_SECONDS + 1.0
+
+        # Same session_id, but the dedup entry has expired → counts again (+1).
+        second = await async_client.post(
+            "/api/session-start", json={"session_id": sid}
+        )
+        assert second.json() == {"deduplicated": False}
+
+        after = _get_metric_sample("ecm_session_starts_total")
+        assert after - before == pytest.approx(2.0)
+
+    @pytest.mark.asyncio
+    async def test_dedup_holds_inside_ttl(self, async_client, monkeypatch):
+        """Inside the TTL window, the same session_id remains deduplicated."""
+        from routers import session_starts as ss
+
+        fake_now = [1000.0]
+        monkeypatch.setattr(ss.time, "monotonic", lambda: fake_now[0])
+
+        sid = _valid_session_id()
+        first = await async_client.post(
+            "/api/session-start", json={"session_id": sid}
+        )
+        assert first.json() == {"deduplicated": False}
+
+        # Advance time but stay well inside the 24h window.
+        fake_now[0] += ss.DEDUP_TTL_SECONDS / 2
+
+        second = await async_client.post(
+            "/api/session-start", json={"session_id": sid}
+        )
+        assert second.json() == {"deduplicated": True}
+
+
+# ---------------------------------------------------------------------------
+# Schema validation — UUIDv4 required, extra fields forbidden
+# ---------------------------------------------------------------------------
+class TestSchemaValidation:
+
+    @pytest.mark.asyncio
+    async def test_non_uuid_session_id_returns_422(self, async_client):
+        response = await async_client.post(
+            "/api/session-start", json={"session_id": "not-a-uuid"}
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_empty_session_id_returns_422(self, async_client):
+        response = await async_client.post(
+            "/api/session-start", json={"session_id": ""}
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_uuid_v1_rejected(self, async_client):
+        # UUIDv1 has version=1 in the third group; the regex requires v4.
+        response = await async_client.post(
+            "/api/session-start",
+            json={"session_id": str(uuid.uuid1())},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_extra_fields_rejected(self, async_client):
+        response = await async_client.post(
+            "/api/session-start",
+            json={
+                "session_id": _valid_session_id(),
+                "user_id": "leak-attempt",
+            },
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_missing_session_id_returns_422(self, async_client):
+        response = await async_client.post("/api/session-start", json={})
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_body_returns_422(self, async_client):
+        response = await async_client.post(
+            "/api/session-start",
+            content=b"not-json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Size cap — oversized body is rejected before parsing
+# ---------------------------------------------------------------------------
+class TestSizeCap:
+
+    @pytest.mark.asyncio
+    async def test_oversized_body_returns_413(self, async_client):
+        from routers import session_starts as ss
+
+        # Build a body that exceeds MAX_REQUEST_BYTES even though it would
+        # otherwise be valid JSON shape.
+        oversized = b'{"session_id": "' + b"x" * (ss.MAX_REQUEST_BYTES + 100) + b'"}'
+        response = await async_client.post(
+            "/api/session-start",
+            content=oversized,
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_oversized_body_does_not_increment_counter(self, async_client):
+        from routers import session_starts as ss
+
+        before = _get_metric_sample("ecm_session_starts_total")
+        oversized = b'{"session_id": "' + b"x" * (ss.MAX_REQUEST_BYTES + 100) + b'"}'
+        await async_client.post(
+            "/api/session-start",
+            content=oversized,
+            headers={"Content-Type": "application/json"},
+        )
+        after = _get_metric_sample("ecm_session_starts_total")
+        assert after == pytest.approx(before)
+
+
+# ---------------------------------------------------------------------------
+# Dedup-set-size gauge — exposes operational visibility
+# ---------------------------------------------------------------------------
+class TestDedupGauge:
+
+    @pytest.mark.asyncio
+    async def test_dedup_size_gauge_reflects_set_size(self, async_client):
+        # Reset confirms gauge starts at 0.
+        assert _get_metric_sample("ecm_session_dedup_set_size") == pytest.approx(0.0)
+
+        await async_client.post(
+            "/api/session-start", json={"session_id": _valid_session_id()}
+        )
+        await async_client.post(
+            "/api/session-start", json={"session_id": _valid_session_id()}
+        )
+        await async_client.post(
+            "/api/session-start", json={"session_id": _valid_session_id()}
+        )
+
+        # Three distinct session_ids → gauge reads 3.
+        assert _get_metric_sample("ecm_session_dedup_set_size") == pytest.approx(3.0)
+
+    @pytest.mark.asyncio
+    async def test_dedup_size_gauge_reflects_pruning(self, async_client, monkeypatch):
+        """After TTL expiry + a new request, the gauge drops the expired entries."""
+        from routers import session_starts as ss
+
+        fake_now = [1000.0]
+        monkeypatch.setattr(ss.time, "monotonic", lambda: fake_now[0])
+
+        # Seed two sessions.
+        await async_client.post(
+            "/api/session-start", json={"session_id": _valid_session_id()}
+        )
+        await async_client.post(
+            "/api/session-start", json={"session_id": _valid_session_id()}
+        )
+        assert _get_metric_sample("ecm_session_dedup_set_size") == pytest.approx(2.0)
+
+        # Advance past TTL so both entries are stale.
+        fake_now[0] += ss.DEDUP_TTL_SECONDS + 1.0
+
+        # A third request prunes the two stale entries before inserting itself,
+        # leaving the gauge at exactly 1.
+        await async_client.post(
+            "/api/session-start", json={"session_id": _valid_session_id()}
+        )
+        assert _get_metric_sample("ecm_session_dedup_set_size") == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Telemetry-disabled gate — operator toggle short-circuits the endpoint
+# ---------------------------------------------------------------------------
+class TestTelemetryDisabledGate:
+
+    @pytest.mark.asyncio
+    async def test_disabled_telemetry_skips_counter_bump(self, async_client, monkeypatch):
+        """When telemetry_client_errors_enabled is False, no counter bump."""
+        from config import get_settings
+
+        # Read the current settings, flip telemetry off, write back.
+        original = get_settings()
+        # The settings object is a Pydantic model; rebuild with override.
+        import config as cfg_mod
+
+        class _StubSettings:
+            telemetry_client_errors_enabled = False
+
+        monkeypatch.setattr(cfg_mod, "get_settings", lambda: _StubSettings())
+
+        before = _get_metric_sample("ecm_session_starts_total")
+        response = await async_client.post(
+            "/api/session-start",
+            json={"session_id": _valid_session_id()},
+        )
+        assert response.status_code == 200
+        assert response.json() == {"deduplicated": False}
+        after = _get_metric_sample("ecm_session_starts_total")
+        # No counter bump when the operator has disabled telemetry.
+        assert after == pytest.approx(before)
+        # Sanity — original settings still readable post-test fixture cleanup.
+        assert original is not None

--- a/docs/sre/prometheus_rules.yaml
+++ b/docs/sre/prometheus_rules.yaml
@@ -257,61 +257,87 @@ groups:
           runbook_url: docs/runbooks/readiness_subcheck_latency.md
 
   # =====================================================================
-  # SLO-6: Frontend Error-free Session Rate (ADR-006, bd-i6a1m)
+  # SLO-6: Frontend Error-free Session Rate (ADR-006, bd-i6a1m, bd-arp3o)
   # =====================================================================
   # Shipped alongside ADR-006 Phase 1 frontend error telemetry. The alert
   # inherits the operator-provisioned posture from bd-5uxwh — defined in
   # YAML, consumed by an operator's own Prometheus+Alertmanager, not shipped
   # as a running service.
   #
+  # Ratio-based as of bd-arp3o (spike bd-1tl01): the SLI denominator
+  # `ecm_session_starts_total` exists, so the alerts now match the SLO-6
+  # statement ("error-free *session rate*", not "absolute error rate").
+  # The previous absolute-rate alerts fired on traffic spikes even when
+  # the per-session error ratio was flat — replaced here with the same
+  # ratio expression that drives the SLO calculation.
+  #
   # Thresholds are first-pass defaults:
-  #   - Warning at >0.2 errors/sec (5m rate) sustained for 15m.
-  #   - Page at >2 errors/sec (5m rate) sustained for 5m — roughly the rate
-  #     at which a chunk-load incident on a small LAN instance becomes
-  #     operator-visible within a quarter-hour.
-  # Expect one round of tuning after 30 days of real traffic (ADR-006
-  # "Unresolved Questions" #1).
+  #   - Elevated at >0.5% boundary errors per session (5m ratio) sustained
+  #     for 10m.
+  #   - Critical at >5% boundary errors per session (5m ratio) sustained
+  #     for 5m — roughly the rate at which a chunk-load or bundle-regression
+  #     incident on a small LAN instance becomes operator-visible.
+  # The "and rate(...) > 0" guards the ratio against div-by-zero during
+  # idle periods (no sessions started in the window).
+  # Expect one round of tuning after 30 days of real traffic.
   - name: ecm_client_error_rate
     interval: 30s
     rules:
       - record: ecm:client_errors:rate5m
         expr: sum by (kind, release) (rate(ecm_client_errors_total[5m]))
 
-      - alert: ECMClientErrorRateElevated
-        # Sustained low-but-nontrivial client-error rate. Likely a bad
-        # deploy ("release" label spikes on one value) or an API contract
-        # drift triggering many unhandled rejections.
-        expr: sum(ecm:client_errors:rate5m) > 0.2
-        for: 15m
+      - record: ecm:client_error_session_ratio:5m
+        # SLO-6 SLI numerator over denominator on a 5m window. The SLO
+        # statement uses 28d for budget calculation; this 5m ratio is
+        # the burn signal the alert rules consume.
+        expr: |
+          sum(rate(ecm_client_errors_total{kind="boundary"}[5m]))
+          /
+          sum(rate(ecm_session_starts_total[5m]))
+
+      - alert: ECMClientErrorRatioElevated
+        # Sustained low-but-nontrivial boundary-error ratio. Likely a
+        # bad deploy ("release" label spikes on one value of
+        # ecm:client_errors:rate5m) or an API contract drift triggering
+        # many React-tree boundary catches.
+        expr: |
+          ecm:client_error_session_ratio:5m > 0.005
+          and
+          sum(rate(ecm_session_starts_total[5m])) > 0
+        for: 10m
         labels:
           severity: ticket
           slo: client_error_rate
           service: ecm
         annotations:
-          summary: "ECM frontend client-error rate {{ $value | humanize }}/s > 0.2/s for 15m+"
+          summary: "ECM frontend boundary-error ratio {{ $value | humanizePercentage }} > 0.5% for 10m+"
           description: |
-            Frontend runtime errors are being reported at >0.2/sec
+            Frontend boundary-error ratio per session has exceeded 0.5%
             sustained. Check /metrics for the breakdown by `kind` and
-            `release` labels; a spike on one `release` != current points
-            to a stale-bundle chunk-load incident (operator should bust
-            browser cache), while a spike on the current release points
-            to a regression in the just-deployed bundle.
+            `release` labels on `ecm:client_errors:rate5m`; a spike on
+            one `release` != current points to a stale-bundle
+            chunk-load incident (operator should bust browser cache),
+            while a spike on the current release points to a regression
+            in the just-deployed bundle.
           runbook_url: docs/runbooks/frontend_error_rate.md
 
-      - alert: ECMClientErrorRateCritical
-        # Outage-scale client-error storm. Something in the latest bundle
-        # is broken for a significant fraction of active sessions.
-        expr: sum(ecm:client_errors:rate5m) > 2.0
+      - alert: ECMClientErrorRatioCritical
+        # Outage-scale boundary-error storm. Something in the latest
+        # bundle is broken for a significant fraction of active sessions.
+        expr: |
+          ecm:client_error_session_ratio:5m > 0.05
+          and
+          sum(rate(ecm_session_starts_total[5m])) > 0
         for: 5m
         labels:
           severity: page
           slo: client_error_rate
           service: ecm
         annotations:
-          summary: "ECM frontend client-error rate {{ $value | humanize }}/s > 2/s — critical"
+          summary: "ECM frontend boundary-error ratio {{ $value | humanizePercentage }} > 5% — critical"
           description: |
-            Frontend client-error rate has exceeded 2/sec for 5 minutes.
-            Treat as an incident. Begin runbook, page on-call, identify
-            the offending `release` label from /metrics and consider
-            rolling back the last deploy.
+            Frontend boundary-error ratio per session has exceeded 5%
+            for 5 minutes. Treat as an incident. Begin runbook, page
+            on-call, identify the offending `release` label from
+            /metrics and consider rolling back the last deploy.
           runbook_url: docs/runbooks/frontend_error_rate.md

--- a/docs/sre/slos.md
+++ b/docs/sre/slos.md
@@ -230,34 +230,24 @@ A bug-report ratio — `1 - (bug_reports_containing_normaliz_30d) / (auto_creati
 
 ## SLO-6: Frontend Error-free Session Rate
 
-**SLI:** Fraction of authenticated user sessions that report zero client errors over a rolling 28-day window. A "session" is approximated by distinct `user_agent_hash` labels seen on `ecm_client_errors_total` within the window. The SLI is computed as:
+**SLI:** Fraction of unique frontend sessions that report zero client errors over a rolling 28-day window. A "session" is defined per the [SLO-6 session-semantics spike](./spike-slo-6-session-semantics.md) (bd-1tl01) as one `sessionStorage` lifetime in a single browser tab — the frontend generates a SubtleCrypto-backed UUIDv4 on first SPA mount and POSTs it once to `/api/session-start`, where the backend deduplicates via a 24h in-memory TTL set before incrementing `ecm_session_starts_total`. The SLI is computed as:
 
 ```
-1 - (sessions_with_errors / total_sessions)
+1 - (sessions_with_boundary_errors / total_sessions)
 ```
 
-**Prometheus expression (SLI, until a dedicated session counter exists):**
+**Prometheus expression (SLI — PromQL-native, bd-arp3o):**
 ```promql
-# Sessions that reported at least one client error, over 28d.
-# NOTE: ecm_client_errors_total is keyed by {kind, release} — the session
-# dimension is not exposed as a label (bounded cardinality, per ADR-006).
-# Until a session counter ships (see "Instrumentation gap" below), the
-# numerator here is approximated by 'count of distinct user_agent_hash
-# values seen in the structlog stream' via the log-aggregation substrate,
-# not by a PromQL-native expression. The denominator is the same over
-# the same window from the log stream.
 1
 -
 (
-  # Placeholder — replace with the session counter once instrumented.
-  sum(increase(ecm_client_errors_total[28d]))
+  sum(rate(ecm_client_errors_total{kind="boundary"}[28d]))
   /
-  # Denominator: total sessions. For now, read from the structured-log
-  # aggregator. When the session counter lands, swap this for:
-  #   sum(increase(ecm_session_starts_total[28d]))
-  1
+  sum(rate(ecm_session_starts_total[28d]))
 )
 ```
+
+The numerator filters on `kind="boundary"` because React-tree boundary errors are the single most operationally-meaningful failure class — the user saw the fallback UI, not what they asked for. Other `kind` values (`chunk_load`, `unhandled_rejection`, `resource`, `other`) are tracked on the same counter family and surfaced via the alert rules in `prometheus_rules.yaml`, but `boundary` is the SLO-6 numerator by construction. Revisit if 30 days of production data shows the other kinds dominate user-perceived breakage.
 
 **SLO target:** **99.0%** error-free sessions over a rolling 28-day window, **marked uncalibrated** until 30 days of production data exists.
 
@@ -269,7 +259,7 @@ A bug-report ratio — `1 - (bug_reports_containing_normaliz_30d) / (auto_creati
 
 **Evaluation gate:** Per ADR-006 §11, the SLI is computed only when the window contains **sessions ≥ 50/day** (1,400+ sessions over 28d). Below the gate, SLO-6 reports **insufficient-data** rather than a value — a LAN instance with 3 daily sessions cannot produce a statistically meaningful error-free-session rate. Operators below the gate still see the raw `ecm_client_errors_total` counter on `/metrics`; they just don't get a computed SLO.
 
-**Instrumentation gap:** The current backend emits `ecm_client_errors_total` per report but does not emit a session counter. To produce a Prometheus-native SLI (no log-aggregation dependency), a follow-up bead needs to add `ecm_session_starts_total` (incremented on frontend login or on first protected-route navigation per `user_agent_hash`). Until then, the SLI lives in the log substrate and the target above is aspirational.
+**Instrumentation status:** PromQL-native as of bd-arp3o. The denominator counter `ecm_session_starts_total` is registered in `backend/observability.py` and incremented by `POST /api/session-start` (`backend/routers/session_starts.py`); the operational gauge `ecm_session_dedup_set_size` exposes the in-memory dedup set's current cardinality so SRE can spot pruner regressions. The frontend tracker in `frontend/src/services/sessionTracker.ts` emits the beacon once per `sessionStorage` lifetime per spike Option C. The SLI no longer depends on a log-aggregation substrate.
 
 **What breaks this SLO:**
 
@@ -278,7 +268,7 @@ A bug-report ratio — `1 - (bug_reports_containing_normaliz_30d) / (auto_creati
 - Unhandled promise rejections from an API client contract change (`kind: 'unhandled_rejection'`).
 - Pre-mount bundle load failures (`kind: 'resource'`, emitted by the inline script in `index.html`).
 
-**Runbook:** [`docs/runbooks/frontend_error_rate.md`](../runbooks/frontend_error_rate.md) — covers the `ECMClientErrorRateElevated` (ticket) and `ECMClientErrorRateCritical` (page) alerts in `prometheus_rules.yaml` group `ecm_client_error_rate`: triage by `kind` × `release`, kind-by-kind common causes, rollback / cache-flush / suppression mitigation patterns, and the severity-promotion ladder (bd-pls9m).
+**Runbook:** [`docs/runbooks/frontend_error_rate.md`](../runbooks/frontend_error_rate.md) — covers the `ECMClientErrorRatioElevated` (ticket) and `ECMClientErrorRatioCritical` (page) alerts in `prometheus_rules.yaml` group `ecm_client_error_rate`: triage by `kind` × `release`, kind-by-kind common causes, rollback / cache-flush / suppression mitigation patterns, and the severity-promotion ladder (bd-pls9m). Alert names changed from `Rate*` to `Ratio*` in bd-arp3o when the alerts switched from absolute-rate to ratio-based; the runbook update is tracked under a separate follow-up bead per spike §6.7.
 
 ---
 
@@ -346,6 +336,19 @@ For the scaffold we ship simpler single-window thresholds for SLO-2/3 (p95 laten
 
 ## Changelog
 
+- **2026-04-24 (bd-arp3o, spike bd-1tl01):** SLO-6 SLI promoted from
+  log-aggregation-fallback to PromQL-native. New backend counter
+  `ecm_session_starts_total` (no labels) registered in
+  `backend/observability.py`; new gauge `ecm_session_dedup_set_size`
+  exposes dedup set cardinality. New endpoint `POST /api/session-start`
+  in `backend/routers/session_starts.py` deduplicates by UUIDv4
+  `session_id` with a 24h in-memory TTL set. Frontend wiring
+  `installSessionTracker()` in `frontend/src/services/sessionTracker.ts`
+  generates the UUID via `crypto.randomUUID()`, persists in
+  `sessionStorage`, fail-open on strict-privacy browsers per spike §3.3.
+  `prometheus_rules.yaml` group `ecm_client_error_rate` swapped from
+  absolute-rate alerts to ratio-based alerts so the alert thresholds
+  match the SLO-6 ratio target.
 - **2026-04-24 (bd-i6a1m):** Added **SLO-6: Frontend Error-free Session Rate** — 99.0% error-free sessions over 28d, uncalibrated until 30d of data, gated at sessions ≥ 50/day. Supported by the new `/api/client-errors` router + `ecm_client_errors_total{kind,release}` counter from ADR-006 Phase 1. Instrumentation gap: a session-start counter is a follow-up bead; until then the SLI denominator lives in the log-aggregation substrate. Companion alert rule shipped in `prometheus_rules.yaml` (group `ecm_client_error_rate`).
 - **2026-04-24 (bd-5uxwh, absorbs bd-9mi6f):** Added **Alerting posture** section. Makes explicit that ECM emits SLI metrics on `/metrics` and ships `prometheus_rules.yaml` as rules-as-code, but does not ship a Prometheus/Alertmanager runtime — operators provision their own scraper if they want alerts to fire. Per-SLO ownership table added. SLO-5 noted as the edge case: its breach signal is the nightly CI canary, not Prometheus-primary.
 - **2026-04-22 (bd-eio04.9):** Added **SLO-5: Normalization Correctness** — canary-based parity SLI with zero-tolerance target. Supported by new metrics in `observability.py` (`ecm_normalization_canary_divergence_total`, plus rule-match / no-change / duration / per-creation-normalized counters), a structured decision log (see `NORMALIZATION_DECISION_LOGGER`), and a nightly CI canary (`.github/workflows/normalization-canary.yml`). Runbook at `docs/runbooks/normalization-canary-divergence.md`.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import {
   installGlobalErrorHandlers,
   reportClientError,
 } from './services/clientErrorReporter'
+import { installSessionTracker } from './services/sessionTracker'
 import './index.css'
 import './shared/common.css'
 
@@ -15,6 +16,13 @@ import './shared/common.css'
 // tree mounts so a crash during initial render still produces a
 // telemetry event. installGlobalErrorHandlers() is idempotent.
 installGlobalErrorHandlers()
+
+// SLO-6 / bd-arp3o (spike bd-1tl01): emit a one-time session-start
+// beacon so the backend's ecm_session_starts_total counter has a
+// PromQL-native denominator. Idempotent + fail-open — strict-privacy
+// browsers without sessionStorage / crypto.randomUUID are silently
+// excluded from the SLO denominator rather than blocked from the app.
+void installSessionTracker()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/frontend/src/services/sessionTracker.test.ts
+++ b/frontend/src/services/sessionTracker.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for the frontend session tracker (bd-arp3o, spike bd-1tl01).
+ *
+ * Covers:
+ *  - First-mount path: generate UUID + persist + POST.
+ *  - Idempotency: a re-install in the same tab does not re-POST.
+ *  - Existing sessionStorage entry: no UUID generation, no POST.
+ *  - Fail-open: sessionStorage unavailable / crypto.randomUUID
+ *    unavailable / setItem throws — never raises, never POSTs.
+ *  - Telemetry runtime toggle disables the beacon.
+ *  - UUIDv4 schema sanity (the persisted/sent value matches the regex
+ *    the backend enforces).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  installSessionTracker,
+  resetSessionTrackerForTests,
+  SESSION_START_ENDPOINT,
+  SESSION_STORAGE_KEY,
+} from './sessionTracker';
+import {
+  setTelemetryRuntimeEnabled,
+} from './clientErrorReporter';
+
+const UUID_V4_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** Settle one microtask + macrotask so fire-and-forget POSTs land. */
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe('installSessionTracker — happy path (first SPA mount)', () => {
+  beforeEach(() => {
+    resetSessionTrackerForTests();
+    setTelemetryRuntimeEnabled(undefined);
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    setTelemetryRuntimeEnabled(undefined);
+    window.sessionStorage.clear();
+  });
+
+  it('generates a UUIDv4, persists it, and POSTs once', async () => {
+    // Force the fetch path by stubbing sendBeacon to undefined so we
+    // can spy on a single transport.
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: undefined,
+    });
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ deduplicated: false }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await installSessionTracker();
+    await flush();
+
+    // sessionStorage now holds a UUIDv4.
+    const stored = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    expect(stored).toMatch(UUID_V4_RE);
+
+    // Exactly one POST to /api/session-start with that UUID.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(SESSION_START_ENDPOINT);
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('include');
+    expect(init.keepalive).toBe(true);
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({ session_id: stored });
+  });
+
+  it('prefers sendBeacon when available and it queues', async () => {
+    const sendBeacon = vi.fn().mockReturnValue(true);
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      writable: true,
+      value: sendBeacon,
+    });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await installSessionTracker();
+    await flush();
+
+    expect(sendBeacon).toHaveBeenCalledTimes(1);
+    expect(sendBeacon.mock.calls[0][0]).toBe(SESSION_START_ENDPOINT);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('installSessionTracker — idempotency', () => {
+  beforeEach(() => {
+    resetSessionTrackerForTests();
+    setTelemetryRuntimeEnabled(undefined);
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    setTelemetryRuntimeEnabled(undefined);
+    window.sessionStorage.clear();
+  });
+
+  it('does NOT re-POST when sessionStorage already has a session_id (simulated reload)', async () => {
+    // Simulate a reload inside the same tab — sessionStorage entry from
+    // a prior mount still exists. The new install must not re-POST.
+    window.sessionStorage.setItem(
+      SESSION_STORAGE_KEY,
+      '11111111-1111-4111-8111-111111111111',
+    );
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: undefined,
+    });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await installSessionTracker();
+    await flush();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // The pre-existing session_id is left untouched.
+    expect(window.sessionStorage.getItem(SESSION_STORAGE_KEY)).toBe(
+      '11111111-1111-4111-8111-111111111111',
+    );
+  });
+
+  it('does NOT re-POST on a second call within the same module lifetime', async () => {
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: undefined,
+    });
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ deduplicated: false }), { status: 200 }),
+      );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await installSessionTracker();
+    await flush();
+    await installSessionTracker();
+    await flush();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('installSessionTracker — fail-open behavior', () => {
+  beforeEach(() => {
+    resetSessionTrackerForTests();
+    setTelemetryRuntimeEnabled(undefined);
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    setTelemetryRuntimeEnabled(undefined);
+    window.sessionStorage.clear();
+  });
+
+  it('does not throw and does not POST when sessionStorage.setItem throws', async () => {
+    // Simulate a strict-privacy / quota-exhausted browser.
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('SecurityError: storage disabled');
+      });
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: undefined,
+    });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    let threw = false;
+    try {
+      await installSessionTracker();
+      await flush();
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    setItemSpy.mockRestore();
+  });
+
+  it('does not POST when crypto.randomUUID is unavailable', async () => {
+    // Stash the original crypto and replace with a stub missing randomUUID.
+    const originalCrypto = globalThis.crypto;
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: { subtle: originalCrypto?.subtle } as Crypto,
+    });
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: undefined,
+    });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    try {
+      await installSessionTracker();
+      await flush();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      // Nothing persisted because we couldn't generate an id.
+      expect(window.sessionStorage.getItem(SESSION_STORAGE_KEY)).toBeNull();
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', {
+        configurable: true,
+        value: originalCrypto,
+      });
+    }
+  });
+
+  it('swallows fetch errors — does not rethrow', async () => {
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: undefined,
+    });
+    const fetchSpy = vi.fn().mockRejectedValue(new Error('network down'));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    let threw = false;
+    try {
+      await installSessionTracker();
+      await flush();
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+    // sessionStorage was still seeded — the network call is best-effort.
+    expect(window.sessionStorage.getItem(SESSION_STORAGE_KEY)).toMatch(
+      UUID_V4_RE,
+    );
+  });
+});
+
+describe('installSessionTracker — telemetry runtime toggle', () => {
+  beforeEach(() => {
+    resetSessionTrackerForTests();
+    setTelemetryRuntimeEnabled(undefined);
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    setTelemetryRuntimeEnabled(undefined);
+    window.sessionStorage.clear();
+  });
+
+  it('does NOT POST or persist when telemetry is runtime-disabled', async () => {
+    setTelemetryRuntimeEnabled(false);
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: undefined,
+    });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await installSessionTracker();
+    await flush();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // No sessionStorage write either — short-circuit before generation.
+    expect(window.sessionStorage.getItem(SESSION_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/services/sessionTracker.ts
+++ b/frontend/src/services/sessionTracker.ts
@@ -1,0 +1,214 @@
+/**
+ * Frontend session tracker — emits SLO-6 denominator beacon.
+ *
+ * Implements bd-arp3o per the spike decision in
+ * ``docs/sre/spike-slo-6-session-semantics.md`` (bd-1tl01) — Option C:
+ * cookie/sessionStorage lifetime as the session boundary.
+ *
+ * Behavior on first SPA mount per browser tab:
+ *   1. Read ``sessionStorage.getItem('ecm_session_id')``.
+ *   2. If present, do nothing — the session has already been counted.
+ *   3. If absent (and ``sessionStorage`` is available + telemetry is
+ *      enabled), generate ``crypto.randomUUID()`` (SubtleCrypto-backed),
+ *      persist it, and POST it to ``/api/session-start``.
+ *
+ * Fail-open contract: the entire flow is wrapped in try/catch. If
+ * ``sessionStorage`` is unavailable (private mode, strict-privacy
+ * browser, SecurityError, QuotaExceededError) OR ``crypto.randomUUID``
+ * is unavailable (Tor Browser default, very old browsers), the function
+ * silently no-ops. The user is excluded from the SLO denominator but is
+ * NOT blocked from the app — per spike §3.3 UX rationale.
+ *
+ * Honors the same gates as ``clientErrorReporter.ts`` —
+ * ``VITE_ECM_ERROR_TELEMETRY_ENABLED`` build flag and the runtime
+ * operator toggle (``settings.telemetry_client_errors_enabled``). One
+ * toggle controls both telemetry surfaces, per spike §6.1.
+ *
+ * The session_id is NEVER read or written by the rest of the codebase.
+ * It exists only to deduplicate the backend's ``ecm_session_starts_total``
+ * counter. The reporter never sends it as a label or returns it from
+ * any function — once persisted, it's opaque even to its own module.
+ */
+
+import { isTelemetryEnabled } from './clientErrorReporter';
+
+export const SESSION_STORAGE_KEY = 'ecm_session_id';
+export const SESSION_START_ENDPOINT = '/api/session-start';
+
+/**
+ * UUIDv4 regex — matches the server-side ``_UUID_V4_RE`` in
+ * ``backend/routers/session_starts.py``. Used as a defensive guard
+ * against a corrupt sessionStorage entry (e.g. from a downgrade where
+ * the user previously had a non-UUID value cached).
+ */
+const UUID_V4_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Probe sessionStorage availability without raising.
+ *
+ * Some browsers (Firefox in dom.storage.enabled=false, Tor Browser
+ * with strict privacy, Safari in Private Browsing on quota-exhausted
+ * tabs) throw SecurityError or QuotaExceededError on either getItem
+ * or setItem. Probing once with a trial round-trip is the only
+ * reliable signal — checking ``typeof sessionStorage`` is not enough.
+ *
+ * Returns the underlying Storage instance when usable, or null when
+ * any access throws.
+ */
+function getSessionStorageOrNull(): Storage | null {
+  try {
+    if (typeof window === 'undefined' || !window.sessionStorage) {
+      return null;
+    }
+    const probeKey = '__ecm_storage_probe__';
+    window.sessionStorage.setItem(probeKey, '1');
+    window.sessionStorage.removeItem(probeKey);
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Generate a UUIDv4 via SubtleCrypto-backed ``crypto.randomUUID``.
+ *
+ * Returns null if ``crypto.randomUUID`` is unavailable. We do NOT fall
+ * back to Math.random() — a non-crypto-strong identifier would
+ * regress the spike's security constraint (§3.2: "SubtleCrypto-generated
+ * v4 UUID, NOT a hash of UA / IP / user identifiers"). Better to skip
+ * the session count than to send a weak identifier.
+ */
+function generateSessionId(): string | null {
+  try {
+    const c = globalThis.crypto;
+    if (!c || typeof c.randomUUID !== 'function') {
+      return null;
+    }
+    const id = c.randomUUID();
+    if (!UUID_V4_RE.test(id)) {
+      // crypto.randomUUID is specified to return v4; this branch is
+      // pure paranoia for a polyfill that returns a non-v4 string.
+      return null;
+    }
+    return id;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Send the session-start beacon. Fire-and-forget — every error path is
+ * caught so a transport failure cannot bubble up and aggravate any
+ * crash the page is already experiencing.
+ *
+ * Mirrors the transport selection in clientErrorReporter.sendPayload:
+ * ``navigator.sendBeacon`` first (best-effort delivery on page unload),
+ * fallback to ``fetch`` with ``keepalive: true``.
+ */
+async function sendSessionStart(sessionId: string): Promise<boolean> {
+  const body = JSON.stringify({ session_id: sessionId });
+  try {
+    if (
+      typeof navigator !== 'undefined' &&
+      typeof navigator.sendBeacon === 'function'
+    ) {
+      const blob = new Blob([body], { type: 'application/json' });
+      const queued = navigator.sendBeacon(SESSION_START_ENDPOINT, blob);
+      if (queued) return true;
+    }
+  } catch {
+    // fall through to fetch
+  }
+  try {
+    await fetch(SESSION_START_ENDPOINT, {
+      method: 'POST',
+      body,
+      credentials: 'include',
+      keepalive: true,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Idempotency guard — prevents a second invocation in the same tab
+ * from re-checking sessionStorage and re-issuing the POST. The
+ * sessionStorage entry would already short-circuit the POST, but this
+ * guard avoids the storage round-trip entirely on subsequent calls.
+ */
+let _installed = false;
+
+/**
+ * Install the session tracker. Reads ``sessionStorage`` for an existing
+ * session_id; if absent, generates one, persists it, and POSTs to
+ * ``/api/session-start`` so the backend's
+ * ``ecm_session_starts_total`` counter increments by 1 for this tab's
+ * lifetime.
+ *
+ * Idempotent within a single tab: calling more than once never issues
+ * a second POST — the sessionStorage entry blocks the network call,
+ * and the in-module guard blocks the storage round-trip.
+ *
+ * Safe to call before the React tree mounts.
+ */
+export async function installSessionTracker(): Promise<void> {
+  if (_installed) return;
+  _installed = true;
+
+  // Build-time + runtime telemetry gate (one toggle controls both
+  // /api/client-errors and /api/session-start, per spike §6.1).
+  if (!isTelemetryEnabled()) return;
+
+  const storage = getSessionStorageOrNull();
+  if (!storage) {
+    // Fail-open: strict-privacy browsers / private mode are silently
+    // excluded from the SLO-6 denominator. They can still use the app.
+    return;
+  }
+
+  let existing: string | null = null;
+  try {
+    existing = storage.getItem(SESSION_STORAGE_KEY);
+  } catch {
+    // Treat any read failure as "no prior session" but bail rather than
+    // attempt a write that will probably also fail.
+    return;
+  }
+  if (existing && UUID_V4_RE.test(existing)) {
+    // Session already counted in this tab — nothing to do.
+    return;
+  }
+
+  const sessionId = generateSessionId();
+  if (!sessionId) {
+    // SubtleCrypto / crypto.randomUUID unavailable — fail open.
+    return;
+  }
+
+  try {
+    storage.setItem(SESSION_STORAGE_KEY, sessionId);
+  } catch {
+    // setItem failure (quota or security policy) — skip the POST so we
+    // never count a session whose id we couldn't persist for the rest
+    // of the tab's lifetime. Otherwise a refresh would re-count.
+    return;
+  }
+
+  // Fire-and-forget. Do NOT await — the caller (main.tsx) doesn't need
+  // to block React mount on a telemetry beacon. Errors are swallowed
+  // inside sendSessionStart.
+  void sendSessionStart(sessionId);
+}
+
+/**
+ * Test-only helper — clears the in-module install guard so a fresh
+ * test can simulate a brand-new tab. Does NOT touch sessionStorage —
+ * tests manage that directly.
+ */
+export function resetSessionTrackerForTests(): void {
+  _installed = false;
+}

--- a/frontend/src/services/sessionTracker.ts
+++ b/frontend/src/services/sessionTracker.ts
@@ -170,7 +170,7 @@ export async function installSessionTracker(): Promise<void> {
     return;
   }
 
-  let existing: string | null = null;
+  let existing: string | null;
   try {
     existing = storage.getItem(SESSION_STORAGE_KEY);
   } catch {


### PR DESCRIPTION
## Summary

Implements bd-arp3o per the spike decision in [`docs/sre/spike-slo-6-session-semantics.md`](docs/sre/spike-slo-6-session-semantics.md) (bd-1tl01) — Option C: cookie/sessionStorage lifetime as the session boundary.

- New backend Counter `ecm_session_starts_total` (no labels) + Gauge `ecm_session_dedup_set_size` registered in `backend/observability.py`.
- New endpoint `POST /api/session-start` in `backend/routers/session_starts.py` with UUIDv4 schema, 24h in-memory dedup TTL, lazy prune, and identical operator-toggle posture to `/api/client-errors`. `session_id` is never logged, returned, or persisted.
- Frontend `installSessionTracker()` in `frontend/src/services/sessionTracker.ts` generates UUID via `crypto.randomUUID()`, persists in `sessionStorage`, fail-open on strict-privacy browsers per spike §3.3. Wired into `frontend/src/main.tsx`.
- SLO-6 SLI in `docs/sre/slos.md` promoted from log-aggregation-fallback to PromQL-native ratio expression. `docs/sre/prometheus_rules.yaml` `ecm_client_error_rate` group switched from absolute-rate alerts (`ECMClientErrorRate*`) to ratio-based alerts (`ECMClientErrorRatio*`) with new recording rule `ecm:client_error_session_ratio:5m`.

## Why

SLO-6 was scaffolded in bd-i6a1m with a placeholder denominator that fell back to log-aggregation. The spike (bd-1tl01) committed to Option C; this PR delivers the counter so the SLO becomes Prometheus-native and the alerts stop firing on traffic spikes when the actual per-session error ratio is flat.

## Test plan

- [x] Backend: `cd backend && python -m pytest tests/ --tb=short --no-header -p no:warnings` → **3174 passed** (18 new in `tests/routers/test_session_starts.py` covering happy path, dedup, TTL expiry with monkeypatched monotonic clock, schema validation, size cap, dedup gauge pruning, operator-toggle short-circuit).
- [x] Frontend: `cd frontend && npx vitest run` → **1185 passed** (8 new in `services/sessionTracker.test.ts` covering first-mount POST, sendBeacon-vs-fetch transport, idempotency, sessionStorage-throws fail-open, crypto.randomUUID-missing fail-open, fetch-error fail-open, telemetry runtime-disabled gate).
- [x] YAML validation: `prometheus_rules.yaml` parses cleanly, `ecm_client_error_rate` group has 4 rules (2 recording + 2 alert).
- [x] Smoke in `ecm-ecm-1`: POST a fresh UUIDv4 → 200 `{"deduplicated": false}` and `ecm_session_starts_total` goes 0 → 1; re-POST same UUID → 200 `{"deduplicated": true}` and counter stays at 1.

## Out of scope (per spike §7)

- Pre-auth coverage — endpoint inherits the JWT-required posture of `/api/client-errors`. ADR-006 amendment can revisit if PO chooses to expand coverage.
- Runbook update at `docs/runbooks/frontend_error_rate.md` — tracked under follow-up bead **enhancedchannelmanager-06jyv** per spike §6.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)