### PR TITLE
v0.16.0-0077: docs(auto-creation): rule analyzer user guide + api.md endpoint shapes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -413,7 +413,10 @@ The frontend uses this to drive the "add alert method" form so new method types 
 | `GET /api/auto-creation/schema/actions` | Get available action types |
 | `GET /api/auto-creation/schema/template-variables` | Get available template variables |
 | `GET /api/auto-creation/lint-findings` | Read-only view of saved auto-creation rules that fail the current write-time linter (bd-eio04.7) |
-| `GET /api/auto-creation/debug-bundle` | Download diagnostic bundle (obfuscated channels, rules, streams, probe stats, settings, task schedules, logs) |
+| `POST /api/auto-creation/rules/analyze` | Run the advisory rule analyzer over the rules currently in the DB; returns warnings only (saves are never blocked) |
+| `POST /api/auto-creation/rules/analyze/from-bundle` | Run the analyzer over `rules.yaml` inside an uploaded debug-bundle `tar.gz`; never touches the DB, so it is safe for support diagnosis of any user's bundle. See `docs/auto_creation_rule_analyzer.md` |
+| `POST /api/auto-creation/debug-bundle` | Start a diagnostic-bundle build; returns `{job_id, status: "running"}` immediately and dispatches a supervised background task |
+| `GET /api/auto-creation/debug-bundle/{job_id}` | Poll a bundle build: JSON status while running, JSON `{status: "failed", error}` on failure, or the `tar.gz` (`application/gzip`) attachment when ready (obfuscated channels, rules, normalization rules, streams, probe stats, settings, task schedules, logs). Job is evicted on successful read; abandoned jobs pruned after 30 min |
 
 `POST /api/auto-creation/rules/bulk-update` applies the same partial update to every rule in `rule_ids` in a single transaction. Send only the fields you want to change; omitted fields are left as-is per rule.
 

