### PR TITLE
v0.17.0-0020: Stats v2 Users panel — local-tz dates + in-progress today (bd-1qxo9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Fixed
+- Stats v2 Users panel — daily watch-minutes chart now displays dates in the operator's **local timezone** and visually marks today as "in progress" (amber dot vs teal for completed days), with a caption explaining the UTC bucketing + 10s update cadence. Resolves the misleading appearance of watch-time "going down" across the UTC date boundary when yesterday-UTC is complete but today-UTC is still accumulating. Server-side aggregation stays UTC; the relabeling anchors each bucket at noon UTC then formats in the operator's tz to pick the most-overlapping local day. ([bd-1qxo9])
+
+### Fixed (existing entry continues below)
 - Stats v2 Providers panel polish: provider rows now display the actual M3U account name instead of `Provider <id>`. Frontend side-loads the existing `/api/providers` endpoint at panel mount, builds an id→name map, and uses it in chart legends, heatmap row labels, and data tables. Falls back to `Provider <id>` for unmapped IDs (e.g., during the fetch); NULL stays "Unknown". ([bd-vjv7k])
 - Stats v2 Providers heatmap polish: column labels rotated -45° (anchored at column center) and default `cellSize` bumped 32px → 48px; column-label band 24px → 80px to fit rotated text. Resolves the "everything super compressed" overlap when real channel names ("Discovery Channel", "ESPN HD") are wider than the column. The `.heatmap` container's existing `overflow-x: auto` handles wider heatmaps via horizontal scroll. Heatmap primitive interface preserved — `cellSize` prop still overridable for the time-of-day use case. ([bd-yteek])
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.17.0-0019",
+  "version": "0.17.0-0020",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/tabs/UserStatsPanel.css
+++ b/frontend/src/components/tabs/UserStatsPanel.css
@@ -106,6 +106,28 @@
   padding: 8px;
 }
 
