### PR TITLE
fix(database): pre-Alembic stamping bug + self-heal (bd-fwpzw)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -108,15 +108,65 @@ def get_database_url() -> str:
     return f"sqlite:///{JOURNAL_DB_FILE}"
 
 
+# Canary list for the post-upgrade self-heal check in ``_bootstrap_alembic``.
+# Each entry guards against a specific class of pre-Alembic-stamping bug
+# (bd-fwpzw): users whose ``alembic_version`` was stamped at HEAD by an older
+# bootstrap path even though their physical schema is still at the baseline.
+# In that state ``alembic upgrade head`` is a no-op and the missing post-
+# baseline DDL never lands. We probe for at least one column from migration
+# 0002 and one index from migration 0004 so any divergence between the version
+# row and the actual schema fails the canary and triggers self-heal.
+#
+# Keep this list short — 2-3 entries that prove the most-recent migrations ran.
+# Adding a canary per migration is overkill; cross-cutting failure of one
+# representative artifact is enough to know the version row is lying.
+_BOOTSTRAP_CANARIES = (
+    # Migration 0002 — column missed by the original pre-Alembic stamping bug
+    # (the production 500 reported in bd-fwpzw).
+    {"kind": "column", "table": "auto_creation_rules", "name": "match_scope_target_group"},
+    # Migration 0004 — index added on top of the baseline journal_entries table.
+    {"kind": "index", "table": "journal_entries", "name": "idx_journal_batch_id"},
+)
+
+
+def _missing_canaries(engine) -> list[dict]:
+    """Return canaries from ``_BOOTSTRAP_CANARIES`` not present in ``engine``."""
+    missing: list[dict] = []
+    with engine.connect() as conn:
+        for canary in _BOOTSTRAP_CANARIES:
+            if canary["kind"] == "column":
+                rows = conn.execute(text(
+                    f"PRAGMA table_info({canary['table']})"
+                )).fetchall()
+                names = {row[1] for row in rows}
+                if canary["name"] not in names:
+                    missing.append(canary)
+            elif canary["kind"] == "index":
+                rows = conn.execute(text(
+                    f"PRAGMA index_list({canary['table']})"
+                )).fetchall()
+                # PRAGMA index_list returns (seq, name, unique, origin, partial).
+                names = {row[1] for row in rows}
+                if canary["name"] not in names:
+                    missing.append(canary)
+    return missing
+
+
 def _bootstrap_alembic(engine) -> None:
     """Ensure ``alembic_version`` tracks the deployed schema state.
 
     - Fresh install (no tables): ``alembic upgrade head`` creates everything.
     - Existing install from before Alembic (tables exist, no ``alembic_version``):
-      ``alembic stamp head`` records the current revision without re-running
-      DDL that would crash on duplicate-table errors.
+      stamp at the **baseline** revision (the lowest revision in the migration
+      history — by design the baseline schema mirrors the pre-Alembic shape),
+      then run ``upgrade head`` so post-baseline migrations apply. Stamping at
+      HEAD instead would silently skip every post-baseline migration forever
+      (bd-fwpzw).
     - Already on Alembic (``alembic_version`` row present): ``upgrade head`` is
       a no-op when at head, otherwise applies pending revisions.
+    - Self-heal: after upgrade, probe ``_BOOTSTRAP_CANARIES`` to detect any
+      schema/version mismatch (users stamped at HEAD by the buggy older path).
+      If a canary is missing, re-stamp at baseline and re-run upgrade head.
     """
     from alembic import command
     from alembic.config import Config
@@ -132,6 +182,10 @@ def _bootstrap_alembic(engine) -> None:
     alembic_cfg = Config(str(ALEMBIC_INI_PATH))
     alembic_cfg.set_main_option("sqlalchemy.url", str(engine.url))
 
+    script_dir = ScriptDirectory.from_config(alembic_cfg)
+    bases = script_dir.get_bases()
+    baseline_revision = bases[0] if bases else None
+
     with engine.connect() as conn:
         has_alembic_version = conn.execute(text(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='alembic_version'"
@@ -142,16 +196,49 @@ def _bootstrap_alembic(engine) -> None:
         )).fetchone() is not None
 
     if not has_alembic_version and has_any_user_table:
