### PR TITLE
ci: build.yml release/** trigger cherry-picked from v0.16.1 (bd-sxv77)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
       - dev
+      # release/** branches produce pre-release test images so external users
+      # can validate hotfixes before a full release cut. See bd-sxv77 — the
+      # chicken-and-egg constraint is that GitHub Actions reads the workflow
+      # file from the commit being pushed, so this trigger MUST land on the
+      # release/** branch itself before the first build can fire.
+      - 'release/**'
     paths-ignore:
       - '.beads/**'
       - '**.md'
@@ -12,6 +18,7 @@ on:
     branches:
       - main
       - dev
+      - 'release/**'
     paths-ignore:
       - '.beads/**'
       - '**.md'
@@ -764,7 +771,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
           tags: |
-            # Branch name tag
+            # Branch name tag (release/v0.16.1 → release-v0.16.1 after docker-tag sanitization)
             type=ref,event=branch
             # SHA tag for traceability
             type=sha,prefix={{branch}}-
@@ -778,6 +785,11 @@ jobs:
             # Minor version tags (e.g., 0.7-dev or 0.7)
             type=raw,value=${{ steps.version.outputs.minor }}-dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=raw,value=${{ steps.version.outputs.minor }},enable=${{ github.ref == 'refs/heads/main' }}
+            # Release-branch pre-release tag — -test suffix keeps the namespace
+            # separate from final {version} tags (which only main produces).
+            # Yields e.g. 0.16.1-0001-test from frontend/package.json on
+            # release/v0.16.1. See bd-sxv77.
+            type=raw,value=${{ steps.version.outputs.full }}-test,enable=${{ startsWith(github.ref, 'refs/heads/release/') }}
 
       - name: Create manifest list and push
         working-directory: /tmp
@@ -1044,6 +1056,8 @@ jobs:
             type=raw,value=${{ steps.version.outputs.full }},enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=${{ steps.version.outputs.minor }}-dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=raw,value=${{ steps.version.outputs.minor }},enable=${{ github.ref == 'refs/heads/main' }}
+            # Release-branch pre-release tag, see bd-sxv77
+            type=raw,value=${{ steps.version.outputs.full }}-test,enable=${{ startsWith(github.ref, 'refs/heads/release/') }}
 
       - name: Create manifest list and push
         working-directory: /tmp


### PR DESCRIPTION
## [enhancedchannelmanager-o43c4] Cherry-pick build.yml release/** trigger from v0.16.1

Cherry-pick of `ca37bb96` from `release/v0.16.1` (PR #278). Future hotfix branches (release/v0.16.2, release/v0.17.1, etc.) inherit the `release/**` push/PR trigger and the `{full}-test` tag rule automatically — no per-hotfix CI tinkering needed.

### What
- `on.push.branches` and `on.pull_request.branches`: add `release/**`
- `merge-manifests` + `merge-mcp-manifests`: add `{full}-test` tag rule gated on `startsWith(github.ref, 'refs/heads/release/')`

### What is NOT changed
- `latest` / `dev` / `{version}` / `{minor}` tag rules — untouched
- Security-scan gates (npm audit, pip-audit, trivy, dast, iac-scan) — untouched
- CodeQL gates — untouched

### Why
Future hotfix branches should produce pullable test images without per-hotfix CI editing. Originating user-test path: bd-826k3.

### Verification
- YAML well-formed (`python -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"`)
- `actionlint` reports 34 pre-existing warnings before and after this change — **zero new warnings introduced**
- Clean cherry-pick (no conflicts) — dev's `on:` block and tag-rule blocks matched the pre-fix state on `release/v0.16.1`
- This PR's own image-build job exercises the new `on:` filter as a dry-run

### Bead
- `enhancedchannelmanager-o43c4` (this cherry-pick)
- bd-sxv77 (original on release/v0.16.1, already closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)