### PR TITLE
ci: build release/** branches for testable hotfix images (bd-sxv77)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
       - dev
+      # release/** branches produce pre-release test images so external users
+      # can validate hotfixes before a full release cut. See bd-sxv77 — the
+      # chicken-and-egg constraint is that GitHub Actions reads the workflow
+      # file from the commit being pushed, so this trigger MUST land on the
+      # release/** branch itself before the first build can fire.
+      - 'release/**'
     paths-ignore:
       - '.beads/**'
       - '**.md'
@@ -12,6 +18,7 @@ on:
     branches:
       - main
       - dev
+      - 'release/**'
     paths-ignore:
       - '.beads/**'
       - '**.md'
@@ -764,7 +771,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
           tags: |
-            # Branch name tag
+            # Branch name tag (release/v0.16.1 → release-v0.16.1 after docker-tag sanitization)
             type=ref,event=branch
             # SHA tag for traceability
             type=sha,prefix={{branch}}-
@@ -778,6 +785,11 @@ jobs:
             # Minor version tags (e.g., 0.7-dev or 0.7)
             type=raw,value=${{ steps.version.outputs.minor }}-dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=raw,value=${{ steps.version.outputs.minor }},enable=${{ github.ref == 'refs/heads/main' }}
+            # Release-branch pre-release tag — -test suffix keeps the namespace
+            # separate from final {version} tags (which only main produces).
+            # Yields e.g. 0.16.1-0001-test from frontend/package.json on
+            # release/v0.16.1. See bd-sxv77.
+            type=raw,value=${{ steps.version.outputs.full }}-test,enable=${{ startsWith(github.ref, 'refs/heads/release/') }}
 
       - name: Create manifest list and push
         working-directory: /tmp
@@ -1044,6 +1056,8 @@ jobs:
             type=raw,value=${{ steps.version.outputs.full }},enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=${{ steps.version.outputs.minor }}-dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=raw,value=${{ steps.version.outputs.minor }},enable=${{ github.ref == 'refs/heads/main' }}
+            # Release-branch pre-release tag, see bd-sxv77
+            type=raw,value=${{ steps.version.outputs.full }}-test,enable=${{ startsWith(github.ref, 'refs/heads/release/') }}
 
       - name: Create manifest list and push
         working-directory: /tmp


### PR DESCRIPTION
## Summary

CI-only change: extend `.github/workflows/build.yml` so push and PR events on `release/**` branches produce a ghcr.io image without requiring a full release cut.

### Why

- bd-ix1g6's MCP `/health` diagnostic improvement landed on `release/v0.16.1` via [PR #275](https://github.com/MotWakorb/enhancedchannelmanager/pull/275) (merge commit `0716fd62`).
- The follow-up bead **bd-826k3** needs a pullable test image so the external reporter can validate the new `api_key_status` field before the v0.16.1 release cut.
- Today `build.yml` only fires on `main`/`dev` pushes/PRs, so `release/v0.16.1` produces zero images.

### What

| Change | Detail |
|---|---|
| Triggers | Add `release/**` to `on.push.branches` and `on.pull_request.branches`. |
| Tag rule (main image) | New `type=raw,value={full}-test,enable=startsWith(github.ref, 'refs/heads/release/')` in `merge-manifests`. |
| Tag rule (MCP image) | Same `{full}-test` rule added to `merge-mcp-manifests`. |
| Existing tag rules | Untouched. `latest`, `dev`, `{version}` (unsuffixed), `{minor}` are still main/dev-only — the `-test` suffix keeps the pre-release namespace separate. |
| Security-scan gates | Untouched. `release/**` does **not** run `npm audit`, `pip-audit`, `trivy`, `dast-scan`, `iac-security-scan`, or `codeql-analysis`. CodeQL is enforced at the release-cut PR to `main`; running it on release-branch PRs would add noise without changing the gate. |

### Chicken-and-egg

GitHub Actions reads the `on:` filter from the workflow file at the commit being pushed, so this trigger MUST land on `release/v0.16.1` itself before any image build can fire. The merge push satisfies the new trigger, so the first image build fires immediately on merge (no follow-up empty commit needed).

### Tags produced on `release/v0.16.1` after merge

```
ghcr.io/motwakorb/enhancedchannelmanager:release-v0.16.1
ghcr.io/motwakorb/enhancedchannelmanager:release-v0.16.1-<sha>
ghcr.io/motwakorb/enhancedchannelmanager:0.16.1-0001-test
ghcr.io/motwakorb/enhancedchannelmanager-mcp:release-v0.16.1
ghcr.io/motwakorb/enhancedchannelmanager-mcp:release-v0.16.1-<sha>
ghcr.io/motwakorb/enhancedchannelmanager-mcp:0.16.1-0001-test
```

### How verified

- YAML well-formedness: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"` (top-level keys parse).
- `actionlint` via `rhysd/actionlint:latest` (docker): **zero new warnings**. Pre-existing shellcheck (SC2046/SC2086) warning count is **31 before and 31 after** my change — none in the lines I edited.
- Version-extraction sanity: `jq -r .version frontend/package.json` on this branch returns `0.16.1-0001`, so the `-test` tag resolves to `0.16.1-0001-test` as designed.

### Beads

- This PR: bd-sxv77
- Diagnostic fix (already shipped): bd-ix1g6 (PR #275)
- Pending reporter outreach (unblocked by this PR's image): bd-826k3

### Scope discipline

This is CI-only — no app code, no `frontend/package.json` version bump (version stays at `0.16.1-0001`), no `backend/routers/backup.py` `APP_VERSION` change. The cherry-pick of this trigger into `dev` is a follow-up step for the orchestrator, not part of this PR.

## Test plan

- [ ] PR build (triggered by `pull_request` against `release/**`) passes — this PR itself is the dry-run for the new trigger
- [ ] After merge, the push event on `release/v0.16.1` triggers `build.yml` and produces the expected tag set
- [ ] `docker pull ghcr.io/motwakorb/enhancedchannelmanager:release-v0.16.1` succeeds
- [ ] `docker pull ghcr.io/motwakorb/enhancedchannelmanager:0.16.1-0001-test` succeeds