### PR TITLE
fix(backup): redact secrets in ZIP export path (bd-l0nhi)

### DIFF
--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -7,10 +7,14 @@ YAML export: settings + DB tables + Dispatcharr state in a single file.
 import io
 import json
 import logging
+import os
 import re
 import shutil
+import sqlite3
+import tempfile
 import zipfile
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional
 
 import yaml
@@ -60,6 +64,23 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # App version for manifest (imported at call time to avoid circular imports)
 APP_VERSION = "0.16.0"
 
+REDACTED = "***REDACTED***"
+
+# Credential fields in DispatcharrSettings that must never appear raw in an
+# exported backup. Mirrors the YAML export contract for parity (bd-l0nhi).
+_SETTINGS_CREDENTIAL_FIELDS = (
+    "password",
+    "api_key",
+    "smtp_password",
+    "telegram_bot_token",
+    "mcp_api_key",
+)
+
+# Credential-class keys that may live inside alert_methods.config JSON. Matches
+# the masking set in AlertMethod.to_dict (models.py) so backup redaction stays
+# in lock-step with the API-response masking already shipped to clients.
+_ALERT_METHOD_CREDENTIAL_KEYS = ("password", "bot_token", "webhook_url", "api_key")
+
 
 def _get_backup_filename() -> str:
     """Generate a timestamped backup filename."""
@@ -74,6 +95,71 @@ def _build_manifest(files: list[str]) -> dict:
         "created_at": datetime.now(timezone.utc).isoformat(),
         "files": files,
     }
+
+
+def _scrub_journal_db_to_temp(src: Path) -> Path:
+    """Copy journal.db to a temp file and redact credential-class keys in
+    alert_methods.config rows. Returns the temp file path; caller must unlink.
+
+    Per bd-l0nhi: PR #163 began storing SMTP password (and other creds) inside
+    alert_methods.config JSON, so the live DB cannot be zipped raw without
+    leaking credentials.
+    """
+    fd, tmp_name = tempfile.mkstemp(prefix="ecm-backup-journal-", suffix=".db")
+    os.close(fd)
+    tmp_path = Path(tmp_name)
+    shutil.copyfile(src, tmp_path)
+
+    try:
+        conn = sqlite3.connect(str(tmp_path))
+    except sqlite3.Error as e:
+        # Source isn't a usable SQLite DB — log and ship the byte-for-byte copy
+        # so the backup doesn't fail outright. The validator will still reject
+        # it on restore if it's truly malformed.
+        logger.warning("[BACKUP] Could not open journal.db for scrub, shipping as-is: %s", e)
+        return tmp_path
+
+    try:
+        cur = conn.cursor()
+        # alert_methods table may not exist on freshly-bootstrapped DBs.
+        try:
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='alert_methods'"
+            )
+            if cur.fetchone() is None:
+                return tmp_path
+            cur.execute("SELECT id, config FROM alert_methods")
+            rows = cur.fetchall()
+        except sqlite3.DatabaseError as e:
+            logger.warning("[BACKUP] alert_methods scrub skipped (DB read failed): %s", e)
+            return tmp_path
+
+        for row_id, raw_config in rows:
+            if not raw_config:
+                continue
+            try:
+                cfg = json.loads(raw_config)
+            except (json.JSONDecodeError, TypeError):
+                # Leave malformed rows alone — restore-side will refuse to
+                # parse them anyway, and we don't want to silently rewrite.
+                continue
+            if not isinstance(cfg, dict):
+                continue
+            changed = False
+            for key in _ALERT_METHOD_CREDENTIAL_KEYS:
+                if key in cfg and cfg[key]:
+                    cfg[key] = REDACTED
+                    changed = True
+            if changed:
+                cur.execute(
+                    "UPDATE alert_methods SET config=? WHERE id=?",
+                    (json.dumps(cfg), row_id),
+                )
+        conn.commit()
+        logger.info("[BACKUP] Scrubbed alert_methods.config in %d rows", len(rows))
+    finally:
+        conn.close()
+    return tmp_path
 
 
 def _create_backup_zip() -> io.BytesIO:
@@ -93,35 +179,51 @@ def _create_backup_zip() -> io.BytesIO:
 
     buf = io.BytesIO()
     files_added = []
+    scrubbed_db_path: Optional[Path] = None
 
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        # Add settings.json
-        if CONFIG_FILE.exists():
-            zf.write(CONFIG_FILE, "settings.json")
-            files_added.append("settings.json")
-            logger.info("[BACKUP] Added settings.json")
+    try:
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            # Add settings.json — written from the redacted dict so credential
+            # fields (password, api_key, smtp_password, telegram_bot_token,
+            # mcp_api_key) never hit the archive raw.
+            if CONFIG_FILE.exists():
+                redacted = _gather_settings()
+                zf.writestr("settings.json", json.dumps(redacted, indent=2))
+                files_added.append("settings.json")
+                logger.info("[BACKUP] Added settings.json (redacted)")
 
-        # Add journal.db
-        if JOURNAL_DB_FILE.exists():
-            zf.write(JOURNAL_DB_FILE, "journal.db")
-            files_added.append("journal.db")
-            logger.info("[BACKUP] Added journal.db (%d bytes)", JOURNAL_DB_FILE.stat().st_size)
+            # Add journal.db — copied to a temp file and scrubbed of
+            # alert_methods.config credential-class keys before zipping.
+            if JOURNAL_DB_FILE.exists():
+                scrubbed_db_path = _scrub_journal_db_to_temp(JOURNAL_DB_FILE)
+                zf.write(scrubbed_db_path, "journal.db")
+                files_added.append("journal.db")
+                logger.info(
+                    "[BACKUP] Added journal.db (%d bytes, scrubbed)",
+                    scrubbed_db_path.stat().st_size,
+                )
 
-        # Add directories
-        for dir_rel in BACKUP_DIRS:
-            dir_path = CONFIG_DIR / dir_rel
-            if dir_path.exists() and dir_path.is_dir():
-                for file_path in dir_path.rglob("*"):
-                    if file_path.is_file():
-                        arcname = str(file_path.relative_to(CONFIG_DIR))
-                        zf.write(file_path, arcname)
-                        files_added.append(arcname)
-                if any(1 for _ in dir_path.rglob("*") if _.is_file()):
-                    logger.info("[BACKUP] Added directory %s", dir_rel)
+            # Add directories
+            for dir_rel in BACKUP_DIRS:
+                dir_path = CONFIG_DIR / dir_rel
+                if dir_path.exists() and dir_path.is_dir():
+                    for file_path in dir_path.rglob("*"):
+                        if file_path.is_file():
+                            arcname = str(file_path.relative_to(CONFIG_DIR))
+                            zf.write(file_path, arcname)
+                            files_added.append(arcname)
+                    if any(1 for _ in dir_path.rglob("*") if _.is_file()):
+                        logger.info("[BACKUP] Added directory %s", dir_rel)
 
-        # Add manifest
-        manifest = _build_manifest(files_added)
-        zf.writestr("ecm_backup.json", json.dumps(manifest, indent=2))
+            # Add manifest
+            manifest = _build_manifest(files_added)
+            zf.writestr("ecm_backup.json", json.dumps(manifest, indent=2))
+    finally:
+        if scrubbed_db_path is not None:
+            try:
+                scrubbed_db_path.unlink()
+            except OSError as e:
+                logger.warning("[BACKUP] Failed to unlink scrubbed journal temp %s: %s", scrubbed_db_path, e)
 
     buf.seek(0)
     logger.info("[BACKUP] Backup created with %d files", len(files_added))
@@ -168,18 +270,164 @@ def _validate_backup_zip(zf: zipfile.ZipFile) -> dict:
     return manifest
 
 