-        head = ScriptDirectory.from_config(alembic_cfg).get_current_head()
-        logger.info(
-            "[DATABASE] Pre-Alembic install detected — stamping as revision %s",
-            head,
-        )
-        command.stamp(alembic_cfg, "head")
-        return
+        if baseline_revision is None:
+            logger.error(
+                "[DATABASE] Pre-Alembic install detected but no baseline revision found in script directory — skipping stamp"
+            )
+        else:
+            logger.info(
+                "[DATABASE] Pre-Alembic install detected — stamping at baseline revision %s, then upgrading to head",
+                baseline_revision,
+            )
+            command.stamp(alembic_cfg, baseline_revision)
+            # Fall through to upgrade head so post-baseline migrations apply.
 
     logger.info("[DATABASE] Running alembic upgrade head")
     command.upgrade(alembic_cfg, "head")
+
+    # Self-heal: a user stamped at HEAD by the buggy pre-fix bootstrap will
+    # have ``upgrade head`` no-op, leaving missing post-baseline schema. Probe
+    # canaries to detect that state and recover by re-stamping at baseline and
+    # re-running ``upgrade head``.
+    missing = _missing_canaries(engine)
+    if missing:
+        current_rev = get_current_schema_revision(engine)
+        logger.error(
+            "[DATABASE] Schema/Alembic mismatch detected — re-stamping at baseline and re-running upgrade head (current_rev=%s, missing_canaries=%s)",
+            current_rev or "unstamped",
+            [c["name"] for c in missing],
+        )
+        if baseline_revision is None:
+            raise RuntimeError(
+                "Schema/Alembic mismatch detected but baseline revision is unavailable — cannot self-heal"
+            )
+        with engine.begin() as conn:
+            conn.execute(
+                text("UPDATE alembic_version SET version_num = :rev"),
+                {"rev": baseline_revision},
+            )
+        command.upgrade(alembic_cfg, "head")
+        still_missing = _missing_canaries(engine)
+        if still_missing:
+            raise RuntimeError(
+                "Schema/Alembic self-heal failed — canaries still missing after baseline re-run: "
+                f"{[c['name'] for c in still_missing]}"
+            )
 
 
 def get_current_schema_revision(engine=None) -> str:

