### PR TITLE
refactor(settings): SMTP recipients — useState + extract pure helpers (bd-uomm7 + bd-cp14f)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.16.0-0066",
+  "version": "0.16.0-0067",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -15,6 +15,7 @@ import { useAuth } from '../../hooks/useAuth';
 import type { ChannelProfile, M3UDigestSettings, M3UDigestFrequency } from '../../types';
 import { logger } from '../../utils/logger';
 import { copyToClipboard } from '../../utils/clipboard';
+import { normalizeSmtpRecipientsPaste, parseSmtpRecipients } from '../../utils/smtpRecipients';
 import type { LogLevel as FrontendLogLevel } from '../../utils/logger';
 import { DeleteOrphanedGroupsModal } from '../DeleteOrphanedGroupsModal';
 import { ScheduledTasksSection } from '../ScheduledTasksSection';
@@ -428,46 +429,13 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
   const [smtpAlertRecipientsError, setSmtpAlertRecipientsError] = useState<string | null>(null);
   const [smtpAlertRecipientsLastSavedAt, setSmtpAlertRecipientsLastSavedAt] = useState<Date | null>(null);
   const [smtpAlertRecipientsFlashState, setSmtpAlertRecipientsFlashState] = useState<'success' | null>(null);
-  const smtpAlertRecipientsPersistedRef = useRef<{ methodId: number | null; recipients: string }>({
+  const [smtpAlertRecipientsPersisted, setSmtpAlertRecipientsPersisted] = useState<{
+    methodId: number | null;
+    recipients: string;
+  }>({
     methodId: null,
     recipients: '',
   });
-
-  const isValidHtml5EmailAddress = (value: string): boolean => {
-    // HTML Standard's "valid email address" (pragmatic RFC 5322 intent).
-    // See: WHATWG HTML - valid-email-address production.
-    const re =
-      /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
-    return re.test(value);
-  };
-
-  const parseSmtpRecipients = (raw: string): { recipients: string[]; normalized: string; invalid?: string; dedupedCount: number } => {
-    const parts = raw
-      .split(',')
-      .map(s => s.trim())
-      .filter(Boolean);
-
-    for (const token of parts) {
-      if (!isValidHtml5EmailAddress(token)) {
-        return { recipients: [], normalized: raw, invalid: token, dedupedCount: 0 };
-      }
-    }
-
-    const seen = new Set<string>();
-    const deduped: string[] = [];
-    let dedupedCount = 0;
-    for (const token of parts) {
-      const key = token.toLowerCase();
-      if (seen.has(key)) {
-        dedupedCount += 1;
-        continue;
-      }
-      seen.add(key);
-      deduped.push(token);
-    }
-
-    return { recipients: deduped, normalized: deduped.join(', '), dedupedCount };
-  };
 
   // Shared Discord settings
   const [discordWebhookUrl, setDiscordWebhookUrl] = useState('');
@@ -877,11 +845,11 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
           const recipients = extractToEmails(smtpMethod.config);
           const persisted = recipients ?? '';
           setSmtpAlertRecipients(persisted);
-          smtpAlertRecipientsPersistedRef.current = { methodId: smtpMethod.id, recipients: persisted };
+          setSmtpAlertRecipientsPersisted({ methodId: smtpMethod.id, recipients: persisted });
         } else {
           setSmtpAlertMethodId(null);
           setSmtpAlertRecipients('');
-          smtpAlertRecipientsPersistedRef.current = { methodId: null, recipients: '' };
+          setSmtpAlertRecipientsPersisted({ methodId: null, recipients: '' });
         }
       } catch (err) {
         logger.warn('Failed to load alert methods (SMTP recipients)', err);
@@ -932,12 +900,12 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
           notify_error: true,
         });
         setSmtpAlertMethodId(created.id);
