### PR TITLE
v0.16.0-0083: docs(readme): create_task_schedule is no longer cron-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ If running ECM locally, use `localhost` as your host. If the MCP container is on
 | `cancel_task` | Cancel a running task |
 | `get_task_history` | View task execution history |
 | `list_task_schedules` | List schedules for a task |
-| `create_task_schedule` | Create a cron schedule |
+| `create_task_schedule` | Create a schedule for a task (interval / daily / weekly / biweekly / monthly) |
 | `delete_task_schedule` | Delete a schedule |
 | **Stats (7)** | |
 | `get_channel_stats` | Channel viewing stats and active viewers |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.16.0-0082",
+  "version": "0.16.0-0083",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

One-line README fix. `bd-vtghg` phase 2 (PR #236) changed the `create_task_schedule` MCP tool from `(task_id, cron_expression)` to `(task_id, schedule_type ∈ {interval, daily, weekly, biweekly, monthly}, schedule_time, interval_seconds, days_of_week, day_of_month, enabled, name)` — the old `cron_expression` form always 422'd at the backend. The README tools-table description still said "Create a cron schedule"; corrected to "Create a schedule for a task (interval / daily / weekly / biweekly / monthly)".

Docs-only (README + the version-bump tag-stone); no CHANGELOG entry.

`bd-tbs3i`

🤖 Generated with [Claude Code](https://claude.com/claude-code)