### PR TITLE
fix(release): collapse duplicate version lines (v0.17.1-0027)

### DIFF
--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,8 +63,6 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 APP_VERSION = "0.17.1-0027"
-APP_VERSION = "0.17.1-0027"
-APP_VERSION = "0.17.1-0027"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,8 +2,6 @@
   "name": "enhanced-channel-manager",
   "private": true,
   "version": "0.17.1-0027",
-  "version": "0.17.1-0027",
-  "version": "0.17.1-0027",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- BD-I's earlier rebase left duplicate \`\"version\":\` lines in \`frontend/package.json\` and duplicate \`APP_VERSION =\` lines in \`backend/routers/backup.py\`.
- JSON/Python last-wins masked it at runtime, but the next agent's sed-based version bump would only touch one occurrence and break \`check_version_consistency\`.
- Surgical collapse to single canonical line at \`0.17.1-0027\`. No semantic change.

## Test plan
- [x] \`python scripts/check_version_consistency.py\` passes
- [x] JSON parses (\`python -c "import json; json.load(...)"\`)
- [x] Python parses (\`ast.parse\`)
- [x] No content changes outside the duplicate collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)