### PR TITLE
v0.17.0-0021: Stats v2 resolver URL fallback for missing stream_id (bd-kbgey)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Fixed
+- Stats v2 provider resolver — URL fallback when Dispatcharr's `/proxy/ts/status` omits `stream_id`. The skqln.14 resolver previously gave up with `reason=no_stream_id` for any active channel where Dispatcharr didn't surface `stream_id` directly, leaving `provider_id=NULL` (the "Unknown" bucket). In dev, this hit 91% of polls (214 of 235). The resolver now also extracts the stream id from the URL path's trailing `<id>.ts` segment (`r"/(\d+)\.ts(?:\?|$)"`) and feeds it into the same `get_streams_by_ids` batch the resolver already runs per poll — no additional API calls. URL-derived lookups that miss log `reason=stream_not_found_url_derived` so ops can differentiate from the direct-stream-id miss case. ([bd-kbgey])
 - Stats v2 Users panel — daily watch-minutes chart now displays dates in the operator's **local timezone** and visually marks today as "in progress" (amber dot vs teal for completed days), with a caption explaining the UTC bucketing + 10s update cadence. Resolves the misleading appearance of watch-time "going down" across the UTC date boundary when yesterday-UTC is complete but today-UTC is still accumulating. Server-side aggregation stays UTC; the relabeling anchors each bucket at noon UTC then formats in the operator's tz to pick the most-overlapping local day. ([bd-1qxo9])
 
 ### Fixed (existing entry continues below)

--- a/backend/bandwidth_tracker.py
+++ b/backend/bandwidth_tracker.py
@@ -15,6 +15,7 @@ writes are gone.
 import asyncio
 import logging
 import os
+import re
 import time
 from collections import OrderedDict
 from datetime import datetime, date, timedelta, timezone
@@ -32,6 +33,43 @@ from models import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Dispatcharr stream-URL convention: the last path segment before ``.ts`` is
+# the integer Dispatcharr stream row id — the same value that ``stream_id``
+# would have carried on the ``/proxy/ts/status`` payload had it been
+# populated. The resolver falls back to this when ``stream_id`` is missing
+# (bd-kbgey — 214 of 235 dev polls observed with stream_id=None on active
+# channels). One capture group, defensive against query-string suffixes
+# like ``.ts?session=abc123`` so the fallback survives Dispatcharr URL
+# annotation conventions that the proxy may add for transcoding hints.
+_STREAM_ID_URL_PATTERN = re.compile(r"/(\d+)\.ts(?:\?|$)")
+
+
+def _extract_stream_id_from_url(url: Optional[str]) -> Optional[int]:
+    """Pull the Dispatcharr stream row id from a stream URL.
+
+    Returns the integer stream id if the URL matches the
+    ``.../<id>.ts[?...]`` convention, otherwise ``None``. Defensive
+    against malformed input (non-string, empty, no path, no integer
+    segment); the caller treats ``None`` the same as a missing
+    ``stream_id`` field and falls through to the NULL-write path.
+
+    Validates the captured value parses as a positive int — guards
+    against pathological inputs like ``/00000.ts`` mapping to id 0.
+    """
+    if not url or not isinstance(url, str):
+        return None
+    match = _STREAM_ID_URL_PATTERN.search(url)
+    if match is None:
+        return None
+    try:
+        parsed = int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+    if parsed <= 0:
+        return None
+    return parsed
 
 
 def _telemetry_opt_out_enabled() -> bool:
@@ -483,7 +521,9 @@ class BandwidthTracker:
                 # ``/proxy/ts/status``, consumed by the provider resolver
                 # in ``_resolve_provider_ids`` (bd-skqln.14). May be missing
                 # if Dispatcharr serves a degraded stats payload; the