+def _merge_settings_preserving_redacted(zip_settings_bytes: bytes) -> bytes:
+    """Apply restored settings.json on top of existing settings, dropping
+    REDACTED sentinels so existing credentials are preserved.
+
+    Mirrors the YAML restore semantics in _restore_settings (lines below) so
+    a redacted ZIP behaves the same as a redacted YAML export. Backward-compat:
+    legacy non-redacted ZIPs have no sentinels, so every value is taken as-is.
+    """
+    try:
+        zipped = json.loads(zip_settings_bytes)
+    except (json.JSONDecodeError, TypeError):
+        # Validator has already accepted this as JSON; if it's somehow not a
+        # dict, fall back to writing as-is rather than corrupting the file.
+        return zip_settings_bytes
+    if not isinstance(zipped, dict):
+        return zip_settings_bytes
+
+    if CONFIG_FILE.exists():
+        try:
+            existing = json.loads(CONFIG_FILE.read_text())
+            if not isinstance(existing, dict):
+                existing = {}
+        except (OSError, json.JSONDecodeError):
+            existing = {}
+    else:
+        existing = {}
+
+    merged = dict(existing)
+    skipped = []
+    for key, value in zipped.items():
+        if value == REDACTED:
+            skipped.append(key)
+            continue
+        merged[key] = value
+    if skipped:
+        logger.info("[BACKUP] Preserved existing values for redacted settings: %s", skipped)
+    return json.dumps(merged, indent=2).encode("utf-8")
+
+
+def _capture_existing_alert_method_configs() -> dict[int, dict]:
+    """Read existing alert_methods rows directly from journal.db so we can
+    re-merge non-redacted credential fields after the restored DB is written.
+
+    Returns {id: parsed_config_dict}. Rows with malformed JSON or missing
+    table are skipped silently — the caller treats absent ids as 'no merge'.
+    """
+    if not JOURNAL_DB_FILE.exists():
+        return {}
+    out: dict[int, dict] = {}
+    try:
+        conn = sqlite3.connect(str(JOURNAL_DB_FILE))
+    except sqlite3.Error as e:
+        logger.warning("[BACKUP] Could not open journal.db for pre-restore capture: %s", e)
+        return {}
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='alert_methods'"
+            )
+            if cur.fetchone() is None:
+                return {}
+            cur.execute("SELECT id, config FROM alert_methods")
+            rows = cur.fetchall()
+        except sqlite3.DatabaseError as e:
+            logger.warning("[BACKUP] Could not read alert_methods for pre-restore capture: %s", e)
+            return {}
+        for row_id, raw in rows:
+            if not raw:
+                continue
+            try:
+                cfg = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if isinstance(cfg, dict):
+                out[row_id] = cfg
+    finally:
+        conn.close()
+    return out
+
+
+def _merge_alert_method_creds_after_restore(prior: dict[int, dict]) -> None:
+    """For each alert_methods row in the restored DB, restore non-redacted
+    credential-class values from the prior snapshot when the restored value
+    is the REDACTED sentinel. Match by row id.
+
+    Backward-compat: legacy non-redacted ZIPs carry no sentinel — every value
+    survives the merge unchanged.
+    """
+    if not JOURNAL_DB_FILE.exists():
+        return
+    try:
+        conn = sqlite3.connect(str(JOURNAL_DB_FILE))
+    except sqlite3.Error as e:
+        logger.warning("[BACKUP] Could not open restored journal.db for cred merge: %s", e)
+        return
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='alert_methods'"
+            )
+            if cur.fetchone() is None:
+                return
+            cur.execute("SELECT id, config FROM alert_methods")
+            rows = cur.fetchall()
+        except sqlite3.DatabaseError as e:
+            logger.warning("[BACKUP] Could not read alert_methods after restore for merge: %s", e)
+            return
+        merged_count = 0
+        for row_id, raw in rows:
+            if not raw:
+                continue
+            try:
+                cfg = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if not isinstance(cfg, dict):
+                continue
+            prior_cfg = prior.get(row_id, {})
+            changed = False
+            for key in _ALERT_METHOD_CREDENTIAL_KEYS:
+                if cfg.get(key) == REDACTED and prior_cfg.get(key) not in (None, "", REDACTED):
+                    cfg[key] = prior_cfg[key]
+                    changed = True
+            if changed:
+                cur.execute(
+                    "UPDATE alert_methods SET config=? WHERE id=?",
+                    (json.dumps(cfg), row_id),
+                )
+                merged_count += 1
+        conn.commit()
+        if merged_count:
+            logger.info(
+                "[BACKUP] Re-merged credentials into %d alert_methods rows after restore",
+                merged_count,
+            )
+    finally:
+        conn.close()
+
+
 def _restore_from_zip(zf: zipfile.ZipFile, manifest: dict) -> list[str]:
     """Restore files from a validated backup zip."""
     restored = []
