### PR TITLE
test(client-error-reporter): replace setTimeout(0) with vi.waitFor in chunk_load test [bd-nxvst]

### DIFF
--- a/frontend/src/services/clientErrorReporter.test.ts
+++ b/frontend/src/services/clientErrorReporter.test.ts
@@ -470,9 +470,11 @@ describe('withImportTelemetry (ADR-006 §6.5 dynamic-import chunk-load)', () => 
     // ErrorBoundary / Suspense still sees the failure.
     expect(rethrown).toBe(err);
 
-    // Allow the fire-and-forget report to settle.
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(fetchSpy).toHaveBeenCalled();
+    // The fire-and-forget report chains await hashUserAgent (SubtleCrypto)
+    // → buildPayload → sendPayload → fetch. Under v8 coverage instrumentation
+    // on slow CI runners, those hops can spill past a single setTimeout(0)
+    // macrotask, so poll until fetch lands instead of relying on tick count.
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
     const [, init] = fetchSpy.mock.calls[0] as [unknown, RequestInit];
     expect(init.method).toBe('POST');
     const body = JSON.parse(init.body as string);


### PR DESCRIPTION
## Summary

- Replaces a brittle `await new Promise(r => setTimeout(r, 0))` settle with `await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled())` in `clientErrorReporter.test.ts > withImportTelemetry > reports a chunk_load error and re-rejects on failure`.
- Bead: `enhancedchannelmanager-nxvst`

## Why

The fire-and-forget telemetry chain in `withImportTelemetry` is:
`loader.catch` → `reportClientError` → `await buildPayload` (`await hashUserAgent` → `SubtleCrypto.digest`) → `await sendPayload` → `await fetch`.

That's ~4 microtask hops including a SubtleCrypto call. Locally `npm run test:ci` (with `--coverage --reporter=verbose`) passes. On GitHub Actions with v8 coverage instrumentation overhead, those hops intermittently spill past a single `setTimeout(0)` macrotask, intermittently failing the assertion `expected fetch to be called at least once`.

Observed twice consecutively on PR #211 CI run 25254967624 (after `update-branch` merged current `dev` in). The test isn't touched by #211 — the timing margin is just thin.

## Test plan

- [x] `cd frontend && npm run test:ci` locally — 1237/1237 pass, including the formerly flaky test
- [x] Run the file in isolation: 34/34 pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)