### PR TITLE
v0.17.0-0003: feat(stats): session_telemetry table + Alembic migration 0006 (bd-skqln.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+- Stats v2 foundation: new `session_telemetry` table and Alembic migration `0006` — per-session bandwidth/buffer-event telemetry; the data source for the upcoming Users panel. Internal schema only, no UI yet. ([bd-skqln.2])
+
 ## [0.16.0] — 2026-05-12
 
 _This is the shipping 0.16.0. An earlier 0.16.0 build was cut on 2026-04-20 and rolled back before any consumer pulled it (see `[0.16.0-yanked]` below); everything from that attempt is included here, with the blocking bugs fixed._

--- a/backend/alembic/versions/20260512_2212_0006_session_telemetry.py
+++ b/backend/alembic/versions/20260512_2212_0006_session_telemetry.py
@@ -1,0 +1,134 @@
+"""session_telemetry
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-12 22:12:00.000000
+
+Creates the Stats v2 ``session_telemetry`` fact table — one row per
+``BandwidthTracker`` poll cycle per active viewing session. Append-mostly;
+raw rows are pruned by ``observed_at`` per the retention policy in
+``docs/adr/ADR-007-session-telemetry-retention.md``. The daily rollup tables,
+the ``telemetry_rollup_state`` marker, and the nightly prune job are OUT of
+scope here — they land in bead ``enhancedchannelmanager-7i2vv``. The operator
+opt-out toggle lands in ``enhancedchannelmanager-tp1pd``.
+
+Schema notes:
+
+* ``user_id`` is the only real FK (``users.id`` ``ON DELETE SET NULL`` —
+  account deletion scrubs the behavioral trail; see
+  ``docs/security/threat_model_stats_v2.md`` §7.8).
+* ``channel_id`` / ``provider_id`` are plain nullable indexed integers, NOT
+  foreign keys — ``channels``/``providers`` are upstream Dispatcharr entities,
+  not ECM tables (same house pattern as ``channel_watch_stats`` etc.).
+* Named CHECK ``ck_session_telemetry_bytes_delta_non_negative`` — unnamed
+  SQLite CHECK names are unstable across versions (``docs/database_migrations.md``).
+* The ``(provider_id, channel_id, observed_at, bytes_delta)`` composite is the
+  GH-59 channels-by-provider heatmap covering index (skqln.16); GH-59 is in
+  v0.17.0 scope per the skqln epic. The Postgres ``INCLUDE`` form is invalid in
+  SQLite, so this is a plain composite with a trailing covering column.
+* ``bitrate_bps`` is intentionally not stored (derivable from
+  ``bytes_delta / poll_interval_ms``).
+
+Fresh ``CREATE TABLE`` — no ``batch_alter_table`` needed (batch mode only
+applies to later ``ALTER``s, not the initial create).
+
+Bead: enhancedchannelmanager-skqln.2.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0006"
+down_revision: Union[str, Sequence[str], None] = "0005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    """Create the session_telemetry fact table and its indexes."""
+    op.create_table(
+        "session_telemetry",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("session_id", sa.Text(), nullable=False),
+        sa.Column("observed_at", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("provider_id", sa.Integer(), nullable=True),
+        sa.Column("channel_id", sa.Integer(), nullable=True),
+        sa.Column("bytes_delta", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "buffer_event_count",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column("poll_interval_ms", sa.Integer(), nullable=False),
+        sa.CheckConstraint(
+            "bytes_delta >= 0",
+            name="ck_session_telemetry_bytes_delta_non_negative",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_session_telemetry_observed_at",
+        "session_telemetry",
+        ["observed_at"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_session_telemetry_user_observed",
+        "session_telemetry",
+        ["user_id", "observed_at"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_session_telemetry_provider_observed",
+        "session_telemetry",
+        ["provider_id", "observed_at"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_session_telemetry_session_id",
+        "session_telemetry",
+        ["session_id"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_session_telemetry_provider_channel_observed_bytes",
+        "session_telemetry",
+        ["provider_id", "channel_id", "observed_at", "bytes_delta"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop the session_telemetry indexes and table."""
+    op.drop_index(
+        "idx_session_telemetry_provider_channel_observed_bytes",
+        table_name="session_telemetry",
+    )
+    op.drop_index(
+        "idx_session_telemetry_session_id",
+        table_name="session_telemetry",
+    )
+    op.drop_index(
+        "idx_session_telemetry_provider_observed",
+        table_name="session_telemetry",
+    )
+    op.drop_index(
+        "idx_session_telemetry_user_observed",
+        table_name="session_telemetry",
+    )
+    op.drop_index(
+        "idx_session_telemetry_observed_at",
+        table_name="session_telemetry",
+    )
+    op.drop_table("session_telemetry")

--- a/backend/models.py
+++ b/backend/models.py
@@ -4,7 +4,7 @@ SQLAlchemy ORM models for the Journal and Bandwidth tracking features.
 import json
 import logging
 from datetime import datetime, date
-from sqlalchemy import Column, Integer, BigInteger, String, Text, Boolean, DateTime, Date, Float, Index, ForeignKey, UniqueConstraint
+from sqlalchemy import Column, Integer, BigInteger, String, Text, Boolean, DateTime, Date, Float, Index, ForeignKey, UniqueConstraint, CheckConstraint
 from sqlalchemy.orm import relationship
 from db_base import Base
 
@@ -1218,6 +1218,102 @@ class ChannelPopularityScore(Base):
 
     def __repr__(self):
         return f"<ChannelPopularityScore(id={self.id}, channel={self.channel_name}, score={self.score}, rank={self.rank})>"
+
+
+# =============================================================================
+# Stats v2 — session_telemetry fact table (v0.17.0)
+# =============================================================================
+
+class SessionTelemetry(Base):
+    """Unified per-poll stream-telemetry fact table (Stats v2).
+
+    One row is written per ``BandwidthTracker`` poll cycle for each active
+    viewing session. Append-mostly: rows are pruned by ``observed_at`` per the
+    retention policy in ``docs/adr/ADR-007-session-telemetry-retention.md``
+    (raw rows pruned at 30 days; the daily rollup tables, the
+    ``telemetry_rollup_state`` marker, and the nightly prune job are out of
+    scope here — they live in bead ``enhancedchannelmanager-7i2vv``).
+
+    Privacy classification + redaction rules:
+    ``docs/security/threat_model_stats_v2.md`` §2.1, §7. ``user_id`` is the only
+    real FK (``ON DELETE SET NULL`` — deleting a ``users`` row scrubs the
+    behavioral trail; the rollup-table extension of that scrub is
+    ``enhancedchannelmanager-7i2vv``'s responsibility). ``channel_id`` and
+    ``provider_id`` are plain nullable indexed integers, NOT foreign keys —
+    ``channels``/``providers`` are upstream Dispatcharr entities, not ECM
+    tables (same house pattern as ``channel_watch_stats`` / ``channel_bandwidth``
+    / ``channel_popularity_scores``).
+
+    ``bitrate_bps`` is deliberately NOT stored — it is derivable from
+    ``bytes_delta / poll_interval_ms`` and storing a derived value invites
+    disagreement (DBA, team-plan).
+
+    Bead: ``enhancedchannelmanager-skqln.2``.
+    """
+    __tablename__ = "session_telemetry"
+
+    # Synthetic PK — matches the house pattern for these fact tables
+    # (channel_bandwidth, channel_popularity_scores). SQLite needs a PK; the
+    # query/access keys are the composite indexes below.
+    id = Column(Integer, primary_key=True, autoincrement=True)
+
+    # UUID string correlating all rows of one viewing session.
+    session_id = Column(Text, nullable=False)
+    # Unix-epoch milliseconds. Mandatory index — retention sweeps and all
+    # time-range queries key off this.
+    observed_at = Column(Integer, nullable=False)
+
+    # The only real FK. ON DELETE SET NULL: account deletion scrubs the trail.
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    # Upstream Dispatcharr M3U provider. Plain indexed column, NOT a FK
+    # (providers is not an ECM table). Nullable — provider tagging (GH-59)
+    # lands separately (skqln.14).
+    provider_id = Column(Integer, nullable=True)
+    # Upstream Dispatcharr channel. Plain indexed column, NOT a FK
+    # (channels is not an ECM table).
+    channel_id = Column(Integer, nullable=True)
+
+    # Per-poll bytes delta (NOT cumulative). Named CHECK so the constraint
+    # name is stable across SQLite versions (docs/database_migrations.md).
+    bytes_delta = Column(BigInteger, nullable=False)
+    # Count of buffer/stall events observed during this poll window.
+    buffer_event_count = Column(Integer, nullable=False, server_default="0", default=0)
+    # Poll cadence in ms — avoids baking in a fixed-interval assumption and
+    # makes bitrate derivable.
+    poll_interval_ms = Column(Integer, nullable=False)
+
+    __table_args__ = (
+        CheckConstraint(
+            "bytes_delta >= 0",
+            name="ck_session_telemetry_bytes_delta_non_negative",
+        ),
+        # Retention sweeps + bare time-range scans.
+        Index("idx_session_telemetry_observed_at", observed_at),
+        # GH-62 "watch time by user" — index-range scan per user.
+        Index("idx_session_telemetry_user_observed", user_id, observed_at),
+        # GH-59 per-provider performance (forward-looking).
+        Index("idx_session_telemetry_provider_observed", provider_id, observed_at),
+        # Session reconstruction.
+        Index("idx_session_telemetry_session_id", session_id),
+        # GH-59 channels-by-provider heatmap (skqln.16). Trailing bytes_delta
+        # makes it a covering index for that aggregate. Plain composite — the
+        # Postgres ``INCLUDE`` form is not valid in SQLite; an ``INCLUDE``
+        # variant is a Postgres-migration future enhancement (ADR D7).
+        Index(
+            "idx_session_telemetry_provider_channel_observed_bytes",
+            provider_id,
+            channel_id,
+            observed_at,
+            bytes_delta,
+        ),
+    )
+
+    def __repr__(self):
+        return (
+            f"<SessionTelemetry(id={self.id}, session={self.session_id}, "
+            f"observed_at={self.observed_at}, user_id={self.user_id}, "
+            f"provider_id={self.provider_id}, channel_id={self.channel_id})>"
+        )
 
 
 # =============================================================================

--- a/backend/tests/fixtures/session_telemetry_volume.py
+++ b/backend/tests/fixtures/session_telemetry_volume.py
@@ -1,0 +1,175 @@
+"""Bulk volume-fixture generator for the ``session_telemetry`` table.
+
+This is shared infra. Two consumers:
+
+* ``tests/integration/test_session_telemetry_migration.py`` — the local
+  pre-merge 5M-row migration up/down gate (bead ``enhancedchannelmanager-skqln.2``).
+* ``enhancedchannelmanager-skqln.10`` — the hot-query benchmark gate, which
+  needs a realistic-shape population to measure aggregate read paths.
+
+Design constraints:
+
+* **Fast.** Row-by-row ORM ``session.add`` is far too slow at 5M rows; this
+  uses batched multi-row ``INSERT`` via raw ``executemany`` on the DBAPI
+  connection. ~5M rows seed in a couple of minutes on a laptop SSD.
+* **Realistic-ish.** Multi-provider distribution (a handful of providers,
+  Zipf-ish skew) with ~5% ``provider_id IS NULL`` rows (the GH-59 provider
+  tagging gap — pre-tagging history has no provider). ``user_id`` spans a
+  modest set of synthetic accounts; ``channel_id`` a larger set. ``observed_at``
+  walks backwards from "now" in ``poll_interval_ms`` steps so retention-sweep
+  queries (``WHERE observed_at < ?``) hit realistic ranges.
+* **Synthetic identities only.** ``user_id`` values are small integers
+  (1..``user_count``); the generator first seeds matching synthetic ``users``
+  rows (``synthetic-volume-user-NNN`` / ``…@example.invalid``) so the
+  ``user_id`` FK is satisfied under ``PRAGMA foreign_keys=ON``. Nothing here is
+  derived from production data (``threat_model_stats_v2`` §7.7).
+
+Both the ``session_telemetry`` table and the ``users`` table must already
+exist (run ``alembic upgrade head`` first).
+"""
+from __future__ import annotations
+
+import random
+import time
+from dataclasses import dataclass
+from typing import Iterator
+
+# Realistic-ish shape knobs. Tunable by callers via :func:`seed_session_telemetry`.
+DEFAULT_ROW_COUNT = 5_000_000
+DEFAULT_BATCH_SIZE = 50_000
+DEFAULT_USER_COUNT = 40           # synthetic households
+DEFAULT_CHANNEL_COUNT = 600       # upstream Dispatcharr channels
+DEFAULT_PROVIDER_COUNT = 6        # upstream M3U providers
+DEFAULT_NULL_PROVIDER_FRACTION = 0.05  # pre-GH-59-tagging history
+DEFAULT_POLL_INTERVAL_MS = 10_000      # current stats_poll_interval (10s)
+_SEED = 1_234_567  # deterministic — reproducible benchmark populations
+
+
+@dataclass(frozen=True)
+class VolumeShape:
+    row_count: int = DEFAULT_ROW_COUNT
+    batch_size: int = DEFAULT_BATCH_SIZE
+    user_count: int = DEFAULT_USER_COUNT
+    channel_count: int = DEFAULT_CHANNEL_COUNT
+    provider_count: int = DEFAULT_PROVIDER_COUNT
+    null_provider_fraction: float = DEFAULT_NULL_PROVIDER_FRACTION
+    poll_interval_ms: int = DEFAULT_POLL_INTERVAL_MS
+    seed: int = _SEED
+
+
+_INSERT_SQL = (
+    "INSERT INTO session_telemetry "
+    "(session_id, observed_at, user_id, provider_id, channel_id, "
+    " bytes_delta, buffer_event_count, poll_interval_ms) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+)
+
+# session_telemetry.user_id is a real FK (users.id, ON DELETE SET NULL). When
+# PRAGMA foreign_keys=ON (the app/test default), the parent rows must exist.
+# Seed minimal synthetic users (ids 1..user_count) so the bulk insert is
+# FK-clean. Username is deterministic + obviously synthetic — never derived
+# from production data (threat_model_stats_v2 §7.7).
+# NOTE: users has several NOT NULL columns whose defaults are Python-side
+# (is_active, is_admin, created_at, updated_at) — they must be supplied
+# explicitly here, and we must NOT use ``INSERT OR IGNORE`` (it would silently
+# swallow a NOT NULL violation and leave the FK parent missing). We delete +
+# re-insert ids 1..user_count instead, which is idempotent enough for a fixture.
+_USERS_DELETE_SQL = "DELETE FROM users WHERE id BETWEEN 1 AND ?"
+_USERS_SQL = (
+    "INSERT INTO users "
+    "(id, username, email, password_hash, auth_provider, "
+    " is_active, is_admin, created_at, updated_at) "
+    "VALUES (?, ?, ?, NULL, 'local', 1, 0, ?, ?)"
+)
+
+
+def _zipfish_provider(rng: random.Random, provider_count: int) -> int:
+    """Pick a provider id (1..provider_count) with mild skew toward the first few."""
+    # Weight provider k as 1/k — cheap Zipf-ish skew without numpy.
+    weights = [1.0 / k for k in range(1, provider_count + 1)]
+    return rng.choices(range(1, provider_count + 1), weights=weights, k=1)[0]
+
+
+def _row_batches(shape: VolumeShape) -> Iterator[list[tuple]]:
+    """Yield batches of parameter tuples for executemany."""
+    rng = random.Random(shape.seed)
+    # observed_at walks backwards from "now" in poll-interval steps.
+    now_ms = int(time.time() * 1000)
+    # Spread sessions: ~ row_count / (avg session length) distinct sessions.
+    # Keep it simple — a session is just a uuid-ish string; correlation
+    # realism matters less for a volume gate than row count + index shape.
+    remaining = shape.row_count
+    batch: list[tuple] = []
+    i = 0
+    while remaining > 0:
+        n = min(shape.batch_size, remaining)
+        for _ in range(n):
+            observed_at = now_ms - i * shape.poll_interval_ms
+            user_id = rng.randint(1, shape.user_count)
+            if rng.random() < shape.null_provider_fraction:
+                provider_id = None
+            else:
+                provider_id = _zipfish_provider(rng, shape.provider_count)
+            channel_id = rng.randint(1, shape.channel_count)
+            bytes_delta = rng.randint(0, 12_000_000)  # >= 0 — respects the CHECK
+            buffer_event_count = 0 if rng.random() < 0.95 else rng.randint(1, 4)
+            session_id = f"sess-{user_id:03d}-{channel_id:04d}-{i // 30}"
+            batch.append(
+                (
+                    session_id,
+                    observed_at,
+                    user_id,
+                    provider_id,
+                    channel_id,
+                    bytes_delta,
+                    buffer_event_count,
+                    shape.poll_interval_ms,
+                )
+            )
+            i += 1
+        yield batch
+        batch = []
+        remaining -= n
+
+
+def seed_session_telemetry(connection, shape: VolumeShape | None = None) -> int:
+    """Bulk-insert ``shape.row_count`` rows into ``session_telemetry``.
+
+    ``connection`` is a SQLAlchemy ``Connection`` (or anything exposing
+    ``connection.connection`` → a DBAPI connection with a cursor). Commits in
+    batches so the WAL doesn't blow up. Returns the number of rows inserted.
+    """
+    shape = shape or VolumeShape()
+    # Reach down to the raw DBAPI connection for executemany — the SQLAlchemy
+    # Core ``connection.execute(text(...), [dict, dict, ...])` path is markedly
+    # slower for millions of rows.
+    raw = connection.connection  # DBAPI connection (sqlite3.Connection)
+
+    # Seed synthetic parent users so the user_id FK is satisfied under
+    # PRAGMA foreign_keys=ON.
+    _ts = "2026-01-01T00:00:00"
+    user_cur = raw.cursor()
+    try:
+        user_cur.execute(_USERS_DELETE_SQL, (shape.user_count,))
+        user_cur.executemany(
+            _USERS_SQL,
+            [
+                (uid, f"synthetic-volume-user-{uid:03d}",
+                 f"synthetic-volume-{uid:03d}@example.invalid", _ts, _ts)
+                for uid in range(1, shape.user_count + 1)
+            ],
+        )
+    finally:
+        user_cur.close()
+    raw.commit()
+
+    inserted = 0
+    for batch in _row_batches(shape):
+        cur = raw.cursor()
+        try:
+            cur.executemany(_INSERT_SQL, batch)
+        finally:
+            cur.close()
+        raw.commit()
+        inserted += len(batch)
+    return inserted

--- a/backend/tests/integration/test_session_telemetry_migration.py
+++ b/backend/tests/integration/test_session_telemetry_migration.py
@@ -1,0 +1,450 @@
+"""Migration tests for ``session_telemetry`` (revision 0006).
+
+Bead: ``enhancedchannelmanager-skqln.2``.
+
+Covers:
+
+* Up migration on a fresh empty DB → table + all 5 indexes + the named CHECK
+  constraint present (asserted via ``inspect()``).
+* Down migration → table + indexes gone.
+* Up → down → up round-trip on an empty DB is schema-identical.
+* CHECK constraint is actually *enforced* in the test env (SQLite + Alembic
+  can silently drop CHECKs — ``docs/database_migrations.md``).
+* Account-deletion scrub: deleting a ``users`` row NULLs the corresponding
+  ``session_telemetry.user_id`` (FK ``ON DELETE SET NULL`` fires).
+  NOTE: the rollup-table extension of this scrub (delete a ``users`` row →
+  no residual ``user_id`` in the daily rollup tables) is bead
+  ``enhancedchannelmanager-7i2vv``'s responsibility — those tables don't exist
+  yet.
+* The 5M-row seeded migration up/down volume test — a **LOCAL PRE-MERGE GATE**,
+  not a CI job. Marked ``slow`` (CI runs ``-m "not slow"``) AND gated behind
+  ``ECM_RUN_VOLUME_TESTS=1`` so it never runs by accident. Prints wall-time
+  for each direction. To run it locally:
+  ``ECM_RUN_VOLUME_TESTS=1 python -m pytest \\
+      tests/integration/test_session_telemetry_migration.py -m slow -s --no-cov``
+
+All fixtures use synthetic identities only — no production-derived
+``user_id``/``username``/``email`` values (``docs/security/threat_model_stats_v2.md`` §7.7).
+"""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+import database
+
+
+TABLE = "session_telemetry"
+EXPECTED_INDEXES = {
+    "idx_session_telemetry_observed_at": ["observed_at"],
+    "idx_session_telemetry_user_observed": ["user_id", "observed_at"],
+    "idx_session_telemetry_provider_observed": ["provider_id", "observed_at"],
+    "idx_session_telemetry_session_id": ["session_id"],
+    "idx_session_telemetry_provider_channel_observed_bytes": [
+        "provider_id",
+        "channel_id",
+        "observed_at",
+        "bytes_delta",
+    ],
+}
+CHECK_NAME = "ck_session_telemetry_bytes_delta_non_negative"
+
+
+def _make_alembic_config(db_url: str):
+    from alembic.config import Config
+
+    ini_path = Path(database.ALEMBIC_INI_PATH)
+    assert ini_path.exists(), f"alembic.ini missing at {ini_path}"
+    cfg = Config(str(ini_path))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    return cfg
+
+
+def _table_names(engine) -> set[str]:
+    return set(inspect(engine).get_table_names())
+
+
+def _index_map(engine, table: str) -> dict[str, list[str]]:
+    return {
+        idx["name"]: list(idx["column_names"])
+        for idx in inspect(engine).get_indexes(table)
+    }
+
+
+def _check_constraint_names(engine, table: str) -> set[str]:
+    # SQLAlchemy's SQLite dialect surfaces named CHECK constraints via
+    # get_check_constraints since 1.4.
+    return {
+        cc["name"]
+        for cc in inspect(engine).get_check_constraints(table)
+        if cc.get("name")
+    }
+
+
+def _structural_snapshot(engine):
+    insp = inspect(engine)
+    cols = [
+        {"name": c["name"], "type": str(c["type"]), "nullable": c["nullable"]}
+        for c in insp.get_columns(TABLE)
+    ]
+    indexes = sorted(
+        ({"name": i["name"], "unique": i["unique"], "columns": list(i["column_names"])}
+         for i in insp.get_indexes(TABLE)),
+        key=lambda d: d["name"] or "",
+    )
+    fks = sorted(
+        ({"cols": list(fk["constrained_columns"]),
+          "ref": fk["referred_table"],
+          "ref_cols": list(fk["referred_columns"]),
+          "options": fk.get("options", {})}
+         for fk in insp.get_foreign_keys(TABLE)),
+        key=lambda d: tuple(d["cols"]),
+    )
+    checks = sorted(c.get("name") or "" for c in insp.get_check_constraints(TABLE))
+    pk = list(insp.get_pk_constraint(TABLE).get("constrained_columns", []))
+    return {"columns": cols, "indexes": indexes, "fks": fks, "checks": checks, "pk": pk}
+
+
+@pytest.mark.integration
+class TestSessionTelemetryMigration:
+    """Revision 0006 — fresh up, down, round-trip, CHECK enforcement."""
+
+    def test_upgrade_creates_table_indexes_and_check(self, tmp_path):
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'st_up.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "head")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            assert TABLE in _table_names(engine), "session_telemetry not created"
+
+            idx_map = _index_map(engine, TABLE)
+            for name, cols in EXPECTED_INDEXES.items():
+                assert name in idx_map, f"missing index {name}"
+                assert idx_map[name] == cols, (
+                    f"index {name} columns {idx_map[name]} != expected {cols}"
+                )
+
+            assert CHECK_NAME in _check_constraint_names(engine, TABLE), (
+                f"named CHECK {CHECK_NAME} missing from {TABLE}"
+            )
+
+            # Columns / FK shape.
+            cols = {c["name"]: c for c in inspect(engine).get_columns(TABLE)}
+            assert set(cols) == {
+                "id", "session_id", "observed_at", "user_id", "provider_id",
+                "channel_id", "bytes_delta", "buffer_event_count", "poll_interval_ms",
+            }
+            assert cols["session_id"]["nullable"] is False
+            assert cols["observed_at"]["nullable"] is False
+            assert cols["user_id"]["nullable"] is True
+            assert cols["provider_id"]["nullable"] is True
+            assert cols["channel_id"]["nullable"] is True
+            assert cols["bytes_delta"]["nullable"] is False
+            assert cols["buffer_event_count"]["nullable"] is False
+            assert cols["poll_interval_ms"]["nullable"] is False
+
+            fks = inspect(engine).get_foreign_keys(TABLE)
+            assert len(fks) == 1, f"expected exactly one FK (user_id), got {fks}"
+            fk = fks[0]
+            assert fk["constrained_columns"] == ["user_id"]
+            assert fk["referred_table"] == "users"
+            assert fk["referred_columns"] == ["id"]
+            assert fk.get("options", {}).get("ondelete", "").upper() == "SET NULL"
+        finally:
+            engine.dispose()
+
+    def test_downgrade_removes_table_and_indexes(self, tmp_path):
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'st_down.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "head")
+        command.downgrade(cfg, "0005")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            assert TABLE not in _table_names(engine), (
+                "session_telemetry still present after downgrade to 0005"
+            )
+            # And nothing in sqlite_master references the indexes either.
+            with engine.connect() as conn:
+                rows = conn.execute(text(
+                    "SELECT name FROM sqlite_master WHERE type='index' "
+                    "AND name LIKE 'idx_session_telemetry_%'"
+                )).fetchall()
+            assert rows == [], f"orphan session_telemetry indexes remain: {rows}"
+        finally:
+            engine.dispose()
+
+    def test_round_trip_is_schema_identical(self, tmp_path):
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'st_roundtrip.db'}"
+        cfg = _make_alembic_config(db_url)
+
+        command.upgrade(cfg, "head")
+        engine = create_engine(db_url, future=True)
+        try:
+            before = _structural_snapshot(engine)
+        finally:
+            engine.dispose()
+
+        command.downgrade(cfg, "0005")
+        command.upgrade(cfg, "head")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            after = _structural_snapshot(engine)
+        finally:
+            engine.dispose()
+
+        assert before == after, (
+            f"session_telemetry schema differs across 0006 round-trip:\n"
+            f"  before: {before}\n  after:  {after}"
+        )
+
+    def test_check_constraint_is_enforced(self, tmp_path):
+        """A negative bytes_delta insert must be rejected by the DB.
+
+        Guards against SQLite/Alembic silently dropping the CHECK. PRAGMA
+        foreign_keys / general constraint enforcement is wired by
+        ``database.py``'s connect listener, which Alembic + SQLAlchemy engines
+        both inherit; CHECKs are always enforced in SQLite regardless, but this
+        proves the constraint actually made it into the table DDL.
+        """
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'st_check.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "head")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            with engine.begin() as conn:
+                # Valid row — bytes_delta >= 0 — must succeed.
+                conn.execute(text(
+                    "INSERT INTO session_telemetry "
+                    "(session_id, observed_at, bytes_delta, buffer_event_count, "
+                    " poll_interval_ms) "
+                    "VALUES ('sess-ok', 1000, 0, 0, 10000)"
+                ))
+            with pytest.raises(IntegrityError):
+                with engine.begin() as conn:
+                    conn.execute(text(
+                        "INSERT INTO session_telemetry "
+                        "(session_id, observed_at, bytes_delta, buffer_event_count, "
+                        " poll_interval_ms) "
+                        "VALUES ('sess-bad', 2000, -1, 0, 10000)"
+                    ))
+        finally:
+            engine.dispose()
+
+
+@pytest.mark.integration
+class TestSessionTelemetryAccountDeletionScrub:
+    """Deleting a ``users`` row NULLs ``session_telemetry.user_id`` (ON DELETE SET NULL).
+
+    Privacy 11a §7.8 / ADR-007: account deletion scrubs the behavioral trail.
+    The rollup-table extension of this scrub is bead
+    ``enhancedchannelmanager-7i2vv``'s responsibility (those tables don't exist
+    yet). All identities here are synthetic.
+    """
+
+    def test_deleting_user_nulls_telemetry_user_id(self, tmp_path):
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'st_scrub.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "head")
+
+        # The connect listener that turns on PRAGMA foreign_keys is registered
+        # against the SQLAlchemy Engine class in database.py, so a fresh engine
+        # here inherits it. Belt-and-braces: also set it explicitly.
+        engine = create_engine(db_url, future=True)
+        try:
+            with engine.connect() as conn:
+                conn.execute(text("PRAGMA foreign_keys=ON"))
+                conn.commit()
+
+            Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+            session = Session()
+            try:
+                import models
+
+                user = models.User(
+                    username="synthetic-scrub-user",
+                    email="synthetic-scrub@example.invalid",
+                    password_hash=None,
+                    auth_provider="local",
+                )
+                session.add(user)
+                session.flush()
+                uid = user.id
+                assert uid is not None
+
+                session.add_all([
+                    models.SessionTelemetry(
+                        session_id=f"sess-scrub-{n}",
+                        observed_at=1_700_000_000_000 + n * 10_000,
+                        user_id=uid,
+                        provider_id=1,
+                        channel_id=42,
+                        bytes_delta=1_000 * (n + 1),
+                        buffer_event_count=0,
+                        poll_interval_ms=10_000,
+                    )
+                    for n in range(5)
+                ])
+                # One unattributed row (user_id NULL) — must be untouched.
+                session.add(models.SessionTelemetry(
+                    session_id="sess-anon",
+                    observed_at=1_700_000_000_000,
+                    user_id=None,
+                    provider_id=None,
+                    channel_id=7,
+                    bytes_delta=500,
+                    buffer_event_count=0,
+                    poll_interval_ms=10_000,
+                ))
+                session.commit()
+
+                # FK enforcement must be on for the SET NULL to fire on this
+                # session's connection.
+                session.execute(text("PRAGMA foreign_keys=ON"))
+                session.commit()
+
+                session.delete(user)
+                session.commit()
+
+                rows = session.execute(text(
+                    "SELECT user_id FROM session_telemetry ORDER BY session_id"
+                )).fetchall()
+                # Every row's user_id is now NULL (5 scrubbed + 1 already-null).
+                assert all(r[0] is None for r in rows), (
+                    f"ON DELETE SET NULL did not scrub user_id: {rows}"
+                )
+                assert len(rows) == 6
+            finally:
+                session.close()
+        finally:
+            engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# 5M-row volume gate — LOCAL PRE-MERGE ONLY, not CI.
+# ---------------------------------------------------------------------------
+
+_VOLUME_ENV_FLAG = "ECM_RUN_VOLUME_TESTS"
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not os.environ.get(_VOLUME_ENV_FLAG),
+    reason=(
+        f"Volume test: set {_VOLUME_ENV_FLAG}=1 to run. Local pre-merge gate, "
+        "not CI (also marked 'slow', which CI excludes). See bead skqln.2 / the "
+        "PR checklist."
+    ),
+)
+def test_migration_up_down_against_5m_rows(tmp_path):
+    """Seed ~5M session_telemetry rows, then time ``upgrade head`` (already at
+    head — re-run is a no-op so we instead measure a *fresh* upgrade against a
+    pre-seeded DB) and ``downgrade 0005`` against that population.
+
+    To get a meaningful "upgrade against volume" number we: (1) upgrade head on
+    an empty DB, (2) bulk-seed 5M rows, (3) downgrade to 0005 (this is the
+    DROP-against-5M-rows timing — index + table drop on a big table is the
+    expensive direction in SQLite), (4) upgrade head again (fresh CREATE — fast,
+    empty), (5) re-seed and downgrade once more to confirm repeatability.
+
+    Prints wall-time for the seed and for each migration direction. Leave this
+    test gated; capture the timings in the PR.
+    """
+    from alembic import command
+    from tests.fixtures.session_telemetry_volume import (
+        VolumeShape,
+        seed_session_telemetry,
+    )
+
+    db_url = f"sqlite:///{tmp_path / 'st_volume.db'}"
+    cfg = _make_alembic_config(db_url)
+
+    # 1. Fresh upgrade (empty) — establishes the baseline schema.
+    t0 = time.perf_counter()
+    command.upgrade(cfg, "head")
+    t_up_empty = time.perf_counter() - t0
+
+    # 2. Bulk-seed ~5M rows.
+    shape = VolumeShape()  # 5,000,000 rows, realistic multi-provider + ~5% null
+    engine = create_engine(db_url, future=True)
+    try:
+        with engine.connect() as conn:
+            t0 = time.perf_counter()
+            inserted = seed_session_telemetry(conn, shape)
+            t_seed = time.perf_counter() - t0
+        assert inserted == shape.row_count, f"seeded {inserted}, expected {shape.row_count}"
+        # Sanity: ~5% of rows have NULL provider_id.
+        with engine.connect() as conn:
+            null_frac = conn.execute(text(
+                "SELECT CAST(SUM(CASE WHEN provider_id IS NULL THEN 1 ELSE 0 END) AS FLOAT) "
+                "/ COUNT(*) FROM session_telemetry"
+            )).scalar()
+        assert 0.02 < null_frac < 0.10, f"unexpected NULL-provider fraction: {null_frac}"
+    finally:
+        engine.dispose()
+
+    # 3. Downgrade to 0005 against the 5M-row population — the expensive path.
+    t0 = time.perf_counter()
+    command.downgrade(cfg, "0005")
+    t_down_5m = time.perf_counter() - t0
+
+    engine = create_engine(db_url, future=True)
+    try:
+        assert TABLE not in _table_names(engine), "table survived downgrade against 5M rows"
+    finally:
+        engine.dispose()
+
+    # 4. Re-upgrade (now empty again) — fresh CREATE, should be fast.
+    t0 = time.perf_counter()
+    command.upgrade(cfg, "head")
+    t_up_after = time.perf_counter() - t0
+
+    engine = create_engine(db_url, future=True)
+    try:
+        assert TABLE in _table_names(engine)
+        # Round-trip the indexes back too.
+        assert set(_index_map(engine, TABLE)) == set(EXPECTED_INDEXES)
+    finally:
+        engine.dispose()
+
+    # 5. Re-seed + downgrade once more to confirm repeatability.
+    engine = create_engine(db_url, future=True)
+    try:
+        with engine.connect() as conn:
+            t0 = time.perf_counter()
+            seed_session_telemetry(conn, shape)
+            t_reseed = time.perf_counter() - t0
+    finally:
+        engine.dispose()
+    t0 = time.perf_counter()
+    command.downgrade(cfg, "0005")
+    t_down_5m_again = time.perf_counter() - t0
+
+    print(
+        "\n[session_telemetry 5M-row volume gate] timings (seconds):\n"
+        f"  upgrade head (empty DB)          : {t_up_empty:.3f}\n"
+        f"  bulk-seed {shape.row_count:,} rows       : {t_seed:.3f}\n"
+        f"  downgrade 0005 (against 5M rows) : {t_down_5m:.3f}\n"
+        f"  upgrade head (empty again)       : {t_up_after:.3f}\n"
+        f"  bulk-re-seed {shape.row_count:,} rows    : {t_reseed:.3f}\n"
+        f"  downgrade 0005 (against 5M, #2)  : {t_down_5m_again:.3f}\n"
+    )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.17.0-0002",
+  "version": "0.17.0-0003",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
**Stats v2 foundation** (epic `skqln`, v0.17.0): the raw per-session telemetry fact table that GH-62 (Users panel) and GH-59 (provider stats) read from. First brick of the Users panel.

