### PR TITLE
v0.17.0-0002: docs(security): Stats v2 + DBAS pre-implementation prep (ADR-007, threat models)

### DIFF
--- a/docs/adr/ADR-007-session-telemetry-retention.md
+++ b/docs/adr/ADR-007-session-telemetry-retention.md
@@ -1,0 +1,227 @@
+# ADR-007: Retention & Rollup Policy for `session_telemetry`
+
+- **Status**: Proposed
+- **Date**: 2026-05-12 (proposed)
+- **Author**: IT Architect persona (on behalf of PO), synthesizing input from SRE (retention-window justification), DBA (enforcement mechanism), and Technical Writer (write-up consistency + cross-linking). Schema-lifecycle placement is the Architect's call.
+- **Bead**: `enhancedchannelmanager-skqln.1` (child of epic `enhancedchannelmanager-skqln` — Stats v2 / v0.17.0)
+- **Related**:
+  - `enhancedchannelmanager-skqln.2` — Schema + Alembic migration for `session_telemetry` (this ADR is its hard prerequisite; blocked until accepted)
+  - `enhancedchannelmanager-skqln.3` — BandwidthTracker single-write refactor + `channel_watch_stats_v` compat view (also blocked on this ADR)
+  - `enhancedchannelmanager-skqln.7` — Privacy 11a: pre-implementation threat model + data classification for Stats v2 (`docs/security/threat_model_stats_v2.md`; reviewed alongside this ADR — imposes no retention minimum and accepts the 30d-raw / 400d-rollup numbers below)
+  - `enhancedchannelmanager-skqln.10` — Perf baseline + CI benchmark gate (5 hot queries — validates the rollup-table read path this ADR mandates)
+  - `enhancedchannelmanager-skqln.11` — SLOs, storage-growth alerts, deployment-safety runbook (operationalizes the pruning-job failure modes this ADR specifies)
+  - `enhancedchannelmanager-skqln.12` — Observability instrumentation (the pruning-job metrics this ADR requires)
+  - `enhancedchannelmanager-skqln.14` — Active-stream → provider resolver (produces the `provider_id` dimension this ADR's per-provider rollup depends on)
+  - `docs/database_migrations.md` — Alembic authoring guide; the `session_telemetry` table and its rollup tables land as migrations governed by that doc
+  - `docs/architecture.md` — system overview (Stats v2 data foundation; update on acceptance to reference this ADR's lifecycle policy)
+  - `docs/adr/ADR-006-frontend-error-telemetry.md` — sibling telemetry ADR (Phase 1 local sink, OTel migration target) — precedent for "local SQLite sink now, externalize later" framing
+
+## Context
+
+The Stats v2 initiative (v0.17.0, epic `skqln`) introduces a new `session_telemetry` table — a unified, append-mostly fact table written once per `BandwidthTracker` poll cycle (currently every `stats_poll_interval = 10` seconds, per `backend/config.py:81` / `backend/bandwidth_tracker.py:36`). It replaces the current pattern of incrementally mutating `channel_watch_stats` rows in place; that legacy table is exposed forward via the read-compat `VIEW channel_watch_stats_v` (epic decision, `skqln.3`). `session_telemetry` becomes the system of record for:
+
+- **Per-user watch time** (GH-62 / `skqln.5` `skqln.6`): the Users panel needs watch-time-by-user with a 7/30/90-day selector and a daily trend chart.
+- **Per-provider performance** (GH-59 / `skqln.14`–`skqln.18`, pulled into v0.17.0 by PO override 2026-04-23): the Providers panel needs buffering-events-by-provider, time-spent-per-provider, channels-by-provider heatmap, and bitrate-by-provider — and the operator uses this to make **provider keep/drop decisions at renewal**, which the epic body and the 2026-04-23 comment on this bead frame as a **quarterly-window** analysis ("useful in 30d, fully useful in 90d", keep/drop call at renewal).
+
+### Why this ADR must land before the first write
+
+Architect and DBA both asserted this during the 2026-04-21 team-plan as a hard prerequisite. SQLite is the primary datastore (`/config/journal.db`, single-container, WAL mode). At a 10-second poll cadence, every active channel emits a row per poll:
+
+- DBA's projection: **~13–26M rows over 3–6 months at current load** (~1.5–3 GB with indexes). For SQLite that is workable **only** with disciplined retention and pre-aggregated rollups. Without a retention policy in place at first write, the table grows unbounded, the WAL grows with it, `VACUUM` becomes a long-lock event, and the hot aggregation queries (`skqln.10`'s 5-query benchmark gate) degrade super-linearly because SQLite has no parallel scan and no partitioning.
+- The DBA's strong position — endorsed here — is that the read path **must** hit pre-aggregated rollup *tables*, never a view over raw rows. A view re-scans the full 26M-row table on every panel load; a daily rollup table is a few thousand rows.
+
+So this ADR is not "should we have retention?" — the answer is unconditionally yes. The architectural questions are: **how long is the raw window, what shape are the rollups, who prunes, and when does this outgrow SQLite?**
+
+### Privacy interaction (concurrent bead `skqln.7`)
+
+`skqln.7` (Privacy threat model + data classification — `docs/security/threat_model_stats_v2.md`) was reviewed alongside this ADR. Security sets the retention **minimum**, DBA/SRE the operational **maximum**; the threat model imposes **no minimum** (shorter raw retention is strictly safer) and recommends the per-user rollup be **bounded** (~13 months) rather than kept forever. The values below honor that. Field-level handling adopted:
+
+- `user_id` is **PII-adjacent behavioral data** (threat model class C2). Raw per-user rows are not retained longer than the stated use cases require (per-user 7/30/90-day watch time); the per-user rollup is bounded, not "forever".
+- **Provider attribution** reveals which upstream M3U providers an operator uses and how heavily. Treat as **operator-visible-only** — not exposed to non-admin users — but it is *not* end-user PII (the operator owns their own provider relationships). Provider rollups can be retained longer than user rollups.
+
+## Decision
+
+### D1 — Raw retention window: **30 days**
+
+`session_telemetry` raw rows are pruned at **30 days** of age (by `observed_at`). This is the DBA's proposal and the SRE's "full-fidelity" tier; it is *not* the Architect's earlier 180-day lean, and it is *not* the SRE's "30d full + 90d 5-min-bucket downsampled raw" two-tier proposal. Rationale for picking 30 days over the alternatives:
+
+| Driver | Verdict at 30d raw |
+|---|---|
+| **Per-user use case (GH-62)** | Fully satisfied. The Users panel's longest selector is 90 days, but it reads the **per-user daily rollup** (D4), not raw rows. Raw rows beyond ~2 days are never read by the user panel — they exist only to *build* the daily rollup, which the nightly job (D3) does within hours of ingest. 30 days of raw is generous headroom for a rollup job that runs nightly. |
+| **Per-provider quarterly use case (GH-59, the 2026-04-23 amendment)** | Satisfied **via rollups, not raw**. The keep/drop-at-renewal decision needs a *quarterly trend*, which is a sequence of **daily provider rollup rows** (D5) covering ~90+ days — not 90 days of raw 10-second samples. Retaining raw for a quarter to serve this would be ~13M rows for zero additional analytic value over the daily rollup. The correct fix for the quarterly need is **long-lived provider daily rollups (D5: 400 days)**, not a longer raw window. |
+| **Operational cost** | 30 days ≈ 2–4M rows ≈ 250–500 MB with indexes — comfortably inside SQLite's happy range; `VACUUM` stays short; WAL stays bounded. The SRE's 90-day downsampled-raw tier would add a second write path (the downsampler) and a second schema, for data that the daily rollups already capture at the granularity the panels use. Rejected as complexity without a consumer. |
+| **Privacy minimization** | 30 days is the shortest window that still leaves comfortable slack for a *failed* nightly rollup to be caught and re-run before the source rows age out (see D3 failure modes). Going shorter (DBA floated nothing shorter; 30 is the floor of the proposals) would tighten that recovery window. Going longer retains PII-adjacent per-user rows past their use. |
+
+**The tradeoff being accepted:** ad-hoc forensic queries against *sub-daily* granularity (e.g., "what did the 14:32–14:38 buffering spike on provider X look like minute-by-minute three months ago?") are only answerable for the last 30 days. Beyond that, only daily-granularity rollups exist. This is judged acceptable: the panels are daily-granularity by design, and sub-daily forensics on month-old data is not a stated requirement. If it becomes one, the cheap fix is the SRE's downsampled-raw tier as an additive change — see Exit Path.
+
+> **`skqln.7` outcome (2026-05-12):** the Stats v2 privacy threat model imposes **no minimum** on raw retention and does not object to 30 days. The 30-day window stands as final for both user- and provider-dimension data.
+
+### D2 — Rollups are **tables**, not views
+
+Daily rollups are materialized **tables**, populated by a scheduled job (D3), not SQL `VIEW`s computed at query time. This is the DBA's strong preference, adopted without reservation: a view over `session_telemetry` re-scans up to 26M rows on every Stats-panel load; a daily rollup table is on the order of `days_retained × distinct_keys` rows (thousands), and the `skqln.10` benchmark gate is written against the table read path. The legacy `channel_watch_stats_v` (`skqln.3`) is a *compat* view over a small legacy table — that is a different animal and stays a view; the new aggregates do not.
+
+### D3 — Rollup schedule: **nightly scheduled job**, idempotent, re-runnable
+
+A single nightly job (not on-demand, not per-request) recomputes the previous day's rollup rows and prunes aged raw rows. Design:
+
+- **Trigger**: runs once per day during a low-traffic window (default ~03:30 local; configurable). Implemented as an `asyncio` task scheduled from `main.py`'s startup (the same place `BandwidthTracker` is wired, `backend/main.py:793`), guarded so it runs at most once per calendar day even across restarts (persist a `last_rollup_date` marker — a row in a small `telemetry_rollup_state` table or a settings key). **Not** a cron-in-container (the app is the only long-lived process; adding `cron` is unjustified infra) and **not** APScheduler (a new dep for one job — overkill; the existing `asyncio` loop pattern is the precedent).
+- **Operation order, each run**:
+  1. **Roll up** all *complete* days not yet rolled up (UTC day boundaries; "complete" = `observed_at < start_of_today_UTC`). Compute per-user and per-provider daily aggregates (D4, D5) with an **upsert** keyed on the rollup PK, so a re-run is idempotent and a partial prior run self-heals.
+  2. **Verify** the rollup wrote rows for every day it claimed to cover (sanity assertion; if a day's source rows existed but produced zero rollup rows, that is a failure, not a no-op).
+  3. **Prune** raw `session_telemetry` rows older than the D1 window (`observed_at < now - 30d`) — *only after* step 2 confirms those days are durably rolled up. Pruning is `DELETE` in bounded batches (e.g., 50k rows/statement) to avoid a single long write lock; followed by an incremental `PRAGMA wal_checkpoint(TRUNCATE)` and a periodic (weekly) `VACUUM` in the same window.
+  4. **Emit metrics** (D6).
+- **Idempotency / catch-up**: because step 1 covers *all* unrolled complete days (not just yesterday), a job that was skipped for N days because the container was down catches up on the next run. The 30-day raw window is the catch-up budget: as long as the rollup job runs successfully at least once every ~28 days, no raw data is pruned before it is rolled up. Below that, raw rows age out unrolled — see failure modes.
+
+### D4 — Per-user rollup: `watch_time_by_user_daily`
+
+```
+watch_time_by_user_daily
+  user_id        TEXT     NOT NULL    -- Dispatcharr user identifier; NULL → 'unknown' sentinel row, not dropped
+  channel_id     TEXT     NOT NULL    -- so the panel's per-channel table (total minutes, last watched) is servable from the rollup
+  day            DATE     NOT NULL    -- UTC calendar day
+  watch_seconds  INTEGER  NOT NULL    -- sum of poll_interval × client_count contributions for (user, channel, day)
+  session_count  INTEGER  NOT NULL    -- distinct viewing sessions that day (for "times watched")
+  last_watched   DATETIME NOT NULL    -- max(observed_at) for (user, channel, day) — feeds the panel's "last watched" column
+  PRIMARY KEY (user_id, channel_id, day)
+```
+
+- **PK = `(user_id, channel_id, day)`.** This is the grain the Users panel queries at: the 7/30/90-day selector is `SUM(watch_seconds) WHERE user_id = ? AND day >= ?`; the channel table is `GROUP BY channel_id WHERE user_id = ?`; the daily trend chart is `GROUP BY day WHERE user_id = ?`. All three are index-range scans over a table with `≈ active_users × active_channels × days_retained` rows.
+- **Retention of *this* table: 400 days** (≈ 13 months — covers a full year plus slack for year-over-year glances and for a late audit). After 400 days these rows are pruned by the same nightly job. *This is the privacy-relevant horizon for user data* — it is bounded, not "forever". Flagged for `skqln.7` confirmation: if the privacy minimum for user-attributed aggregates is shorter (e.g., 90 days), this drops to that value and the 90-day panel selector is served from a table that goes exactly as far back as the longest selector plus a small buffer.
+- Secondary index: `(day)` for the cross-user "all users" admin view and for the prune scan.
+
+### D5 — Per-provider rollup: `provider_performance_daily`
+
+```
+provider_performance_daily
+  provider_id          TEXT     NOT NULL  -- upstream M3U provider id from the skqln.14 resolver; NULL → 'unknown' bucket row, surfaced not dropped
+  channel_id           TEXT     NOT NULL  -- enables the channels-by-provider heatmap without a raw rescan
+  day                  DATE     NOT NULL  -- UTC calendar day
+  watch_seconds        INTEGER  NOT NULL  -- time spent on this (provider, channel) that day → stacked-area "time per provider"
+  bytes_delta_sum      INTEGER  NOT NULL  -- summed bytes for the day → derives daily mean bitrate (bytes_delta_sum*8 / watch_seconds)
+  buffer_event_count   INTEGER  NOT NULL  -- buffering events ingested for this provider that day (skqln.15) → "buffering by provider" time-series
+  sample_count         INTEGER  NOT NULL  -- number of poll samples contributing — denominator for averages, and a data-quality signal
+  PRIMARY KEY (provider_id, channel_id, day)
+```
+
+- **PK = `(provider_id, channel_id, day)`.** Covers all four Providers-panel visualizations: buffering-by-provider (`SUM(buffer_event_count) GROUP BY provider_id, day`), time-per-provider stacked area (`SUM(watch_seconds) GROUP BY provider_id, day`), channels-by-provider heatmap (`GROUP BY provider_id, channel_id` over a window), bitrate-by-provider (`SUM(bytes_delta_sum)·8 / SUM(watch_seconds) GROUP BY provider_id, day`). All are range scans on a table with `≈ providers (<20) × active_channels × days_retained` rows — small.
+- **Retention of *this* table: 400 days.** This is what actually serves the **quarterly keep/drop-at-renewal use case** that the 2026-04-23 amendment raised. 400 days lets the operator compare this renewal window against the last one (annual contracts) and see a full year of provider trend. Provider attribution is operator-visible-only data, not end-user PII, so a longer horizon than the user rollup is acceptable — but 400 days is still a *bounded* horizon, not "forever", because unbounded growth (even at thousands of rows/day) is exactly the failure mode this ADR exists to prevent, and there is no use case beyond ~13 months.
+- Secondary index: `(provider_id, day)` (the dominant query prefix) and `(day)` for the prune scan.
+- **NULL `provider_id`**: surfaces as an `'unknown'` bucket row, never silently excluded (epic decision; `skqln.11` runbook covers the cascade). The resolver (`skqln.14`) is best-effort; the rollup must not hide its misses.
+
+### D6 — Pruning-job ownership, failure modes, alerting
+
+- **Ownership**: the **SRE persona owns the operational behavior** (SLOs, alert thresholds, the deployment-safety runbook entry — `skqln.11`); the **engineer owns the implementation** (the `asyncio` task, the upsert, the batched delete); the **DBA owns the enforcement correctness** (that pruning is gated on durable rollup, that batch sizes don't lock-storm, that `VACUUM` cadence is right). There is no separate "pruning service" — it is a function of the ECM container, like `BandwidthTracker`.
+- **Metrics emitted each run** (Prometheus, via `skqln.12`): `ecm_telemetry_rollup_last_success_timestamp` (gauge — for staleness alerting), `ecm_telemetry_rollup_duration_seconds`, `ecm_telemetry_rollup_days_processed`, `ecm_telemetry_raw_rows_pruned`, `ecm_telemetry_raw_row_count` (current size — feeds the storage-growth alert), `ecm_telemetry_rollup_errors_total`. **Cardinality discipline (SRE veto, epic decision): `user_id` and `channel_id` are NEVER metric labels; `provider_id` IS allowed (bounded <20).** The rollup metrics above are label-free or provider-labeled only.
+- **Failure modes & responses** (full version in the `skqln.11` runbook):
+  1. **Rollup job hasn't succeeded in >36 h** (one missed nightly + margin) → **warning alert**. Likely cause: container restart loop, an exception in the job, or a schema mismatch. Action: inspect logs, re-run manually; raw data is safe (30-day window).
+  2. **Rollup job hasn't succeeded in >25 days** → **page**. Now within striking distance of raw rows aging out *before* being rolled up — permanent data loss risk for the un-rolled days. Action: emergency manual rollup before the prune step would fire.
+  3. **`ecm_telemetry_raw_row_count` exceeds the SQLite-comfort ceiling** (DBA-set, e.g., >5M rows) when the rollup *is* succeeding → indicates the prune step is failing silently or the poll cadence/active-channel count has grown beyond projection. Action: investigate prune; this is also the **Postgres-trigger early-warning signal** (see D7).
+  4. **Prune `DELETE` batch causes a lock-contention spike** (write latency SLI breach during the rollup window) → tune batch size down; if persistent, move the window or split the prune across multiple short runs. The `skqln.11` SLOs include a per-provider read-latency SLI and a write-latency SLI that this would trip.
+  5. **Rollup wrote zero rows for a day that had source rows** (the D3 step-2 sanity check fails) → the job aborts *before* pruning that day's raw rows, logs an error, increments `ecm_telemetry_rollup_errors_total`, and the staleness clock keeps running (so failure mode 1 fires if it persists). Fail-safe: never prune what you couldn't roll up.
+- **Deployment safety**: the `session_telemetry` schema, both rollup tables, and the `telemetry_rollup_state` marker land via Alembic per `docs/database_migrations.md` — including the `(provider_id, channel_id, observed_at) INCLUDE (bytes_delta)` covering index the epic mandates for the heatmap query (`skqln.2`). The first deploy ships an *empty* table; the "useful in 30d, fully useful in 90d" operator messaging (epic risk-acceptance item 2) is the consequence — there is no backfill path into the provider-free legacy history, and this ADR does not invent one.
+
+### D7 — Postgres migration trigger: **>50M `session_telemetry` rows OR a second writer**, not v0.17.0
+
+ECM stays on SQLite for Stats v2. The DBA's threshold, adopted: a migration to PostgreSQL is triggered when **either**:
+
+- `session_telemetry` (raw) is projected to exceed **~50M rows** at steady state — which, with the 30-day retention in D1, only happens if poll cadence drops well below 10 s *or* active-channel counts grow ~20× over current. At that scale SQLite's single-writer + no-parallel-scan limits start to bite even with rollups. The `ecm_telemetry_raw_row_count` metric (D6 failure mode 3) is the leading indicator; SRE/DBA review it at the standing monthly cadence.
+- **OR** ECM gains a second concurrent writer to the telemetry path (e.g., a separate ingest worker, a sidecar, or a multi-instance deployment) — SQLite's single-writer lock makes that a correctness hazard, not just a performance one.
+
+Neither condition holds for v0.17.0 (`skqln`'s explicit "single-write to `session_telemetry`" decision keeps it one writer; the 30-day window keeps row count in the low millions). When the trigger fires, that is its own ADR (the rollup *tables* and the nightly-job design port cleanly to Postgres; the `asyncio` scheduler and the batched-delete-then-vacuum dance get simpler, not harder, on Postgres with partitioning).
+
+## Alternatives Considered
+
+| # | Option | Pros | Cons | Portability | Cost |
+|---|---|---|---|---|---|
+| 1 | **30d raw + nightly rollup tables + 400d rollup retention (chosen)** | Satisfies both use cases (user 7/30/90 via daily rollup; provider quarterly via 400d provider rollup); SQLite stays comfortable; one write path; one scheduled job reuses the existing `asyncio` pattern; privacy-minimizing on the raw window; bounded rollup horizon | Sub-daily forensics on >30-day-old data is unavailable; the empty-panel-for-30d operator UX cost is real; the nightly job is a new operational surface (mitigated by D6 alerting) | High — pure SQLite + `asyncio`; ports to Postgres cleanly | One Alembic migration set + one `asyncio` task; ~0 new infra |
+| 2 | **180d raw, no/late rollups (Architect's earlier lean)** | Ad-hoc raw forensics for 6 months; defers the rollup-job work | ~13–26M raw rows in SQLite — `VACUUM` lock events, WAL bloat, super-linear panel-query degradation (no partitioning); retains PII-adjacent per-user rows 6× longer than any use case needs; panels still need rollups eventually, so this just delays the real work while paying the storage cost | High but operationally fragile | Low now, high later (forced rollup retrofit + a painful first prune of 25M rows) |
+| 3 | **30d full raw + 90d 5-min-bucket downsampled raw (SRE's two-tier proposal)** | Preserves sub-daily (5-min) granularity for a quarter; richer forensics | A *second* write path (the downsampler) and a *second* schema, for data the daily rollups already cover at the granularity every panel actually uses; downsampler is itself a job that can fail/fall behind; more surface for the same analytic outcomes | High | Higher — two jobs, two schemas, two sets of failure modes |
+| 4 | **Rollups as SQL `VIEW`s, no materialized tables** | Zero rollup-job complexity; always "fresh"; no rollup-table retention to manage | Every Stats-panel load full-scans up to 26M raw rows; `skqln.10`'s 5-query benchmark gate would fail by design; degrades with raw growth; the DBA's explicit veto | High | Zero build cost, unacceptable run cost |
+| 5 | **On-demand rollup (compute-and-cache on first panel hit each day)** | No scheduled job; rollup happens lazily | First panel load each day eats the full aggregation latency (multi-second on a 26M-row table); cache invalidation is a new concern; pruning still needs *some* scheduled trigger so you don't actually remove the job — you just make it user-latency-visible | High | Similar to chosen, worse UX |
+| 6 | **Move to Postgres now for v0.17.0** | Partitioning, parallel scan, `pg_partman`-style retention, no single-writer lock | ECM is a single-container self-hosted app; adding Postgres is a deployment-model change for users, a new ops burden, and unjustified at low-millions row scale; violates the project's "SQLite primary, single container" posture; the DBA's threshold (D7) isn't met | Medium — adds an external datastore dependency | High — operator-facing deployment change, far ahead of need |
+
+## Consequences
+
+### Positive
+
+- **`session_telemetry` is bounded by construction.** Raw rows can't accumulate past 30 days; rollup tables can't accumulate past 400 days. SQLite stays in its comfort zone for the foreseeable life of v0.17.0; `VACUUM` stays a short weekly event; the WAL stays small.
+- **Both Stats v2 use cases are served from cheap reads.** The Users panel and the Providers panel hit small daily-rollup tables (thousands of rows), not the fact table. `skqln.10`'s benchmark gate is written against that read path and is achievable.
+- **The quarterly provider keep/drop decision is actually answerable** — and it's answerable from the *right* artifact (a 400-day sequence of daily provider rollups), not from an unaffordable 90-day raw window.
+- **Privacy posture is defensible.** Raw PII-adjacent rows live 30 days; user-attributed aggregates live a bounded 400 days (subject to `skqln.7` possibly shortening either). Nothing is "retained forever". Provider attribution is operator-visible-only by data classification.
+- **One write path, one scheduled job, no new infra.** Reuses the `asyncio` startup-task pattern already used for `BandwidthTracker`. No cron, no APScheduler, no external scheduler, no Postgres.
+- **Clean Postgres exit when (if) the threshold trips** — rollup tables and the nightly-job logic port directly; the operational dance gets simpler on Postgres, not harder.
+- **Fail-safe pruning.** The job never deletes a raw row for a day it hasn't durably rolled up; the 30-day window is a ~28-day catch-up budget for a job that's been down.
+
+### Negative
+
+- **30-day raw window means sub-daily forensics on older data is gone.** "Show me the minute-by-minute buffering on provider X during last quarter's incident" is answerable only for the last 30 days. Accepted (not a stated requirement); mitigated by the additive-downsampler exit path if it ever becomes one.
+- **The Providers panel is sparse for the first 30 days post-deploy and not "fully useful" until ~90 days** (epic risk-acceptance item 2). No backfill into the provider-free legacy history exists, and this ADR doesn't invent one. Operator messaging ("useful in 30d, fully useful in 90d") is the mitigation, owned by `skqln.9` (user guide) and `skqln.11` (runbook).
+- **A new operational surface: the nightly rollup/prune job.** It can fail, fall behind, or lock-storm on the prune `DELETE`. D6's metrics + the `skqln.11` SLOs/alerts are the backstop; the >25-day "page" threshold is the hard floor against data loss.
+- **Rollup-table retention is a second knob to get right.** 400 days is a judgment call, PO-confirmed 2026-05-12 and accepted by the `skqln.7` privacy review (which recommends bounding the per-user rollup at ~13 months — 400 days satisfies it). It's a one-line config change if a future need shifts it.
+- **`telemetry_rollup_state` is one more table** (the once-per-day marker). Trivial, but it's schema surface that lands via Alembic and must be in the drift test.
+
+### Neutral / Out of Scope
+
+- **The `session_telemetry` schema itself** — column list, types, the covering index — is `skqln.2`'s deliverable, governed by `docs/database_migrations.md`. This ADR specifies the *rollup* table shapes (D4, D5) and the *retention* knobs; it does not redefine the fact table.
+- **The provider resolver's correctness** (`skqln.14`) and **buffer-event ingestion** (`skqln.15`) are upstream of this ADR. This ADR only specifies that NULL `provider_id` becomes an `'unknown'` bucket, never a silent drop.
+- **The Stats tab IA / sub-nav refactor** is explicitly deferred to v0.18.0 (epic decision) and is unrelated to retention.
+- **Externalizing telemetry to an OTel/Prometheus-remote-write pipeline** (cf. ADR-006's migration target for *frontend error* telemetry) is not in scope. If ECM ever ships a "send my stats to my own observability stack" feature, that's a new ADR; this one is about the local SQLite sink's lifecycle.
+
+## Exit Path
+
+If the chosen policy proves wrong:
+
+1. **Soft exit — extend the raw window.** If 30 days turns out too tight for the rollup-catch-up budget (frequent container downtime in the field), bump the D1 window to 45 or 60 days. One config value + one Alembic-free change (the prune predicate reads the config). Costs more SQLite storage; no schema change.
+2. **Additive exit — add the SRE downsampled-raw tier.** If sub-daily forensics on month-old data becomes a real requirement, add a `session_telemetry_5min` rollup table (5-minute buckets, ~90-day retention) populated by an extra step in the same nightly job. Additive: doesn't touch the existing tables or the daily rollups; one migration + one job step.
+3. **Adjust rollup-table retention.** 400 days → whatever `skqln.7` mandates (down) or the operator community asks for (up, within reason). Config value; the prune predicate reads it. No schema change.
+4. **Hard exit — Postgres migration** when D7's threshold trips. Own ADR. Rollup tables and the nightly-job logic port directly; SQLite-specific bits (`PRAGMA wal_checkpoint`, batched `DELETE` to dodge the write lock, weekly `VACUUM`) get replaced by Postgres-native partitioning + `DROP PARTITION`-style retention, which is simpler. Operator-facing: a deployment-model change (adds a Postgres container) — the reason D7 sets the bar high.
+
+No vendor relationship to unwind; no external dependency introduced by this ADR.
+
+## Open Questions
+
+### Resolved inline (no PO action needed)
+
+- **Raw retention window?** → **30 days** (D1). DBA's proposal; serves both use cases via rollups; privacy-minimizing on raw.
+- **Rollup schedule — nightly vs. on-demand?** → **Nightly scheduled `asyncio` task** (D3), idempotent and catch-up-capable. On-demand rejected (user-latency cost; still needs a scheduled prune trigger anyway).
+- **Rollup tables vs. views?** → **Tables** (D2). DBA's strong preference; views re-scan 26M rows; the benchmark gate assumes tables.
+- **Per-user rollup PK/shape?** → `watch_time_by_user_daily`, **PK `(user_id, channel_id, day)`** (D4). Matches all three Users-panel queries.
+- **Per-provider rollup PK/shape?** → `provider_performance_daily`, **PK `(provider_id, channel_id, day)`** (D5). Covers all four Providers-panel visualizations.
+- **Pruning job — who owns it, alerting, failure modes?** → SRE owns operational behavior, engineer owns implementation, DBA owns enforcement correctness; failure modes 1–5 with warn/page thresholds at >36 h / >25 days; fail-safe (never prune an un-rolled day) (D6).
+- **When does the Postgres trigger fire?** → **>50M raw rows OR a second concurrent telemetry writer** — neither holds for v0.17.0 (D7).
+- **Does the quarterly provider need force a longer raw window?** → **No.** It forces a long-lived *provider rollup* (400 days, D5), which is the correct artifact for a quarterly/annual trend. "30d raw + rollups (bounded) forever" stands — with the clarification that "forever" is operationalized as a *bounded 400-day* rollup horizon, not literally unbounded.
+
+### PO decisions — resolved 2026-05-12
+
+1. **Rollup-table retention horizon → 400 days for both `watch_time_by_user_daily` and `provider_performance_daily`.** PO-confirmed. Implemented as a config value; revisit only if a concrete need appears.
+
+2. **Privacy sign-off (`skqln.7`) — 30-day raw window and 400-day user-attributed-aggregate horizon accepted.** The concurrent Stats v2 threat model (`docs/security/threat_model_stats_v2.md`) imposes no minimum on raw retention (shorter is strictly safer) and explicitly does not object to 30 days; it recommends the per-user rollup be bounded (~13 months), which the 400-day horizon satisfies. D1 and D4 are therefore final, not provisional. (The threat model's remaining conditions — `user_id` FK `ON DELETE SET NULL`, redaction requirements folded into `skqln.2`/`.3` acceptance, synthetic-identity test fixtures — are tracked on those beads, not here.)
+
+3. **Operator messaging for the 30/90-day "warm-up" → empty-state banner in the Providers panel + a line in the `skqln.9` user-guide entry.** PO-confirmed.
+
+4. **Telemetry opt-out (related, decided alongside this ADR) → operator-level global toggle only**, no per-user opt-out, for v0.17.0. Disables `session_telemetry` collection entirely when off. (Tracked under `skqln.7`/`skqln.8`; noted here because it bounds what the pruning/rollup pipeline must handle — when the toggle is off there is simply no data to retain.)
+
+## References
+
+- Bead `enhancedchannelmanager-skqln.1` — this ADR's tracker
+- Bead `enhancedchannelmanager-skqln` — Stats v2 epic (v0.17.0); carries the full scope + PO-override trail
+- Bead `enhancedchannelmanager-skqln.2` — `session_telemetry` schema + Alembic migration (blocked on this ADR)
+- Bead `enhancedchannelmanager-skqln.3` — BandwidthTracker single-write refactor + `channel_watch_stats_v` compat view (blocked on this ADR)
+- Bead `enhancedchannelmanager-skqln.7` — Privacy 11a threat model + data classification (concurrent; sets the retention minimum)
+- Bead `enhancedchannelmanager-skqln.10` — Perf baseline + CI benchmark gate (5 hot queries — validates the rollup-table read path)
+- Bead `enhancedchannelmanager-skqln.11` — SLOs, storage-growth alerts, deployment-safety runbook (operationalizes D6)
+- Bead `enhancedchannelmanager-skqln.12` — Observability instrumentation (the D6 metrics)
+- Bead `enhancedchannelmanager-skqln.14` — Active-stream → provider resolver (produces the `provider_id` dimension)
+- Bead `enhancedchannelmanager-skqln.15` — Buffer-event ingestion (feeds `provider_performance_daily.buffer_event_count`)
+- `docs/database_migrations.md` — Alembic authoring guide; `session_telemetry` + rollup tables + `telemetry_rollup_state` land per that doc
+- `docs/architecture.md` — system overview (update on acceptance to reference this lifecycle policy)
+- `docs/adr/ADR-006-frontend-error-telemetry.md` — sibling telemetry ADR (local-sink-now, externalize-later precedent)
+- `backend/bandwidth_tracker.py` — the writer (`_collect_stats`, 10 s poll); `main.py:793` — where the scheduled rollup task wires in
+- `backend/config.py` — `stats_poll_interval` (the cadence driving row volume)
+- `backend/models.py` — `ChannelWatchStats` (the legacy table `channel_watch_stats_v` views over)
+
+## Revision History
+
+| Date | Bead | Change | Rationale |
+|---|---|---|---|
+| 2026-05-12 | `enhancedchannelmanager-skqln.1` | Proposed | Initial retention/rollup/lifecycle contract for `session_telemetry`; hard prerequisite for `skqln.2`/`skqln.3` |

--- a/docs/database_migrations.md
+++ b/docs/database_migrations.md
@@ -163,6 +163,12 @@ docker exec ecm-ecm-1 sh -c "cd /app && alembic stamp <known-good-rev>"
 - **Foreign keys are per-connection.** They are only enforced when `PRAGMA foreign_keys=ON`. The app-wide connect listener in `database.py` handles this everywhere SQLAlchemy opens a connection (including Alembic via `env.py`), but if you run raw `sqlite3` in a shell for debugging, you must set the PRAGMA yourself. Raw `sqlite3.connect()` calls bypass the listener.
 - **WAL journal mode is per-connection too.** The listener sets it on every connect, but direct `sqlite3` CLI sessions will use `delete` mode. This is expected and harmless — both modes see the same committed state.
 
+## Data-lifecycle / retention policy
+
+Some tables are append-mostly fact tables that grow with time and need an explicit retention + rollup policy, not just a schema. The first of these is `session_telemetry` (Stats v2, v0.17.0): its retention window, the daily rollup tables (`watch_time_by_user_daily`, `provider_performance_daily`), the `telemetry_rollup_state` marker, the nightly rollup/prune job, and the Postgres-migration trigger are all specified in **[`docs/adr/ADR-007-session-telemetry-retention.md`](adr/ADR-007-session-telemetry-retention.md)**. When you author the migration that creates one of those tables (`bd-skqln.2`), follow the ADR for the table shapes, indexes, and PKs — and add the new tables to the drift test like any other schema object.
+
+General rule: if a new table accumulates rows per unit time (telemetry, events, audit logs), it needs a retention/rollup ADR *before* its first write, not after.
+
 ## What bead `bd-c5wf5` did NOT do
 
 - No retroactive per-column migrations for historical schema changes. The 30+ ad-hoc `_add_*` functions in `database.py` predate Alembic; they continue to run after `_bootstrap_alembic()` for installs that already crossed those versions. **New columns should land as Alembic revisions**, not new helpers in `database.py`.

--- a/docs/security/threat_model_dbas_import.md
+++ b/docs/security/threat_model_dbas_import.md
@@ -1,10 +1,10 @@
 # STRIDE Threat Model: DBAS Import / Restore
 
-**Bead:** bd-qmuij (informs bd-gb5r5.3 — DBAS import engine)
+**Bead:** bd-qmuij (informs bd-gb5r5.3 — DBAS import engine); §8–§9 addenda + checklist 18–26: `enhancedchannelmanager-0i2vt.3` (Phase 0, v0.18.0 DBAS absorption)
 **Author:** Security Engineer persona (Claude)
-**Date:** 2026-04-20
-**Status:** Draft — pending PO review of assumptions
-**Related:** bd-ppe28 (closed, OWASP hardening), ADR-002 (restore transaction model, pending), ADR-004 (DBAS instance trust — referenced)
+**Date:** 2026-04-20 · **Addenda A & B added:** 2026-05-12
+**Status:** Draft — pending PO review of assumptions (§6) + Addendum A residual-risk decision (§8.4)
+**Related:** bd-ppe28 (closed, OWASP hardening), ADR-002 (restore transaction model, pending), ADR-004 (DBAS instance trust — referenced), epic `enhancedchannelmanager-0i2vt` + "ADR-008" (DBAS absorption — content in the epic bead; **no `docs/adr/ADR-008-*.md` file present as of 2026-05-12** — see note at end of §7), beads `0i2vt.4` (Fernet credential models) / `0i2vt.5` (SSRF wizard) / `0i2vt.7` (ZIP builder) / `0i2vt.8` (cloud upload)
 
 ---
 
@@ -153,6 +153,89 @@ The DBAS import engine implementation (bd-gb5r5.3) must satisfy **all** of the f
 16. **CSRF posture** — DBAS endpoint must not rely on cookie-only auth; require `Authorization: Bearer` token. Test asserts. *(P1)*
 17. **Authz denial logging** — 401/403 on DBAS endpoint emits structured WARN log including reason. *(R6)*
 
+### 4.1 Addendum checklist items (v0.18.0 DBAS absorption — Addenda A & B)
+
+The v0.18.0 epic (`enhancedchannelmanager-0i2vt`, ADR-008) adds an **export/backup** path
+and **outbound cloud destinations** that did not exist when items 1–17 were written. The
+following items extend the checklist; they are acceptance criteria for the Phase-0 work
+(`0i2vt.1`, `0i2vt.2`, `0i2vt.3`) and the Phase-1 work (`0i2vt.4`, `0i2vt.5`, `0i2vt.7`,
+`0i2vt.8`). See Addendum A (§8) and Addendum B (§9) for the threat tables these map to.
+
+18. **Export-artifact redaction parity (Addendum A)** — the v0.18.0 backup ZIP builder
+    (`0i2vt.7`) MUST apply the same redaction the existing YAML/`settings.json` export path
+    applies (`backend/routers/backup.py` → `REDACTED` marker + `_scrub_journal_db_to_temp` +
+    `_gather_settings`): every credential-class key across all **13 Dispatcharr categories**
+    (M3U account passwords/usernames, EPG source creds, XC host creds, core-settings SMTP
+    password, plugin config secrets, user `password_hash`, DVR/comskip tokens, cloud-target
+    tokens) is replaced with the `REDACTED` sentinel **or** stored encrypted (item 19) before
+    the bytes enter the ZIP. The denylist is the single shared `_REDACT_KEYS`-style set used by
+    both YAML and ZIP paths — no second, divergent list. Unit test: build a backup whose source
+    state contains a known M3U password, an SMTP password, and a cloud token; assert none of the
+    three plaintext values appear anywhere in the ZIP bytes (manifest, `settings.json`,
+    `journal.db`, per-category YAML, binary subtree). *(A1, A2, A4 — Addendum A; closes Security
+    Mandatory #4 + #6)*
+19. **Encrypted-rather-than-redacted carve-out (Addendum A)** — where a backup is intended to
+    be **restorable with credentials intact** (cross-instance migration), credential fields MAY
+    be carried in ciphertext instead of redacted, but ONLY via the existing Fernet primitive
+    (`backend/cloud_storage/crypto.py`, per ADR-008 D3) and ONLY for the `SyncTarget`/`CloudTarget`
+    credential columns defined in `0i2vt.4`. The Fernet key is **never** placed in the ZIP. A
+    backup taken on instance A and restored on instance B without the key MUST surface the
+    credential fields as unreadable (decryption-failure → field treated as absent, restore
+    continues with a WARN), never as plaintext and never as a hard crash. Test: restore a
+    backup whose `CloudTarget.token_ciphertext` was encrypted under a different key → token field
+    absent, restore proceeds. *(A3 — Addendum A; ties into ADR-008 D3)*
+20. **Manifest covers redacted state (Addendum A)** — the ZIP `manifest` / `schema_version`
+    block records SHA-256 over the **post-redaction** bytes (the bytes actually written), so
+    integrity verification on restore validates what is present, not a pre-redaction phantom.
+    The manifest itself is enumerated as metadata-only on dry-run (path/size/sha256), per item 8.
+    *(A5 — Addendum A)*
+21. **SSRF validator on ALL outbound URLs (Addendum B)** — every outbound HTTP(S) request the
+    backup/sync subsystem makes — cloud-destination uploads (S3 endpoint URL, WebDAV base URL,
+    OneDrive/Dropbox/GDrive API hosts and any user-overridable endpoint), `SyncTarget` Dispatcharr-B
+    URL, and any user-supplied callback/webhook — passes through a shared SSRF validator BEFORE the
+    connection is opened. The validator is the single chokepoint; no adapter (`s3_adapter.py`,
+    `onedrive_adapter.py`, `dropbox_adapter.py`, `gdrive_adapter.py`, WebDAV) may issue a raw
+    `httpx`/`requests` call that bypasses it. This is the Phase-1 deliverable in `0i2vt.5`/`0i2vt.8`;
+    this checklist item is the contract. *(B1, B2, B4, B6 — Addendum B; ADR-008 D4)*
+22. **Always-on denylist regardless of LAN-friendly choice (Addendum B)** — even when the
+    first-run wizard (`0i2vt.5`) chose LAN-friendly mode, the validator ALWAYS rejects, with
+    no opt-out: link-local `169.254.0.0/16` (incl. IMDS `169.254.169.254/32`), CGNAT
+    `100.64.0.0/10`, `0.0.0.0/8`, IPv6 loopback `::1`, IPv6 ULA `fc00::/7`, IPv6 link-local
+    `fe80::/10`, IPv6 site-local `fec0::/10`, IPv4-mapped-IPv6 `::ffff:0:0/96`, and any
+    non-`http`/`https` scheme. `127.0.0.0/8` and RFC1918 ranges are rejected in public-only mode
+    and allowed in LAN-friendly mode; everything in the always-on list is rejected in **both**.
+    Test corpus: each denied range + an IPv4-mapped-IPv6 representation of the IMDS address + a
+    `gopher://`/`file://`/`ftp://` scheme → all rejected in both modes. *(B2, B6 — Addendum B;
+    ADR-008 D4)*
+23. **DNS-rebinding mitigation: resolve-then-connect-by-IP (Addendum B)** — the validator
+    resolves the destination hostname **once**, validates the returned address(es) against the
+    denylist (and, if any A/AAAA record is denied, rejects the whole request — no "use the allowed
+    one"), then the HTTP client connects **by that validated IP**, sending the original hostname
+    only as SNI and `Host:` header. The window between validation and connect must not contain a
+    second, unvalidated DNS lookup. Test: a hostname that returns two A records (one public, one
+    `169.254.169.254`) → rejected; a hostname whose resolution is mocked to change between
+    validation and connect → connection still goes to the validated IP. *(B3 — Addendum B; ADR-008 D4)*
+24. **Redirect re-validation (Addendum B)** — 3xx responses are NOT auto-followed to a new host
+    without re-running the full denylist + resolve-by-IP check on the redirect target; a redirect
+    to a previously-unvalidated host is either blocked outright or only followed after a fresh
+    validation pass. Cross-scheme downgrades (`https://` → `http://`) on redirect are rejected.
+    Test: server replies `302` to `http://169.254.169.254/latest/meta-data/` → request fails, no
+    connection to the IMDS host. *(B3, B6 — Addendum B; ADR-008 D4)*
+25. **TLS-verify default + audited insecure flag (Addendum B)** — outbound requests use
+    `verify=True` by default. A per-`CloudTarget`/`SyncTarget` `insecure=true` escape hatch MAY
+    exist (self-signed WebDAV/MinIO are real deployments) but every outbound request made with
+    `insecure=true` writes a `journal.log_entry` audit row (`category='backup_outbound'`,
+    target id, host, `tls_verified=false`) — not just once at config time, on **every** request.
+    Test: configure an `insecure=true` target, trigger a backup upload, assert an audit row with
+    `tls_verified=false` exists for that request. *(B1, B5 — Addendum B; ADR-008 D4)*
+26. **Outbound-credential freshness binding (Addendum B / cross-ref `0i2vt.4`)** — a scheduled
+    backup/sync op that fires after the target's credentials were rotated or revoked MUST NOT use
+    the stale token: the `CloudTarget`/`SyncTarget` model carries `credential_version` and
+    `token_revoked_at`; the scheduler captures `credential_version` at enqueue time and the worker
+    re-checks it at execution time, aborting (WARN + audit row) if it changed or if
+    `token_revoked_at` is set. (This is Security Mandatory #5; the schema lands in `0i2vt.4`, the
+    enforcement in `0i2vt.6`/`0i2vt.8`.) *(B5 — Addendum B)*
+
 ---
 
 ## 5. Test Cases (for `backend/tests/security/`)
@@ -233,3 +316,193 @@ Assumes auth is bearer-token only (not cookie-based). If cookie-based sessions a
 - ADR-003 (pending) — WebSocket long-running job pattern; DBAS import will run as a background job with progress events.
 - ADR-004 (pending) — DBAS instance-trust posture (same-instance vs. cross-instance).
 - bd-gb5r5.3 — DBAS import engine; hardening checklist in §4 will be appended to that bead's acceptance criteria.
+
+> **Note on bead lineage (2026-05-12).** The 42-bead plan `bd-gb5r5` referenced above was
+> retired 2026-04-21 and superseded by epic `enhancedchannelmanager-0i2vt` ("v0.18.0 DBAS
+> absorption: Backup + Restore") with `docs/adr/ADR-008-dbas-absorption-approach.md` as its
+> source of truth. **As of 2026-05-12 `docs/adr/ADR-008-dbas-absorption-approach.md` is not
+> present in the repo** — the ADR-008 content lives only in the epic bead's description (nine
+> PO decisions D1–D9). This is a missing-doc note for the PO: either land ADR-008 or accept
+> that the epic bead is the canonical record. The Addenda below cite "ADR-008 D4" etc. against
+> that bead's decision list, not against a file. The §1–§7 body still reads against `bd-gb5r5.3`
+> because that body has not been re-baselined; the **Addenda A & B (below) and checklist items
+> 18–26 are the v0.18.0-current layer** and take precedence where they overlap.
+
+---
+
+## 8. Addendum A — Export Artifact Redaction (v0.18.0 backup ZIP)
+
+**Added:** 2026-05-12 · **Bead:** `enhancedchannelmanager-0i2vt.3` (Phase 0) · **Feeds:** `0i2vt.4` (Fernet credential models), `0i2vt.7` (ZIP artifact builder) · **Closes:** "Security Mandatory #4 + #6"
+
+### 8.1 Scope
+
+The v0.18.0 backup feature produces an **export artifact** — a ZIP wrapping per-category YAML
+plus a binary subtree (uploaded logos, TLS material), with a `manifest` block carrying
+`schema_version`, per-file SHA-256, and sizes, across the **13 Dispatcharr config categories**
+(M3U accounts, EPG sources, channel groups, channel profiles, stream profiles, user agents,
+core settings, plugins, DVR rules, comskip config, users, channels-with-streams, logos).
+
+This is a **new outbound data egress path** that the original threat model (§1–§7, written
+against the *import* engine) does not cover. It is, however, structurally the mirror image of a
+control ECM **already implements** on the legacy backup path: `backend/routers/backup.py` already
+redacts credential-class keys before they enter the backup ZIP — `REDACTED = "***REDACTED***"`
+sentinel, `_scrub_journal_db_to_temp()` rewrites credential keys inside `journal.db`,
+`_gather_settings()` returns a redacted `settings.json`. **Addendum A requires the v0.18.0
+13-category ZIP builder to extend that same redaction to the categories the legacy path does not
+yet touch** (M3U/EPG/XC creds per-category, plugin config secrets, cloud-target tokens, etc.),
+using the *same shared denylist* — not a second, divergent one.
+
+**Trust boundary:** the export artifact crosses **ECM → operator's hands → (optionally) cloud
+storage**. Once it leaves the container it is outside every ECM control. Treat it as if it will
+be stored unencrypted on a third party's disk, because it often will be (Dropbox, an S3 bucket,
+a USB stick).
+
+### 8.2 STRIDE rows — Export Artifact
+
+| # | Surface | STRIDE | Threat | Attack scenario | Mitigation | Status | Sev |
+|---|---------|--------|--------|-----------------|------------|--------|-----|
+| A1 | ZIP build | Information Disclosure | Backup ZIP ships plaintext credentials from any of the 13 categories | Operator downloads a routine backup; the ZIP contains M3U `username`/`password`, EPG/XC creds, core-settings SMTP password, user `password_hash`, cloud-target tokens. Operator emails it to support, drops it in a shared Dropbox, or it's swept up by an automated backup-of-the-backup. All those secrets are now exfiltrated. | Shared `_REDACT_KEYS`-style denylist (the *same* set `backend/routers/backup.py` uses for the legacy path) applied per-category before bytes enter the ZIP: every matched key → `REDACTED` sentinel **or** Fernet ciphertext (A3). `journal.db` scrubbed via the existing `_scrub_journal_db_to_temp()` pattern. Unit test asserts no known plaintext secret appears anywhere in the ZIP. | to-build (`0i2vt.7`) | **High** |
+| A2 | ZIP build / dry-run | Information Disclosure | Backup *preview* or progress log echoes secret values | The Phase-1 backup runs as an HTTP-polled task (ADR-008 D5); a verbose progress line or a "what will be included" preview lists raw category rows including secret fields. | Reuse the §3.4/I2 rule: preview/log lines enumerate **metadata only** (category, count, sizes), and any per-row preview runs through the shared `_redact()` helper. No secret value ever reaches a log line or a progress event. | to-build (`0i2vt.7`) | High |
+| A3 | ZIP build | Information Disclosure (mitigated form) | A *restorable* backup needs creds intact, so redaction would break cross-instance migration → temptation to ship plaintext | Operator wants to migrate Dispatcharr config A→B *including* M3U passwords so they don't have to re-enter 40 sources. Redaction defeats that, so someone "just for migration" turns redaction off. | Carry credential fields as **Fernet ciphertext** (ADR-008 D3 primitive, `backend/cloud_storage/crypto.py`), restricted to the `SyncTarget`/`CloudTarget` credential columns from `0i2vt.4`. The Fernet **key is never in the ZIP**. Restore on an instance lacking the key → field unreadable → treated as absent, restore continues with WARN (never plaintext, never crash). No global "disable redaction" switch exists. | to-build (`0i2vt.4` + `0i2vt.7`) | Med |
+| A4 | ZIP build | Tampering / Spoofing | Manifest SHA-256 covers pre-redaction bytes, so a tampered redacted file passes verification | Attacker who can write into the ZIP after redaction but before manifest finalisation swaps a redacted `settings.json` for one with a malicious SMTP relay; if the manifest was computed over the *original* bytes, the swap goes undetected on restore. | Manifest SHA-256 is computed over the **exact bytes written into the ZIP** (post-redaction, post-encryption), as the last step before sealing the archive. Restore verifies what is present. (Reuses the §3.3/T4 manifest-hash mechanism, just pinned to the redacted content.) | to-build (`0i2vt.7`) | Med |
+| A5 | ZIP build | Repudiation | No record that a backup was taken / who took it / whether it was redacted | An operator (or a compromised admin session) silently exfiltrates config via a backup; no trail. | `journal.log_entry` per backup: `category='backup'`, `user_id`, request ID, timestamp, category counts, artifact SHA-256, and a `redaction_mode` field (`redacted` vs `encrypted`). Mirrors §3.3/R1. | to-build (`0i2vt.7`) | Med |
+
+### 8.3 Mitigations summary (Addendum A)
+
+1. **Single shared redaction denylist.** One `_REDACT_KEYS`-style constant, imported by both the legacy `backup.py` path and the new 13-category ZIP builder. Adding a category never means forgetting to add it to a second list. (Checklist 18.)
+2. **Redact-by-default, encrypt-as-carve-out.** Default behaviour redacts to the `REDACTED` sentinel. The only path that carries readable-with-key ciphertext is `SyncTarget`/`CloudTarget` credentials via the existing Fernet primitive; the key never travels with the artifact. No global "ship plaintext" switch. (Checklist 19.)
+3. **Metadata-only previews & progress.** Dry-run / preview / progress events enumerate path, size, sha256, counts — never row contents. Per-row preview, where it exists, runs through `_redact()`. (Checklist 18, reuse I2.)
+4. **Manifest over post-redaction bytes.** SHA-256 is the last step before sealing; it covers exactly what's in the ZIP. (Checklist 20.)
+5. **Backup audit row.** Every backup is journalled with subject, request ID, counts, artifact hash, and redaction mode. (Checklist 18/Addendum A row A5; reuse R1.)
+
+### 8.4 Residual risk (Addendum A)
+
+- **Residual: artifact handling after egress — Medium, accepted-pending-PO.** Once the ZIP leaves the container ECM has zero control. Even fully redacted, the artifact still reveals the *shape* of a deployment (channel names, source URLs minus creds, user list). Mitigations reduce a credential breach to a topology disclosure; they cannot make the artifact safe to publish. **PO decision:** is "redacted backup may be stored anywhere; encrypted backup needs the key kept separate" an acceptable posture for v0.18.0, or does the PO want an *optional* whole-artifact passphrase (age/Fernet over the entire ZIP) as a follow-on bead? Recommendation: ship redacted-by-default for v0.18.0, file whole-artifact encryption as a v0.18.x candidate.
+- **Residual: redaction-denylist completeness — Low.** A credential-class key not in the denylist ships in plaintext. Mitigated by the shared-list discipline (one place to audit) and the unit test that fails if a known secret leaks; but a *novel* category added without a denylist review is the failure mode. Action: the "add a Dispatcharr category" checklist must include "add its secret keys to `_REDACT_KEYS`".
+- **Residual: Fernet key compromise — Low (for v0.18.0 scope).** If both the encrypted artifact and the Fernet key leak, the carve-out creds are exposed. Out of scope to fix here (no KMS for MVP, ADR-008 D3); the key-bootstrap integrity check (`0i2vt.2`, mode 0600 + ownership) is the compensating control.
+
+---
+
+## 9. Addendum B — Outbound Destinations & SSRF (v0.18.0 cloud upload + v0.18.1 sync)
+
+**Added:** 2026-05-12 · **Bead:** `enhancedchannelmanager-0i2vt.3` (Phase 0) · **Feeds:** `0i2vt.4` (SyncTarget/CloudTarget models), `0i2vt.5` (first-run SSRF wizard + always-on denylist + DNS-rebinding mitigations), `0i2vt.8` (cloud upload wiring) · **Source:** ADR-008 D4 + "Security Mandatory #2, #3, #5"
+
+### 9.1 Scope
+
+v0.18.0 adds **operator-configurable outbound destinations**:
+
+- **CloudTarget** — S3 (incl. S3-compatible: MinIO, Wasabi, B2 — *operator supplies the endpoint URL*), WebDAV (*operator supplies the base URL*), OneDrive, Dropbox, Google Drive. Adapters already scaffolded in `backend/cloud_storage/` (`s3_adapter.py`, `onedrive_adapter.py`, `dropbox_adapter.py`, `gdrive_adapter.py`, `factory.py`).
+- **SyncTarget** — a second Dispatcharr instance's URL (reserved for v0.18.1 sync; schema lands in v0.18.0 per ADR-008).
+
+**The threat:** an authenticated admin (or an attacker who has compromised an admin session)
+can point ECM at an arbitrary URL — and ECM, running *inside the operator's network*, will make
+the request. That is a classic **server-side request forgery (SSRF)** primitive: hit the cloud
+metadata endpoint (`169.254.169.254`) for instance credentials, scan/poke internal infrastructure
+(routers, databases, other containers), or use ECM as an unwitting proxy. The §1–§7 import model
+only ever talked about *inbound* archives and the *one* admin-configured local Dispatcharr (ADR-004
+treated as trusted, sync-to-third-party explicitly out of scope). v0.18.0 changes that: ECM now
+deliberately makes outbound requests to **destinations the operator typed in**, including
+*endpoint URLs* (not just API tokens) for S3-compatible and WebDAV. Every one of those URLs is
+attacker-influenceable and must be validated.
+
+ADR-008 D4 resolves the policy: a **first-run wizard** lets the operator pick *LAN-friendly*
+(RFC1918 + loopback allowed — the default, because plenty of operators back up to a NAS on
+`192.168.x.x`) vs *public-only* (private ranges blocked). **Regardless of that choice**, an
+always-on denylist blocks metadata/link-local/CGNAT/etc., and DNS-rebinding mitigations are
+mandatory. This addendum is the threat-model backing for `0i2vt.5`; §9.4 hands the concrete
+validator requirements to that bead.
+
+**Trust boundary added:** **ECM → arbitrary operator-supplied URL** (cloud APIs, S3-compatible
+endpoints, WebDAV servers, Dispatcharr-B). This is a new boundary; treat the destination as
+untrusted *and* treat the act of connecting as a capability that must be gated.
+
+### 9.2 STRIDE rows — Outbound Destinations
+
+| # | Surface | STRIDE | Threat | Attack scenario | Mitigation | Status | Sev |
+|---|---------|--------|--------|-----------------|------------|--------|-----|
+| B1 | CloudTarget config | Tampering / Spoofing | Operator-supplied S3/WebDAV **endpoint URL** is malicious | Admin (or hijacked admin session) sets the "S3 endpoint" to `http://169.254.169.254/` or `http://10.0.0.5:6379/` ("MinIO on the LAN"). ECM dutifully connects on the next backup upload. | Shared SSRF validator (§9.4) on **every** outbound URL before connect — endpoint URLs included, not just tokens. No adapter issues a raw `httpx`/`requests` call that bypasses the validator (single chokepoint). | to-build (`0i2vt.5` + `0i2vt.8`) | **High** |
+| B2 | Any outbound URL | Information Disclosure / EoP | SSRF to cloud metadata / link-local / internal ranges | Destination resolves to `169.254.169.254` → ECM fetches the instance's IAM credentials and (because it's a "backup destination") may even *upload to it* or surface the response in an error. Or destination is `127.0.0.1:<admin-port>` / `100.64.x.x` / `[::1]` and ECM is now an internal-network scanner/proxy. | **Always-on denylist** (regardless of wizard choice): `169.254.0.0/16` (incl. IMDS), `100.64.0.0/10`, `0.0.0.0/8`, `::1`, `fc00::/7`, `fe80::/10`, `fec0::/10`, `::ffff:0:0/96`, non-`http(s)` schemes — *all rejected in both modes*. `127.0.0.0/8` + RFC1918 rejected in public-only mode, allowed in LAN-friendly. (§9.4 item 2.) | to-build (`0i2vt.5`) | **High** |
+| B3 | Any outbound URL | Tampering | DNS rebinding / TOCTOU — hostname validated, then re-resolves to a denied IP at connect time (or a redirect lands on one) | Attacker controls `evil.example.com`; first DNS lookup (validation) returns a public IP, second lookup (the actual connect) returns `169.254.169.254`. Or the destination replies `302 → http://169.254.169.254/latest/meta-data/`. The naïve "validate the hostname then `requests.get(hostname)`" pattern is bypassed. | **Resolve-then-connect-by-IP:** resolve once, validate *every* returned A/AAAA against the denylist (any denied record → reject the whole request), connect by the validated IP with the hostname as SNI/`Host:`. **Redirect re-validation:** 3xx to a new host is not auto-followed; re-run the full denylist + resolve-by-IP on the redirect target, and reject `https→http` downgrades. (§9.4 items 3–4.) | to-build (`0i2vt.5`) | **High** |
+| B4 | Cloud adapters | EoP / bypass | An adapter (`s3_adapter.py` etc.) makes a raw HTTP call that skips the validator | The S3 SDK or a WebDAV client library opens its own connection straight from the endpoint URL string, never touching ECM's validator → SSRF protection is theatre. | The validator is the **single chokepoint**: either (a) all adapters route through one ECM-owned HTTP client that validates on every request and pins to the resolved IP, or (b) where an SDK insists on doing its own DNS, ECM pre-resolves + validates and hands the SDK an IP + `Host:` override. CI test: grep adapters for direct `httpx`/`requests`/`urllib` calls; any hit fails the build unless it's the validated client. (§9.4 item 1.) | to-build (`0i2vt.8`) | High |
+| B5 | CloudTarget/SyncTarget creds | Tampering / Repudiation | Scheduled backup uses a *stale* (rotated/revoked) cloud token; or `insecure=true` is set with no audit trail | (a) Admin rotates the Dropbox token; a backup schedule created earlier still fires with the old token — silently failing or, worse, hitting a now-attacker-controlled account that reused the old token. (b) Admin sets `insecure=true` for a self-signed WebDAV box; later that box is MITM'd and nobody knows ECM was talking to it without TLS verification. | (a) `credential_version` + `token_revoked_at` columns on the model (`0i2vt.4`); scheduler captures version at enqueue, worker re-checks at execute, aborts with WARN + audit row on mismatch (Security Mandatory #5). (b) `verify=True` default; `insecure=true` per-target escape hatch writes a `journal.log_entry` (`category='backup_outbound'`, host, `tls_verified=false`) on **every** request, not once at config time. (§9.4 items 5–6, checklist 25–26.) | to-build (`0i2vt.4` + `0i2vt.8`) | Med |
+| B6 | First-run wizard / settings | EoP / misconfig | Wizard default or a later settings change weakens the denylist | Operator clicks through the wizard picking "LAN-friendly" without reading; or a future settings page lets someone add `169.254.169.254` to an allowlist "to scrape metadata for monitoring". | The always-on denylist is **not** subject to the wizard choice or any allowlist — it is unconditional in code, with no settings key that can disable it. The wizard choice only toggles the RFC1918/loopback band. A test asserts the always-on entries are rejected in *both* modes and that no settings key removes them. (§9.4 item 2.) | to-build (`0i2vt.5`) | Med |
+
+### 9.3 Mitigations summary (Addendum B)
+
+1. **One SSRF chokepoint.** A single ECM-owned validated HTTP client (or pre-resolve+IP-pin shim for SDKs that won't cooperate). CI grep forbids raw outbound calls in the adapters. (Checklist 21, 24; §9.4 item 1.)
+2. **Always-on denylist, unconditional.** Metadata/link-local/CGNAT/IPv6-special/non-http(s) rejected in *both* wizard modes; no settings key, no allowlist can re-enable them. (Checklist 22; §9.4 item 2.)
+3. **LAN-friendly is the only knob.** The wizard toggles RFC1918 + `127.0.0.0/8` only; default LAN-friendly per ADR-008 D4. (Checklist 22; §9.4 item 2.)
+4. **Resolve-then-connect-by-IP.** Resolve once, validate all records, connect by validated IP with hostname as SNI/`Host:`. Closes DNS-rebinding TOCTOU. (Checklist 23; §9.4 item 3.)
+5. **Redirect re-validation + no scheme downgrade.** 3xx to a new host re-runs the full check; `https→http` rejected. (Checklist 24; §9.4 item 4.)
+6. **TLS verify on; insecure flag is audited per request.** `verify=True` default; `insecure=true` → audit row every time. (Checklist 25; §9.4 item 6.)
+7. **Credential-freshness binding.** `credential_version` + `token_revoked_at`; enqueue-time capture, execute-time re-check. (Checklist 26; §9.4 item 5.)
+
+### 9.4 Phase-1 handoff — SSRF validator requirements (for `0i2vt.5`)
+
+`0i2vt.5` MUST deliver a validator meeting **all** of the following. (`0i2vt.5`'s own description
+already lists most of this — restating here so the threat model is the single source the bead's
+acceptance criteria check against. Where `0i2vt.5` says "extends bead `zbt74` validator pattern":
+that pattern covers scheme + IPv4 RFC1918; the items below add IPv6, CGNAT, IMDS, and
+DNS-rebinding coverage that `zbt74` does not.)
+
+1. **Single validated outbound client / chokepoint.** All outbound HTTP(S) from the backup/sync
+   subsystem goes through one validated client. Cloud SDKs that do their own DNS get pre-resolved
+   IPs + `Host:` overrides from the validator. CI test forbids raw `httpx`/`requests`/`urllib`
+   calls in `backend/cloud_storage/` adapters and the sync code.
+2. **Scheme allowlist + always-on IP denylist + wizard-toggled band.**
+   - Scheme: only `http` and `https`. Reject `file`, `ftp`, `gopher`, `data`, `dict`, etc.
+   - Always-on deny (both wizard modes, no opt-out, no settings override, no allowlist):
+     `0.0.0.0/8`, `169.254.0.0/16` (incl. `169.254.169.254/32` IMDS), `100.64.0.0/10` (CGNAT),
+     `::1/128`, `fc00::/7` (ULA), `fe80::/10` (link-local), `fec0::/10` (site-local),
+     `::ffff:0:0/96` (IPv4-mapped — must be unwrapped and re-checked against the IPv4 rules so
+     `::ffff:169.254.169.254` is caught), `::/128`, multicast (`224.0.0.0/4`, `ff00::/8`).
+   - Wizard-toggled: `127.0.0.0/8` and RFC1918 (`10/8`, `172.16/12`, `192.168/16`) + IPv6
+     equivalents — *allowed* in LAN-friendly (default), *rejected* in public-only.
+3. **Resolve-then-connect-by-IP (DNS-rebinding mitigation).** Resolve the hostname once; validate
+   **every** returned A and AAAA record against the rules; if **any** record is denied, reject the
+   whole request (do not "pick the allowed one"). Connect by the validated IP, with the original
+   hostname as TLS SNI and `Host:` header. No second DNS lookup between validation and connect.
+4. **Redirect handling.** Do not transparently follow 3xx to a different host. Either block all
+   cross-host redirects, or re-run steps 2–3 on each redirect target before following. Reject any
+   redirect that downgrades `https` → `http`. Cap redirect chain length (≤ 5).
+5. **Credential-freshness binding (with `0i2vt.4`).** Honour `credential_version` /
+   `token_revoked_at`: scheduler captures `credential_version` at enqueue; worker aborts (WARN +
+   `journal.log_entry`) if it changed or `token_revoked_at` is set at execute time.
+6. **TLS posture.** `verify=True` default. Optional per-target `insecure=true`; when set, every
+   outbound request with it logs a `journal.log_entry` (`category='backup_outbound'`, target id,
+   host, `tls_verified=false`).
+7. **First-run wizard.** Appears on first run; records the LAN-friendly vs public-only choice;
+   default = LAN-friendly (ADR-008 D4). The choice is re-editable in settings, but editing it can
+   only move the *RFC1918/loopback band* — it can never touch the always-on denylist (item 2).
+8. **Regression corpus (mandatory, ships with `0i2vt.5`).** Covers, at minimum: each always-on
+   denied range (v4 and v6); `::ffff:169.254.169.254` and other IPv4-mapped representations of
+   denied addresses; unicode/punycode hostnames that decode to a denied target; a two-A-record
+   response (one allowed, one denied) → rejected; a resolution that changes between validate and
+   connect → connection still goes to the validated IP; a `302 → http://169.254.169.254/...`
+   redirect → blocked; an `https → http` redirect → blocked; each non-http(s) scheme → rejected;
+   RFC1918 allowed in LAN-friendly / rejected in public-only.
+
+### 9.5 Residual risk (Addendum B)
+
+- **Residual: authenticated-admin abuse — Low, accepted.** An admin can still configure a backup
+  destination that is *attacker-controlled but a perfectly valid public host* and exfiltrate the
+  (redacted, per Addendum A) backup there. The SSRF validator stops ECM from hitting *internal*
+  and *metadata* targets; it cannot stop a legitimate admin from sending a backup to a public S3
+  bucket they shouldn't. This is inherent to "operator configures their own backup destination"
+  and is bounded by the admin-only gating + the audit row on every backup (Addendum A row A5).
+  No further mitigation proposed for v0.18.0.
+- **Residual: SDK DNS behaviour — Low/Medium until verified.** Item 1's "pre-resolve + `Host:`
+  override for SDKs" assumes the boto3 / Dropbox / Graph / WebDAV clients can be made to connect
+  by IP. If one cannot (e.g., SNI/cert validation that insists on the hostname *and* does its own
+  resolution), that adapter has a residual rebinding window. **Action for `0i2vt.8`:** verify each
+  adapter's HTTP layer can be IP-pinned; if not, document the gap and consider an egress-proxy
+  shim. Re-rate to Medium if any adapter can't be pinned.
+- **Residual: IPv6 / new special-purpose ranges — Low.** IANA adds special-purpose ranges over
+  time; a future reserved range not in item 2's list would not be denied. Mitigated by using the
+  Python `ipaddress` module's `is_private` / `is_link_local` / `is_reserved` / `is_loopback` /
+  `is_multicast` properties as a *backstop* in addition to the explicit CIDR list, so the validator
+  fails closed on categories even if a specific new prefix isn't enumerated.
+- **Residual: time-of-day DNS for long-running uploads — Low.** A multi-GB upload holds a
+  connection open for a long time; the validated IP is fixed for that connection (good), but if
+  the connection drops and the client retries, the retry must re-run validation, not reuse a
+  cached hostname. **Action for `0i2vt.8`:** retries go back through the validator.

--- a/docs/security/threat_model_stats_v2.md
+++ b/docs/security/threat_model_stats_v2.md
@@ -1,0 +1,210 @@
+# Threat Model & Data Classification: Stats v2 / `session_telemetry`
+
+**Bead:** enhancedchannelmanager-skqln.7 (Privacy 11a — pre-implementation threat model + data classification)
+**Author:** Security Engineer persona (Claude)
+**Date:** 2026-05-12
+**Status:** PO decisions resolved 2026-05-12 (§8). Conditional schema sign-off granted (§9) — converts to full sign-off when conditions (a)–(c) land in the skqln.2 bead.
+**Blocks:** skqln.2 (`session_telemetry` schema + Alembic migration) — schema merge requires this document's sign-off. skqln.8 (post-implementation privacy sign-off) re-checks the built result against this.
+**Feeds:** skqln.1 (ADR-007 retention/rollup policy) — §5 below states the **retention MINIMUM**. ADR-007 authors set the operational maximum on top of that floor.
+**Related:** `docs/auth_middleware.md` (global secure-by-default auth; admin vs. non-admin), `docs/security/threat_model_dbas_import.md` (house style, redaction pattern), epic skqln body (scope-history trail, PO override pulling GH-59 in).
+
+---
+
+## 1. Scope & System Overview
+
+Stats v2 introduces a new database table, `session_telemetry`, written once per stream-stats poll by `BandwidthTracker` (single-write design — see epic). Each row captures, per poll, who was watching what, via which upstream M3U provider, with what bytes-transferred delta and buffer-event count. Two new read-only Stats-tab panels consume it:
+
+- **Users panel (GH-62, skqln.5/.6)** — watch-time-by-user: daily trend, channel table (total minutes, last watched), 7/30/90-day selector.
+- **Providers panel (GH-59, skqln.16/.18)** — operator view of upstream-provider performance: buffering events by provider over time, watch-time per provider, channels-by-provider heatmap, derived bitrate by provider. Used to make provider keep/drop decisions at renewal.
+
+Per the DBA's refined schema (skqln.2), the columns are:
+
+| Column | Type | Notes |
+|---|---|---|
+| `session_id` | TEXT (UUID) | indexed; correlates rows in one viewing session |
+| `observed_at` | INTEGER (unix epoch ms) | mandatory index; retention sweeps key off this |
+| `user_id` | INTEGER, FK `users(id)` ON DELETE SET NULL | nullable |
+| `provider_id` | INTEGER, FK `providers(id)` ON DELETE SET NULL | nullable until provider tagging ships |
+| `channel_id` | INTEGER, FK `channels(id)` ON DELETE SET NULL | nullable |
+| `bytes_delta` | INTEGER NOT NULL, CHECK ≥ 0 | per-poll byte delta |
+| `buffer_event_count` | INTEGER NOT NULL DEFAULT 0 | per-poll buffer-event count |
+| `poll_interval_ms` | INTEGER NOT NULL | poll cadence, so watch-time math doesn't assume a fixed interval |
+
+This is a self-hosted single-container app. There is no multi-tenant boundary in the SaaS sense — but there **is** a user boundary: ECM has accounts (`users` table) with an `is_admin` flag, optional auth (`auth.require_auth`), and a global auth middleware over `/api/*`. The relevant trust boundaries:
+
+- **Browser → ECM** — authenticated user (admin or non-admin), or unauthenticated when `auth.require_auth=False`.
+- **Non-admin user → other users' data** — a non-admin viewing the Users panel must not become a way to surveil other household members' viewing habits. This is the new boundary Stats v2 introduces.
+- **ECM → operator-visible diagnostics** — app logs, support bundles / diagnostic exports, the Discord release-note / digest automation. Behavioral data must not leak here.
+- **ECM → SQLite (`journal.db` / the app DB)** — `session_telemetry` lives in the app database.
+
+### 1.1 What's new vs. existing stats
+
+ECM already exposes `/api/stats/*` (channel stats, popularity, activity, bandwidth) — but those are *channel-scoped aggregates pulled live from Dispatcharr*, not *persisted per-user behavioral history*. Stats v2 is the first time ECM **stores, indefinitely (via rollups), a per-user record of what each human watched and when**. That is a categorical change in the app's data sensitivity, and it's why this threat model exists before the schema lands rather than after.
+
+### 1.2 Shared-household reality
+
+One Dispatcharr username is routinely shared by multiple humans (spouse, kids, roommates). `user_id` in `session_telemetry` is therefore **a household identity, not necessarily a person** — but in single-occupant installs it *is* a person. The model treats `user_id`-keyed history as person-level PII-adjacent data regardless, because the conservative case is the one that causes harm if mishandled.
+
+---
+
+## 2. Data Classification
+
+Classification scale (ECM-local, ordered):
+
+- **C0 — Public/operational** — no privacy concern; safe to log, export, surface anywhere.
+- **C1 — Internal** — operational data with no behavioral inference; safe in admin-visible diagnostics, not deliberately published.
+- **C2 — Behavioral-sensitive** — reveals an individual's (or household's) media-consumption behavior. Viewing habits. Treated as PII-adjacent: not legally PII in most jurisdictions, but it's the kind of data whose disclosure causes real interpersonal/embarrassment/profiling harm. Default-deny across the user boundary; never in logs/exports.
+- **C3 — Relationship-sensitive (operator)** — reveals the operator's commercial relationship with upstream providers (which M3U services they subscribe to, how heavily). Lower harm than C2 to an *end user*, but still operator-private; should not be exposed to non-admin users and should not leak into diagnostics that might be shared publicly (Discord, GitHub issue attachments).
+- **C4 — Secret** — credentials, tokens. Not present in `session_telemetry`. Listed only to note its absence.
+
+### 2.1 `session_telemetry` field classification
+
+| Field | Classification | Rationale | Handling rules |
+|---|---|---|---|
+| `session_id` | **C1** alone; **C2** in combination | A random UUID is meaningless by itself, but it's the join key that reconstructs a full viewing session (channel sequence, timing). Treat as C2 the moment it's correlated with `user_id`/`channel_id`. | Do not log raw `session_id` alongside `user_id`. Fine in DB. Not in support bundles. |
+| `observed_at` | **C1** alone; **C2** in combination | A timestamp is C1; "user X was watching at 02:14" is C2. | Never log together with `user_id` + `channel_id`. |
+| `user_id` | **C2** | The pivot for "whose viewing history." Even as an opaque integer it's re-identifiable against the `users` table. Household-or-person (see §1.2). | Default-deny across the user boundary (§3). Never in logs, support bundles, diagnostic exports, or Discord automation. Rollups keyed by `user_id` are still C2. |
+| `channel_id` | **C1** alone; **C2** when joined to `user_id` | The channel catalog is operator-internal but not behavioral; "channel 412 was watched 9000 min total" is C1-ish aggregate. "User X watched channel 412" is C2. | Aggregate-by-channel (no user dimension) may appear in operator-visible stats. Per-user channel history is C2. |
+| `provider_id` | **C3** | Reveals which upstream M3U providers the operator uses and how heavily — a commercial-relationship signal. Bounded cardinality (<20). Not end-user PII. | Operator-visible (admin) panels OK. Not exposed to non-admin users (recommendation — see §3 / §8 Q3). Not in publicly-shareable diagnostics. Allowed as a Prometheus label per SRE pre-clearance (epic), unlike `user_id`/`channel_id` which are vetoed as labels. |
+| `bytes_delta` | **C1** alone; **C2** in combination | Bandwidth volume is operational. But high-resolution `bytes_delta` over time *is* a behavioral fingerprint (you can infer what was watched from the bitrate curve). Combined with `user_id` → C2; combined with `provider_id` → C3. | Aggregates OK in operator stats. Don't log per-row deltas keyed to a user. |
+| `buffer_event_count` | **C1** alone; **C3** in combination with `provider_id` | Buffer events are a quality metric. Per-provider buffer rates are the operator's keep/drop signal — C3. Not behavioral about a user. | Operator-visible. Fine in aggregate. |
+| `poll_interval_ms` | **C0** | Pure operational metadata about the poller. | No restriction. |
+
+**The combination rule is the important one.** Almost every field is benign in isolation and sensitive in combination — specifically, *any tuple that includes `user_id` and a time/channel/byte dimension is C2*. Engineers and reviewers should treat "does this code path put `user_id` next to `observed_at`/`channel_id`/`bytes_delta` somewhere a non-admin or a log reader can see it?" as the litmus test.
+
+### 2.2 Derived artifacts
+
+| Artifact | Classification | Notes |
+|---|---|---|
+| `watch_time_by_user_daily` rollup (ADR-007) | **C2** | Coarsened (daily granularity, no `session_id`) but still per-user behavioral data. Retention-forever per current plan — accepted, but it stays C2 forever; it's not "anonymized" by rolling up. |
+| `provider_performance_daily` rollup (ADR-007) | **C3** | Per-provider aggregates. No user dimension. Operator-private. |
+| Channel-only aggregates (e.g., total minutes per channel, popularity) | **C1** | No user dimension → not behavioral about an individual. This is the safe shape for any broadly-visible stat. |
+| API responses from `/api/stats/providers/*` | **C3** | Contain provider attribution. Admin-or-all-authenticated is a PO call (§8 Q3); recommend admin-only. |
+| API responses from the Users panel read API (skqln.5) | **C2** | Must be scoped — see §3. |
+
+---
+
+## 3. Access-Control Boundary
+
+**Decision (Security domain — this stands unless challenged on reasoning):**
+
+> **Least-privilege default: a non-admin user sees only their own `user_id`'s watch-time data. Cross-user visibility (any other user's, or the all-users view) is admin-only. Provider-attribution data (the Providers panel and `/api/stats/providers/*`) is recommended admin-only (operator-private, C3) — but whether non-admins may see it is a PO call (§8 Q3).**
+
+Concretely, for the implementing engineers (skqln.5 backend, skqln.6 frontend, skqln.16 backend, skqln.18 frontend):
+
+1. **Watch-time read API (skqln.5)** must derive the target `user_id` from the authenticated principal, **not** from a client-supplied parameter — *unless* the caller is an admin, in which case an explicit `user_id` query param (or "all users") is permitted. A non-admin passing `?user_id=<someone else>` gets `403`, not someone else's data. This must be a server-side check; the frontend hiding the control is not sufficient.
+2. **When `auth.require_auth=False`** (single-user install, no login), there is effectively one principal — the Users panel shows that install's aggregate. That's acceptable: the threat ("one household member surveils another via the panel") only exists when there *are* distinct accounts, and the operator chose to run without auth. Document this in the user guide (skqln.9) so it isn't a surprise.
+3. **Provider panels (skqln.16/.18)** — gate behind `RequireAdminIfEnabled` (matching `backup.py`'s admin-only pattern) per the recommendation. If the PO decides provider stats are fine for all authenticated users (Q3), drop to `RequireAuthIfEnabled` — but never make `/api/stats/providers/*` exempt in `AUTH_EXEMPT_PATHS`.
+4. **No `user_id` enumeration oracle.** The admin "all users" view returns the list of users the admin can already see in the Users-management UI — it must not become a way to discover accounts an admin otherwise couldn't see (there's only one admin tier today, so this is mostly a "don't regress later" note).
+5. **Tests must assert the boundary** (see §6): non-admin → own data only; non-admin requesting another `user_id` → 403; provider endpoints → 403 for non-admin (if admin-only); endpoints absent from `AUTH_EXEMPT_PATHS`.
+
+Rationale: the harm scenario for C2 data is *interpersonal*, not external-attacker — a roommate, parent, partner, or guest with a non-admin login using the panel to see what someone else watched. Least-privilege-by-default closes that without any feature loss for the legitimate use case (each person sees their own history; the operator sees the aggregate). The cost is one server-side authz check per endpoint — cheap, and exactly the pattern `backup.py` already uses.
+
+---
+
+## 4. DREAD Threat Analysis
+
+DREAD scoring, 1–10 per dimension (Damage, Reproducibility, Exploitability, Affected users, Discoverability), averaged to a 1–10 risk score, mapped to the persona's standard severity bands (Crit 9–10, High 7–8.9, Med 4–6.9, Low 0.1–3.9). "Status" ∈ {**existing** (already enforced), **to-build** (a Stats-v2 bead must implement it), **accepted-risk** (PO-signed deviation)}.
+
+| # | Threat | D | R | E | A | Di | Score | Severity | Mitigation | Status | Bead |
+|---|---|--|--|--|--|--|--|--|--|--|--|
+| **T1** | **Non-admin reads another user's watch history** by passing a forged `user_id` to the watch-time read API (the IDOR / broken-object-level-authz classic). | 7 | 9 | 7 | 6 | 6 | **7.0** | **High** | Server-side derive `user_id` from principal; admin-only override; 403 on cross-user request by non-admin (§3.1). | to-build | skqln.5 |
+| **T2** | **Watch-time / behavioral data leaks into application logs** — a `logger.info(f"...user {uid} watching {channel_id} at {ts}")` style line, or an exception dump that includes a row. | 6 | 8 | 5 | 7 | 5 | **6.2** | **Medium** | Redaction rules §7: no `user_id`+time/channel tuple in any log line; `BandwidthTracker` write path logs counts/aggregates only; exception handlers don't echo rows. Lint/grep test. | to-build | skqln.2, skqln.3, skqln.12 |
+| **T3** | **Behavioral data leaks into a support bundle / diagnostic export** that the operator then posts publicly (forum, GitHub issue). | 7 | 6 | 4 | 5 | 6 | **5.6** | **Medium** | Support-bundle / diagnostic-export generators must exclude `session_telemetry` rows and per-user rollups (or include only C1 channel-aggregates). Documented in §7; verified when/if such an export exists. | to-build | (whichever bead owns support-bundle export; note for PO if none) |
+| **T4** | **Provider attribution leaks into the Discord release-note / digest automation** (the `m3u_digest_template` / Discord alert path), revealing the operator's provider list to a Discord channel. | 4 | 5 | 3 | 4 | 5 | **4.2** | **Medium** | Discord automation must never template `provider_id`/provider-name or `session_telemetry` aggregates into messages. §7. Confirm the existing digest template doesn't already pull provider names. | to-build / verify | skqln.12, and audit `m3u_digest_template.py` / `alert_methods_discord.py` |
+| **T5** | **Indefinite-retention rollups become a long-tail privacy liability** — `watch_time_by_user_daily` kept forever means a years-long behavioral dossier per household, surviving long after anyone remembers it exists. | 5 | 8 | 2 | 6 | 3 | **4.8** | **Medium** | Retention *minimum* in §5; ADR-007 sets the max. Recommendation: cap the per-user rollup at a bounded window (see §5.3) rather than literally forever; provider rollups (no user dimension) can stay longer. PO call on the ceiling. | to-build | skqln.1 (ADR-007) |
+| **T6** | **No consent / visibility surface** — users have no way to see that ECM is recording their viewing history or what it has on them. Silent behavioral tracking. | 6 | 9 | 1 | 8 | 7 | **6.2** | **Medium** | §6 consent/visibility UX requirement: a per-user "what's recorded about you" view and a plain-language disclosure in the user guide + first-run/admin docs. Opt-out is a PO call (§8 Q1). | to-build | skqln.6 (the panel is the natural home), skqln.9 (docs) |
+| **T7** | **`user_id` becomes a Prometheus metric label** (or `channel_id`), exporting per-user behavior into the metrics pipeline (high cardinality *and* a privacy leak — metrics are often scraped by external dashboards). | 7 | 7 | 3 | 6 | 4 | **5.4** | **Medium** | SRE veto already standing: `user_id`/`channel_id` NEVER metric labels; `provider_id` is allowed (bounded <20, C3, operator-private). Enforce in skqln.12 instrumentation review. | existing (SRE veto) + to-build (enforce) | skqln.12 |
+| **T8** | **`user_id` not nulled on account deletion** — `ON DELETE SET NULL` is in the schema, but a rollup table built later might copy `user_id` and not get the same cascade, leaving orphaned identifiable history after a user is deleted. | 5 | 6 | 3 | 5 | 3 | **4.4** | **Medium** | ADR-007 must specify: rollup tables either (a) carry the same `ON DELETE SET NULL`/cascade, or (b) the pruning/rollup job scrubs rows whose `user_id` no longer resolves. Don't let "delete my account" leave a behavioral shadow. | to-build | skqln.1 (ADR-007), skqln.2 |
+| **T9** | **Heatmap / aggregate endpoint re-identification** — the channels-by-provider heatmap or a small-N install's "all users" aggregate is granular enough that a single user's behavior is trivially inferable (k=1). | 4 | 5 | 4 | 4 | 4 | **4.2** | **Medium** | Acknowledge: in a 1–2 user install, *all* aggregates are effectively per-user — that's inherent and acceptable (the operator is the user). The mitigation is the access-control boundary (§3), not k-anonymity: don't show non-admins the all-users/heatmap views. No suppression-threshold needed for a self-hosted single-operator app. | accepted-risk (documented) | — |
+| **T10** | **`session_id` correlation across channels reveals a full viewing session** to anyone who can read raw rows (e.g., a future "export my data" feature dumps raw `session_telemetry`). | 5 | 6 | 3 | 5 | 3 | **4.4** | **Medium** | The per-user visibility view (§6) should show *rollup-level* data (daily minutes per channel), not raw per-poll rows — raw rows are higher-resolution than the user needs and higher-risk if exported. PII-minimization: surface rollups, not raw rows, to users. | to-build | skqln.6 |
+| **T11** | **Migration / fixture data leaks real viewing history** — the 5M-row seeded fixture for migration testing (skqln.2/.10) uses real-looking or, worse, real `user_id`s and gets committed. | 6 | 4 | 3 | 4 | 5 | **4.4** | **Medium** | Fixture generator must use synthetic `user_id`s (sequential ints with no link to any real account) and synthetic provider/channel IDs. No production DB dumps in test fixtures. Note for skqln.10 fixture-generator update. | to-build | skqln.2, skqln.10 |
+| **T12** | **`bytes_delta` time-series fingerprinting** — even without `channel_id`, a high-resolution per-user `bytes_delta` curve can be matched against known-content bitrate profiles to infer *what* was watched. | 4 | 4 | 2 | 4 | 3 | **3.4** | **Low** | Inherent to storing bandwidth telemetry; the realistic exposure is "someone with DB access," which is already the operator. Mitigation: don't expose per-user per-poll `bytes_delta` outside the DB (covered by §3 and the redaction rules). No further action. | accepted-risk (documented) | — |
+
+**Coverage note:** 12 threats spanning the three new data classes (user behavioral / channel / provider attribution), the access-control boundary, retention, the four diagnostic-leak channels named in the bead (logs, support bundles, diagnostic exports, Discord automation), PII minimization (raw rows vs. rollups), and the consent/visibility gap. Highest residual risk after planned mitigations is **T1 (High)** — and that's a single server-side authz check away from Medium. Everything else is Medium or below.
+
+---
+
+## 5. Retention — Security MINIMUM (for ADR-007)
+
+This section is the deliverable ADR-007 (skqln.1) authors must incorporate. **Security sets the floor; SRE/DBA set the operational ceiling and the enforcement mechanism.**
+
+### 5.1 The minimum
+
+> **There is no security-imposed *minimum* retention on raw `session_telemetry` rows. Zero days of raw retention is acceptable from a privacy standpoint — shorter is strictly safer for C2/C3 data. The feature's *functional* need (the team's "keep raw 30 days" plan, so the 7/30/90-day Users-panel selector works without an immediate rollup dependency) is the real floor, and Security does not object to 30 days raw. Security objects only if raw retention is proposed *beyond* what the panels functionally need — every extra day of raw per-poll `user_id`-keyed rows is additional C2 exposure for no privacy benefit.**
+
+In other words: the privacy-minimum is 0; the functional-minimum is whatever the panels require (the team says ~30 days raw); Security's position is "30 days raw is fine, don't go higher than the feature needs, and the rollups are where the long-tail risk lives — bound them."
+
+### 5.2 Mandatory deletion guarantees (these ARE security requirements, not just operational nice-to-haves)
+
+ADR-007 **must** specify all of:
+
+1. **A pruning job actually runs and is monitored.** Raw rows past the chosen window are deleted on a schedule; if the job falls behind, an alert fires (SRE owns the alert). "Retention policy exists on paper but the cron is broken" is the failure mode that turns 30 days into forever.
+2. **Account deletion scrubs behavioral history.** When a `users` row is deleted, every `session_telemetry` row and every rollup row for that `user_id` is either deleted or has `user_id` set to NULL — *including in rollup tables created later* (see T8). This must be tested.
+3. **Rollups inherit the classification, not an exemption.** `watch_time_by_user_daily` is C2 forever; rolling up is coarsening, not anonymization. If the PO wants a literally-forever per-user rollup (current plan), that's the PO's risk to accept (§8 Q2) — but it must be an explicit acceptance in ADR-007, not a default that slid in.
+
+### 5.3 Recommendation (not a hard requirement — PO/ADR-007 call)
+
+- **Cap the per-user rollup (`watch_time_by_user_daily`) at a bounded window** — e.g., rolling 13 months (covers year-over-year comparison) or 2 years — rather than literally forever. The Users panel's longest selector is 90 days; nothing in the *feature* needs five-year-old per-user data. A bounded ceiling limits the dossier-accumulation risk (T5) at essentially no functional cost.
+- **Provider rollups (`provider_performance_daily`) carry no user dimension (C3, not C2)** and *do* have a stated need for multi-quarter trend analysis (provider keep/drop at renewal — per the GH-59 pull-in). Keeping these longer (e.g., 2–3 years, or forever) is fine — there's no individual-privacy concern, only operator-private commercial data the operator owns.
+- **Net:** if the team wants a single simple rule, "raw 30 days; per-user rollup capped at ~2 years; provider rollup retained long-term/forever" satisfies the feature, the GH-59 quarterly use case, *and* the privacy posture. The "rollups forever" line in the epic is acceptable **only for the provider (non-user) rollup**; for the per-user rollup, prefer a cap and require explicit PO acceptance if forever is chosen anyway.
+
+---
+
+## 6. Consent / Visibility UX Requirement
+
+**Requirement (Security asks; UX owns the design; PO owns the opt-out decision):**
+
+1. **Disclosure.** ECM must tell users, in plain language, that it records per-user viewing history (which channels, when, how much). Home: the Stats-v2 user-guide entry (skqln.9) **and** a short note surfaced in the app where a user would encounter the Users panel — not buried. First-run / admin-setup docs should mention it too.
+2. **"What's recorded about you" view.** A user (any authenticated user, scoped to their own `user_id`) must be able to see what `session_telemetry`-derived data exists about them. The Users panel itself is the natural home — it already shows "your watch time by channel." It should be framed not just as a feature ("look at your stats!") but as transparency ("this is what's recorded"). Show **rollup-level** data (daily minutes per channel), not raw per-poll rows (T10).
+3. **Opt-out — flagged for PO (§8 Q1).** Whether a user (or the operator on a user's behalf, or globally) can disable recording of their viewing history is a **PO decision**, not Security's call. Security's *recommendation*: support at least an operator-level global toggle ("don't record per-user watch history") — it's cheap (gate the `user_id` write in `BandwidthTracker`; write NULL instead), it's the strongest privacy lever, and some operators in shared-household setups will want it. A per-user opt-out is nicer but more work; not required. **Document the decision in ADR-007 or the epic either way** — "we considered opt-out and decided X" is the minimum, so skqln.8 (post-impl sign-off) can check the as-built against the decision.
+
+---
+
+## 7. Redaction Requirements — Hand-off to the Implementing Engineer
+
+The following are **acceptance criteria** for the schema/write beads (skqln.2, skqln.3), the instrumentation bead (skqln.12), and the read-API beads (skqln.5, skqln.16). They mirror the redaction discipline in `threat_model_dbas_import.md` §4.9.
+
+1. **No behavioral tuple in application logs.** No log line — at any level, including DEBUG and exception dumps — may contain `user_id` together with any of `observed_at`, `channel_id`, `session_id`, or per-row `bytes_delta`. The `BandwidthTracker` single-write path logs **counts and aggregates only** ("wrote 47 telemetry rows", "poll completed in 31ms"), never row contents keyed to a user. Exception handlers that catch DB errors on the telemetry write must not echo the row. *(T2)*
+2. **`session_telemetry` excluded from support bundles / diagnostic exports.** Any support-bundle or diagnostic-export generator must exclude `session_telemetry` rows and per-user rollup tables. If a bundle needs *any* stats data for debugging, it includes only **C1 channel-only aggregates** (no `user_id` dimension). If no such export feature exists yet, this becomes a requirement on whatever bead introduces one. *(T3)*
+3. **`provider_id` / provider names never in Discord automation.** The Discord release-note / digest path (`alert_methods_discord.py`, `m3u_digest_template.py`, `task_engine` digest jobs) must not template `provider_id`, provider names, or any `session_telemetry`-derived aggregate into outbound Discord messages. Audit the existing digest template to confirm it doesn't already pull provider names; if it does, that's a pre-existing C3 leak to file separately. *(T4)*
+4. **`user_id` / `channel_id` never become Prometheus metric labels.** Standing SRE veto — re-state it as a redaction rule. `provider_id` is permitted as a label (bounded <20, C3, operator-private). Any new metric in skqln.12 that would put `user_id` or `channel_id` in a label fails review. *(T7)*
+5. **Read-API responses are access-scoped, not just filtered client-side.** The watch-time read API derives `user_id` from the authenticated principal for non-admins; admins may pass an explicit `user_id`/"all". A non-admin requesting another user's data gets `403`. Provider endpoints gate on `RequireAdminIfEnabled` (recommended) and are never in `AUTH_EXEMPT_PATHS`. *(T1, §3)*
+6. **User-facing visibility view shows rollups, not raw rows.** The "what's recorded about you" surface (the Users panel) presents daily-granularity rollup data, not raw per-poll `session_telemetry` rows. If a future "export my data" feature is built, it too exports rollups, not raw rows — or if it must export raw rows, that needs its own privacy review. *(T10)*
+7. **Test fixtures use synthetic identities.** The 5M-row migration/benchmark fixture (skqln.2, skqln.10) uses synthetic `user_id`/`provider_id`/`channel_id` values with no linkage to real accounts. No production DB dumps in committed fixtures. *(T11)*
+8. **Account deletion scrubs the behavioral trail.** Verified by test: deleting a `users` row leaves no `session_telemetry` row (or rollup row) carrying that `user_id` — either deleted or NULLed, in raw *and* rollup tables. *(T8, and a hard ask on ADR-007.)*
+
+---
+
+## 8. PO Decisions — resolved 2026-05-12
+
+- **Q1 — Opt-out support → operator-level global toggle only** (no per-user opt-out) for v0.17.0. When the toggle is off, `session_telemetry` collection is disabled entirely. The §6.1 disclosure is surfaced regardless of the toggle. Recorded in ADR-007 and to be verified by the post-impl sign-off (skqln.8).
+- **Q2 — Per-user rollup horizon → 400 days (≈13 months).** Matches Security's recommendation to bound the C2 per-user rollup; "rollups forever" is not adopted. ADR-007 D4.
+- **Q3 — Provider-attribution visibility → admin-only.** The Providers panel and `/api/stats/providers/*` use `RequireAdminIfEnabled`. Provider attribution (C3, operator-private commercial data) is not exposed to non-admin users.
+- **Q4 — Support-bundle / diagnostic-export ownership → forward requirement.** No decision needed now; §7.2 stays a forward requirement and gets a follow-up review item on whatever bead introduces a support-bundle/diagnostic-export surface. (Restated under §9.)
+
+---
+
+## 9. Sign-off Status
+
+- **Pre-implementation threat model + data classification:** complete (this document).
+- **Schema sign-off (gates skqln.2 merge):** the DBA's refined `session_telemetry` schema (§1) is **acceptable from a privacy standpoint** with the following conditions carried into the schema/migration bead: (a) `user_id` FK keeps `ON DELETE SET NULL` (already specified) — and ADR-007 extends the same scrub to rollup tables (T8); (b) the redaction requirements in §7 are added to skqln.2/.3 acceptance criteria; (c) test fixtures use synthetic identities (§7.7). No additional columns required; no columns need to be removed for data-minimization (the schema is already minimal — no IP, no user-agent, no device fingerprint, no derived bitrate). **Conditional sign-off granted; convert to full sign-off when (a)–(c) are reflected in the skqln.2 bead.**
+- **Retention sign-off (informs skqln.1):** §5 is the input. Full sign-off on ADR-007 happens when ADR-007 incorporates the §5.2 mandatory guarantees; the §5.3 recommendations are advisory.
+- **Post-implementation sign-off (skqln.8):** out of scope here — that bead re-checks the as-built against §3, §6, and §7.
+
+---
+
+## 10. References
+
+- `docs/security/threat_model_dbas_import.md` — house style; redaction-discipline precedent (§4.9).
+- `docs/auth_middleware.md` — global secure-by-default auth; `RequireAdminIfEnabled` / `RequireAuthIfEnabled`; `AUTH_EXEMPT_PATHS`.
+- `backend/auth/dependencies.py` — `get_current_active_admin`, `require_admin_if_enabled` (the admin-gate pattern §3 references).
+- `backend/routers/stats.py` — existing `/api/stats/*` router (channel/popularity/activity/bandwidth) — Stats v2 adds persisted per-user history alongside it.
+- `backend/routers/backup.py` — existing admin-only endpoint pattern (`RequireAdminIfEnabled`).
+- Epic `enhancedchannelmanager-skqln` — scope-history trail, PO override (2026-04-23) pulling GH-59 in, SRE Prometheus-label veto, "raw 30d / rollups forever" plan.
+- `enhancedchannelmanager-skqln.2` — `session_telemetry` schema + Alembic migration (blocked by this doc).
+- `enhancedchannelmanager-skqln.1` — ADR-007 retention/rollup policy (consumes §5).
+- `enhancedchannelmanager-skqln.5/.6/.16/.18` — Users / Providers read APIs + panels (must satisfy §3 and §7).
+- `enhancedchannelmanager-skqln.8` — post-implementation privacy sign-off (re-checks against this).
+- `enhancedchannelmanager-skqln.9` — Stats v2 user guide (home for the §6.1 disclosure).
+- `enhancedchannelmanager-skqln.12` — observability instrumentation (enforces §7.4, audits §7.3).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.17.0-0001",
+  "version": "0.17.0-0002",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Three foundation docs, with the PO decisions of 2026-05-12 folded in. Doc-only + version bump; no source/behavior changes.

### `docs/adr/ADR-007-session-telemetry-retention.md` (new — Status: Proposed) — bd-skqln.1
Retention & rollup policy for `session_telemetry`: raw **30 days**; rollups are **tables, not views**, retained **400 days** for both `watch_time_by_user_daily` and `provider_performance_daily`; nightly `asyncio` pruning task (rollup-then-prune, fail-safe); Postgres trigger at >50M rows or a second writer. Cross-linked from `docs/database_migrations.md` (new data-lifecycle section). All Open Questions resolved inline. *Ready for the PO to ratify Proposed → Accepted.*

### `docs/security/threat_model_stats_v2.md` (new) — bd-skqln.7
12 DREAD-scored threats; full `session_telemetry` data classification; least-privilege access boundary (non-admin sees only their own watch time; Providers panel + `/api/stats/providers/*` admin-only); redaction requirements handed to `skqln.2`/`.3`; PO decisions recorded (opt-out = operator-global toggle only; per-user rollup = 400d). **Conditional schema sign-off** granted — converts to full when these land in `skqln.2`: `user_id` FK `ON DELETE SET NULL`, §7 redaction reqs in acceptance, synthetic-identity test fixtures. Highest residual risk: **IDOR on the watch-time read API** — `user_id` must be derived server-side from the principal.

### `docs/security/threat_model_dbas_import.md` (extended) — bd-0i2vt.3
§8 Addendum A (export-artifact ZIP redaction parity with the existing YAML path) and §9 Addendum B (outbound destinations + SSRF) — STRIDE rows, mitigations, residual-risk; hardening checklist extended to items 18–26; §9.4 hands the SSRF-validator spec to the Phase-1 wizard (`0i2vt.5`).

Note: `ADR-008` (DBAS-absorption approach) is referenced by the v0.18.0 epic but doesn't exist as a file yet; the addendum flags it — file-vs-epic-bead-canonical deferred to v0.18.0 grooming.

Closes `enhancedchannelmanager-skqln.1`, `enhancedchannelmanager-skqln.7`, `enhancedchannelmanager-0i2vt.3`.