-                # resolver tolerates that and returns NULL.
+                # resolver tolerates that and falls back to URL parsing
+                # (bd-kbgey) when ``url`` carries the same id as the trailing
+                # ``.../<stream_id>.ts`` path segment, then NULL.
                 telemetry_channel_snapshot.append({
                     "channel_uuid": channel_id,
                     "channel_number": channel_number,
@@ -491,6 +531,7 @@ class BandwidthTracker:
                     "client_user_map": dict(client_user_map),
                     "channel_bytes_delta": channel_bytes_delta,
                     "stream_id": channel.get("stream_id"),
+                    "url": channel.get("url"),
                 })
 
         # Check for channels that stopped being watched
@@ -995,16 +1036,33 @@ class BandwidthTracker:
         unresolvable_channels: list[str] = []
         # {channel_uuid: stream_id} for channels we'll attempt to resolve.
         stream_id_by_channel: dict[str, int] = {}
+        # Channels whose stream_id came from URL parsing (bd-kbgey fallback)
+        # rather than the direct ``stream_id`` field. Used only to
+        # differentiate the ``stream_not_found`` failure log so operators
+        # can tell a Dispatcharr-direct miss from a URL-derived miss when
+        # we triage; the resolved-success path is identical.
+        url_derived_channels: set[str] = set()
         for entry in channel_snapshot:
             channel_uuid = entry["channel_uuid"]
             stream_id = entry.get("stream_id")
             if stream_id is None:
-                unresolvable_channels.append(channel_uuid)
-                provider_by_channel[channel_uuid] = None
-                logger.warning(
-                    "[STATS_V2] provider_resolution_failed channel=%s reason=no_stream_id",
-                    channel_uuid,
-                )
+                # Fallback (bd-kbgey): Dispatcharr inconsistently surfaces
+                # ``stream_id`` on the ``/proxy/ts/status`` payload, but the
+                # ``url`` field carries the same id as the trailing path
+                # segment before ``.ts``. Parse it and feed it into the
+                # same batched lookup below — no extra API call.
+                url = entry.get("url")
+                derived = _extract_stream_id_from_url(url) if url else None
+                if derived is None:
+                    unresolvable_channels.append(channel_uuid)
+                    provider_by_channel[channel_uuid] = None
+                    logger.warning(
+                        "[STATS_V2] provider_resolution_failed channel=%s reason=no_stream_id",
+                        channel_uuid,
+                    )
+                    continue
+                stream_id_by_channel[channel_uuid] = derived
+                url_derived_channels.add(channel_uuid)
                 continue
             stream_id_by_channel[channel_uuid] = int(stream_id)
 
@@ -1055,11 +1113,18 @@ class BandwidthTracker:
                 # or its m3u_account was None. Both surface as NULL.
                 provider_by_channel[channel_uuid] = None
                 unresolved_count += 1
