### PR TITLE
v0.17.1-0036: migration 0017 — Plex + Jellyfin attribution columns (bd-r5f0c.1)

### DIFF
--- a/backend/alembic/versions/20260517_0900_0017_session_telemetry_plex_jellyfin_attribution.py
+++ b/backend/alembic/versions/20260517_0900_0017_session_telemetry_plex_jellyfin_attribution.py
@@ -1,0 +1,221 @@
+"""session_telemetry: add Plex + Jellyfin user attribution columns
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-05-17 09:00:00.000000
+
+Plex + Jellyfin user attribution epic (bd-r5f0c) substrate, at parity
+with the shipped Emby attribution from migration 0016 (bd-k026g, parent
+epic bd-2cenq). ECM only sees the Dispatcharr stream session's IP. When
+users watch via a Plex or Jellyfin server, ALL stream pulls come from
+that media server's IP, so Stats can't distinguish individual viewers —
+they all collapse to a single "Plex server" / "Jellyfin server" identity
+(or get attributed to the admin/API user, same namespace-collision the
+Emby work fixed). The Plex + Jellyfin integrations cross-reference each
+live upstream session against ECM's active streams and surface the real
+upstream username in Watch Time and per-channel attribution, identical
+in shape to the Emby cross-ref resolver.
+
+This migration adds four NULLABLE TEXT columns to ``session_telemetry``
+so ``BandwidthTracker`` (W4 in this epic) can persist the resolved
+upstream attribution on each per-poll row:
+
+* ``plex_user_id TEXT NULL`` — Plex user identifier (Plex account IDs
+  are typically integers but Plex serves them as strings in the
+  ``/sessions`` payload; carrying them as TEXT avoids the implicit
+  parse/cast every read path would otherwise pay and stays aligned with
+  the Emby ``emby_user_id`` TEXT choice from migration 0016). Plain
+  nullable column, NOT a FK — Plex's user table is upstream and not an
+  ECM table, mirroring the established pattern for every other upstream
+  identifier on this row (``user_id``, ``provider_id``, ``channel_id``,
+  ``stream_id``, ``emby_user_id``).
+* ``plex_user_name TEXT NULL`` — denormalized Plex username captured at
+  write time from the per-poll Plex ``/status/sessions`` lookup the
+  resolver (W2 in this epic) maintains. No read-side joins against any
+  Plex endpoint or local table. Mirrors the bd-gsn3r
+  ``dispatcharr_username`` and bd-k026g ``emby_user_name``
+  denormalization patterns: read paths surface this column verbatim.
+* ``jellyfin_user_id TEXT NULL`` — Jellyfin user identifier (GUID, same
+  shape as Emby user IDs since Jellyfin forked from Emby and preserves
+  the GUID-string identity contract). Stored as TEXT for the same
+  reasons as ``emby_user_id`` and ``plex_user_id``. Plain nullable
+  column, NOT a FK — Jellyfin's user table is upstream and not an ECM
+  table.
+* ``jellyfin_user_name TEXT NULL`` — denormalized Jellyfin username
+  captured at write time from the per-poll Jellyfin ``/Sessions``
+  lookup the resolver (W3 in this epic) maintains. Same
+  denormalization rationale as the other three.
+
+Schema posture: denormalized on ``session_telemetry`` rather than split
+into separate ``plex_users`` / ``jellyfin_users`` tables. The columns
+are NULL for non-Plex / non-Jellyfin rows (the vast majority on most
+installs — only the subset whose client IP matches the configured Plex
+or Jellyfin server IP AND has a concurrent matching upstream session is
+enriched). The Stats v2 query pattern (per-poll projection of user
+attribution alongside ``dispatcharr_username`` and ``emby_user_name``)
+stays flat — a per-row JOIN to a normalized table would be more
+expensive than the per-poll resolver lookup, which already runs once
+per poll window and caches in the per-integration session-cache layer.
+This mirrors the explicit posture established for migration 0016: keep
+upstream attribution denormalized here, let the resolver own the
+identity lookup. If a future normalization need surfaces (e.g.
+upstream user metadata beyond id+name becomes a hot query), file a
+follow-up bead rather than refactor upfront.
+
+Backfill / pre-migration rows: NOT auto-applied. Pre-migration rows
+keep all four new columns NULL — exactly matching the truthful posture
+for any non-Plex / non-Jellyfin row, since "upstream attribution was
+not resolved at write time" and "this row predates the integration"
+are operationally equivalent from the read side. The Stats v2
+history-cutover policy from bd-skqln.3 ("accept the gap") covers this —
+the panel was already attributing all Plex / Jellyfin traffic to the
+wrong user before this fix; the pre-migration rows now honestly admit
+that. W4 will wire bandwidth_tracker and stats.py against these
+columns once W1/W2/W3 all land on dev.
+
+SQLite specifics:
+
+* Four independent ``ALTER TABLE ADD COLUMN`` statements. Each is a
+  plain NULLABLE TEXT column add; SQLite supports this directly without
+  batch-rebuild because NULL is the implicit default for nullable
+  columns — no row-rewrite cost.
+* No view drop/recreate dance needed — the existing
+  ``channel_watch_stats_v`` view only SELECTs ``channel_id``,
+  ``observed_at``, and ``poll_interval_ms`` from ``session_telemetry``,
+  so adding columns to the underlying table cannot disturb it. Same
+  reasoning as migrations 0013, 0011, and 0016's column-add path.
+
+bd-5w6jz idempotency: long-running installs may already have some or
+all columns via ``create_all()`` from the post-0017 ORM model in
+``models.py``, or via a smart-bootstrap fast-path stamp through this
+revision. The migration guards each column-add independently — present
+columns are skipped, absent columns get added. If all four columns are
+already present, the migration returns immediately without paying the
+no-op ALTER cost. This mirrors the bd-ov5vb (migration 0013), bd-d0ha9
+(migration 0015), and bd-k026g (migration 0016) idempotency pattern
+verbatim.
+
+Index decisions: deferred. Read-side query shape for the new columns
+(equality on a single user_id, or projection only) does not benefit
+from a dedicated index at the row-volume scale ADR-007 plans for.
+If a future profile shows a hot scan filtered on
+``plex_user_id`` / ``jellyfin_user_id`` directly, file a follow-up
+bead for the index — do not preempt it here.
+
+Pre-merge gate: ``backend/tests/integration/test_alembic_smoke.py::TestMigration0017``
+covers fresh up, fresh down, full idempotency (all four columns
+already present), and partial idempotency (each individual column
+already present — the guard must add only the missing ones without
+raising).
+
+Bead: ``enhancedchannelmanager-r5f0c.1`` (parent epic
+``enhancedchannelmanager-r5f0c``).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0017"
+down_revision: Union[str, Sequence[str], None] = "0016"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+# The four new Plex + Jellyfin attribution columns added in this
+# migration. Listed once so the upgrade/downgrade/guard helpers stay in
+# lockstep — if a fifth attribution column is added in a future
+# migration, it lives in its own revision, not by mutating this list.
+_NEW_COLUMNS = (
+    "plex_user_id",
+    "plex_user_name",
+    "jellyfin_user_id",
+    "jellyfin_user_name",
+)
+
+
+def _session_telemetry_columns(connection) -> set[str]:
+    """Return the set of column names currently on ``session_telemetry``.
+
+    Returns the empty set if the table is missing — every prior 0006-0016
+    migration is idempotent and may have skipped its create on a fully-
+    drifted DB. The bd-5w6jz guard treats a missing table as "no columns
+    to add" so this migration becomes a no-op rather than raising; the
+    next ``create_all()`` + ``_assert_schema_matches_models`` pass surfaces
+    the missing table.
+    """
+    insp = inspect(connection)
+    if not insp.has_table("session_telemetry"):
+        return set()
+    return {c["name"] for c in insp.get_columns("session_telemetry")}
+
+
+def upgrade() -> None:
+    """Add the four Plex + Jellyfin user attribution columns to ``session_telemetry``.
+
+    Each ADD COLUMN is independently guarded so a partial-drift state
+    (some columns already present from a previous interrupted run, or
+    some columns already added via ``create_all()`` against a newer ORM
+    snapshot) cleans up rather than raising
+    ``OperationalError: duplicate column name``.
+
+    Idempotent (bd-5w6jz): if all four columns are already present, return
+    without paying even the inspect-then-skip cost.
+    """
+    conn = op.get_bind()
+    existing = _session_telemetry_columns(conn)
+    missing = [c for c in _NEW_COLUMNS if c not in existing]
+
+    if not missing:
+        # Fully drifted forward — every target column already exists.
+        # Common on long-running installs where ``create_all()`` has
+        # materialised the post-0017 ORM shape between two alembic runs.
+        return
+
+    for column_name in missing:
+        # NULLABLE TEXT, no default; pre-migration rows surface as NULL
+        # ("non-Plex / non-Jellyfin viewer" on the frontend) per the
+        # accept-the-gap policy described in the module docstring.
+        op.add_column(
+            "session_telemetry",
+            sa.Column(column_name, sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    """Drop the four Plex + Jellyfin user attribution columns.
+
+    Defensive (bd-5w6jz): inspect first; skip whichever column(s) are
+    already absent so a partial-rerun cleans up rather than raising.
+    The view-drop/recreate dance from migration 0011 is NOT needed —
+    ``channel_watch_stats_v`` does not reference any of the dropped
+    columns, so SQLite's per-column drop succeeds without it.
+
+    Operators who downgrade past this point lose the Plex + Jellyfin
+    attribution columns; the W4 ``BandwidthTracker`` writer continues to
+    function but the resolved upstream user_id/user_name are no longer
+    persisted. Read paths fall back to ``dispatcharr_username`` (which
+    will surface the Plex / Jellyfin server's API token user — exactly
+    the namespace-collision the epic exists to fix, same as the
+    pre-0016 state for Emby).
+    """
+    conn = op.get_bind()
+    existing = _session_telemetry_columns(conn)
+    present = [c for c in _NEW_COLUMNS if c in existing]
+
+    if not present:
+        return
+
+    # SQLite's native ``ALTER TABLE DROP COLUMN`` (3.35+) is supported by
+    # SQLAlchemy's plain ``op.drop_column``. Wrapping in batch mode would
+    # force a full table rebuild for each drop — unnecessary cost when
+    # the native path works. Each drop is independently guarded above
+    # so a partial-rerun (e.g. one column already dropped manually) is
+    # still safe. Same approach as migrations 0013 and 0016's downgrade
+    # path.
+    for column_name in present:
+        op.drop_column("session_telemetry", column_name)

--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0035",
+    version="0.17.1-0036",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/models.py
+++ b/backend/models.py
@@ -1400,6 +1400,25 @@ class SessionTelemetry(Base):
     # ``provider_id``, ``channel_id``, ``stream_id``).
     emby_user_id = Column(Text, nullable=True)
     emby_user_name = Column(Text, nullable=True)
+    # bd-r5f0c.1 (migration 0017): Plex + Jellyfin user attribution
+    # columns, at parity with the Emby pair above. Identical rationale —
+    # ECM only sees the Dispatcharr stream session's IP, so when users
+    # watch via a Plex or Jellyfin server all stream pulls collapse to
+    # the media server's IP. The Plex (W2) and Jellyfin (W3) resolvers
+    # cross-reference each live upstream session against ECM's active
+    # streams and the W4 ``BandwidthTracker`` writer populates these
+    # four columns from the per-poll upstream lookup. Both ID columns
+    # are TEXT — Plex serves user IDs as strings in its ``/sessions``
+    # payload, and Jellyfin (Emby fork) uses GUID-string IDs — staying
+    # aligned with the ``emby_user_id`` TEXT choice. All four are NULL
+    # for non-Plex / non-Jellyfin rows. Plain nullable columns, NOT
+    # FKs — Plex's and Jellyfin's user tables are upstream and not ECM
+    # tables, mirroring the established pattern for every other
+    # upstream identifier on this row.
+    plex_user_id = Column(Text, nullable=True)
+    plex_user_name = Column(Text, nullable=True)
+    jellyfin_user_id = Column(Text, nullable=True)
+    jellyfin_user_name = Column(Text, nullable=True)
 
     __table_args__ = (
         CheckConstraint(

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0035"
+APP_VERSION = "0.17.1-0036"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/tests/integration/test_alembic_smoke.py
+++ b/backend/tests/integration/test_alembic_smoke.py
@@ -3088,3 +3088,335 @@ class TestMigration0016Idempotent:
                 )
         finally:
             engine.dispose()
+
+
+# Migration 0017 — session_telemetry Plex + Jellyfin user attribution columns (bd-r5f0c.1)
+
+@pytest.mark.integration
+class TestMigration0017:
+    """Migration 0017 — Plex + Jellyfin user attribution columns on ``session_telemetry``.
+
+    bd-r5f0c.1 is the schema substrate for the Plex + Jellyfin user
+    attribution epic (parent ``enhancedchannelmanager-r5f0c``), at
+    parity with the shipped Emby attribution (migration 0016, bd-k026g,
+    parent epic ``enhancedchannelmanager-2cenq``). ECM only sees the
+    Dispatcharr stream session's IP; when users watch via a Plex or
+    Jellyfin server all stream pulls collapse to a single "Plex server"
+    / "Jellyfin server" identity in Stats. The Plex (W2) and Jellyfin
+    (W3) integrations cross-reference each live upstream session
+    against ECM's active streams and persist the resolved user via four
+    new NULLABLE TEXT columns on ``session_telemetry``:
+
+      - ``plex_user_id`` (TEXT NULL — Plex serves user IDs as strings
+        in ``/sessions``; staying aligned with the Emby TEXT choice)
+      - ``plex_user_name`` (TEXT NULL — denormalized at write time)
+      - ``jellyfin_user_id`` (TEXT NULL — Jellyfin user IDs are GUIDs,
+        same as Emby since Jellyfin forked from Emby)
+      - ``jellyfin_user_name`` (TEXT NULL — denormalized at write time)
+
+    Pre-existing columns (every column carried through 0016 — including
+    the Emby pair ``emby_user_id`` / ``emby_user_name``) are preserved
+    verbatim — this migration is additive only.
+
+    Coverage:
+      - Fresh upgrade through 0017 — all four new columns exist as
+        TEXT NULL; ``dispatcharr_username`` and the Emby pair are
+        untouched.
+      - Fresh downgrade — all four new columns are gone; the Emby
+        pair and ``dispatcharr_username`` are still present.
+    """
+
+    NEW_COLUMNS = (
+        "plex_user_id",
+        "plex_user_name",
+        "jellyfin_user_id",
+        "jellyfin_user_name",
+    )
+
+    def test_fresh_sqlite_upgrade_through_0017(self, tmp_path):
+        """Fresh DB: ``alembic upgrade 0017`` adds the four new columns."""
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'mig0017_fresh.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "0017")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            cols = _column_names(engine, "session_telemetry")
+            for new_col in self.NEW_COLUMNS:
+                assert new_col in cols, (
+                    f"{new_col} missing after upgrade 0017 — migration "
+                    f"0017 did not run correctly."
+                )
+            # dispatcharr_username and the Emby pair are preserved —
+            # pre-bd-r5f0c.1 back-compat (the per-row writer maintains
+            # Dispatcharr + Emby + Plex + Jellyfin attribution side-by-
+            # side; each upstream populates its own pair for the
+            # matching mediated streams, and the columns surface
+            # independently in Stats).
+            assert "dispatcharr_username" in cols, (
+                "dispatcharr_username must be preserved by 0017 — the "
+                "Plex + Jellyfin attribution columns are additive, not "
+                "a rename."
+            )
+            assert "emby_user_id" in cols, (
+                "emby_user_id must be preserved by 0017 — the Plex + "
+                "Jellyfin attribution columns are additive, not a "
+                "replacement for the Emby pair."
+            )
+            assert "emby_user_name" in cols, (
+                "emby_user_name must be preserved by 0017 — the Plex + "
+                "Jellyfin attribution columns are additive, not a "
+                "replacement for the Emby pair."
+            )
+            # Verify NULLABLE TEXT via PRAGMA.
+            with engine.connect() as conn:
+                rows = conn.execute(text(
+                    "PRAGMA table_info(session_telemetry)"
+                )).fetchall()
+            col_info = {r[1]: r for r in rows}
+            for new_col in self.NEW_COLUMNS:
+                _, name, col_type, notnull, dflt, _pk = col_info[new_col]
+                assert notnull == 0, (
+                    f"{name} must be NULLABLE (notnull=0); got notnull={notnull}"
+                )
+                # SQLAlchemy ``sa.Text()`` renders as ``TEXT`` in SQLite.
+                assert col_type == "TEXT", (
+                    f"{name} must be TEXT; got type={col_type!r}"
+                )
+                # No DEFAULT for nullable text columns.
+                assert dflt is None, (
+                    f"{name} must have no DEFAULT; got dflt={dflt!r}"
+                )
+        finally:
+            engine.dispose()
+
+    def test_fresh_sqlite_downgrade_from_0017(self, tmp_path):
+        """Downgrade 0017 -> 0016: the four new columns are dropped."""
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'mig0017_downgrade.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "0017")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            cols = _column_names(engine, "session_telemetry")
+            for new_col in self.NEW_COLUMNS:
+                assert new_col in cols, (
+                    f"test setup is wrong — {new_col} missing post-upgrade"
+                )
+        finally:
+            engine.dispose()
+
+        command.downgrade(cfg, "0016")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            cols = _column_names(engine, "session_telemetry")
+            for new_col in self.NEW_COLUMNS:
+                assert new_col not in cols, (
+                    f"{new_col} still present after downgrade — 0017's "
+                    f"downgrade() did not drop the column."
+                )
+            # The Emby pair and dispatcharr_username must survive the
+            # downgrade — they were never added or dropped by 0017.
+            assert "dispatcharr_username" in cols, (
+                "dispatcharr_username must survive downgrade — it was "
+                "never added or dropped by 0017."
+            )
+            assert "emby_user_id" in cols, (
+                "emby_user_id must survive downgrade — it was added by "
+                "0016, not by 0017."
+            )
+            assert "emby_user_name" in cols, (
+                "emby_user_name must survive downgrade — it was added "
+                "by 0016, not by 0017."
+            )
+        finally:
+            engine.dispose()
+
+
+@pytest.mark.integration
+class TestMigration0017Idempotent:
+    """Regression lock for bd-5w6jz idempotency on migration 0017.
+
+    Drift scenarios mirror the 0016 idempotency tests scaled to the
+    four-column shape:
+
+    1. All four new columns already present via ``create_all()`` from
+       the post-0017 ORM model (long-running install, alembic_version
+       still at 0016). The upgrade must early-return without raising
+       ``OperationalError: duplicate column name``.
+
+    2. ONE of the four columns already present (partial drift — e.g.
+       the migration crashed mid-run after one ADD COLUMN succeeded,
+       or a manual ALTER added one column ahead of the migration).
+       The upgrade must add the remaining three without raising on the
+       already-present one. We exercise each of the four columns
+       individually as the "already present" one — each ADD is
+       independently guarded so any subset of drifted columns is safe
+       to re-encounter.
+    """
+
+    NEW_COLUMNS = (
+        "plex_user_id",
+        "plex_user_name",
+        "jellyfin_user_id",
+        "jellyfin_user_name",
+    )
+
+    def test_drifted_all_columns_already_added(self, tmp_path):
+        """create_all()-style drift: all four columns present pre-0017."""
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'mig0017_full_drift.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "0016")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            cols = _column_names(engine, "session_telemetry")
+            for new_col in self.NEW_COLUMNS:
+                assert new_col not in cols, (
+                    f"test setup is wrong — {new_col} already at 0016"
+                )
+            # Inject all four columns via raw SQL — matches what
+            # create_all() would emit from the post-0017 ORM model.
+            with engine.begin() as conn:
+                for new_col in self.NEW_COLUMNS:
+                    conn.execute(text(
+                        f"ALTER TABLE session_telemetry ADD COLUMN "
+                        f"{new_col} TEXT"
+                    ))
+            cols = _column_names(engine, "session_telemetry")
+            for new_col in self.NEW_COLUMNS:
+                assert new_col in cols
+            with engine.connect() as conn:
+                row = conn.execute(
+                    text("SELECT version_num FROM alembic_version")
+                ).fetchone()
+            assert row is not None and row[0] == "0016"
+        finally:
+            engine.dispose()
+
+        # Pre-fix this would raise:
+        #   OperationalError: duplicate column name: plex_user_id
+        command.upgrade(cfg, "head")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            cols = _column_names(engine, "session_telemetry")
+            for new_col in self.NEW_COLUMNS:
+                assert new_col in cols
+            with engine.connect() as conn:
+                row = conn.execute(
+                    text("SELECT version_num FROM alembic_version")
+                ).fetchone()
+            assert row is not None and row[0] == database.get_alembic_head_revision()
+        finally:
+            engine.dispose()
+
+    @pytest.mark.parametrize("drifted_col", [
+        "plex_user_id",
+        "plex_user_name",
+        "jellyfin_user_id",
+        "jellyfin_user_name",
+    ])
+    def test_drifted_single_column_present(self, tmp_path, drifted_col):
+        """Partial drift: exactly one of the four columns already present.
+
+        Each of the four columns is exercised individually as the
+        already-drifted one — the per-column guard must add the
+        remaining three without raising on the present one.
+        """
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / f'mig0017_partial_{drifted_col}.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "0016")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            with engine.begin() as conn:
+                conn.execute(text(
+                    f"ALTER TABLE session_telemetry ADD COLUMN "
+                    f"{drifted_col} TEXT"
+                ))
+        finally:
+            engine.dispose()
+
+        command.upgrade(cfg, "head")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            cols = _column_names(engine, "session_telemetry")
+            for new_col in self.NEW_COLUMNS:
+                assert new_col in cols, (
+                    f"{new_col} missing after partial-drift upgrade — "
+                    f"the per-column guard must add absent columns "
+                    f"even when {drifted_col} is already present."
+                )
+        finally:
+            engine.dispose()
+
+    def test_round_trip_up_down_up(self, tmp_path):
+        """Round-trip: upgrade 0017, downgrade to 0016, re-upgrade to 0017.
+
+        Covers the rollback/re-apply path: a migration that breaks on
+        re-apply after a downgrade is the hardest mistake to catch in
+        a fresh-DB test. All four columns must reappear after the
+        second upgrade with their NULLABLE TEXT shape intact.
+        """
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'mig0017_round_trip.db'}"
+        cfg = _make_alembic_config(db_url)
+
+        # Up.
+        command.upgrade(cfg, "0017")
+        engine = create_engine(db_url, future=True)
+        try:
+            cols = _column_names(engine, "session_telemetry")
+            for new_col in self.NEW_COLUMNS:
+                assert new_col in cols
+        finally:
+            engine.dispose()
+
+        # Down.
+        command.downgrade(cfg, "0016")
+        engine = create_engine(db_url, future=True)
+        try:
+            cols = _column_names(engine, "session_telemetry")
+            for new_col in self.NEW_COLUMNS:
+                assert new_col not in cols
+        finally:
+            engine.dispose()
+
+        # Up again — re-apply after downgrade must work.
+        command.upgrade(cfg, "0017")
+        engine = create_engine(db_url, future=True)
+        try:
+            cols = _column_names(engine, "session_telemetry")
+            for new_col in self.NEW_COLUMNS:
+                assert new_col in cols, (
+                    f"{new_col} missing after re-upgrade — the migration "
+                    f"must be re-appliable after a downgrade."
+                )
+            # Verify the shape held across the round-trip.
+            with engine.connect() as conn:
+                rows = conn.execute(text(
+                    "PRAGMA table_info(session_telemetry)"
+                )).fetchall()
+            col_info = {r[1]: r for r in rows}
+            for new_col in self.NEW_COLUMNS:
+                _, name, col_type, notnull, _dflt, _pk = col_info[new_col]
+                assert notnull == 0, (
+                    f"{name} must be NULLABLE after round-trip"
+                )
+                assert col_type == "TEXT", (
+                    f"{name} must be TEXT after round-trip"
+                )
+        finally:
+            engine.dispose()

--- a/backend/tests/integration/test_session_telemetry_migration.py
+++ b/backend/tests/integration/test_session_telemetry_migration.py
@@ -151,15 +151,21 @@ class TestSessionTelemetryMigration:
             # ``event_type`` to its own per-poll counter. ``emby_user_id``
             # and ``emby_user_name`` land in migration 0016 (bd-k026g) —
             # both TEXT NULL, denormalized Emby attribution from the
-            # bd-2cenq epic resolver. Carry every column in the
-            # head-shape assertion so a future delete/rename surfaces
-            # here.
+            # bd-2cenq epic resolver. ``plex_user_id``, ``plex_user_name``,
+            # ``jellyfin_user_id``, and ``jellyfin_user_name`` land in
+            # migration 0017 (bd-r5f0c.1) — all four TEXT NULL,
+            # denormalized Plex + Jellyfin attribution at parity with
+            # the Emby pair (the W2/W3/W4 resolvers + writer in epic
+            # bd-r5f0c). Carry every column in the head-shape assertion
+            # so a future delete/rename surfaces here.
             assert set(cols) == {
                 "id", "session_id", "observed_at", "user_id", "provider_id",
                 "channel_id", "bytes_delta", "buffer_event_count", "poll_interval_ms",
                 "stream_id", "stream_name", "dispatcharr_username",
                 "reconnect_event_count", "error_event_count", "switch_event_count",
                 "emby_user_id", "emby_user_name",
+                "plex_user_id", "plex_user_name",
+                "jellyfin_user_id", "jellyfin_user_name",
             }
             assert cols["session_id"]["nullable"] is False
             assert cols["observed_at"]["nullable"] is False
@@ -197,6 +203,14 @@ class TestSessionTelemetryMigration:
             # as NULL on read).
             assert cols["emby_user_id"]["nullable"] is True
             assert cols["emby_user_name"]["nullable"] is True
+            # bd-r5f0c.1: all four Plex + Jellyfin attribution columns
+            # are NULLABLE (non-Plex / non-Jellyfin viewers + rows where
+            # the resolver could not match the active stream + pre-0017
+            # rows surface as NULL on read).
+            assert cols["plex_user_id"]["nullable"] is True
+            assert cols["plex_user_name"]["nullable"] is True
+            assert cols["jellyfin_user_id"]["nullable"] is True
+            assert cols["jellyfin_user_name"]["nullable"] is True
 
             # bd-gsn3r: migration 0011 dropped the FK to ECM ``users.id``.
             # ECM and Dispatcharr ``users`` are different namespaces with

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0035",
+  "version": "0.17.1-0036",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Schema gate for bd-r5f0c (Plex + Jellyfin user attribution epic). Adds 4 nullable TEXT columns to `session_telemetry` mirroring migration 0016 verbatim:
- `plex_user_id`, `plex_user_name`
- `jellyfin_user_id`, `jellyfin_user_name`

No data backfill. Idempotent `_NEW_COLUMNS` guard mirrors 0016.

## Test plan
- [x] `pytest tests/integration/test_alembic_smoke.py tests/integration/test_session_telemetry_migration.py` → 57 passed, 1 skipped (volume test gated on `ECM_RUN_VOLUME_TESTS=1`, by design)
- [x] `alembic upgrade head` runs idempotently on existing 0016 schema
- [x] `alembic downgrade -1` cleanly drops all 4 new columns (SQLite 3.35+)

W2/W3 (Plex/Jellyfin client+cache+resolver) and W4 (bandwidth_tracker wiring) dispatch after this lands.

Closes bd-r5f0c.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)