-        smtpAlertRecipientsPersistedRef.current = { methodId: created.id, recipients: parsed.normalized };
+        setSmtpAlertRecipientsPersisted({ methodId: created.id, recipients: parsed.normalized });
       }
 
       setSmtpAlertRecipients(parsed.normalized);
       if (smtpAlertMethodId) {
-        smtpAlertRecipientsPersistedRef.current = { methodId: smtpAlertMethodId, recipients: parsed.normalized };
+        setSmtpAlertRecipientsPersisted({ methodId: smtpAlertMethodId, recipients: parsed.normalized });
       }
 
       if (parsed.dedupedCount > 0) {
@@ -2932,9 +2900,9 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
           <span className="material-icons">alternate_email</span>
           <h3>Email Alert Recipients</h3>
           <span
-            className={`badge badge-sm ${(smtpAlertRecipientsPersistedRef.current.methodId && smtpAlertRecipientsPersistedRef.current.recipients.trim()) ? 'badge-success' : ''}`}
+            className={`badge badge-sm ${(smtpAlertRecipientsPersisted.methodId && smtpAlertRecipientsPersisted.recipients.trim()) ? 'badge-success' : ''}`}
           >
-            {(smtpAlertRecipientsPersistedRef.current.methodId && smtpAlertRecipientsPersistedRef.current.recipients.trim()) ? 'Configured' : 'Unconfigured'}
+            {(smtpAlertRecipientsPersisted.methodId && smtpAlertRecipientsPersisted.recipients.trim()) ? 'Configured' : 'Unconfigured'}
           </span>
           {smtpAlertRecipientsLastSavedAt && (
             <span className="settings-saved-at">
@@ -2945,7 +2913,7 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
         <p className="section-description">
           Scheduled tasks use the Email alert channel to send notifications. Add one or more recipient email addresses here.
         </p>
-        {!smtpAlertRecipientsPersistedRef.current.methodId && !smtpAlertRecipientsPersistedRef.current.recipients.trim() && (
+        {!smtpAlertRecipientsPersisted.methodId && !smtpAlertRecipientsPersisted.recipients.trim() && (
           <p className="settings-empty-state">
             No recipients configured. Scheduled task email alerts won&apos;t be delivered until you add at least one recipient.
           </p>
@@ -2963,9 +2931,9 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
               onBlur={handleBlurSmtpRecipients}
               onPaste={(e) => {
                 const text = e.clipboardData.getData('text');
-                if (/[;\n\r]/.test(text)) {
+                const { needsRewrite, normalized } = normalizeSmtpRecipientsPaste(text);
+                if (needsRewrite) {
                   e.preventDefault();
-                  const normalized = text.replace(/[;\n\r]+/g, ', ');
                   const el = e.currentTarget;
                   const start = el.selectionStart ?? el.value.length;
                   const end = el.selectionEnd ?? el.value.length;

--- a/frontend/src/utils/smtpRecipients.test.ts
+++ b/frontend/src/utils/smtpRecipients.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for the SMTP recipient parsing helpers extracted from
+ * SettingsTab.tsx (bd-cp14f). These pin down the validation, dedup, and
+ * paste-normalization rules introduced in PR #163.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  isValidHtml5EmailAddress,
+  normalizeSmtpRecipientsPaste,
+  parseSmtpRecipients,
+} from './smtpRecipients';
+
+// ---------------------------------------------------------------------------
+// isValidHtml5EmailAddress
+// ---------------------------------------------------------------------------
+describe('isValidHtml5EmailAddress', () => {
+  it('accepts a plain address', () => {
+    expect(isValidHtml5EmailAddress('alice@example.com')).toBe(true);
+  });
+
+  it('accepts a plus-tag address', () => {
+    expect(isValidHtml5EmailAddress('alice+tag@x.co')).toBe(true);
+  });
+
+  it('rejects an address without an @', () => {
+    expect(isValidHtml5EmailAddress('not-an-email')).toBe(false);
+  });
+
+  it('rejects an address with embedded CRLF (header-injection guard)', () => {
+    expect(isValidHtml5EmailAddress('alice@x.co\r\nBcc:x')).toBe(false);
+  });
+
+  it('rejects an address with an embedded LF', () => {
+    expect(isValidHtml5EmailAddress('alice@x.co\nBcc:x')).toBe(false);
+  });
+
+  it('rejects the empty string', () => {
+    expect(isValidHtml5EmailAddress('')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSmtpRecipients
+// ---------------------------------------------------------------------------
+describe('parseSmtpRecipients', () => {
+  it('parses a single valid address', () => {
+    const result = parseSmtpRecipients('alice@example.com');
+    expect(result.recipients).toEqual(['alice@example.com']);
+    expect(result.normalized).toBe('alice@example.com');
+    expect(result.invalid).toBeUndefined();
+    expect(result.dedupedCount).toBe(0);
+  });
+
+  it('accepts a plus-tag address', () => {
+    const result = parseSmtpRecipients('alice+tag@x.co');
+    expect(result.recipients).toEqual(['alice+tag@x.co']);
+    expect(result.invalid).toBeUndefined();
+  });
+
+  it('flags the first invalid token and returns the raw input', () => {
+    const result = parseSmtpRecipients('not-an-email');
+    expect(result.recipients).toEqual([]);
+    expect(result.invalid).toBe('not-an-email');
+    expect(result.normalized).toBe('not-an-email');
+    expect(result.dedupedCount).toBe(0);
+  });
+
+  it('rejects header-injection payloads via CRLF in a token', () => {
+    const result = parseSmtpRecipients('alice@x.co\r\nBcc:x');
+    expect(result.recipients).toEqual([]);
+    expect(result.invalid).toBe('alice@x.co\r\nBcc:x');
+  });
+
+  it('dedupes case-insensitively, preserving first-seen casing', () => {
+    const result = parseSmtpRecipients('A@x.co, a@x.co');
+    expect(result.recipients).toEqual(['A@x.co']);
+    expect(result.normalized).toBe('A@x.co');
+    expect(result.dedupedCount).toBe(1);
+  });
+
+  it('counts each duplicate in dedupedCount', () => {
+    const result = parseSmtpRecipients('a@x.co, A@x.co, b@x.co, B@x.co');
+    expect(result.recipients).toEqual(['a@x.co', 'b@x.co']);
+    expect(result.dedupedCount).toBe(2);
+  });
+
+  it('returns empty for empty input', () => {
+    const result = parseSmtpRecipients('');
+    expect(result.recipients).toEqual([]);
+    expect(result.normalized).toBe('');
+    expect(result.invalid).toBeUndefined();
+    expect(result.dedupedCount).toBe(0);
+  });
+
+  it('returns empty for whitespace-only input', () => {
+    const result = parseSmtpRecipients('   ,  , ');
+    expect(result.recipients).toEqual([]);
+    expect(result.normalized).toBe('');
+    expect(result.invalid).toBeUndefined();
+    expect(result.dedupedCount).toBe(0);
+  });
+
+  it('trims whitespace around tokens', () => {
+    const result = parseSmtpRecipients('  alice@x.co ,  bob@x.co  ');
+    expect(result.recipients).toEqual(['alice@x.co', 'bob@x.co']);
+    expect(result.normalized).toBe('alice@x.co, bob@x.co');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeSmtpRecipientsPaste
+// ---------------------------------------------------------------------------
+describe('normalizeSmtpRecipientsPaste', () => {
+  it('passes through commas-only input untouched', () => {
+    const result = normalizeSmtpRecipientsPaste('alice@x.co, bob@x.co');
+    expect(result.needsRewrite).toBe(false);
+    expect(result.normalized).toBe('alice@x.co, bob@x.co');
+  });
+
+  it('rewrites semicolon separators to ", "', () => {
+    const result = normalizeSmtpRecipientsPaste('alice@x.co;bob@x.co');
+    expect(result.needsRewrite).toBe(true);
+    expect(result.normalized).toBe('alice@x.co, bob@x.co');
+  });
+
+  it('rewrites newline separators to ", "', () => {
+    const result = normalizeSmtpRecipientsPaste('alice@x.co\nbob@x.co');
+    expect(result.needsRewrite).toBe(true);
+    expect(result.normalized).toBe('alice@x.co, bob@x.co');
+  });
+
+  it('rewrites mixed ";"/"\\n"/"\\r" separators in one pass', () => {
+    const result = normalizeSmtpRecipientsPaste('alice@x.co;bob@x.co\r\ncarol@x.co');
+    expect(result.needsRewrite).toBe(true);
+    expect(result.normalized).toBe('alice@x.co, bob@x.co, carol@x.co');
+  });
+
+  it('collapses runs of separators into a single ", "', () => {
+    const result = normalizeSmtpRecipientsPaste('alice@x.co;;\n\nbob@x.co');
+    expect(result.needsRewrite).toBe(true);
+    expect(result.normalized).toBe('alice@x.co, bob@x.co');
+  });
+
+  it('flags rewrite for an empty string only when separators are present', () => {
+    const result = normalizeSmtpRecipientsPaste('');
+    expect(result.needsRewrite).toBe(false);
+    expect(result.normalized).toBe('');
+  });
+});

--- a/frontend/src/utils/smtpRecipients.ts
+++ b/frontend/src/utils/smtpRecipients.ts
@@ -1,0 +1,91 @@
+/**
+ * SMTP alert recipient parsing helpers.
+ *
+ * Extracted from SettingsTab.tsx so the parsing/validation/dedup/normalization
+ * rules are unit-testable in isolation. Behavior must match what shipped in
+ * PR #163 — this module is purely a relocation, not a behavior change.
+ */
+
+/**
+ * Result of parsing a raw recipient string.
+ *
+ * - `recipients` — deduplicated, validated email addresses in input order
+ * - `normalized` — recipients joined as `", "` (or the raw input on the invalid path)
+ * - `invalid` — the first token that failed validation (undefined when all valid)
+ * - `dedupedCount` — number of duplicate tokens removed (case-insensitive)
+ */
+export interface ParsedSmtpRecipients {
+  recipients: string[];
+  normalized: string;
+  invalid?: string;
+  dedupedCount: number;
+}
+
+/**
+ * Match the HTML Standard's "valid email address" production (a pragmatic
+ * subset of RFC 5322). The local part rejects CR/LF and other control
+ * characters by construction, which guards against header-injection style
+ * payloads such as `alice@x.co\r\nBcc: x`.
+ *
+ * See: WHATWG HTML — valid-email-address production.
+ */
+export function isValidHtml5EmailAddress(value: string): boolean {
+  const re =
+    /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+  return re.test(value);
+}
+
+/**
+ * Parse a comma-separated recipient string into a deduplicated, validated list.
+ *
+ * On the first invalid token the function short-circuits and returns
+ * `{ recipients: [], normalized: raw, invalid, dedupedCount: 0 }` so the
+ * caller can surface a precise validation error.
+ */
+export function parseSmtpRecipients(raw: string): ParsedSmtpRecipients {
+  const parts = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  for (const token of parts) {
+    if (!isValidHtml5EmailAddress(token)) {
+      return { recipients: [], normalized: raw, invalid: token, dedupedCount: 0 };
+    }
+  }
+
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  let dedupedCount = 0;
+  for (const token of parts) {
+    const key = token.toLowerCase();
+    if (seen.has(key)) {
+      dedupedCount += 1;
+      continue;
+    }
+    seen.add(key);
+    deduped.push(token);
+  }
+
+  return { recipients: deduped, normalized: deduped.join(', '), dedupedCount };
+}
+
+/**
+ * Normalize a clipboard payload that uses `;`, `\n`, or `\r` as separators
+ * into the comma-separated form `parseSmtpRecipients` understands. Returns
+ * the input unchanged when no separators of interest are present so callers
+ * can defer to the input's default paste behavior.
+ *
+ * Returns:
+ *   - `needsRewrite: true` when the input contains `;`, `\n`, or `\r`
+ *   - `normalized` — the rewritten string (only meaningful when `needsRewrite`)
+ */
+export function normalizeSmtpRecipientsPaste(text: string): {
+  needsRewrite: boolean;
+  normalized: string;
+} {
+  if (!/[;\n\r]/.test(text)) {
+    return { needsRewrite: false, normalized: text };
+  }
+  return { needsRewrite: true, normalized: text.replace(/[;\n\r]+/g, ', ') };
+}


### PR DESCRIPTION
## Summary
PR #163 round-2 follow-ups, both bundled because both touch `SettingsTab.tsx`.

- **`bd-uomm7`** — Convert `smtpAlertRecipientsPersistedRef` from `useRef` to `useState`. The ref was read in JSX at the Configured/Unconfigured badge and empty-state hint, but refs don't trigger re-render — the badge could go stale until an unrelated state change forced a render. Flagged independently by UX, CR, and Engineer in the PR #163 round-2 review.
- **`bd-cp14f`** — Extract `parseSmtpRecipients`, `isValidHtml5EmailAddress`, and the `onPaste` normalizer from `SettingsTab.tsx` into `frontend/src/utils/smtpRecipients.ts` + sibling test file. 21 unit tests cover validation, dedup, paste normalization, header-injection guard, plus-tag.
- Util location: `frontend/src/utils/` (matches the pattern of other pure helpers — templateEngine, naturalSort, etc.).
- Behavior is verbatim relocation; SettingsTab.tsx now imports the helpers.
- Bumps dev version to `0.16.0-0067`.

## Test plan
- [x] 21 new tests in `smtpRecipients.test.ts`
- [x] Full frontend suite: 1231 passed (54 files)
- [x] `tsc --noEmit` + `eslint` clean
- [x] Smoke-tested in `ecm-ecm-1` after deploy

## Closes
`bd-uomm7`, `bd-cp14f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)