+
+    # Capture existing alert_methods.config BEFORE we close/replace the DB so
+    # we can merge real creds back where the restored ZIP has REDACTED.
+    prior_alert_configs = _capture_existing_alert_method_configs()
 
     # Close database before replacing files
     close_db()
     logger.info("[BACKUP] Database closed for restore")
 
     try:
-        # Restore settings.json
+        # Restore settings.json — drop REDACTED sentinels in favor of the
+        # currently-on-disk value, mirroring YAML restore semantics.
         if "settings.json" in zf.namelist():
-            CONFIG_FILE.write_bytes(zf.read("settings.json"))
+            CONFIG_FILE.write_bytes(_merge_settings_preserving_redacted(zf.read("settings.json")))
             restored.append("settings.json")
             logger.info("[BACKUP] Restored settings.json")
 
@@ -188,6 +436,9 @@ def _restore_from_zip(zf: zipfile.ZipFile, manifest: dict) -> list[str]:
             JOURNAL_DB_FILE.write_bytes(zf.read("journal.db"))
             restored.append("journal.db")
             logger.info("[BACKUP] Restored journal.db")
+            # Merge any REDACTED alert_methods.config creds back from the
+            # pre-restore snapshot so existing rows aren't degraded.
+            _merge_alert_method_creds_after_restore(prior_alert_configs)
 
         # Restore directories — clear existing before writing
         for dir_rel in BACKUP_DIRS:
@@ -320,9 +571,9 @@ def _gather_settings() -> dict:
     settings = get_settings()
     data = settings.model_dump()
     # Redact credentials — the export is for review/portability, not secret storage
-    for key in ("password", "smtp_password"):
+    for key in _SETTINGS_CREDENTIAL_FIELDS:
         if key in data:
-            data[key] = "***REDACTED***"
+            data[key] = REDACTED
     return data
 
 
@@ -553,8 +804,6 @@ RESTORABLE_SECTIONS = {
     "channel_profiles": {"label": "Channel Profiles", "dispatcharr": True},
     "stream_profiles": {"label": "Stream Profiles", "dispatcharr": True},
 }
-
-REDACTED = "***REDACTED***"
 
 
 def _parse_yaml_export(content: bytes) -> dict:

--- a/backend/tests/routers/test_backup.py
+++ b/backend/tests/routers/test_backup.py
@@ -1249,3 +1249,376 @@ class TestRestoreYaml:
         assert test_session.query(TagGroup).first().name == "Countries"
         assert test_session.query(FFmpegProfile).count() == 1
         assert test_session.query(FFmpegProfile).first().name == "Test Profile"