--- a/backend/tests/unit/test_database_bootstrap.py
+++ b/backend/tests/unit/test_database_bootstrap.py
@@ -1,0 +1,230 @@
+"""Tests for ``database._bootstrap_alembic`` (bd-fwpzw).
+
+The bootstrap is the only path that runs at every container start, so its
+correctness directly determines whether post-baseline migrations land on
+upgrade. This suite covers four shapes of journal.db a user can present at
+startup:
+
+1. Pre-Alembic install — user tables exist, ``alembic_version`` table missing
+   (the population that originally hit the bug). Bootstrap must stamp at the
+   baseline revision (NOT head) and then run ``upgrade head`` so 0002, 0003,
+   0004 land.
+
+2. Stamped-at-head-but-schema-at-baseline — the affected-user state created
+   by the original buggy bootstrap. ``upgrade head`` is a no-op for these
+   users; the self-heal canary check has to detect the divergence and
+   recover by re-stamping at baseline.
+
+3. Fresh install — empty DB, bootstrap must produce the full head schema.
+
+4. Already at head, healthy — bootstrap must be idempotent and not log the
+   self-heal error path.
+
+5. Pathological — canaries still missing after self-heal (mocked
+   ``command.upgrade`` no-op) must raise rather than silently continue.
+
+Each test uses a temp file-backed SQLite DB. Alembic operations need a real
+file URI (``ScriptDirectory`` + multi-statement transactions are unhappy
+against ``:memory:`` engines created independently).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import StaticPool
+
+import database
+
+
+def _make_engine(db_file: Path):
+    """Return a file-backed SQLite engine matching production settings."""
+    return create_engine(
+        f"sqlite:///{db_file}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+
+
+def _alembic_config(db_file: Path):
+    """Build an Alembic ``Config`` pointed at ``db_file``."""
+    from alembic.config import Config
+
+    cfg = Config(str(database.ALEMBIC_INI_PATH))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_file}")
+    return cfg
+
+
+def _build_pre_alembic_install(db_file: Path) -> None:
+    """Materialize a DB with the baseline schema but no ``alembic_version`` table.
+
+    Strategy: run ``alembic upgrade 0001`` to land the baseline DDL — that IS
+    the pre-Alembic schema by design — then drop the ``alembic_version``
+    table so the bootstrap path sees it as an unstamped legacy install.
+    """
+    from alembic import command
+
+    cfg = _alembic_config(db_file)
+    command.upgrade(cfg, "0001")
+
+    engine = _make_engine(db_file)
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("DROP TABLE alembic_version"))
+    finally:
+        engine.dispose()
+
+
+def _build_stamped_at_head_missing_columns(db_file: Path) -> None:
+    """Reproduce the affected-user state: stamped at head, schema at baseline.
+
+    The original buggy bootstrap stamped ``alembic_version`` at head while
+    leaving the physical schema at the baseline. ``upgrade head`` is then a
+    no-op and post-baseline migrations never apply.
+    """
+    from alembic import command
+
+    cfg = _alembic_config(db_file)
+    command.upgrade(cfg, "0001")
+
+    engine = _make_engine(db_file)
+    head = database.get_alembic_head_revision()
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text("UPDATE alembic_version SET version_num = :rev"),
+                {"rev": head},
+            )
+    finally:
+        engine.dispose()
+
+
+def _table_columns(engine, table: str) -> set[str]:
+    with engine.connect() as conn:
+        rows = conn.execute(text(f"PRAGMA table_info({table})")).fetchall()
+    return {row[1] for row in rows}
+
+
+def _table_indexes(engine, table: str) -> set[str]:
+    with engine.connect() as conn:
+        rows = conn.execute(text(f"PRAGMA index_list({table})")).fetchall()
+    return {row[1] for row in rows}
+
+
+def _alembic_version(engine) -> str:
+    with engine.connect() as conn:
+        row = conn.execute(text("SELECT version_num FROM alembic_version")).fetchone()
+    return row[0] if row else ""
+
+
+class TestBootstrapAlembic:
+    """End-to-end coverage for the four DB shapes ``init_db`` may encounter."""
+
+    def test_bootstrap_pre_alembic_install_runs_all_migrations(self, tmp_path):
+        """Pre-Alembic install: stamp at baseline, then upgrade head applies 0002-0004."""
+        db_file = tmp_path / "pre_alembic.db"
+        _build_pre_alembic_install(db_file)
+
+        engine = _make_engine(db_file)
+        try:
+            # Sanity: baseline column from 0002 must NOT yet be present.
+            assert "match_scope_target_group" not in _table_columns(engine, "auto_creation_rules")
+
+            database._bootstrap_alembic(engine)
+
+            head = database.get_alembic_head_revision()
+            assert _alembic_version(engine) == head, (
+                "alembic_version must be stamped at head after bootstrap"
+            )
+            assert "match_scope_target_group" in _table_columns(engine, "auto_creation_rules"), (
+                "Migration 0002 column missing — bootstrap stamped instead of upgrading"
+            )
+            assert "idx_journal_batch_id" in _table_indexes(engine, "journal_entries"), (
+                "Migration 0004 index missing — bootstrap stopped before head"
+            )
+        finally:
+            engine.dispose()
+
+    def test_bootstrap_self_heal_when_stamped_at_head_but_column_missing(self, tmp_path):
+        """Already-affected user: stamped-at-head with baseline schema must self-heal."""
+        db_file = tmp_path / "stamped_head.db"
+        _build_stamped_at_head_missing_columns(db_file)
+
+        engine = _make_engine(db_file)
+        try:
+            # Precondition: version is at head, but the canary column is absent.
+            assert _alembic_version(engine) == database.get_alembic_head_revision()
+            assert "match_scope_target_group" not in _table_columns(engine, "auto_creation_rules")
+
+            database._bootstrap_alembic(engine)
+
+            assert "match_scope_target_group" in _table_columns(engine, "auto_creation_rules"), (
+                "Self-heal did not recover the missing canary column"
+            )
+            assert "idx_journal_batch_id" in _table_indexes(engine, "journal_entries"), (
+                "Self-heal did not recover the missing canary index"
+            )
+            assert _alembic_version(engine) == database.get_alembic_head_revision()
+        finally:
+            engine.dispose()
+
+    def test_bootstrap_fresh_install_creates_full_schema(self, tmp_path):
+        """Empty DB: bootstrap must produce the full head schema."""
+        db_file = tmp_path / "fresh.db"
+        engine = _make_engine(db_file)
+        try:
+            database._bootstrap_alembic(engine)
+
+            head = database.get_alembic_head_revision()
+            assert _alembic_version(engine) == head
+            # Spot-check a baseline-era column plus both post-baseline canaries.
+            assert "name" in _table_columns(engine, "auto_creation_rules")
+            assert "match_scope_target_group" in _table_columns(engine, "auto_creation_rules")
+            assert "idx_journal_batch_id" in _table_indexes(engine, "journal_entries")
+        finally:
+            engine.dispose()
+
+    def test_bootstrap_already_at_head_is_idempotent(self, tmp_path):
+        """A healthy at-head DB must round-trip through bootstrap unchanged."""
+        from alembic import command
+
+        db_file = tmp_path / "at_head.db"
+        cfg = _alembic_config(db_file)
+        command.upgrade(cfg, "head")
+
+        engine = _make_engine(db_file)
+        try:
+            head = database.get_alembic_head_revision()
+            assert _alembic_version(engine) == head
+
+            database._bootstrap_alembic(engine)
+
+            assert _alembic_version(engine) == head
+            assert "match_scope_target_group" in _table_columns(engine, "auto_creation_rules")
+            assert "idx_journal_batch_id" in _table_indexes(engine, "journal_entries")
+        finally:
+            engine.dispose()
+
+    def test_bootstrap_self_heal_raises_if_canary_still_missing_after_recovery(self, tmp_path):
+        """If self-heal cannot restore the canaries, bootstrap must raise.
+
+        Simulate a pathological case where ``command.upgrade`` is wedged
+        (e.g. mounted-read-only versions dir, broken migration). The canary
+        check after the recovery attempt must fail loudly rather than let
+        the app start with an inconsistent schema.
+        """
+        db_file = tmp_path / "broken.db"
+        _build_stamped_at_head_missing_columns(db_file)
+
+        engine = _make_engine(db_file)
+        try:
+            # Make ``command.upgrade`` a no-op so the self-heal recovery
+            # cannot actually advance the schema.
+            with patch("alembic.command.upgrade", return_value=None):
+                with pytest.raises(RuntimeError, match="self-heal failed"):
+                    database._bootstrap_alembic(engine)
+        finally:
+            engine.dispose()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.16.0-0062",
+  "version": "0.16.0-0063",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- **P0 production fix.** Users with pre-Alembic-baseline DBs (anyone running ECM before ~2026-04-20) were stamped at HEAD by the original `_bootstrap_alembic`, which then silently skipped every post-baseline migration forever. In the wild: `no such column: auto_creation_rules.match_scope_target_group` 500s on Auto Creation, because migration `0002` never ran.
- **Bootstrap**: pre-Alembic install now stamps at the **baseline revision** (resolved dynamically via `ScriptDirectory.get_bases()[0]` — no hardcoded `"0001"`) and falls through to `upgrade head`, applying `0002`, `0003`, `0004`.
- **Self-heal for already-stuck users**: module-level `_BOOTSTRAP_CANARIES` (one column from `0002`, one index from `0004`) probed after `upgrade head`. If a canary is missing, `alembic_version` is forced back to baseline via raw `UPDATE` and `upgrade head` re-runs. If canaries are still missing post-recovery, raises `RuntimeError` so divergence surfaces instead of silently shipping a broken DB.
- Bumps dev version to `0.16.0-0063` — the trigger for affected installs to pull the new container image.

## Test plan
- [x] 5 new tests in `backend/tests/unit/test_database_bootstrap.py` covering: pre-Alembic install, self-heal-from-stamped-at-head, fresh install, idempotent at head, self-heal raises if recovery still fails
- [x] Full backend suite: **3191 passed** (engineer's run)
- [x] Sidecar SQLite smoke against the real Alembic config — all three states (pre-Alembic, stamped-at-head + missing column, healthy at-head) behave as designed

## Recovery path (no longer needed for users on 0.16.0-0063+)
For anyone on an older image awaiting the fix, the manual workaround remains:
```bash
docker exec <container> sqlite3 /config/journal.db "UPDATE alembic_version SET version_num='0001';"
docker restart <container>
```

## Closes
`bd-fwpzw`

🤖 Generated with [Claude Code](https://claude.com/claude-code)