### PR TITLE
docs(claude-md): fix bd create example syntax (bd-xaloo)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,9 @@ Before reading code, editing files, or exploring the codebase for ANY code task:
    ```
 2. **Create a bead** for the current task:
    ```bash
-   bd create enhancedchannelmanager "Brief description"
+   bd create "Brief title" --description "Why this exists and what needs to be done"
    ```
+   The first positional arg is the **title**, not the repo. Repo is auto-routed from `.beads/`. Don't pass `enhancedchannelmanager` as the title — that's the most common foot-gun.
 
 No exceptions. No "I'll do it later." The bead comes before the first Read, Grep, or Edit.
 After the work is deployed and verified, close it: `bd close <bead-id>`
@@ -28,7 +29,7 @@ bd list --status closed       # View closed beads for context
 bd sync                       # Sync beads data only (NOT for code commits)
 ```
 
-- Always use `enhancedchannelmanager` as the repository name
+- Beads auto-route to this repo via `.beads/`. If you ever need to override (e.g., creating a bead targeting a different rig), use `--repo enhancedchannelmanager`.
 - **NEVER chain `bd create` and `bd close`** — run them as separate commands
 - The `.git/beads-worktrees/dev` worktree is **only for beads issue tracking** (sparse checkout of `.beads/` only — no code files). Do NOT edit code there.
 


### PR DESCRIPTION
## Summary
- The CLAUDE.md "create a bead" example showed `bd create enhancedchannelmanager "Brief description"`. `bd create`'s first positional arg is the **title**, so this silently dropped the description and produced beads titled "enhancedchannelmanager" (discovered in PR #163 team review when filing 6 follow-up beads).
- Replace with `bd create "Brief title" --description "..."` and add an explicit foot-gun note so future agents don't repeat the mistake.
- Reframe the "Always use `enhancedchannelmanager` as the repository name" bullet — `.beads` auto-routing handles repo selection; `--repo` is the override flag.

## Test plan
- [x] Verify the new example syntax works: `bd create "Title" --description "..." --silent` produced bead `enhancedchannelmanager-xaloo` with both fields populated correctly (`bd show xaloo`).
- [ ] Docs-only change — no code or test impact. Required CI gates should be green via the docs-only sentinel path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)