+/* Caption below the chart explaining the today-in-progress marker and
+ * the UTC-vs-local-tz aggregation. Operators glance at this once. */
+.user-stats-panel .chart-caption {
+  margin: 6px 0 0 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+/* In-progress marker for "today" in the data-table fallback. Yellow tag
+ * mirrors the chart's amber dot (palette index 3, "Yellow"). */
+.user-stats-panel .chart-data-table .in-progress-tag {
+  margin-left: 4px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: rgba(204, 187, 68, 0.18); /* #ccbb44 at 18% */
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
 /* Data-table fallback for the chart --------------------------------------- */
 
 .user-stats-panel .chart-data-table {

--- a/frontend/src/components/tabs/UserStatsPanel.test.tsx
+++ b/frontend/src/components/tabs/UserStatsPanel.test.tsx
@@ -21,7 +21,11 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { UserStatsPanel } from './UserStatsPanel';
+import {
+  UserStatsPanel,
+  formatLocalDayLabel,
+  isTodayInLocalTz,
+} from './UserStatsPanel';
 import * as api from '../../services/api';
 import { HttpError } from '../../services/httpClient';
 import type {
@@ -338,6 +342,132 @@ describe('UserStatsPanel — a11y / keyboard navigation', () => {
     await waitFor(() => {
       // <caption> is exposed as the table's accessible name.
       expect(screen.getByRole('table', { name: /daily watch-minutes data table/i })).toBeInTheDocument();
+    });
+  });
+});
+
+describe('UserStatsPanel — date label helpers (bd-1qxo9)', () => {
+  it('formatLocalDayLabel renders short "MMM D" label in the requested tz (en-US)', () => {
+    // 2026-05-14 UTC midday → May 14 in America/Chicago (UTC-5/-6).
+    expect(formatLocalDayLabel('2026-05-14', 'en-US', 'America/Chicago')).toBe('May 14');
+  });
+
+  it('formatLocalDayLabel uses noon-UTC as the anchor so the most-overlapping local day wins', () => {
+    // The UTC day "2026-05-14" spans 00:00–24:00 UTC. In America/Chicago
+    // (UTC-5 during DST) that's 19:00 May 13 → 19:00 May 14 local. The
+    // local day with the most overlap is May 14 (19 hours of overlap vs.
+    // 5 hours on May 13). Anchoring at 12:00 UTC ensures we land on May 14
+    // even at the western edge of the US (UTC-10 Hawaii: 12:00 UTC = 02:00
+    // local same day).
+    expect(formatLocalDayLabel('2026-05-14', 'en-US', 'Pacific/Honolulu')).toBe('May 14');
+  });
+
+  it('isTodayInLocalTz returns true when the UTC-day string matches "today" in the local tz', () => {
+    // System "now" is 2026-05-14 14:00 UTC. In Chicago (UTC-5 DST) that's
+    // 09:00 local on May 14. The UTC-day "2026-05-14" maps to local
+    // May 14 via the noon-anchor rule, which equals local today.
+    const now = new Date('2026-05-14T14:00:00Z');
+    expect(isTodayInLocalTz('2026-05-14', now, 'America/Chicago')).toBe(true);
+    expect(isTodayInLocalTz('2026-05-13', now, 'America/Chicago')).toBe(false);
+  });
+
+  it('isTodayInLocalTz handles the local-day rollover edge case', () => {
+    // "Now" = 2026-05-15 02:00 UTC. In Chicago that's 21:00 May 14 local.
+    // The UTC-day string "2026-05-15" (most-overlap local = May 15) is NOT
+    // today-local; "2026-05-14" (most-overlap local = May 14) IS today-local.
+    const now = new Date('2026-05-15T02:00:00Z');
+    expect(isTodayInLocalTz('2026-05-14', now, 'America/Chicago')).toBe(true);
+    expect(isTodayInLocalTz('2026-05-15', now, 'America/Chicago')).toBe(false);
+  });
+});
+
+describe('UserStatsPanel — chart data-table labels & in-progress marker (bd-1qxo9)', () => {
+  beforeEach(() => {
+    // Pin system time to 2026-05-14 14:00 UTC so the daily response's last
+    // row ("2026-05-14") is "today" regardless of CI tz. Only fake Date —
+    // leaving timers real lets React effects & promises resolve normally.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-05-14T14:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders localized "MMM D" labels in the chart data-table fallback (not raw YYYY-MM-DD)', async () => {
+    // Daily rows: 05-12, 05-13, 05-14 (today). With noon-UTC anchor + US
+    // locale, labels should be "May 12", "May 13", "May 14".
+    vi.mocked(api.getWatchTimeByUser).mockImplementation(async ({ groupBy } = {}) => {
+      if (groupBy === 'day') {
+        return {
+          data: [
+            { user_id: 1, username: 'a', day: '2026-05-12', watch_seconds: 600 },
+            { user_id: 1, username: 'a', day: '2026-05-13', watch_seconds: 1200 },
+            { user_id: 1, username: 'a', day: '2026-05-14', watch_seconds: 300 },
+          ],
+          meta: { from_iso: null, to_iso: null, group_by: 'day' as const, total_rows: 3 },
+          pagination: null,
+        };
+      }
+      return mockTotalsResponse;
+    });
+
+    render(<UserStatsPanel />);
+
+    // Toggle table visible so getByText doesn't have to search hidden nodes
+    // (visually-hidden is in the DOM either way; we toggle for clarity).
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /show chart data/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /show chart data/i }));
+
+    // Raw YYYY-MM-DD should NOT appear in the table any more.
+    expect(screen.queryByText('2026-05-12')).not.toBeInTheDocument();
+    expect(screen.queryByText('2026-05-14')).not.toBeInTheDocument();
+    // Localized short label should appear (en-US default in test env).
+    // Match leniently — month name in the user's locale will lead, then day.
+    const tbody = screen.getByRole('table', { name: /daily watch-minutes data table/i });
+    expect(tbody.textContent).toMatch(/May\s*1[234]/);
+  });
+
+  it('marks "today" as in-progress in the data-table (yesterday is not marked)', async () => {
+    vi.mocked(api.getWatchTimeByUser).mockImplementation(async ({ groupBy } = {}) => {
+      if (groupBy === 'day') {
+        return {
+          data: [
+            { user_id: 1, username: 'a', day: '2026-05-13', watch_seconds: 1200 },
+            { user_id: 1, username: 'a', day: '2026-05-14', watch_seconds: 300 },
+          ],
+          meta: { from_iso: null, to_iso: null, group_by: 'day' as const, total_rows: 2 },
+          pagination: null,
+        };
+      }
+      return mockTotalsResponse;
+    });
+
+    render(<UserStatsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /show chart data/i })).toBeInTheDocument();
+    });
+
+    // Today's row in the data table carries an in-progress class/marker;
+    // yesterday's does not. We assert via the "in-progress" cell content
+    // tag so screen-reader users hear the asymmetry too.
+    const inProgressRow = screen.getByTestId('chart-data-row-today');
+    expect(inProgressRow).toBeInTheDocument();
+    expect(inProgressRow.textContent).toMatch(/in progress/i);
+
+    // No other row carries the in-progress testid.
+    const allInProgress = screen.queryAllByTestId('chart-data-row-today');
+    expect(allInProgress).toHaveLength(1);
+  });
+
+  it('renders an "updates every ~10s" caption under the chart so operators know today is live', async () => {
+    render(<UserStatsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/updates every ~?10s/i)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/tabs/UserStatsPanel.tsx
+++ b/frontend/src/components/tabs/UserStatsPanel.tsx
@@ -97,6 +97,80 @@ function aggregateDailyMinutes(rows: WatchTimeUserDayRow[]): DailyTrendPoint[] {
     .sort((a, b) => a.day.localeCompare(b.day));
 }
 
+/**
+ * Format a UTC day-string ("YYYY-MM-DD") as a short localized label.
+ *
+ * The backend buckets by UTC day (SQLite `date(observed_at/1000, 'unixepoch')`)
+ * but renders to operators who think in their own local timezone. Two
+ * approaches are possible:
+ *
+ *   (A) Relabel: keep server-side UTC bucketing, but show the
+ *       most-overlapping local day. ← chosen
+ *   (B) Client-side re-bucketing: fetch wider, re-bin per local day.
+ *
+ * (A) is correct enough: the UTC day "2026-05-14" spans 00:00–24:00 UTC,
+ * which is at most one local-day boundary off (a few hours of the UTC
+ * day fall in the previous local day). Anchoring at 12:00 UTC means we
+ * convert to the local day that owns the *majority* of the bucket, for
+ * every IANA-recognized tz between UTC-12 and UTC+14. Worst case the
+ * label is off by one date for the bucket whose data is dominated by the
+ * other local day — acceptable for a 30-day trend chart.
+ *
+ * `locale` and `timeZone` are optional injection points for unit tests.
+ * In production we pass nothing and let the browser pick.
+ */
+// eslint-disable-next-line react-refresh/only-export-components -- pure helper co-located with the only component that uses it; splitting is mechanical churn
+export function formatLocalDayLabel(
+  utcDayStr: string,
+  locale?: string,
+  timeZone?: string,
+): string {
+  // Noon UTC is safely inside the bucket for every fixed tz offset between
+  // -12 and +14 hours, so the date that Intl.DateTimeFormat resolves in
+  // the operator's tz is the bucket's most-overlapping local day.
+  const anchor = new Date(`${utcDayStr}T12:00:00Z`);
+  if (Number.isNaN(anchor.getTime())) return utcDayStr;
+  return new Intl.DateTimeFormat(locale, {
+    month: 'short',
+    day: 'numeric',
+    timeZone,
+  }).format(anchor);
+}
+
+/**
+ * Returns true when the UTC day-string maps to the operator's current
+ * local-tz date. Uses the same most-overlapping-day anchor as
+ * `formatLocalDayLabel` so the "today" marker lines up with the label.
+ *
+ * `now` and `timeZone` are injection points for unit tests.
+ */
+// eslint-disable-next-line react-refresh/only-export-components -- pure helper co-located with the only component that uses it; splitting is mechanical churn
+export function isTodayInLocalTz(
+  utcDayStr: string,
+  now: Date = new Date(),
+  timeZone?: string,
+): boolean {
+  // Format both the bucket's anchor and "now" through the same Intl
+  // formatter in the target tz, then compare the year/month/day parts.
+  // This avoids any manual offset math (DST, half-hour tz, etc.).
+  const anchor = new Date(`${utcDayStr}T12:00:00Z`);
+  if (Number.isNaN(anchor.getTime())) return false;
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone,
+  });
+  // en-CA renders ISO-ish "YYYY-MM-DD" — easy to compare as strings.
+  return fmt.format(anchor) === fmt.format(now);
+}
+
+/** Tol "bright" palette yellow — used as the in-progress amber. Imported
+ *  inline rather than from chartPalette so this file stays self-contained
+ *  and the test mock doesn't need to know about the palette. */
+const IN_PROGRESS_COLOR = '#ccbb44';
+const COMPLETE_COLOR = '#14b8a6';
+
 function isAdminOnly403(err: unknown): boolean {
   return err instanceof HttpError && err.status === 403;
 }
