### PR TITLE
docs(normalization): operator remediation for prefix/suffix stripping after upgrade (bd-0tryb)

### DIFF
--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -217,6 +217,24 @@ Work this checklist in order:
 4. **Rule ordering.** Does an earlier rule in the pipeline already transform the input away from what your pattern expects? The Test Rules trace drawer shows the intermediate values; read it top-down.
 5. **Regex timeout.** Check logs for `[SAFE_REGEX]` WARN mentioning your rule_id. If present, the pattern is timing out on this input — rewrite per style guide.
 
+### "Auto Create stopped stripping country prefixes / quality suffixes after upgrade" (bd-0tryb)
+
+Symptom: channels land with the full raw stream name (e.g., `DE: RTL 3840P` instead of `RTL`, or `RX: RELAX TROPICAL BEACH ᵁᴴᴰ 3840P` instead of `RELAX TROPICAL BEACH`). Test Rules shows the expected normalized output, so the engine is healthy.
+
+Cause: per-rule normalization. The legacy `normalize_names: true` boolean was replaced in v0.16.0 by `normalization_group_ids` (a list of `NormalizationRuleGroup` IDs to apply on this rule). The migration sets `normalization_group_ids` to all enabled groups for any rule that had `normalize_names=true`; rules that had `normalize_names=false` (the default for new rules created before the migration) end up with `normalization_group_ids = NULL`, which means **normalization is skipped on that rule** — and so does the `merge_streams` core-name fallback that strips country/quality tags before channel lookup (see `auto_creation_executor.py` _merge_streams core-name branch).
+
+Fix:
+
+1. **UI**: Auto-Creation Rules → edit the rule → **Normalization Groups** picker → select the groups you want this rule to apply (typically all enabled groups). Save. Re-run the rule.
+2. **API**: `PUT /api/auto-creation/rules/{id}` with body `{"normalization_group_ids": [<ids>]}`. To list available group IDs: `GET /api/normalization/groups`.
+
+Pre-existing channels created before you set the groups are not retroactively renamed by this change — they were stored with their original raw names. Use [Re-normalize existing channels](#re-normalize-existing-channels) (Settings UI or `POST /api/normalization/apply-to-channels`) for a one-shot cleanup.
+
+Verification:
+
+- Test Rules with the raw stream name should already show the desired normalized output (proof the engine and tag groups are correct).
+- After enabling `normalization_group_ids`, run the rule in **dry-run mode** first and inspect the execution log for `Normalization applied` entries — these confirm the new behavior on the actual streams.
+
 ### `[SAFE_REGEX]` log entries
 
 ```


### PR DESCRIPTION
## Summary

User reported auto-creation rules that previously normalized `DE: RTL 3840P` → `RTL` had stopped working — channels landing with full prefix+suffix.

**Investigation classified this as route B: rule misconfiguration / migration consequence — NOT a logic regression.** Reproducer:
- `NormalizationEngine.extract_core_name('DE: RTL 3840P')` → `'RTL'` ✅
- `NormalizationEngine.extract_core_name('RX: RELAX TROPICAL BEACH ᵁᴴᴰ 3840P')` → `'RELAX TROPICAL BEACH'` ✅

Engine is healthy. The user's bundle (ECM 0.16.0, captured 2026-04-28) has all 7 rules with `normalize_names: false`, which the v0.16.0 migration in `backend/database.py:2031` translates to `normalization_group_ids = NULL`. With NULL `normalization_group_ids`, the `merge_streams` core-name fallback (`backend/auto_creation_executor.py:1059, 1103`) never fires, so `DE: RTL 3840P` never matches a channel called `RTL`.

## Fix
Operator-facing troubleshooting subsection added to `docs/normalization.md` §Troubleshooting (after the existing "My rule doesn't match this input" checklist):
- Explains the per-rule `normalization_group_ids` requirement post-upgrade
- UI + API remediation steps (`GET /api/normalization/groups` to list available groups, then PATCH the rule with the chosen group ids)
- Note that pre-existing channels need a one-shot Re-normalize to clean up legacy data

**No code change. No version bump.** Pure documentation.

## Related
- bd-0gntx (closed 2026-04-28) shipped the auto-creation rule analyzer for the same operator's bundle. That bead flagged regex bugs but didn't surface the per-rule normalization migration consequence — this docs PR fills that gap.

Bead: [bd-0tryb](https://github.com/MotWakorb/enhancedchannelmanager).

## Test plan
- [x] Targeted suite (`test_api_auto_creation.py`, `test_auto_creation_executor.py`, `test_normalization_parity.py`, `test_bd_0gntx_user_bundle.py`): 228 passed
- [x] No code changes — full backend gate not required for docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)