### PR TITLE
fix(database): loud-fail on alembic bootstrap + model-schema parity check (bd-zaaey)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -241,6 +241,73 @@ def _bootstrap_alembic(engine) -> None:
             )
 
 
+def _assert_schema_matches_models(engine) -> None:
+    """Verify every SQLAlchemy model column exists on the live DB.
+
+    The hand-curated ``_BOOTSTRAP_CANARIES`` list above only covers migrations
+    0002 and 0004 — historical artifacts from the bd-fwpzw stamped-at-head
+    bug. A user whose ``alembic_version`` row is plausible but whose physical
+    schema is missing later-migration columns (e.g. migration 0010's
+    ``session_telemetry.stream_id`` — bd-zaaey symptom) sails past the
+    canaries and runs forever with a half-broken schema, flooding the logs
+    with ``OperationalError: no column named stream_id`` on every poll.
+
+    This check replaces the hand-curated canary list with an automatically-
+    derived diff between ``Base.metadata`` (what the running code expects)
+    and the live DB (what is actually there). Any future migration's columns
+    are covered without extending a canary list per release — the model IS
+    the canary list.
+
+    What the check flags:
+        - Missing **columns on existing tables** — those are exactly the
+          columns an ``ALTER TABLE`` migration is supposed to add, and that
+          ``create_all()`` cannot add to an existing table. This is the
+          bd-zaaey failure surface.
+
+    What the check deliberately does NOT flag:
+        - Missing tables — ``Base.metadata.create_all(engine)`` (called
+          right after this function in ``init_db``) handles that idempotently.
+        - Extra columns in the DB that aren't on the model — that's a
+          downgrade signal, not a missing-migration signal, and not the bug
+          this guard is designed to catch.
+        - Column type mismatches — SQLite type affinity makes that fuzzy
+          enough that a strict diff produces false positives; the migration
+          history is the source of truth for type evolution, not this check.
+
+    Raises:
+        RuntimeError: with a message naming the missing ``table.column``
+        pairs so the operator can act without re-running the app under a
+        debugger.
+    """
+    from sqlalchemy import inspect
+
+    inspector = inspect(engine)
+    live_tables = set(inspector.get_table_names())
+
+    drift: list[str] = []
+    for table_name, table in Base.metadata.tables.items():
+        if table_name not in live_tables:
+            # Missing tables are ``create_all``'s job, not this check's.
+            continue
+        live_columns = {c["name"] for c in inspector.get_columns(table_name)}
+        for column in table.columns:
+            if column.name not in live_columns:
+                drift.append(f"{table_name}.{column.name}")
+
+    if drift:
+        # Sorted so the diagnostic is stable across runs — operators
+        # reporting "we got error X" should see the same list every time.
+        drift.sort()
+        raise RuntimeError(
+            "schema drift detected — model declares columns not present in "
+            "the live database (likely an un-applied Alembic migration): "
+            f"{drift}. The container's journal.db is in an inconsistent "
+            "state. Recovery: stop the container, back up "
+            "/config/journal.db, run `alembic upgrade head` against the "
+            "DB (or restore the DB from a known-good backup), then restart."
+        )
+
+
 def get_current_schema_revision(engine=None) -> str:
     """Return the ``alembic_version`` currently applied to the DB, or ``""``."""
     eng = engine if engine is not None else _engine
@@ -297,18 +364,34 @@ def init_db() -> None:
         # Apply Alembic migrations first so schema tracking is authoritative
         # (see ``docs/database_migrations.md``). For legacy installs we stamp
         # to head rather than re-run DDL that would fail on duplicate tables.
-        try:
-            _bootstrap_alembic(_engine)
-        except Exception:
-            logger.exception(
-                "[DATABASE] Alembic bootstrap failed; falling back to create_all()"
-            )
+        #
+        # bd-zaaey: an Exception here used to be swallowed with a "falling
+        # back to create_all()" log line. That fallback is the disease
+        # vector — ``create_all`` is a no-op for an existing table, so any
+        # partially-applied migration leaves the schema half-broken forever
+        # and floods the logs with ``OperationalError: no column named X``
+        # WARN lines on every poll. Loud-fail instead: re-raise so the
+        # operator sees a boot failure and acts on it, rather than running
+        # for days on a silently-broken DB.
+        _bootstrap_alembic(_engine)
 
         # Create all tables (idempotent; no-op on clean Alembic installs but
         # keeps legacy in-process additions working until a proper revision
         # lands for them).
         Base.metadata.create_all(bind=_engine)
         logger.debug("[DATABASE] Database tables created/verified")
