### PR TITLE
chore: bump dev to 0.16.0-0061 after observability batch

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.16.0-0060",
+  "version": "0.16.0-0061",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Tag-stone bump capturing the post-dep-bump observability + cleanup batch:

- PR #191 (bd-sllwg): suppress empty flake-list comments
- PR #192 (bd-1tl01): SLO-6 session-semantics spike doc
- PR #193 (bd-h0wfu): container freshness probe (/api/version + ecm_app_info gauge)
- PR #194 (bd-3d0tv): mechanical release-cut gate verification
- PR #195 (bd-f5l03): purity fix (Date.now in render → useState + tick)
- PR #196 (bd-arp3o): ecm_session_starts_total + dedup gauge for SLO-6 denominator
- PR #197 (bd-m3vej): /api/session-start unauthenticated for pre-auth coverage

Build counter only — no minor/patch bump, no CHANGELOG touch (release-cut work).

Bead: enhancedchannelmanager-2q74m