@@ -183,6 +257,17 @@ export function UserStatsPanel() {
 
   const dailyTrend = useMemo(() => aggregateDailyMinutes(daily), [daily]);
 
+  // Enrich each point with its localized label and an in-progress flag for
+  // today. Computed in a memo so re-renders don't redo Intl work per point.
+  const dailyTrendDecorated = useMemo(() => {
+    const now = new Date();
+    return dailyTrend.map(p => ({
+      ...p,
+      label: formatLocalDayLabel(p.day),
+      isToday: isTodayInLocalTz(p.day, now),
+    }));
+  }, [dailyTrend]);
+
   // Auth still resolving — stay quiet until we know the posture.
   if (authLoading) {
     return (
@@ -242,10 +327,10 @@ export function UserStatsPanel() {
         </div>
         <div className="chart-container" aria-hidden="true">
           <ResponsiveContainer width="100%" height={180}>
-            <LineChart data={dailyTrend} margin={{ top: 10, right: 16, bottom: 8, left: 8 }}>
+            <LineChart data={dailyTrendDecorated} margin={{ top: 10, right: 16, bottom: 8, left: 8 }}>
               <CartesianGrid stroke="var(--border-primary)" strokeDasharray="3 3" />
               <XAxis
-                dataKey="day"
+                dataKey="label"
                 tick={{ fontSize: 11, fill: 'var(--text-primary)' }}
                 axisLine={{ stroke: 'var(--border-primary)' }}
                 tickLine={false}
@@ -260,14 +345,42 @@ export function UserStatsPanel() {
               <Line
                 type="monotone"
                 dataKey="minutes"
-                stroke="#14b8a6"
+                stroke={COMPLETE_COLOR}
                 strokeWidth={2}
-                dot={{ fill: '#14b8a6', r: 3 }}
+                // Today's dot renders amber; complete days render teal.
+                // Recharts passes the row payload as `payload` to the dot
+                // renderer — we key off `isToday` to color the marker.
+                dot={(props: {
+                  cx?: number;
+                  cy?: number;
+                  payload?: { isToday?: boolean };
+                  key?: string | number;
+                }) => {
+                  const isToday = Boolean(props.payload?.isToday);
+                  const fill = isToday ? IN_PROGRESS_COLOR : COMPLETE_COLOR;
+                  const stroke = isToday ? IN_PROGRESS_COLOR : COMPLETE_COLOR;
+                  return (
+                    <circle
+                      key={props.key ?? `${props.cx}-${props.cy}`}
+                      cx={props.cx}
+                      cy={props.cy}
+                      r={isToday ? 4 : 3}
+                      fill={fill}
+                      stroke={stroke}
+                      strokeWidth={isToday ? 2 : 1}
+                    />
+                  );
+                }}
                 isAnimationActive={false}
               />
             </LineChart>
           </ResponsiveContainer>
         </div>
+        <p className="chart-caption">
+          Today's value updates every ~10s as new watch data arrives.
+          Metrics aggregated in UTC; labels show the local date with the
+          most overlap.
+        </p>
         {/* Data-table fallback for the chart — always in the DOM for SR users,
             visually-hidden by default. */}
         <table
@@ -282,14 +395,23 @@ export function UserStatsPanel() {
             </tr>
           </thead>
           <tbody>
-            {dailyTrend.length === 0 ? (
+            {dailyTrendDecorated.length === 0 ? (
               <tr>
                 <td colSpan={2}>No data</td>
               </tr>
             ) : (
-              dailyTrend.map(point => (
-                <tr key={point.day}>
-                  <td>{point.day}</td>
+              dailyTrendDecorated.map(point => (
+                <tr
+                  key={point.day}
+                  data-testid={point.isToday ? 'chart-data-row-today' : undefined}
+                  className={point.isToday ? 'in-progress-row' : ''}
+                >
+                  <td>
+                    {point.label}
+                    {point.isToday && (
+                      <span className="in-progress-tag"> (in progress)</span>
+                    )}
+                  </td>
                   <td>{point.minutes}</td>
                 </tr>
               ))


### PR DESCRIPTION
Closes the UTC date-boundary UX issue the PO surfaced post-deploy: yesterday-UTC complete vs today-UTC in-progress caused the daily watch-minutes line to appear to trend down.

- Date labels now display in operator's local timezone (anchored at noon UTC + Intl.DateTimeFormat)
- Today's data point renders amber (vs teal for completed days); colorblind-safe (Tol palette)
- Caption explains UTC aggregation + 10s update cadence
- 7 new tests; 1285 total pass

Bead: bd-1qxo9