### PR TITLE
feat(alert-methods): canonicalize to_emails + server validation + API docs (bd-9vz32, bd-8rd5m, bd-6e8gv)

### DIFF
--- a/backend/alert_methods_smtp.py
+++ b/backend/alert_methods_smtp.py
@@ -6,16 +6,51 @@ This alert method only configures recipients and alert filters - SMTP server
 configuration is centralized in Settings > Email Settings.
 """
 import logging
+import re
 import smtplib
 import ssl
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
-from typing import List
+from typing import Any, Dict, List, Tuple
 
 from alert_methods import AlertMethod, AlertMessage, register_method
 from config import get_settings
 
 logger = logging.getLogger(__name__)
+
+# HTML5-style email regex — copied verbatim from
+# frontend/src/components/tabs/SettingsTab.tsx (`isValidHtml5EmailAddress`)
+# so server-side and client-side validation accept the same set. When the
+# frontend regex is extracted into `frontend/src/utils/smtpRecipients.ts`
+# (bd-cp14f), that file is the source-of-truth — keep this constant in sync
+# manually rather than importing across the JS/Python boundary.
+_HTML5_EMAIL_REGEX = re.compile(
+    r"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+"
+    r"@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
+    r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
+)
+
+# Characters that must never appear in an email recipient token. CR/LF would
+# enable header injection if a future code path used to_emails inside a header
+# without sanitization; angle brackets and colons are header-structure
+# delimiters per RFC 5322. Python's stdlib (`email.generator`, `smtplib`)
+# already rejects CR/LF in headers — this defends the property at the sink.
+_FORBIDDEN_EMAIL_CHARS = ("\r", "\n", "<", ">", ":")
+
+
+def _coerce_to_emails_to_list(value: Any) -> List[str]:
+    """Normalize a to_emails value to a list of trimmed, non-empty strings.
+
+    Accepts both the canonical `list[str]` shape and the legacy comma-joined
+    `str` shape (kept for backward-compat reads of pre-bd-9vz32 rows).
+    Anything else returns an empty list — the caller is expected to treat
+    that as "no recipients configured" and surface an error.
+    """
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [token.strip() for token in value.split(",") if token.strip()]
+    return []
 
 
 @register_method
@@ -36,6 +71,42 @@ class SMTPMethod(AlertMethod):
         "warning": "[WARNING]",
         "error": "[ERROR]",
     }
+
+    @classmethod
+    def validate_config(cls, config: Dict[str, Any]) -> Tuple[bool, str]:
+        """Validate SMTP method config.
+
+        Extends the base presence check with token-shape and per-recipient
+        validation. Defense-in-depth (bd-6e8gv): rejects header-control
+        characters (CR/LF), header-structure delimiters (<, >, :), and any
+        token that fails the HTML5 email regex. No active exploit path today
+        — admin-authenticated input plus stdlib `smtplib`/`email.generator`
+        already reject CR/LF in headers — but this closes the property at
+        the sink rather than depending on incidental defenses.
+        """
+        is_valid, error = super().validate_config(config)
+        if not is_valid:
+            return is_valid, error
+
+        raw = config.get("to_emails")
+        # Accept both list[str] (canonical) and comma-joined str (legacy).
+        # Anything else (dict, int, None-after-presence-check) is a shape error.
+        if not isinstance(raw, (list, str)):
+            return False, "to_emails must be a list of email addresses"
+
+        tokens = _coerce_to_emails_to_list(raw)
+        if not tokens:
+            return False, "to_emails must contain at least one email address"
+
+        for token in tokens:
+            for forbidden in _FORBIDDEN_EMAIL_CHARS:
+                if forbidden in token:
+                    label = {"\r": "CR", "\n": "LF"}.get(forbidden, forbidden)
+                    return False, f"to_emails entry contains forbidden character ({label}): {token!r}"
+            if not _HTML5_EMAIL_REGEX.match(token):
+                return False, f"to_emails entry is not a valid email address: {token!r}"
+
+        return True, ""
 
     def _get_smtp_config(self) -> dict | None:
         """Get shared SMTP configuration from settings."""
@@ -142,18 +213,11 @@ class SMTPMethod(AlertMethod):
         from_email = smtp_config["from_email"]
         from_name = smtp_config["from_name"]
 
-        # Get recipients from this alert method's config
-        to_emails = self.config.get("to_emails")
+        # Canonical shape is list[str] (bd-9vz32). Legacy rows persisted as a
+        # comma-joined str continue to read correctly via the coerce helper.
+        to_emails = _coerce_to_emails_to_list(self.config.get("to_emails"))
 
         logger.debug("[ALERTS-SMTP] SMTP method %s: Using shared SMTP, recipients configured", self.name)
-
-        if not to_emails:
-            logger.error("[ALERTS-SMTP] SMTP method %s: No recipients configured", self.name)
-            return False
-
-        # Parse to_emails if it's a string
-        if isinstance(to_emails, str):
-            to_emails = [e.strip() for e in to_emails.split(",") if e.strip()]
 
         if not to_emails:
             logger.error("[ALERTS-SMTP] SMTP method %s: No recipients configured", self.name)
@@ -219,14 +283,8 @@ class SMTPMethod(AlertMethod):
         if not smtp_config:
             return False, "Shared SMTP not configured. Configure in Settings > Email Settings first."
 
-        to_emails = self.config.get("to_emails")
-        if not to_emails:
-            return False, "No recipient email addresses configured"
-
-        # Parse to_emails if it's a string
-        if isinstance(to_emails, str):
-            to_emails = [e.strip() for e in to_emails.split(",") if e.strip()]
-
+        # Canonical shape is list[str] (bd-9vz32); legacy str rows still read.
+        to_emails = _coerce_to_emails_to_list(self.config.get("to_emails"))
         if not to_emails:
             return False, "No recipient email addresses configured"
 
@@ -297,14 +355,8 @@ class SMTPMethod(AlertMethod):
         from_email = smtp_config["from_email"]
         from_name = smtp_config["from_name"]
 
-        to_emails = self.config.get("to_emails")
-        if not to_emails:
-            logger.error("[ALERTS-SMTP] SMTP method %s: No recipients configured", self.name)
-            return False
-
-        if isinstance(to_emails, str):
-            to_emails = [e.strip() for e in to_emails.split(",") if e.strip()]
-
+        # Canonical shape is list[str] (bd-9vz32); legacy str rows still read.
+        to_emails = _coerce_to_emails_to_list(self.config.get("to_emails"))
         if not to_emails:
             logger.error("[ALERTS-SMTP] SMTP method %s: No recipients configured", self.name)
             return False

--- a/backend/alert_methods_smtp.py
+++ b/backend/alert_methods_smtp.py
@@ -6,13 +6,13 @@ This alert method only configures recipients and alert filters - SMTP server
 configuration is centralized in Settings > Email Settings.
 """
 import logging