-                reason = (
-                    "stream_not_found"
-                    if stream_id not in provider_by_stream
-                    else "stream_has_no_provider"
-                )
+                if stream_id not in provider_by_stream:
+                    # Distinguish "Dispatcharr didn't find the id we
+                    # extracted from the URL" from "Dispatcharr didn't
+                    # find the id it gave us directly" — helps observability
+                    # if the URL convention shifts (bd-kbgey).
+                    reason = (
+                        "stream_not_found_url_derived"
+                        if channel_uuid in url_derived_channels
+                        else "stream_not_found"
+                    )
+                else:
+                    reason = "stream_has_no_provider"
                 logger.warning(
                     "[STATS_V2] provider_resolution_failed channel=%s stream=%s reason=%s",
                     channel_uuid,

--- a/backend/tests/unit/test_bandwidth_tracker_session_telemetry.py
+++ b/backend/tests/unit/test_bandwidth_tracker_session_telemetry.py
@@ -134,6 +134,7 @@ def _channel_payload(
     avg_bitrate_kbps: int = 1000,
     name: str = "Test Channel",
     stream_id: int | None = None,
+    url: str | None = None,
 ) -> dict:
     """Build a single ``channels[]`` entry as Dispatcharr's stats endpoint
     surfaces it. Defaults match a single-viewer stream.
@@ -142,6 +143,11 @@ def _channel_payload(
     ``/proxy/ts/status`` payload surfaces — the integer ID of the stream
     currently being served. This is the input the provider resolver (bead
     skqln.14) uses to map the active stream back to its ``m3u_account_id``.
+
+    ``url`` mirrors the per-channel ``url`` field Dispatcharr surfaces in
+    the same payload. The trailing path-segment integer before ``.ts`` is
+    the Dispatcharr stream row id — the resolver's URL-fallback path
+    (bead kbgey) parses it when ``stream_id`` is absent.
     """
     if client_ips is None:
         client_ips = ["10.0.0.1"]
@@ -162,6 +168,8 @@ def _channel_payload(
     }
     if stream_id is not None:
         payload["stream_id"] = stream_id
+    if url is not None:
+        payload["url"] = url
     return payload
 
 
@@ -984,6 +992,271 @@ async def test_resolver_handles_null_m3u_account_on_stream(
         "[STATS_V2] provider_resolution_failed" in r.message
         for r in caplog.records
     )
+
+
+# ---------------------------------------------------------------------------
+# URL-fallback resolver tests (bd-kbgey)
+# ---------------------------------------------------------------------------
+#
+# Dispatcharr's ``/proxy/ts/status`` payload INCONSISTENTLY populates
+# ``stream_id`` per channel — 214 of 235 polls observed in dev surfaced
+# the field missing on active connections (see bd-kbgey description for
+# real payload evidence). The URL field is reliably present, and its
+# trailing path segment before ``.ts`` is the same Dispatcharr stream row
+# id that ``stream_id`` would have carried. The resolver derives the id
+# from the URL when ``stream_id`` is missing, then routes the result
+# through the SAME batched ``get_streams_by_ids`` call — no extra API
+# round-trip.
+
+
+@pytest.mark.asyncio
+async def test_resolver_url_fallback_when_stream_id_missing(
+    patched_session_local,
+    seed_synthetic_user,
+    tracker,
+    mock_client,
+):
+    """``stream_id`` absent but ``url`` present — resolver parses the
+    trailing ``.../<stream_id>.ts`` integer from the URL, feeds it into
+    the same batched lookup, and writes the resulting provider_id.
+
+    This is the dev-observed Infinity case: TNT active, ``stream_id``
+    missing, URL ``https://infinity.gives/live/mot/16118141/85796.ts``.
+    """
+    stream_id = 85796
+    provider_id = 9
+    mock_client.get_streams_by_ids = AsyncMock(
+        return_value=[{"id": stream_id, "m3u_account": provider_id}]
+    )
+    first = _channel_payload(
+        total_bytes=1_000_000,
+        client_user_ids={"10.0.0.1": seed_synthetic_user},
+        url=f"https://infinity.gives/live/mot/16118141/{stream_id}.ts",
+    )
+    second = _channel_payload(
+        total_bytes=2_000_000,
+        client_user_ids={"10.0.0.1": seed_synthetic_user},
+        url=f"https://infinity.gives/live/mot/16118141/{stream_id}.ts",
+    )
+
+    await _drive_two_polls(tracker, mock_client, first, second)
+
+    session = patched_session_local()
+    try:
+        rows = session.query(SessionTelemetry).order_by(SessionTelemetry.id).all()
+    finally:
+        session.close()
+    assert rows, "session_telemetry rows must still be written"
+    assert all(r.provider_id == provider_id for r in rows), [
+        (r.id, r.provider_id) for r in rows
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resolver_url_fallback_malformed_url_falls_through_to_null(
+    patched_session_local,
+    seed_synthetic_user,
+    tracker,
+    mock_client,
+    caplog,
+):
+    """URL present but missing the trailing ``<n>.ts`` segment — resolver
+    has no stream id to look up and falls through to NULL with a
+    ``no_stream_id`` reason log. The row is still written.
+    """
+    import logging as _logging
+
+    mock_client.get_streams_by_ids = AsyncMock(return_value=[])
+    first = _channel_payload(
+        total_bytes=1_000_000,
+        client_user_ids={"10.0.0.1": seed_synthetic_user},
+        url="https://example.com/foo/bar",
+    )
+    second = _channel_payload(
+        total_bytes=2_000_000,
+        client_user_ids={"10.0.0.1": seed_synthetic_user},
+        url="https://example.com/foo/bar",
+    )
+
+    caplog.clear()
+    with caplog.at_level(_logging.WARNING, logger="bandwidth_tracker"):
+        await _drive_two_polls(tracker, mock_client, first, second)
+
+    session = patched_session_local()
+    try:
+        rows = session.query(SessionTelemetry).all()
+    finally:
+        session.close()
+    assert rows, "session_telemetry rows must still be written"
+    assert all(r.provider_id is None for r in rows)
+    assert any(
+        "[STATS_V2] provider_resolution_failed" in r.message
+        and "reason=no_stream_id" in r.message
+        for r in caplog.records
+    ), [r.message for r in caplog.records]
+
+
+@pytest.mark.asyncio
+async def test_resolver_url_fallback_with_query_string(
+    patched_session_local,
+    seed_synthetic_user,
+    tracker,
+    mock_client,
+):
+    """Dispatcharr URLs occasionally carry a query string after ``.ts``
+    (session token, transcode hint). The regex must still extract the
+    stream id from ``.../85796.ts?session=abc123``.
+    """
+    stream_id = 85796
+    provider_id = 9
+    mock_client.get_streams_by_ids = AsyncMock(
+        return_value=[{"id": stream_id, "m3u_account": provider_id}]
+    )
+    first = _channel_payload(
+        total_bytes=1_000_000,
+        client_user_ids={"10.0.0.1": seed_synthetic_user},
+        url=f"https://infinity.gives/live/mot/16118141/{stream_id}.ts?session=abc123",
+    )
+    second = _channel_payload(
+        total_bytes=2_000_000,
+        client_user_ids={"10.0.0.1": seed_synthetic_user},
+        url=f"https://infinity.gives/live/mot/16118141/{stream_id}.ts?session=abc123",
+    )
+
+    await _drive_two_polls(tracker, mock_client, first, second)
+
+    session = patched_session_local()
+    try:
+        rows = session.query(SessionTelemetry).all()
+    finally:
+        session.close()
+    assert rows and all(r.provider_id == provider_id for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_resolver_mixed_batch_url_and_stream_id_share_one_lookup(
+    patched_session_local,
+    seed_synthetic_user,
+    tracker,
+    mock_client,
+):
+    """Mixed poll: one channel has ``stream_id`` directly, one needs URL
+    parsing. Both ids end up in the SAME batched
+    ``get_streams_by_ids`` call — the URL-fallback path must not
+    multiply the API round-trip count.
+    """
+    mock_client.get_streams_by_ids = AsyncMock(
+        return_value=[
+            {"id": 100, "m3u_account": 1},
+            {"id": 85796, "m3u_account": 9},
+        ]
+    )
+    ch_a_first = _channel_payload(
+        channel_uuid="ch-direct",
+        channel_number=101,
+        total_bytes=1_000_000,
+        client_ips=["10.0.0.1"],
+        client_user_ids={"10.0.0.1": seed_synthetic_user},
+        stream_id=100,
+    )
+    ch_b_first = _channel_payload(
+        channel_uuid="ch-url",
+        channel_number=102,
+        total_bytes=1_000_000,
+        client_ips=["10.0.0.2"],
+        url="https://infinity.gives/live/mot/16118141/85796.ts",
+    )
+    ch_a_second = _channel_payload(
+        channel_uuid="ch-direct",
+        channel_number=101,
+        total_bytes=2_000_000,
+        client_ips=["10.0.0.1"],
+        client_user_ids={"10.0.0.1": seed_synthetic_user},
+        stream_id=100,
+    )
+    ch_b_second = _channel_payload(
+        channel_uuid="ch-url",
+        channel_number=102,
+        total_bytes=2_000_000,
+        client_ips=["10.0.0.2"],
+        url="https://infinity.gives/live/mot/16118141/85796.ts",
+    )
+
+    mock_client.get_channel_stats.return_value = {
+        "channels": [ch_a_first, ch_b_first]
+    }
+    await tracker._collect_stats()
+    call_count_after_first = mock_client.get_streams_by_ids.call_count
+    mock_client.get_channel_stats.return_value = {
+        "channels": [ch_a_second, ch_b_second]
+    }
+    await tracker._collect_stats()
+    call_count_after_second = mock_client.get_streams_by_ids.call_count
+
+    # One call per poll, regardless of how many channels needed URL parsing.
+    assert call_count_after_first == 1
+    assert call_count_after_second == 2
+
+    # And the single call covered BOTH stream ids — the set passed to
+    # the lookup must contain 100 (direct) and 85796 (URL-derived).
+    second_poll_call_args = mock_client.get_streams_by_ids.call_args_list[1]
+    ids_arg = second_poll_call_args.args[0]
+    assert set(ids_arg) == {100, 85796}, ids_arg
+
+    session = patched_session_local()
+    try:
+        rows = session.query(SessionTelemetry).all()
+    finally:
+        session.close()
+    provider_by_channel = {(r.channel_id, r.provider_id) for r in rows}
+    assert ("ch-direct", 1) in provider_by_channel
+    assert ("ch-url", 9) in provider_by_channel
+
+
+@pytest.mark.asyncio
+async def test_resolver_url_derived_stream_not_found_logs_distinct_reason(
+    patched_session_local,
+    seed_synthetic_user,
+    tracker,
+    mock_client,
+    caplog,
+):
+    """URL parsing succeeded but ``get_streams_by_ids`` returns no record
+    for the parsed id. The failure log must carry
+    ``reason=stream_not_found_url_derived`` so operators can distinguish
+    "Dispatcharr 404'd the id we extracted from the URL" from
+    "Dispatcharr 404'd an id it told us directly". Helps observability
+    if the URL convention shifts under us.
+    """
+    import logging as _logging
+
+    mock_client.get_streams_by_ids = AsyncMock(return_value=[])
+    first = _channel_payload(
+        total_bytes=1_000_000,
+        client_user_ids={"10.0.0.1": seed_synthetic_user},
+        url="https://infinity.gives/live/mot/16118141/85796.ts",
+    )
+    second = _channel_payload(
+        total_bytes=2_000_000,
+        client_user_ids={"10.0.0.1": seed_synthetic_user},
+        url="https://infinity.gives/live/mot/16118141/85796.ts",
+    )
+
+    caplog.clear()
+    with caplog.at_level(_logging.WARNING, logger="bandwidth_tracker"):
+        await _drive_two_polls(tracker, mock_client, first, second)
+
+    session = patched_session_local()
+    try:
+        rows = session.query(SessionTelemetry).all()
+    finally:
+        session.close()
+    assert rows and all(r.provider_id is None for r in rows)
+    assert any(
+        "[STATS_V2] provider_resolution_failed" in r.message
+        and "reason=stream_not_found_url_derived" in r.message
+        for r in caplog.records
+    ), [r.message for r in caplog.records]
 
 
 @pytest.mark.asyncio

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-channel-manager",
   "private": true,
-  "version": "0.17.0-0020",
+  "version": "0.17.0-0021",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Fixes the real data bug PO surfaced in dev testing: 91% of session_telemetry polls had provider_id=NULL because Dispatcharr's /proxy/ts/status inconsistently populates stream_id. 'Infinity' provider wasn't showing as active even though channels were streaming through it.

The resolver now extracts the stream id from the URL path's trailing `<id>.ts` segment when stream_id is missing, feeding it into the same batched get_streams_by_ids call — no extra API calls. 5 new tests cover the URL parse, query-string suffix, malformed-URL fall-through, mixed batches sharing one lookup, and the distinct stream_not_found_url_derived log reason.

3539 backend tests pass (3534 + 5 new), semgrep clean.

Bead: bd-kbgey