+
+        # bd-zaaey defense-in-depth: structural check that every model
+        # column exists in the live DB. The ``_BOOTSTRAP_CANARIES`` list
+        # above is hand-curated against migrations 0002 + 0004 and does NOT
+        # cover later migrations (0006-0010). A user whose ``alembic_version``
+        # row is plausible but whose physical schema is missing
+        # ``session_telemetry.stream_id`` sailed past every other guard and
+        # ran for days with ``[STATS_V2] session_telemetry write failed:
+        # ... no column named stream_id`` on every poll. This check is the
+        # durable replacement — the model IS the canary list, so any
+        # future column added by an unapplied migration is caught at boot.
+        _assert_schema_matches_models(_engine)
 
         # Run migrations for existing tables (add new columns if missing)
         _run_migrations(_engine)

--- a/backend/tests/unit/test_database_bootstrap.py
+++ b/backend/tests/unit/test_database_bootstrap.py
@@ -228,3 +228,130 @@ class TestBootstrapAlembic:
                     database._bootstrap_alembic(engine)
         finally:
             engine.dispose()
+
+
+class TestInitDbLoudFailOnBootstrap:
+    """``init_db`` must not silently swallow alembic bootstrap failures (bd-zaaey).
+
+    The original ``init_db`` wrapped ``_bootstrap_alembic`` in a bare
+    ``try/except Exception`` and logged a "falling back to create_all()"
+    message before continuing. That fallback path is the disease vector that
+    let a user's container run for days with a half-applied schema and a
+    flood of ``session_telemetry write failed: no column named stream_id``
+    WARN logs: ``create_all()`` is a no-op for an existing table, so a
+    partially-upgraded ``session_telemetry`` stayed broken forever.
+
+    The contract these tests pin: any failure inside ``_bootstrap_alembic``
+    propagates out of ``init_db`` so startup fails loud (the operator sees
+    the boot failure, the symptom is not silently ongoing log noise).
+    """
+
+    def test_init_db_raises_when_bootstrap_alembic_raises(self, tmp_path, monkeypatch):
+        """A raise inside ``_bootstrap_alembic`` must propagate, not be swallowed."""
+        # Redirect the journal DB to a tmp path so we don't touch the real one.
+        monkeypatch.setattr(database, "JOURNAL_DB_FILE", tmp_path / "journal.db")
+        monkeypatch.setattr(database, "_engine", None)
+        monkeypatch.setattr(database, "_SessionLocal", None)
+
+        def boom(_engine):
+            raise RuntimeError("simulated alembic upgrade failure")
+
+        with patch.object(database, "_bootstrap_alembic", side_effect=boom):
+            with pytest.raises(RuntimeError, match="simulated alembic upgrade failure"):
+                database.init_db()
+
+
+class TestModelSchemaParityCheck:
+    """Post-bootstrap parity check: every SQLAlchemy model column must exist
+    in the live DB (bd-zaaey).
+
+    The original ``_BOOTSTRAP_CANARIES`` list covered migrations 0002 and
+    0004 only. A user whose ``alembic_version`` is stamped beyond the
+    canaries but whose physical schema is missing later-migration columns
+    (e.g. ``session_telemetry.stream_id`` from migration 0010) would pass
+    the canary check and silently run with a broken schema. This durable
+    parity check replaces the canary's hand-curated list with an
+    automatically-derived diff between ``Base.metadata`` and the live DB —
+    so any future migration's columns are covered without extending a
+    canary list per release.
+
+    Contract: ``_assert_schema_matches_models`` raises ``RuntimeError`` with
+    a message naming the missing ``table.column`` if a model-declared
+    column is absent from the live DB. Tables that exist in models but not
+    in the DB are not the parity check's concern (``create_all`` covers
+    that — see ``init_db``'s ordering); only missing **columns on existing
+    tables** are flagged, because those are the columns that ``ALTER TABLE``
+    migrations are supposed to add and that ``create_all`` cannot add.
+    """
+
+    def test_parity_check_passes_at_head(self, tmp_path):
+        """A fully-migrated DB must pass the parity check without raising."""
+        from alembic import command
+
+        db_file = tmp_path / "at_head.db"
+        cfg = _alembic_config(db_file)
+        command.upgrade(cfg, "head")
+
+        engine = _make_engine(db_file)
+        try:
+            # Must not raise.
+            database._assert_schema_matches_models(engine)
+        finally:
+            engine.dispose()
+
+    def test_parity_check_raises_on_missing_column(self, tmp_path):
+        """A column dropped from the live DB (simulating an unapplied migration)
+        must trigger the parity check to raise."""
+        from alembic import command
+
+        db_file = tmp_path / "missing_col.db"
+        cfg = _alembic_config(db_file)
+        command.upgrade(cfg, "head")
+
+        engine = _make_engine(db_file)
+        try:
+            # Drop the ``stream_id`` column from ``session_telemetry`` to
+            # simulate a user whose schema lags behind the model (e.g.
+            # migration 0010 was skipped, the bd-zaaey symptom). SQLite has no
+            # native ``DROP COLUMN`` in older versions; the rebuild dance is:
+            # 1. DROP VIEW that references the table (else the RENAME fails
+            #    with "error in view: no such table" — same constraint that
+            #    forced migration 0010 to drop/recreate channel_watch_stats_v).
+            # 2. CREATE TABLE replacement WITHOUT the dropped columns
+            # 3. INSERT SELECT
+            # 4. DROP original
+            # 5. RENAME replacement → original
+            with engine.begin() as conn:
+                conn.execute(text("DROP VIEW IF EXISTS channel_watch_stats_v"))
+                conn.execute(text(
+                    "CREATE TABLE session_telemetry_rebuild ("
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                    "session_id TEXT NOT NULL, "
+                    "observed_at INTEGER NOT NULL, "
+                    "user_id INTEGER, "
+                    "provider_id INTEGER, "
+                    "channel_id VARCHAR(64) NOT NULL, "
+                    "bytes_delta BIGINT NOT NULL, "
+                    "buffer_event_count INTEGER NOT NULL DEFAULT 0, "
+                    "poll_interval_ms INTEGER NOT NULL, "
+                    "CONSTRAINT ck_session_telemetry_bytes_delta_non_negative CHECK (bytes_delta >= 0)"
+                    ")"
+                ))
+                conn.execute(text(
+                    "INSERT INTO session_telemetry_rebuild "
+                    "(id, session_id, observed_at, user_id, provider_id, channel_id, "
+                    " bytes_delta, buffer_event_count, poll_interval_ms) "
+                    "SELECT id, session_id, observed_at, user_id, provider_id, channel_id, "
+                    " bytes_delta, buffer_event_count, poll_interval_ms FROM session_telemetry"
+                ))
+                conn.execute(text("DROP TABLE session_telemetry"))
+                conn.execute(text("ALTER TABLE session_telemetry_rebuild RENAME TO session_telemetry"))
+
+            with pytest.raises(RuntimeError, match="schema drift") as exc_info:
+                database._assert_schema_matches_models(engine)
+
+            # Error message must name the offending column so the operator
+            # can act without re-running pytest.
+            assert "session_telemetry.stream_id" in str(exc_info.value), str(exc_info.value)
+        finally:
+            engine.dispose()