-import re
 import smtplib
 import ssl
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from typing import Any, Dict, List, Tuple
 
+import safe_regex  # bd-eio04.x: ReDoS-guarded wrapper for stdlib re
 from alert_methods import AlertMethod, AlertMessage, register_method
 from config import get_settings
 
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 # frontend regex is extracted into `frontend/src/utils/smtpRecipients.ts`
 # (bd-cp14f), that file is the source-of-truth — keep this constant in sync
 # manually rather than importing across the JS/Python boundary.
-_HTML5_EMAIL_REGEX = re.compile(
+_HTML5_EMAIL_REGEX = safe_regex.compile(
     r"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+"
     r"@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
     r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"

--- a/backend/routers/alert_methods.py
+++ b/backend/routers/alert_methods.py
@@ -42,6 +42,34 @@ class AlertMethodUpdate(BaseModel):
     alert_sources: Optional[dict] = None  # Granular source filtering
 
 
+def _normalize_smtp_config_for_persist(method_type: str, config: dict) -> dict:
+    """Canonicalize SMTP `to_emails` to `list[str]` before persistence (bd-9vz32).
+
+    The frontend has historically sent `to_emails` as either a comma-joined
+    string or a list. We persist as JSON via `json.dumps`, so the shape
+    round-trips unchanged — which means callers reading back have to
+    disambiguate. Decision (bd-9vz32): canonicalize on write to `list[str]`
+    so reads are typed and parse-free. Legacy string rows still load via
+    the SMTPMethod coerce helper, so this is a write-strict / read-tolerant
+    pattern (no Alembic migration needed for the JSON-blob field).
+    """
+    if method_type != "smtp" or not isinstance(config, dict):
+        return config
+    raw = config.get("to_emails")
+    if isinstance(raw, str):
+        normalized = [token.strip() for token in raw.split(",") if token.strip()]
+        # Return a shallow copy — config came from Pydantic and shouldn't be
+        # mutated for the caller.
+        config = {**config, "to_emails": normalized}
+    elif isinstance(raw, list):
+        # Re-strip and drop empties so list-shape input also lands cleanly.
+        config = {
+            **config,
+            "to_emails": [str(item).strip() for item in raw if str(item).strip()],
+        }
+    return config
+
+
 def validate_alert_sources(alert_sources: Optional[dict]) -> Optional[str]:
     """Validate alert_sources structure. Returns error message or None if valid."""
     if alert_sources is None:
@@ -150,10 +178,15 @@ async def create_alert_method(data: AlertMethodCreate):
             logger.warning("[ALERTS] Unknown method type attempted: %s", data.method_type)
             raise HTTPException(status_code=400, detail=f"Unknown method type: {data.method_type}")
 
+        # Canonicalize SMTP to_emails to list[str] before validation/persistence (bd-9vz32).
+        # Legacy comma-joined string input is normalized at the API boundary so all
+        # downstream readers see a single shape.
+        config = _normalize_smtp_config_for_persist(data.method_type, data.config)
+
         # Validate config
-        method = create_method(data.method_type, 0, data.name, data.config)
+        method = create_method(data.method_type, 0, data.name, config)
         if method:
-            is_valid, error = method.validate_config(data.config)
+            is_valid, error = method.validate_config(config)
             if not is_valid:
                 logger.warning("[ALERTS] Invalid config for method %s: %s", data.name, error)
                 raise HTTPException(status_code=400, detail=error)
@@ -169,7 +202,7 @@ async def create_alert_method(data: AlertMethodCreate):
         method_model = AlertMethodModel(
             name=data.name,
             method_type=data.method_type,
-            config=json.dumps(data.config),
+            config=json.dumps(config),
             enabled=data.enabled,
             notify_info=data.notify_info,
             notify_success=data.notify_success,
@@ -266,14 +299,16 @@ async def update_alert_method(method_id: int, data: AlertMethodUpdate):
         if data.name is not None:
             method.name = data.name
         if data.config is not None:
+            # Canonicalize SMTP to_emails to list[str] before validation/persistence (bd-9vz32).
+            new_config = _normalize_smtp_config_for_persist(method.method_type, data.config)
             # Validate new config
-            method_instance = create_method(method.method_type, method.id, method.name, data.config)
+            method_instance = create_method(method.method_type, method.id, method.name, new_config)
             if method_instance:
-                is_valid, error = method_instance.validate_config(data.config)
+                is_valid, error = method_instance.validate_config(new_config)
                 if not is_valid:
                     logger.warning("[ALERTS] Invalid config for method %s: %s", method_id, error)
                     raise HTTPException(status_code=400, detail=error)
-            method.config = json.dumps(data.config)
+            method.config = json.dumps(new_config)
         if data.enabled is not None:
             method.enabled = data.enabled
         if data.notify_info is not None:

--- a/backend/tests/routers/test_alert_methods.py
+++ b/backend/tests/routers/test_alert_methods.py
@@ -275,6 +275,236 @@ class TestDeleteAlertMethod:
         assert response.status_code == 404
 
 
+class TestSMTPToEmailsCanonicalization:
+    """Tests for SMTP to_emails canonicalization on POST/PATCH (bd-9vz32)."""
+
+    @pytest.mark.asyncio
+    async def test_post_persists_list_input_as_list(self, async_client, test_session):
+        """POST with list to_emails persists canonical list shape."""
+        from models import AlertMethod as AlertMethodModel
+
+        response = await async_client.post(
+            "/api/alert-methods",
+            json={
+                "name": "Email Alerts",
+                "method_type": "smtp",
+                "config": {"to_emails": ["alice@example.com", "bob@example.com"]},
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        # Read the row back from the DB and confirm canonical shape persisted.
+        row = test_session.query(AlertMethodModel).filter_by(id=data["id"]).one()
+        persisted = json.loads(row.config)
+        assert isinstance(persisted["to_emails"], list)
+        assert persisted["to_emails"] == ["alice@example.com", "bob@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_post_normalizes_string_input_to_list(self, async_client, test_session):
+        """POST with comma-joined string to_emails normalizes to list shape."""
+        from models import AlertMethod as AlertMethodModel
+
+        response = await async_client.post(
+            "/api/alert-methods",
+            json={
+                "name": "Email Alerts",
+                "method_type": "smtp",
+                "config": {"to_emails": "alice@example.com, bob@example.com"},
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        row = test_session.query(AlertMethodModel).filter_by(id=data["id"]).one()
+        persisted = json.loads(row.config)
+        assert isinstance(persisted["to_emails"], list)
+        assert persisted["to_emails"] == ["alice@example.com", "bob@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_patch_normalizes_string_input_to_list(self, async_client, test_session):
+        """PATCH with string to_emails normalizes to canonical list shape."""
+        method = _create_alert_method(
+            test_session,
+            name="Email",
+            method_type="smtp",
+            config=json.dumps({"to_emails": ["old@example.com"]}),
+        )
+        mock_manager = MagicMock()
+
+        with patch("routers.alert_methods.get_alert_manager", return_value=mock_manager):
+            response = await async_client.patch(
+                f"/api/alert-methods/{method.id}",
+                json={"config": {"to_emails": "new1@example.com,new2@example.com"}},
+            )
+
+        assert response.status_code == 200
+        test_session.refresh(method)
+        persisted = json.loads(method.config)
+        assert persisted["to_emails"] == ["new1@example.com", "new2@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_round_trip_preserves_list_shape(self, async_client, test_session):
+        """List input round-trips back through GET as a list."""
+        post_response = await async_client.post(
+            "/api/alert-methods",
+            json={
+                "name": "Email Alerts",
+                "method_type": "smtp",
+                "config": {"to_emails": ["alice@example.com"]},
+            },
+        )
+        method_id = post_response.json()["id"]
+
+        get_response = await async_client.get(f"/api/alert-methods/{method_id}")
+        assert get_response.status_code == 200
+        config = get_response.json()["config"]
+        assert isinstance(config["to_emails"], list)
+        assert config["to_emails"] == ["alice@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_legacy_string_row_reads_as_string(self, async_client, test_session):
+        """Existing rows persisted as a string still load successfully (read-tolerant)."""
+        # Simulate a pre-bd-9vz32 row whose config was persisted with a string.
+        method = _create_alert_method(
+            test_session,
+            name="Legacy SMTP",
+            method_type="smtp",
+            config=json.dumps({"to_emails": "old@example.com"}),
+        )
+
+        response = await async_client.get(f"/api/alert-methods/{method.id}")
+        assert response.status_code == 200
+        # Read returns whatever was stored — legacy rows still expose a string.
+        # The SMTP runtime path handles this via _coerce_to_emails_to_list.
+        config = response.json()["config"]
+        assert config["to_emails"] == "old@example.com"
+
+
+class TestSMTPValidateConfig:
+    """Tests for SMTPMethod.validate_config defense-in-depth (bd-6e8gv)."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_token_with_carriage_return(self, async_client):
+        """POST with CR in to_emails entry returns 400."""
+        response = await async_client.post(
+            "/api/alert-methods",
+            json={
+                "name": "Bad Email",
+                "method_type": "smtp",
+                "config": {"to_emails": ["alice@example.com\rinjected"]},
+            },
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_token_with_line_feed(self, async_client):
+        """POST with LF in to_emails entry returns 400."""
+        response = await async_client.post(
+            "/api/alert-methods",
+            json={
+                "name": "Bad Email",
+                "method_type": "smtp",
+                "config": {"to_emails": ["alice@example.com\nBcc: attacker@evil.com"]},
+            },
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_token_with_angle_bracket(self, async_client):
+        """POST with < in to_emails entry returns 400."""
+        response = await async_client.post(
+            "/api/alert-methods",
+            json={
+                "name": "Bad Email",
+                "method_type": "smtp",
+                "config": {"to_emails": ["<alice@example.com>"]},
+            },
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_email_format(self, async_client):
+        """POST with malformed email address returns 400."""
+        response = await async_client.post(
+            "/api/alert-methods",
+            json={
+                "name": "Bad Email",
+                "method_type": "smtp",
+                "config": {"to_emails": ["not-an-email"]},
+            },
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_accepts_valid_plus_addressed_email(self, async_client):
+        """POST with valid `+tag` plus-addressed email is accepted."""
+        response = await async_client.post(
+            "/api/alert-methods",
+            json={
+                "name": "Plus Addr",
+                "method_type": "smtp",
+                "config": {"to_emails": ["alice+tag@x.co"]},
+            },
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_accepts_legacy_string_input(self, async_client):
+        """POST with legacy comma-joined string is accepted and validated per token."""
+        response = await async_client.post(
+            "/api/alert-methods",
+            json={
+                "name": "Legacy",
+                "method_type": "smtp",
+                "config": {"to_emails": "alice@example.com, bob@example.com"},
+            },
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_rejects_legacy_string_with_invalid_token(self, async_client):
+        """POST with legacy string containing a bad token returns 400."""
+        response = await async_client.post(
+            "/api/alert-methods",
+            json={
+                "name": "Bad Legacy",
+                "method_type": "smtp",
+                "config": {"to_emails": "alice@example.com, not-an-email"},
+            },
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_list(self, async_client):
+        """POST with an empty list returns 400 (presence-check fails first)."""
+        response = await async_client.post(
+            "/api/alert-methods",
+            json={
+                "name": "Empty",
+                "method_type": "smtp",
+                "config": {"to_emails": []},
+            },
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_patch_validates_new_config(self, async_client, test_session):
+        """PATCH with malformed token rejects with 400."""
+        method = _create_alert_method(
+            test_session,
+            name="Email",
+            method_type="smtp",
+            config=json.dumps({"to_emails": ["good@example.com"]}),
+        )
+
+        response = await async_client.patch(
+            f"/api/alert-methods/{method.id}",
+            json={"config": {"to_emails": ["alice@example.com\rinjected"]}},
+        )
+        assert response.status_code == 400
+
+
 class TestTestAlertMethod:
     """Tests for POST /api/alert-methods/{method_id}/test."""
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -303,6 +303,72 @@ See [`docs/normalization.md` §Re-normalize existing channels](normalization.md#
 | `DELETE /api/alert-methods/{id}` | Delete alert method |
 | `POST /api/alert-methods/{id}/test` | Send test notification |
 
+An **alert method** is one configured channel (Discord webhook, Telegram bot, SMTP recipient list) that ECM uses to notify operators about scheduled-task results, probe failures, M3U/EPG refresh outcomes, and other system events. Each method carries its own per-type `config` blob, four per-severity opt-in flags (`notify_info`, `notify_success`, `notify_warning`, `notify_error`), and an optional granular `alert_sources` filter for per-EPG-source / per-M3U-account routing. **`method_type` uniqueness is NOT enforced** — multiple SMTP methods (or multiple Discord webhooks) can coexist, each with its own recipient set, severity opt-ins, and source filter; this is intentional so operators can route different alert categories to different recipients without collapsing them onto one row.
+
+`GET /api/alert-methods` returns an array of alert-method records. Each record carries:
+
+```json
+{
+  "id": 7,
+  "name": "Ops Email",
+  "method_type": "smtp",
+  "enabled": true,
+  "config": { "to_emails": ["alice@example.com", "bob@example.com"] },
+  "notify_info": false,
+  "notify_success": true,
+  "notify_warning": true,
+  "notify_error": true,
+  "alert_sources": null,
+  "last_sent_at": "2026-04-25T14:30:12Z",
+  "created_at": "2026-04-01T10:00:00Z"
+}
+```
+
+`config` shape varies by `method_type`:
+- **`discord`** — `{ "webhook_url": "https://discord.com/api/webhooks/..." }`
+- **`telegram`** — `{ "bot_token": "...", "chat_id": "..." }`
+- **`smtp`** — `{ "to_emails": ["alice@example.com", "bob@example.com"] }` (recipient list only — shared SMTP server settings live under `/api/settings`, see `smtp_*` fields)
+
+`alert_sources` is either `null` (send for every event) or a structured filter object documented under the per-section keys `epg_refresh`, `m3u_refresh`, and `probe_failures` (each with `enabled`, `filter_mode` ∈ `{all, only_selected, all_except}`, and a per-section ID list or `min_failures` threshold).
+
+`POST /api/alert-methods` accepts:
+
+```json
+{
+  "name": "Ops Email",
+  "method_type": "smtp",
+  "config": { "to_emails": ["alice@example.com", "bob@example.com"] },
+  "enabled": true,
+  "notify_info": false,
+  "notify_success": true,
+  "notify_warning": true,
+  "notify_error": true,
+  "alert_sources": null
+}
+```
+
+`name`, `method_type`, and `config` are required; the four `notify_*` flags and `enabled` default per the table above; `alert_sources` defaults to `null` (send everything). The handler rejects unknown `method_type` values with `400`. Per-type `config` is run through that type's `validate_config()` — for SMTP, every entry in `to_emails` must pass an HTML5-style email regex and is rejected if it contains any of `\r \n < > :` (defense-in-depth against header injection at the SMTP sink, bd-6e8gv). The response is the abbreviated form `{ id, name, method_type, enabled }`; round-trip via `GET /api/alert-methods/{id}` for the full record.
+
+**SMTP `to_emails` shape (bd-9vz32):** the canonical write shape is `list[str]`. The route accepts either `list[str]` or a legacy comma-joined `str` on POST/PATCH and normalizes string input to a list **before** persistence — so reads from rows written after bd-9vz32 always return `list[str]`. This is a **write-strict / read-tolerant** contract: pre-bd-9vz32 rows that were stored as a `str` continue to load (the SMTP runtime path coerces both shapes via `_coerce_to_emails_to_list`), so no Alembic migration is needed for the JSON-blob field. Writers should send `list[str]`; readers should expect `list[str]` for any row created or last-updated after bd-9vz32 and tolerate `str` for older rows.
+
+`PATCH /api/alert-methods/{id}` is a partial update — every field on the body is `Optional`, and only fields present on the wire are touched. The common shape since PR #163 is **config-only** (e.g. `{"config": {"to_emails": [...]}}`), used by the Settings → Email Alerts panel to push recipient changes without re-sending the unchanged severity flags. The handler validates the same per-type `validate_config()` and applies the same SMTP `to_emails` canonicalization on PATCH as on POST. `404` if the method doesn't exist; `200` with `{"success": true}` on success.
+
+`DELETE /api/alert-methods/{id}` removes the row and unloads the method from the in-memory `AlertMethodManager`. `404` if the method doesn't exist; `200` with `{"success": true}` on success. Deletion is unconditional — alerts in flight at deletion time are not buffered or re-routed.
+
+`POST /api/alert-methods/{id}/test` invokes the method's `test_connection()` (Discord: posts a test webhook payload; Telegram: sends a test message to the configured chat; SMTP: sends a test email through the shared SMTP settings to the configured `to_emails`). Returns `{"success": <bool>, "message": <str>}` describing the outcome. `404` if the method doesn't exist; `200` with `success: false` if the method exists but the test failed (network error, bad credentials, SMTP not configured, etc.) — failed tests are **not** modeled as `5xx`.
+
+`GET /api/alert-methods/types` returns the registry of available method types with their required and optional config fields:
+
+```json
+[
+  { "type": "discord", "display_name": "Discord", "required_fields": ["webhook_url"], "optional_fields": {} },
+  { "type": "telegram", "display_name": "Telegram", "required_fields": ["bot_token", "chat_id"], "optional_fields": {} },
+  { "type": "smtp", "display_name": "Email", "required_fields": ["to_emails"], "optional_fields": {} }
+]
+```
+
+The frontend uses this to drive the "add alert method" form so new method types appear automatically once registered server-side.
+
 ## Scheduled Tasks
 
 | Endpoint | Description |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.16.0-0067",
+  "version": "0.16.0-0068",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Three coupled PR #163 follow-ups bundled because they share the alert-methods backend + `docs/api.md`.

- **`bd-9vz32`** — Canonicalize `to_emails` representation. Read tolerance, write strictness: routes normalize POST/PATCH input to `list[str]`; `alert_methods_smtp.py` send/test_connection/send_digest accept both shapes via `_coerce_to_emails_to_list` so legacy rows still load. No Alembic migration needed (JSON-blob field).
- **`bd-6e8gv`** — Defense-in-depth server-side validation. `SMTPMethod.validate_config` rejects tokens containing `\r`, `\n`, `<`, `>`, `:` and runs each through the HTML5 email regex (copied verbatim from `frontend/src/utils/smtpRecipients.ts`).
- **`bd-8rd5m`** — Replaced the `docs/api.md` alert-methods stub with full request/response docs for GET (list, single, types), POST, PATCH (config-only common shape — dominant after PR #163), DELETE, POST `/test`. Documented canonical `to_emails: list[str]` and the write-strict / read-tolerant migration pattern.
- Bumps dev version to `0.16.0-0068`.

## Test plan
- [x] 14 new tests (5 canonicalization + 9 validation)
- [x] Full backend suite: 3205 passed (was 3191)
- [x] Smoke-tested in `ecm-ecm-1` after deploy

## Closes
`bd-9vz32`, `bd-8rd5m`, `bd-6e8gv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)