Implements `bd-skqln.2` per its GROOMING-LOCKED scope: **raw `session_telemetry` table + migration only**. Rollup tables + `telemetry_rollup_state` + nightly pruning are `bd-7i2vv`; the operator opt-out toggle is `bd-tp1pd` (fast-follow of `skqln.3`).

### Schema
`id` PK · `session_id` TEXT (indexed) · `observed_at` INT unix-ms (indexed) · `user_id` INT FK `users.id ON DELETE SET NULL` · `provider_id` / `channel_id` plain nullable indexed INTs (no FK — channels/providers are upstream Dispatcharr entities, not ECM tables; matches `channel_watch_stats` et al.) · `bytes_delta` BIGINT NOT NULL + named CHECK `ck_session_telemetry_bytes_delta_non_negative` (≥ 0) · `buffer_event_count` NOT NULL DEFAULT 0 · `poll_interval_ms` NOT NULL. No `bitrate_bps` (derivable). Indexes: `(observed_at)`, `(user_id, observed_at)`, `(provider_id, observed_at)`, `(session_id)`, `(provider_id, channel_id, observed_at, bytes_delta)`. Migration `0006` — `op.create_table()`/`op.create_index()` (fresh CREATE, no batch mode); `downgrade()` drops indexes then table.

### Tests — `backend/tests/integration/test_session_telemetry_migration.py`
- fresh up (table + 5 indexes + named CHECK via `inspect()`), down (gone), up→down→up round-trip schema-identical, CHECK enforcement, account-deletion scrub (deleting a `users` row NULLs `session_telemetry.user_id` — rollup-table extension is `bd-7i2vv`).
- **5M-row seeded migration up/down — local pre-merge gate, not CI** (`@pytest.mark.slow` + gated on `ECM_RUN_VOLUME_TESTS=1`). Verified locally: `upgrade head` 0.08 s · `downgrade 0005` against 5M rows 2.9 s · bulk-seed 5M rows ~100 s. Reusable bulk-seed fixture at `backend/tests/fixtures/session_telemetry_volume.py` (shared with `skqln.10`'s benchmark gate — note it mutates `users` ids 1..N).
- Synthetic identities only. Drift test (model ↔ migration) green.

### Verification
Full backend suite (ex-e2e): **3376 passed, 1 skipped** (= the gated volume test); no new failures. 57 pre-existing e2e ConnectErrors are unrelated (no live container). Independently re-run by the parent.

Privacy 11a conditional sign-off conditions satisfied here: `user_id` FK `ON DELETE SET NULL` ✓; synthetic-identity fixtures ✓; rollup-scrub extension tracked on `bd-7i2vv`. §7 redaction requirements apply to the read API (`skqln.5`) and the write path (`skqln.3`), not this migration.

Closes `enhancedchannelmanager-skqln.2`.