### PR DESCRIPTION
## [bd-zaaey] session_telemetry write failures: missing stream_id column on user containers

### What
- Removes the silent `try/except Exception → fallback to create_all()` around `_bootstrap_alembic` in `init_db`. Alembic failures now propagate, the container fails to boot, the operator sees a loud signal.
- Adds `_assert_schema_matches_models(engine)` — a structural check that every SQLAlchemy model column exists on the live DB. Runs after the bootstrap upgrade, before any writer touches the DB. The model IS the canary list, so any future migration's columns are covered without extending a hand-curated list per release.

### Why
A user reported `[STATS_V2] session_telemetry write failed: ... no column named stream_id` flooding their container logs. Their `bandwidth_tracker.py` was the new v0.17.0 code that INSERTs `stream_id` + `stream_name`, but their `session_telemetry` table was missing both columns.

**The disease vector**: `init_db` wrapped `_bootstrap_alembic` in `try/except Exception` and logged `"falling back to create_all()"` on any failure. `create_all()` is a no-op for an existing table, so a partially-upgraded `session_telemetry` (missing migration 0010's columns) stayed broken forever. The `_BOOTSTRAP_CANARIES` self-heal only covered migrations 0002 + 0004 — later migrations sailed past it.

The original underlying upgrade failure could come from several plausible histories (mid-upgrade interruption, pre-release image where the model already had `stream_id` but migration 0010 hadn't merged yet, FS lock during alembic, etc.). The fix doesn't try to enumerate them — it changes the failure mode: instead of running for days with a broken schema and noisy logs, the container fails to start with an actionable error naming the missing `table.column` pair and the recovery steps.

End-to-end simulation (a DB with `alembic_version='0010'` but `session_telemetry` missing `stream_id`+`stream_name`):

```
RuntimeError: schema drift detected — model declares columns not present
in the live database (likely an un-applied Alembic migration):
['session_telemetry.stream_id', 'session_telemetry.stream_name']. The
container's journal.db is in an inconsistent state. Recovery: stop the
container, back up /config/journal.db, run `alembic upgrade head`
against the DB (or restore the DB from a known-good backup), then
restart.
```

### How to Test
1. Backend suite: `cd backend && python -m pytest tests/ --tb=short --no-header -p no:warnings --no-cov` → 3667 passed, 1 skipped (volume test, gated).
2. Bootstrap suite specifically: `python -m pytest tests/unit/test_database_bootstrap.py tests/integration/test_alembic_smoke.py --no-cov` → 18 passed.
3. Manual repro of the bd-zaaey failure surface:
   - `alembic upgrade 0009` on a tmp DB
   - `UPDATE alembic_version SET version_num='0010'` (falsely)
   - Run `database.init_db()` → must raise `RuntimeError: schema drift detected` naming `session_telemetry.stream_id` + `session_telemetry.stream_name`.

### Security
- [x] No new vulnerable dependencies, no IaC changes, no hardcoded secrets.

### Deployment
- [x] No infrastructure changes
- [x] No database migration (the parity check reads schema; it does not mutate).
- [x] Rollback: revert this commit. The previous silent-fallback behavior returns; the bug returns with it.

### Hypotheses Investigated
The dispatch listed 7 hypotheses; here's the ruling on each:

1. **`_bootstrap_alembic` doesn't run reliably** — Ruled out. `init_db()` is called synchronously on `@app.on_event("startup")` (main.py:700) before bandwidth_tracker starts (main.py:843). Single-threaded ordering; no race.
2. **`_bootstrap_alembic` silently catches upgrade exceptions** — **CONFIRMED.** Lines 300-305 of the old `database.py`. This was the disease vector. Fixed.
3. **bd-fwpzw self-heal canary doesn't cover all scenarios** — **CONFIRMED.** `_BOOTSTRAP_CANARIES` only covers migrations 0002 + 0004; nothing from 0006-0010. Fixed by the model-schema parity check.
4. **Alembic chain has multiple heads** — Ruled out. `alembic heads` returns `['0010']`, linear chain `0001 → 0002 → ... → 0010`.
5. **Stale migrations baked into image layer** — Ruled out. Dockerfile line 60 `COPY backend/ ./` is a single layer; backend code and `alembic/versions/` ship together.
6. **Alembic can't find migrations at runtime** — Ruled out. `alembic.ini` `script_location = %(here)s/alembic` resolves relative to the file; works in CI, in tests, and in the running container.
7. **BandwidthTracker races init_db** — Ruled out (see #1).

### Bead
`enhancedchannelmanager-zaaey` — see commit message for the diagnostic chain.