### PR TITLE
fix(ci): green the v0.16.0 build on main (dep bumps + CKV_GHA_7 skip)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,7 +270,10 @@ jobs:
           # Skip CKV2_GHA_1 - CodeQL requires security-events:write permission
           # Skip CKV_DOCKER_3 - We use gosu in entrypoint to drop to non-root user after fixing volume permissions
           # Skip CKV_DOCKER_8 - Same reason, entrypoint starts as root then switches to appuser
-          skip_check: CKV2_GHA_1,CKV_DOCKER_3,CKV_DOCKER_8
+          # Skip CKV_GHA_7 - flake-pr-comment.yml's workflow_dispatch.inputs.pr_number is an
+          #   intentional manual-run knob (which PR to re-post the flake comment on); it doesn't
+          #   influence build output, only which PR a read-then-comment job targets.
+          skip_check: CKV2_GHA_1,CKV_DOCKER_3,CKV_DOCKER_8,CKV_GHA_7
 
   # DAST - Dynamic Application Security Testing (loads image from build-amd64 cache)
   dast-scan:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -92,7 +92,7 @@ josepy==2.2.0
     # via -r requirements.in
 limits==5.8.0
     # via slowapi
-mako==1.3.11
+mako==1.3.12
     # via alembic
 markupsafe==3.0.3
     # via mako
@@ -145,7 +145,7 @@ python-dotenv==1.2.2
     # via uvicorn
 python-jose==3.5.0
     # via -r requirements.in
-python-multipart==0.0.26
+python-multipart==0.0.27
     # via -r requirements.in
 pytz==2026.1.post1
     # via -r requirements.in
@@ -192,7 +192,7 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-urllib3==2.6.3
+urllib3==2.7.0
     # via botocore
 uvicorn==0.46.0
     # via -r requirements.in


### PR DESCRIPTION
Completes the **v0.16.0** release by clearing the two scan-job failures that left `main`'s `Build and Push Docker Image` workflow red after PR #238. **No version bump** — this is v0.16.0's intended state, and the `v0.16.0` tag + GitHub release will be re-pointed to this commit once merged. Same two-file change as PR #240 (which fixed `dev`). bd-31gn2.

### What was actually failing
The post-#238 `build.yml` run on `main` succeeded at building **and pushing** the Docker images (AMD64 ✓, ARM64 ✓, multi-arch manifest ✓, MCP images ✓) — but the run was marked **failure** because two sibling jobs in the same workflow failed:

- **Backend Security Scan** (`pip-audit`) — 4 CVEs in pinned deps. Bumped to pip-audit's named fix versions in `backend/requirements.txt`:
  | Package | From → To | CVEs |
  |---|---|---|
  | `urllib3` | 2.6.3 → 2.7.0 | CVE-2026-44431, CVE-2026-44432 |
  | `mako` | 1.3.11 → 1.3.12 | CVE-2026-44307 |
  | `python-multipart` | 0.0.26 → 0.0.27 | CVE-2026-42561 |
- **IaC Security Scan** (`checkov`) — `CKV_GHA_7` fires on `.github/workflows/flake-pr-comment.yml`'s `workflow_dispatch.inputs.pr_number` (an intentional manual-run knob; doesn't affect build output). Added `CKV_GHA_7` to `build.yml`'s `skip_check` list alongside the existing `CKV2_GHA_1` / `CKV_DOCKER_3` / `CKV_DOCKER_8` skips, with a comment.

### Process note
ADR-004 normally forbids non-release PRs to `main` and requires hotfixes to carry a patch bump. This is a PO-directed exception: v0.16.0 itself is the thing being corrected, so introducing a 0.16.1 would be wrong. A retro bead for the missed pre-cut scan (the `build.yml` security jobs aren't in `main`'s required-check set, so they didn't gate the cut) is tracked under bd-31gn2.

This PR's checks run the fixed `build.yml`, so the `Backend Security Scan` / `IaC Security Scan` jobs are exercised here before merge.