+
+
+def _create_journal_db_with_alert_methods(path, rows):
+    """Create a real SQLite journal.db at `path` with the alert_methods table
+    and the supplied rows. Each row is a dict with at least name, method_type,
+    config (dict — will be JSON-encoded for storage)."""
+    import sqlite3
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE alert_methods ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "name TEXT NOT NULL, "
+            "method_type TEXT NOT NULL, "
+            "enabled INTEGER NOT NULL DEFAULT 1, "
+            "config TEXT NOT NULL, "
+            "notify_info INTEGER NOT NULL DEFAULT 0, "
+            "notify_success INTEGER NOT NULL DEFAULT 1, "
+            "notify_warning INTEGER NOT NULL DEFAULT 1, "
+            "notify_error INTEGER NOT NULL DEFAULT 1, "
+            "alert_sources TEXT, "
+            "last_sent_at TEXT, "
+            "created_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00', "
+            "updated_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00'"
+            ")"
+        )
+        for row in rows:
+            conn.execute(
+                "INSERT INTO alert_methods (id, name, method_type, config) VALUES (?, ?, ?, ?)",
+                (
+                    row.get("id"),
+                    row["name"],
+                    row["method_type"],
+                    json.dumps(row["config"]),
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestZipExportRedaction:
+    """ZIP export must scrub credentials from settings.json AND journal.db.
+
+    Closes the secret-leak gap (bd-l0nhi): the YAML export path was already
+    redacting password + smtp_password, but the ZIP path wrote both files
+    raw, leaking 5 settings credentials AND alert_methods.config rows that
+    began carrying SMTP password as of PR #163.
+    """
+
+    @pytest.mark.asyncio
+    async def test_zip_export_redacts_all_5_settings_credentials(
+        self, async_client, tmp_path
+    ):
+        """Exported settings.json must contain ***REDACTED*** for all 5
+        credential fields and none of the raw values."""
+        settings_file = tmp_path / "settings.json"
+        # Distinctive values so we can search the ZIP for raw leaks.
+        raw_creds = {
+            "password": "raw-pass-DUDLAH",
+            "api_key": "raw-apikey-PORDOX",
+            "smtp_password": "raw-smtp-VOLTUM",
+            "telegram_bot_token": "raw-tg-bot-NIXAR",
+            "mcp_api_key": "raw-mcp-MERLIN",
+        }
+        settings_dict = {"url": "http://test:9191", "username": "admin", **raw_creds}
+        # File must exist for the CONFIG_FILE.exists() guard, but the actual
+        # values come from get_settings() — patched below.
+        settings_file.write_text(json.dumps(settings_dict))
+        db_file = tmp_path / "journal.db"
+        # Real (empty) SQLite DB — _scrub_journal_db_to_temp will open it.
+        import sqlite3
+        sqlite3.connect(str(db_file)).close()
+
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_settings = MagicMock()
+        mock_settings.model_dump.return_value = settings_dict
+
+        with patch("routers.backup.CONFIG_DIR", tmp_path), \
+             patch("routers.backup.CONFIG_FILE", settings_file), \
+             patch("routers.backup.JOURNAL_DB_FILE", db_file), \
+             patch("routers.backup.get_engine", return_value=mock_engine), \
+             patch("routers.backup.get_settings", return_value=mock_settings):
+            response = await async_client.get("/api/backup/create")
+
+        assert response.status_code == 200
+        archive_bytes = response.content
+        # Belt-and-suspenders: raw values must not appear anywhere in the
+        # entire archive — defends against future leak paths beyond settings.json.
+        for field, value in raw_creds.items():
+            assert value.encode() not in archive_bytes, (
+                f"raw {field} value leaked into the ZIP archive"
+            )
+
+        buf = io.BytesIO(archive_bytes)
+        with zipfile.ZipFile(buf) as zf:
+            settings_in_zip = json.loads(zf.read("settings.json"))
+        for field in raw_creds:
+            assert settings_in_zip[field] == "***REDACTED***", (
+                f"settings.{field} not redacted in ZIP"
+            )
+        # Non-credential fields must survive untouched.
+        assert settings_in_zip["url"] == "http://test:9191"
+        assert settings_in_zip["username"] == "admin"
+
+    @pytest.mark.asyncio
+    async def test_zip_export_redacts_alert_methods_smtp_password(
+        self, async_client, tmp_path
+    ):
+        """alert_methods.config rows with credential-class keys must be
+        scrubbed before the journal.db gets zipped (bd-l0nhi, PR #163 leak)."""
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps({"url": "http://test:9191"}))
+        db_file = tmp_path / "journal.db"
+        smtp_password_literal = "TOPSECRET-SMTP-LITERAL-XYZ"
+        webhook_url_literal = "https://discord.example/leakme-WEBHOOK-XYZ"
+        bot_token_literal = "tg-bot-LEAK-XYZ"
+        _create_journal_db_with_alert_methods(db_file, [
+            {
+                "id": 1,
+                "name": "SMTP Alerts",
+                "method_type": "smtp",
+                "config": {
+                    "host": "smtp.example.com",
+                    "port": 587,
+                    "username": "alerts@example.com",
+                    "password": smtp_password_literal,
+                },
+            },
+            {
+                "id": 2,
+                "name": "Discord Alerts",
+                "method_type": "discord",
+                "config": {"webhook_url": webhook_url_literal},
+            },
+            {
+                "id": 3,
+                "name": "Telegram Alerts",
+                "method_type": "telegram",
+                "config": {"bot_token": bot_token_literal, "chat_id": "1234"},
+            },
+        ])
+
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        with patch("routers.backup.CONFIG_DIR", tmp_path), \
+             patch("routers.backup.CONFIG_FILE", settings_file), \
+             patch("routers.backup.JOURNAL_DB_FILE", db_file), \
+             patch("routers.backup.get_engine", return_value=mock_engine):
+            response = await async_client.get("/api/backup/create")
+
+        assert response.status_code == 200
+        # The whole archive payload must not contain any of the raw secrets.
+        archive_bytes = response.content
+        for literal in (smtp_password_literal, webhook_url_literal, bot_token_literal):
+            assert literal.encode() not in archive_bytes, (
+                f"raw alert_methods credential {literal!r} leaked into the ZIP"
+            )
+
+        # The scrubbed DB inside the ZIP should still be a valid SQLite
+        # database with the rows replaced by REDACTED.
+        buf = io.BytesIO(archive_bytes)
+        with zipfile.ZipFile(buf) as zf:
+            extracted = tmp_path / "extracted-journal.db"
+            extracted.write_bytes(zf.read("journal.db"))
+        import sqlite3
+        conn = sqlite3.connect(str(extracted))
+        try:
+            cur = conn.cursor()
+            cur.execute("SELECT id, config FROM alert_methods ORDER BY id")
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+        configs = {row_id: json.loads(cfg) for row_id, cfg in rows}
+        assert configs[1]["password"] == "***REDACTED***"
+        assert configs[1]["host"] == "smtp.example.com"  # non-cred preserved
+        assert configs[2]["webhook_url"] == "***REDACTED***"
+        assert configs[3]["bot_token"] == "***REDACTED***"
+        assert configs[3]["chat_id"] == "1234"  # non-cred preserved
+
+
+class TestZipRestoreRedactionAware:
+    """ZIP restore must preserve existing creds when the ZIP contains the
+    REDACTED sentinel — both for settings.json and for alert_methods.config.
+
+    Backward compat: a legacy ZIP with raw values must still restore as-is.
+    """
+
+    @pytest.mark.asyncio
+    async def test_zip_restore_preserves_existing_creds_when_redacted(
+        self, async_client, tmp_path
+    ):
+        """settings.json with ***REDACTED*** sentinels must keep the
+        existing on-disk credential values."""
+        settings_file = tmp_path / "settings.json"
+        existing = {
+            "url": "http://old:9191",
+            "username": "existing_user",
+            "password": "EXISTING-PASS-9999",
+            "api_key": "EXISTING-API-9999",
+            "smtp_password": "EXISTING-SMTP-9999",
+            "telegram_bot_token": "EXISTING-TG-9999",
+            "mcp_api_key": "EXISTING-MCP-9999",
+        }
+        settings_file.write_text(json.dumps(existing))
+        db_file = tmp_path / "journal.db"
+
+        # Build a ZIP whose settings.json carries the redacted sentinels and a
+        # *new* url/username — those non-cred fields must override; the creds
+        # must survive from the existing on-disk file.
+        zipped_settings = json.dumps({
+            "url": "http://restored:9191",
+            "username": "restored_user",
+            "password": "***REDACTED***",
+            "api_key": "***REDACTED***",
+            "smtp_password": "***REDACTED***",
+            "telegram_bot_token": "***REDACTED***",
+            "mcp_api_key": "***REDACTED***",
+        })
+        backup = _make_backup_zip(settings_content=zipped_settings)
+
+        with patch("routers.backup.CONFIG_DIR", tmp_path), \
+             patch("routers.backup.CONFIG_FILE", settings_file), \
+             patch("routers.backup.JOURNAL_DB_FILE", db_file), \
+             patch("routers.backup.close_db"), \
+             patch("routers.backup.init_db"), \
+             patch("routers.backup.clear_settings_cache"), \
+             patch("routers.backup.reset_client"):
+            response = await async_client.post(
+                "/api/backup/restore",
+                files={"file": ("backup.zip", backup, "application/zip")},
+            )
+
+        assert response.status_code == 200
+        restored = json.loads(settings_file.read_text())
+        # Credentials kept from existing file
+        assert restored["password"] == "EXISTING-PASS-9999"
+        assert restored["api_key"] == "EXISTING-API-9999"
+        assert restored["smtp_password"] == "EXISTING-SMTP-9999"
+        assert restored["telegram_bot_token"] == "EXISTING-TG-9999"
+        assert restored["mcp_api_key"] == "EXISTING-MCP-9999"
+        # Non-credential fields took the restored values
+        assert restored["url"] == "http://restored:9191"
+        assert restored["username"] == "restored_user"
+
+    @pytest.mark.asyncio
+    async def test_zip_restore_preserves_alert_method_creds_when_redacted(
+        self, async_client, tmp_path
+    ):
+        """alert_methods.config rows whose credential-class fields are
+        REDACTED in the restored DB must be re-merged from the pre-restore
+        snapshot, matched by row id."""
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps({"url": "http://test:9191"}))
+        db_file = tmp_path / "journal.db"
+
+        # Pre-existing DB has real creds in row id=1 (SMTP) and id=2 (Discord).
+        existing_smtp_pass = "PRESERVE-SMTP-PASS-1234"
+        existing_webhook = "https://discord.example/PRESERVE-WEBHOOK"
+        _create_journal_db_with_alert_methods(db_file, [
+            {
+                "id": 1,
+                "name": "SMTP",
+                "method_type": "smtp",
+                "config": {"host": "smtp.old", "password": existing_smtp_pass},
+            },
+            {
+                "id": 2,
+                "name": "Discord",
+                "method_type": "discord",
+                "config": {"webhook_url": existing_webhook},
+            },
+        ])
+
+        # Build a ZIP whose journal.db has the same row ids but with REDACTED
+        # config keys — emulates a redacted backup made elsewhere.
+        zipped_db = tmp_path / "zipped-journal.db"
+        _create_journal_db_with_alert_methods(zipped_db, [
+            {
+                "id": 1,
+                "name": "SMTP-from-zip",
+                "method_type": "smtp",
+                "config": {"host": "smtp.new", "password": "***REDACTED***"},
+            },
+            {
+                "id": 2,
+                "name": "Discord-from-zip",
+                "method_type": "discord",
+                "config": {"webhook_url": "***REDACTED***"},
+            },
+        ])
+        backup = _make_backup_zip(db_content=zipped_db.read_bytes())
+
+        with patch("routers.backup.CONFIG_DIR", tmp_path), \
+             patch("routers.backup.CONFIG_FILE", settings_file), \
+             patch("routers.backup.JOURNAL_DB_FILE", db_file), \
+             patch("routers.backup.close_db"), \
+             patch("routers.backup.init_db"), \
+             patch("routers.backup.clear_settings_cache"), \
+             patch("routers.backup.reset_client"):
+            response = await async_client.post(
+                "/api/backup/restore",
+                files={"file": ("backup.zip", backup, "application/zip")},
+            )
+
+        assert response.status_code == 200
+        # Verify post-restore DB carries restored row contents BUT with creds
+        # re-merged from the pre-restore snapshot.
+        import sqlite3
+        conn = sqlite3.connect(str(db_file))
+        try:
+            cur = conn.cursor()
+            cur.execute("SELECT id, name, config FROM alert_methods ORDER BY id")
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+        by_id = {row_id: (name, json.loads(cfg)) for row_id, name, cfg in rows}
+        # Names came from the ZIP (full row replacement)
+        assert by_id[1][0] == "SMTP-from-zip"
+        assert by_id[2][0] == "Discord-from-zip"
+        # Non-credential fields came from the ZIP
+        assert by_id[1][1]["host"] == "smtp.new"
+        # Credential fields re-merged from pre-restore snapshot
+        assert by_id[1][1]["password"] == existing_smtp_pass
+        assert by_id[2][1]["webhook_url"] == existing_webhook
+
+    @pytest.mark.asyncio
+    async def test_zip_restore_legacy_non_redacted_still_works(
+        self, async_client, tmp_path
+    ):
+        """Backward-compat smoke: a legacy ZIP with raw credential values
+        (no ***REDACTED*** sentinels) must restore values as-is."""
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps({
+            "url": "http://existing:9191",
+            "password": "should-be-overwritten",
+        }))
+        db_file = tmp_path / "journal.db"
+
+        legacy_settings = json.dumps({
+            "url": "http://restored:9191",
+            "username": "restored_user",
+            "password": "raw-restored-pass",
+            "smtp_password": "raw-restored-smtp",
+        })
+        backup = _make_backup_zip(settings_content=legacy_settings)
+
+        with patch("routers.backup.CONFIG_DIR", tmp_path), \
+             patch("routers.backup.CONFIG_FILE", settings_file), \
+             patch("routers.backup.JOURNAL_DB_FILE", db_file), \
+             patch("routers.backup.close_db"), \
+             patch("routers.backup.init_db"), \
+             patch("routers.backup.clear_settings_cache"), \
+             patch("routers.backup.reset_client"):
+            response = await async_client.post(
+                "/api/backup/restore",
+                files={"file": ("backup.zip", backup, "application/zip")},
+            )
+
+        assert response.status_code == 200
+        restored = json.loads(settings_file.read_text())
+        # All values came from the ZIP, raw, including credentials.
+        assert restored["url"] == "http://restored:9191"
+        assert restored["username"] == "restored_user"
+        assert restored["password"] == "raw-restored-pass"
+        assert restored["smtp_password"] == "raw-restored-smtp"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.16.0-0061",
+  "version": "0.16.0-0062",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- **P0 cut-blocker.** `/api/backup/create` ZIP path previously wrote `settings.json` and `journal.db` raw, leaking the 5 credential fields in `DispatcharrSettings` (`password`, `api_key`, `smtp_password`, `telegram_bot_token`, `mcp_api_key`) and any `alert_methods.config` rows holding SMTP password (added in PR #163).
- **Export side**: `_gather_settings` extended to all 5 fields (also fixes the YAML path's pre-existing 2/5 gap); ZIP `settings.json` written from redacted dict; new `_scrub_journal_db_to_temp` copies `journal.db` to a tempfile and rewrites credential-class keys (`password`, `bot_token`, `webhook_url`, `api_key`) inside `alert_methods.config` JSON with `***REDACTED***`.
- **Restore side**: settings.json restore drops REDACTED sentinels in favor of existing creds; `alert_methods.config` rows are merged row-by-row from a pre-restore snapshot when the restored DB has redaction sentinels. Legacy non-redacted ZIPs still restore as-is (backward compat).
- Bumps dev version to `0.16.0-0062`.

## Test plan
- [x] 5 new tests in `backend/tests/routers/test_backup.py` (`TestZipExportRedaction` + `TestZipRestoreRedactionAware`)
- [x] Full backend suite: 3161 passed (engineer's run)
- [x] Smoke tested in `ecm-ecm-1` against live data — settings.json shows `***REDACTED***` for all 5 fields in the resulting ZIP

## Closes
`bd-l0nhi` (rescoped from `0i2vt.1` to ship in next cut, uncoupled from v0.18.0 DBAS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)