--- a/docs/user_guide/auto-creation/debugging-rules.md
+++ b/docs/user_guide/auto-creation/debugging-rules.md
@@ -1,0 +1,386 @@
+# Debugging Rules
+
+> **Audience:** Operator investigating why an auto-creation rule is not firing
+> as expected, or auditing a large rule set for silent misconfigurations.
+
+## What the rule analyzer is
+
+When a rule does not produce the channels you expected, the cause usually falls
+into one of two categories:
+
+1. **Static configuration bug** — the rule is written in a way that can never
+   work regardless of which streams arrive. Common examples: a regex condition
+   that accidentally matches every stream, a `merge_streams` action targeting
+   a group with no channels to merge into, or a `never` condition that silently
+   disables the whole rule.
+
+2. **Runtime mismatch** — the rule is structurally sound but the streams
+   arriving at runtime do not match the conditions. Diagnosing this requires
+   running a dry-run (see [test-a-rule.md](test-a-rule.md) — planned).
+
+The **rule analyzer** catches category 1 without running anything. It reads
+your saved rules and checks them for known bad patterns, then tells you exactly
+which rule, which condition or action, and what the problem is. It is
+**advisory only**: running it never changes anything in ECM, and saving a rule
+is never blocked by analyzer warnings.
+
+If you have 40 rules and you are not sure which ones are subtly broken, start
+with the analyzer. It is cheap to run and finds the "this rule can never work"
+class in seconds.
+
+---
+
+## Analyzer vs. dry-run: when to use each
+
+| | Rule analyzer | Dry-run / preview |
+|---|---|---|
+| **What it checks** | Static configuration bugs in saved rules | What a rule *would do* against current streams |
+| **Touches the DB?** | Read-only (live mode) or not at all (bundle mode) | Read-only |
+| **Creates or changes channels?** | Never | Never (dry_run=true) |
+| **When to use it** | First — catch rules that can never work | Second — verify that a structurally-sound rule matches the streams you expect |
+
+Run the analyzer first. Fix any findings it reports, then use the dry-run to
+confirm the surviving rules produce the right channels.
+
+---
+
+## The six finding codes
+
+Each finding has a severity (`warning`), a code, the field it points at, and a
+suggestion. All six current codes are `warning` severity — they are problems
+worth fixing, not fatal errors.
+
+### `REGEX_TRIVIALLY_MATCHES_ALL`
+
+**What it looks like in the rule editor:**
+You entered something like `UK|` or `|UK` in a **Matches (Regex)** condition
+field.
+
+**Why it is wrong:**
+The pipe `|` in a regex means "or". `UK|` means "UK or empty string". Because
+every string contains an empty string at position 0, this pattern matches every
+single stream — the condition becomes useless as a filter.
+
+**Worked example:**
+You want to match streams whose group name starts with `UK|`. You type `UK|`
+into Stream Group → Matches (Regex). The rule now applies to every stream in
+every group.
+
+**How to fix it:**
+
+- Switch the operator to **Begins With** and enter `UK` — the pipe is not part
+  of the value, it is a delimiter in the raw M3U group name.
+- Or, if you genuinely need a regex and want to match the literal characters
+  `UK|`, escape the pipe: `^UK\|`.
+
+---
+
+### `OPERATOR_VALUE_LOOKS_LIKE_REGEX`
+
+**What it looks like in the rule editor:**
+You entered something like `^4K` or `HD$` in a **Contains** condition field
+(any `*_contains` operator).
+
+**Why it is wrong:**
+**Contains** is a plain substring search, not a regex. The `^` and `$`
+characters are not anchors here — they are treated as literal characters. A
+search for `^4K` looks for a group name that contains the two characters `^`
+and `4K` next to each other. No M3U group name contains a literal `^`, so the
+condition matches nothing and the rule fires for no streams.
+
+The analyzer does **not** flag a bare `|` in a Contains field. Many M3U group
+names legitimately contain a pipe (`UK| MOVIES`), so searching for `UK|` under
+Contains is a valid substring match.
+
+**Worked example:**
+You want streams whose group name begins with `4K`. You type `^4K` into Stream
+Group Contains. The rule matches nothing, silently.
+
+**How to fix it:**
+
+- Use **Begins With** and enter `4K` (drop the `^`).
+- Use **Ends With** and enter the suffix (drop the `$`).
+- Switch to **Matches (Regex)** if you genuinely need regex, and verify the
+  pattern in the rule editor's preview.
+
+---
+
+### `REGEX_REDUNDANT_ESCAPE_CARET`
+
+**What it looks like in the rule editor:**
+A Matches (Regex) condition field contains a pattern starting with `^\^` —
+that is, a caret anchor followed immediately by an escaped (literal) caret,
+like `^\^4K`.
+
+**Why it is wrong:**
+This almost always means a typo or a double-escape. The user typed `^4K` (or
+the UI's escape pass added a backslash), producing `^\^4K`. The `^` anchors the
+match to the start of the string; `\^` then requires a literal caret character
+at that position. Most stream group names do not start with a caret, so the
+pattern matches far fewer streams than intended — or none.
+
+**Worked example:**
+You want streams whose name starts with `4K`. The condition ends up storing
+`^\^4k` instead of `^4k`.
+
+**How to fix it:**
+Decide which of these you actually want:
+
+- `^4K` — matches strings that start with `4K`.
+- `\^4K` — matches strings that contain a literal caret followed by `4K`
+  anywhere (rarely what you want).
+
+Drop the extra caret accordingly.
+
+---
+
+### `ANDOR_DROPS_GUARD`
+
+**What it looks like in the rule editor:**
+A rule has multiple OR branches, and one or more of those branches includes a
+"guard" condition — for example, **Normalized Name In Group** — but at least
+one other OR branch does not.
+
+Guards in this context are conditions that constrain *which streams* the rule
+applies to at all, regardless of the stream's name or group:
+
+- Normalized Name In Group
+- Normalized Name Not In Group
+- Normalized Name Exists
+- Provider Is
+
+**Why it is wrong:**
+In a condition list, AND binds tighter than OR. The expression:
+
+```
+A AND B OR C
+```
+
+evaluates as:
+
+```
+(A AND B) OR C
+```
+
+The guard in arm 1 (`A AND B`) does **not** carry into arm 2 (`C`). Any stream
+that satisfies arm 2 fires the rule regardless of whether it would have passed
+the guard.
+
+**Worked example:**
+You want a Sports rule that only processes streams already in the Sports
+normalization group, and you add three OR arms to cover different prefixes:
+
+```
+Normalized Name In Group = Sports  AND  Stream Group Matches = UK|
+OR  Stream Group Matches = US|
+OR  Stream Group Contains = ^4K
+```
+
+The second and third arms have no guard. Streams from any `US|` or `^4K` group
+will trigger the rule whether they are in the Sports group or not.
+
+**How to fix it:**
+
+- Repeat the guard in every OR arm:
+
+  ```
+  Normalized Name In Group = Sports  AND  Stream Group Matches = UK|
+  OR  Normalized Name In Group = Sports  AND  Stream Group Matches = US|
+  OR  Normalized Name In Group = Sports  AND  Stream Group Contains = ^4K
+  ```
+
+- Or split the rule into three separate rules (one per OR arm), each carrying
+  its own guard. This also makes individual rules easier to enable or disable
+  independently.
+
+The `detail` field in the API response tells you the exact OR-group index
+numbers that are missing the guard.
+
+---
+
+### `MERGE_STREAMS_NO_TARGET_CHANNELS`
+
+**What it looks like in the rule editor:**
+A rule uses the **Merge Streams** action and points at a specific channel group,
+but that group currently has zero channels in it.
+
+**Why it is wrong:**
+`merge_streams` attaches incoming streams to channels that **already exist** in
+the target group. It does not create channels. If the group is empty, every
+matched stream is silently skipped with "no existing channel found" — no
+channels are created and no errors are raised. The operator typically expected
+new channels to appear.
+
+**Worked example:**
+You set up a "Merge into Sports" rule pointing at group ID 42. Group 42 was
+recently cleared as part of a cleanup. The rule runs, matches 150 streams, and
+produces zero channels.
+
+**How to fix it:**
+
+- If you want new channels created, change the action to **Create Channel**.
+- If you want to merge into existing channels, seed the target group with
+  channels first (either manually or via a Create Channel rule), then re-run.
+
+**Note:** This finding is only available when you run the analyzer via the
+**from-bundle** path and the bundle includes `channel_groups_diagnostic.json`.
+The live-mode endpoint does not fetch channel-group counts.
+
+---
+
+### `RULE_HAS_NO_HOPE_OF_MATCHING`
+
+**What it looks like in the rule editor:**
+Every OR arm of the rule's conditions contains a **Never** condition.
+
+**Why it is wrong:**
+A `never` condition is permanently unsatisfiable — no stream can pass it. If
+every OR arm of your rule contains `never`, the rule matches no stream, ever.
+
+This most commonly appears after a rule is disabled by toggling a condition to
+`never` as a quick workaround, and the operator later forgets the rule is
+effectively dead.
+
+**How to fix it:**
+
+- Disable or delete the rule if it is no longer needed.
+- Remove the `never` conditions you no longer want.
+
+---
+
+## How to run the analyzer
+
+There is **no UI surface for the analyzer today.** This is a known gap tracked
+separately. The three current ways to run it are:
+
+### 1. Call the API directly (live mode)
+
+```
+POST /api/auto-creation/rules/analyze
+```
+
+No request body needed. ECM reads all rules from the database and returns the
+analysis immediately.
+
+This endpoint requires authentication. See [`docs/api.md`](../../api.md) for
+how to authenticate.
+
+Response shape:
+
+```json
+{
+  "rules": [
+    {
+      "rule_id": 2,
+      "rule_name": "Sports Networks - excl Fr and Es",
+      "findings": [
+        {
+          "code": "REGEX_TRIVIALLY_MATCHES_ALL",
+          "severity": "warning",
+          "field": "conditions[1].value",
+          "message": "...",
+          "suggestion": "...",
+          "detail": { "reason": "empty-alternation" }
+        }
+      ]
+    }
+  ],
+  "summary": { "error": 0, "warning": 6, "info": 0 }
+}
+```
+
+Rules with no findings appear in the list with an empty `findings` array. The
+`summary` counts findings by severity across all rules.
+
+### 2. Upload a debug bundle (from-bundle mode)
+
+```
+POST /api/auto-creation/rules/analyze/from-bundle
+```
+
+Upload a debug bundle (`tar.gz`) as a multipart file field named `file`. ECM
+reads `rules.yaml` from inside the bundle and runs the same analysis — **it
+never touches the database**.
+
+This is the safe way to get support help. Because the from-bundle endpoint does
+not read your live installation, you can hand a bundle to someone helping you
+(another operator, a support helper, an AI assistant) without exposing your
+live channel data. The helper runs the analysis on their end against the bundle
+you provided.
+
+To generate a debug bundle from your ECM installation:
+
+1. `POST /api/auto-creation/debug-bundle` — starts the bundle build and returns
+   a `job_id`.
+2. `GET /api/auto-creation/debug-bundle/{job_id}` — poll until `status` is no
+   longer `"running"`. When ready, the response is the `tar.gz` file itself
+   (download it).
+
+If the bundle includes `channel_groups_diagnostic.json` (all bundles generated
+by the current debug-bundle endpoint include this), the
+[`MERGE_STREAMS_NO_TARGET_CHANNELS`](#merge_streams_no_target_channels) finding
+becomes available. Without it, that check is skipped — the analyzer never
+invents findings from data it does not have.
+
+### 3. Use the `/analyze-rules` agent command
+
+If you are working with an AI assistant (Claude Code or the ECM MCP server),
+the `/analyze-rules` command runs the analyzer and formats the results as a
+readable report. See [`docs/commands/analyze-rules.md`](../../commands/analyze-rules.md)
+for how to invoke it and what arguments it accepts.
+
+The command can run in live mode (against the current database) or bundle mode
+(pass a path to a debug bundle `tar.gz`).
+
+---
+
+## Unicode suffix surprises
+
+If a pattern appears to match when you read it but the engine says otherwise
+(or vice versa) for stream names containing `ᴴᴰ`, `ᴿᴬᵂ`, `²`, `³`, or
+invisible characters like zero-width spaces, the cause is almost always a
+normalization mismatch rather than a rule configuration bug.
+
+Under ECM's unified normalization policy, every stream name is NFC-canonicalized,
+certain invisible characters are stripped, and superscript letters and digits
+are converted to their ASCII equivalents **before** any rule condition is
+evaluated. A pattern typed against the raw bytes (for example, one that contains
+a zero-width space you cannot see) will not match the post-policy input even
+though they look identical on screen.
+
+To diagnose this class of mismatch, use **Settings → Normalization → Test
+Rules**: paste the raw stream name and inspect the trace. The trace shows you
+exactly what the engine sees when evaluating conditions.
+
+See [`docs/normalization.md`](../../normalization.md) for the full normalization
+reference and the parity contract.
+
+---
+
+## What the analyzer does not cover (yet)
+
+The current analyzer (Phase 1) checks static configuration. It does not:
+
+- Report how many streams each rule would match ("this regex matches 1,472
+  groups").
+- Run a dry-run replay over a bundle's stream list.
+- Surface findings inside the rule-builder UI (this is a separate, tracked
+  follow-up).
+- Offer auto-fix actions ("click here to change Contains → Begins With").
+
+For the per-rule dry-run, see [test-a-rule.md](test-a-rule.md) (planned).
+
+---
+
+## Going deeper
+
+- [`docs/auto_creation_rule_analyzer.md`](../../auto_creation_rule_analyzer.md)
+  — the full technical reference: all finding codes with the exact trigger
+  logic, the response JSON schema, implementation notes, and what Phase 2 will
+  add.
+- [`docs/api.md`](../../api.md) — the `/api/auto-creation/rules/analyze` and
+  `/api/auto-creation/rules/analyze/from-bundle` endpoints.
+- [`docs/commands/analyze-rules.md`](../../commands/analyze-rules.md) — the
+  `/analyze-rules` agent command.
+- [`docs/normalization.md`](../../normalization.md) — normalization concepts,
+  the parity contract, and the Test Rules preview tool.

--- a/docs/user_guide/auto-creation/index.md
+++ b/docs/user_guide/auto-creation/index.md
@@ -2,7 +2,7 @@
 
 > **Audience:** Operator who wants ECM to create and update channels automatically as new streams appear in their M3U sources.
 >
-> **Status:** Stub — articles below are placeholders.
+> **Status:** Mostly stub — most articles below are placeholders. `debugging-rules.md` is complete.
 
 ## Section purpose
 
@@ -24,11 +24,13 @@ End users do not read this section.
 | `actions.md` | The action catalogue — create channel, update channel, assign to group, attach EPG, etc. — and what state changes each one produces. |
 | `test-a-rule.md` | The dry-run / preview workflow. What's safe to test against production data and what isn't. |
 | `bulk-operations.md` | Running rules across an entire source, the cost of a large run, and the bulk-amplification cautions an operator should know about. |
-| `debugging-rules.md` | "My rule didn't fire" — the diagnostic flow, where the engine logs decisions, common misconfigurations. Will eventually cross-link the `analyze-rules` skill output. |
+| [`debugging-rules.md`](debugging-rules.md) | "My rule didn't fire" — the diagnostic flow using the rule analyzer: the 6 finding codes in plain language with worked examples, how to run the analyzer (API direct call, debug-bundle upload, `/analyze-rules` agent command), and when to use the analyzer vs. the per-rule dry-run preview. |
 | `clone-and-reuse.md` | Duplicating a rule as a starting point, sharing a normalization group across rules. |
 
 ## Going deeper (for now)
 
 - [`docs/api.md`](../../api.md) — the `/auto-creation` router endpoints.
 - [`docs/normalization.md`](../../normalization.md) — auto-creation rules typically reference a normalization group; understand normalization before authoring complex rules.
-- The `analyze-rules` skill (in this repo's `.claude/` skills) — automated rule analysis when you have many rules to audit.
+- [`debugging-rules.md`](debugging-rules.md) — the rule analyzer: what it checks, the 6 finding codes, and how to run it.
+- [`docs/auto_creation_rule_analyzer.md`](../../auto_creation_rule_analyzer.md) — the full technical reference for the rule analyzer (finding-code trigger logic, response schema, implementation notes).
+- [`docs/commands/analyze-rules.md`](../../commands/analyze-rules.md) — the `/analyze-rules` agent command, for running the analyzer via an AI assistant.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.16.0-0076",
+  "version": "0.16.0-0077",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Documentation-only. Closes the doc-debt cluster flagged in standup (bd-z896t / bd-qovsw / bd-obhdj — the `uy053` split):

- **New `docs/user_guide/auto-creation/debugging-rules.md`** — operator-facing guide to the auto-creation **rule analyzer** (`bd-0gntx`): the 6 finding codes (`REGEX_TRIVIALLY_MATCHES_ALL`, `OPERATOR_VALUE_LOOKS_LIKE_REGEX`, `REGEX_REDUNDANT_ESCAPE_CARET`, `ANDOR_DROPS_GUARD`, `MERGE_STREAMS_NO_TARGET_CHANNELS`, `RULE_HAS_NO_HOPE_OF_MATCHING`) in plain language with worked examples and fix instructions; the three ways to run it (direct API, debug-bundle upload — framed as the safe way to get support help without exposing your DB — and the `/analyze-rules` agent command, with an explicit "no UI surface today" note); analyzer-vs-dry-run guidance; the unicode-suffix mismatch class cross-linked to normalization docs; Phase-1 limitations.
- **`docs/user_guide/auto-creation/index.md`** — de-placeholder the `debugging-rules.md` row; replace the stale "`analyze-rules` skill in `.claude/` skills" bullet with correct links (`debugging-rules.md`, `docs/auto_creation_rule_analyzer.md`, `docs/commands/analyze-rules.md`); soften the "Status: Stub" callout honestly.
- **`docs/api.md`** — add `POST /api/auto-creation/rules/analyze` and `POST /api/auto-creation/rules/analyze/from-bundle` (shipped in `bd-0gntx`, were missing from the reference); correct the `debug-bundle` row from the stale single `GET` to the `POST` + `GET /{job_id}` 202+poll shape shipped in `bd-cns7j` (v0.16.0-0072).

No code changes. Drafted by the technical-writer agent against `docs/auto_creation_rule_analyzer.md` (the canonical reference), the router source, and the existing `docs/user_guide/*/index.md` house style.

bd-z896t, bd-qovsw, bd-obhdj

🤖 Generated with [Claude Code](https://claude.com/claude-code)