### PR TITLE
v0.17.1-0037: Plex client+cache+resolver for user attribution (bd-r5f0c.2)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0038",
+    version="0.17.1-0039",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/plex_client.py
+++ b/backend/plex_client.py
@@ -1,0 +1,276 @@
+"""Plex API client (bd-r5f0c.2, epic bd-r5f0c).
+
+Read-only async client for the operator's Plex Media Server. Single concern:
+fetch the ``/status/sessions`` feed so downstream code (plex_cache,
+plex_resolver, BandwidthTracker enrichment) can cross-reference live
+Plex viewers against ECM's active streams and attribute the real Plex
+username instead of collapsing every Plex-mediated pull to the proxy IP.
+
+This module is intentionally narrow:
+
+* No caching here — that lives in plex_cache's wrapper around this client.
+* No resolver / matching logic — plex_resolver owns ``ECM stream → Plex user``.
+* No Settings UI plumbing — W4 wires ``test_connection`` into Settings.
+
+Mirrors ``emby_client.py``'s shape (async httpx, ``[PLEX]`` log prefix,
+dataclass DTOs, dedicated error class) so the patterns stay consistent
+across the two outbound HTTP clients.
+
+Plex-specific differences from Emby:
+* Auth header: ``X-Plex-Token: <token>`` (NOT ``X-Emby-Token``)
+* Endpoint: ``GET /status/sessions`` (NOT ``/Sessions``)
+* Response format: XML (NOT JSON). Parsed via stdlib
+  ``xml.etree.ElementTree`` — no additional deps required. Plex is a
+  configured-by-operator trusted upstream so the XXE risk of stdlib is
+  acceptable (defusedxml is unnecessary here).
+"""
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PlexSession:
+    """A single live Plex session as exposed by ``GET /status/sessions``.
+
+    Fields are a deliberate subset of the upstream Plex XML response — only
+    what the user-attribution resolver (plex_resolver) actually needs. Naming
+    is snake_case ECM convention, mapped from Plex's XML attributes in
+    ``PlexClient.get_sessions``.
+
+    Attributes:
+        session_id: Plex's rating key for the playing item (``ratingKey``
+            attribute on the ``<Video>`` element). Useful only for debugging.
+        user_id: Plex user numeric ID (``User/@id`` in the XML). Persisted to
+            ``session_telemetry.plex_user_id`` once W4 lands.
+        user_name: Human-readable Plex username (``User/@title``). Persisted
+            to ``session_telemetry.plex_user_name``.
+        remote_endpoint: Client IP the Plex session originated from
+            (``Player/@address``). Used as a sanity check in the resolver.
+        now_playing_item_name: The ``Video/@title`` attribute — for live TV
+            this is often ``"<number> | <channel_name>"`` or just the channel
+            name. ``None`` if unparseable.
+        last_activity_date: ``datetime`` parsed from ``Video/@lastViewedAt``
+            (epoch seconds). Used to break ties when multiple Plex sessions
+            match the same ECM stream (most-recent-wins). ``None`` when the
+            attribute is absent or unparseable.
+    """
+
+    session_id: str
+    user_id: str
+    user_name: str
+    remote_endpoint: str
+    now_playing_item_name: str | None
+    last_activity_date: datetime | None
+
+
+class PlexClientError(Exception):
+    """Raised by :class:`PlexClient` on any auth / network / non-2xx /
+    malformed-XML failure.
+
+    Callers decide whether to swallow (e.g. :meth:`PlexClient.test_connection`
+    returns ``False`` on this) or surface (e.g. the resolver should log and
+    fall back to the proxy-IP attribution).
+
+    The underlying exception is preserved in ``__cause__`` where applicable so
+    structured loggers can still capture root cause without re-raising.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+# 5s connect / 10s read — matches the Emby client's timeout tuning. Tight
+# enough that a misconfigured Plex URL fails the Settings UI 'Test
+# Connection' button promptly, but generous enough to absorb a slow LAN
+# response under load.
+_DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=10.0)
+
+
+class PlexClient:
+    """Async HTTP client for the Plex ``/status/sessions`` endpoint.
+
+    Stateless across calls — Plex's ``X-Plex-Token`` auth header is
+    attached per-request, no token-refresh lifecycle to manage.
+    """
+
+    def __init__(self, base_url: str, api_key: str, timeout: httpx.Timeout = _DEFAULT_TIMEOUT):
+        # Strip exactly one trailing slash so ``base + "/status/sessions"``
+        # never produces a double-slash. Preserve any sub-path the operator
+        # configured for reverse-proxy setups.
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self._client = httpx.AsyncClient(timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def get_sessions(self) -> list[PlexSession]:
+        """Fetch the live Plex session list.
+
+        Always hits the API — caching is deliberately not in this layer
+        (plex_cache owns the TTL cache around this method).
+
+        Returns:
+            List of :class:`PlexSession`. Empty list when Plex reports no
+            active sessions (a normal idle-server state, not an error).
+
+        Raises:
+            PlexClientError: On 401 (bad/expired token), any non-2xx
+                response, network failure, or malformed XML. The original
+                exception is preserved as ``__cause__`` where applicable.
+        """
+        url = f"{self.base_url}/status/sessions"
+        headers = {"X-Plex-Token": self.api_key}
+
+        logger.debug("[PLEX] GET %s", url)
+        try:
+            response = await self._client.request("GET", url, headers=headers)
+        except httpx.HTTPError as exc:
+            # ConnectError, ReadTimeout, RemoteProtocolError, etc. — any
+            # transport-level failure. Wrap so callers see one exception
+            # type regardless of whether the failure was DNS, TCP, or TLS.
+            logger.warning("[PLEX] /status/sessions request failed: %s", exc)
+            raise PlexClientError(f"Plex request failed: {exc}") from exc
+
+        if response.status_code == 401:
+            # Surface 401 distinctly — the operator's most common failure
+            # mode is a wrong/revoked token, and the Settings UI surface
+            # will route on this string.
+            logger.warning("[PLEX] /status/sessions returned 401 unauthorized")
+            raise PlexClientError(
+                "Plex /status/sessions returned 401 unauthorized — check token"
+            )
+
+        if response.status_code >= 400:
+            logger.warning(
+                "[PLEX] /status/sessions returned non-2xx: status=%s",
+                response.status_code,
+            )
+            raise PlexClientError(
+                f"Plex /status/sessions returned {response.status_code}"
+            )
+
+        sessions = _parse_sessions_xml(response.text)
+        logger.debug("[PLEX] /status/sessions returned %d sessions", len(sessions))
+        return sessions
+
+    async def test_connection(self) -> bool:
+        """Verify the configured URL + token reach a working Plex server.
+
+        Wired into the Settings UI (W4) 'Test Connection' button.
+        Swallows :class:`PlexClientError` and returns ``False`` so the UI
+        handler only needs to render a bool.
+
+        Returns:
+            ``True`` if ``/status/sessions`` returned a 2xx response,
+            ``False`` on any auth / network / server failure.
+        """
+        try:
+            await self.get_sessions()
+        except PlexClientError as exc:
+            logger.info("[PLEX] test_connection failed: %s", exc)
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def close(self) -> None:
+        """Release the underlying ``httpx.AsyncClient`` connection pool.
+
+        Call from a lifespan shutdown handler or test teardown to avoid
+        leaking sockets.
+        """
+        await self._client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# XML parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_sessions_xml(xml_text: str) -> list[PlexSession]:
+    """Parse Plex ``/status/sessions`` XML into a list of :class:`PlexSession`.
+
+    Plex returns a ``<MediaContainer>`` root element containing zero or more
+    ``<Video>`` (or ``<Track>`` for music) child elements. Each ``<Video>``
+    has nested ``<User>`` and ``<Player>`` elements.
+
+    This function:
+    * Handles an empty ``<MediaContainer/>`` → returns ``[]``
+    * Skips elements without a ``<User>`` child (server-side sessions with
+      no authenticated user, e.g. local-network anonymous sessions)
+    * Wraps malformed XML in :class:`PlexClientError`
+
+    Raises:
+        PlexClientError: On any XML parse error.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        logger.warning("[PLEX] Failed to parse /status/sessions XML: %s", exc)
+        raise PlexClientError(f"Plex /status/sessions returned malformed XML: {exc}") from exc
+
+    sessions: list[PlexSession] = []
+    # Plex session items can be <Video> (live TV, movies, episodes) or
+    # <Track> (music). We look for both under the MediaContainer root.
+    for item in root:
+        session = _map_item(item)
+        if session is not None:
+            sessions.append(session)
+
+    return sessions
+
+
+def _map_item(item: ET.Element) -> PlexSession | None:
+    """Map one Plex session XML element to a :class:`PlexSession`.
+
+    Returns ``None`` when the element lacks a ``<User>`` child — this
+    can happen with server-side anonymous sessions (local-network
+    unauthenticated streams). The resolver can only attribute a user
+    when a real user identity is present.
+    """
+    user_el = item.find("User")
+    if user_el is None:
+        # No user identity — skip this session; the resolver cannot
+        # attribute an anonymous session to a Plex account.
+        return None
+
+    player_el = item.find("Player")
+    remote_endpoint = player_el.get("address", "") if player_el is not None else ""
+
+    # Parse lastViewedAt (epoch seconds) into a timezone-aware datetime.
+    last_viewed_raw = item.get("lastViewedAt")
+    last_activity: datetime | None = None
+    if last_viewed_raw is not None:
+        try:
+            last_activity = datetime.fromtimestamp(int(last_viewed_raw), tz=timezone.utc)
+        except (ValueError, OSError):
+            # Malformed timestamp — treat as absent rather than raise.
+            pass
+
+    return PlexSession(
+        session_id=item.get("ratingKey", ""),
+        user_id=user_el.get("id", ""),
+        user_name=user_el.get("title", ""),
+        remote_endpoint=remote_endpoint,
+        now_playing_item_name=item.get("title"),
+        last_activity_date=last_activity,
+    )

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0038"
+APP_VERSION = "0.17.1-0039"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/services/plex_cache.py
+++ b/backend/services/plex_cache.py
@@ -1,0 +1,257 @@
+"""Plex session cache (bd-r5f0c.2, epic bd-r5f0c).
+
+Thin async wrapper around :class:`plex_client.PlexClient.get_sessions` that
+satisfies one specific operational requirement: the
+:mod:`bandwidth_tracker` polls Dispatcharr every ~5s and (once W4 lands
+the Plex-attribution enrichment) needs the live Plex session list on
+the same cadence. Hitting Plex's ``/status/sessions`` endpoint on every poll
+would both pound the operator's Plex server with redundant traffic AND
+amplify the user-visible latency of every poll cycle by a network
+round-trip.
+
+This module solves that with a small in-memory TTL cache keyed on a single
+constant (``"plex:sessions"``) and a 5-second TTL chosen to match the
+Dispatcharr poll cadence — the next poll sees a fresh value, the
+intermediate polls all hit cache.
+
+Three deliberate departures from the generic :mod:`cache` helper
+(structurally byte-identical to :mod:`services.emby_cache`):
+
+* **Stale-fallback.** The generic cache returns ``None`` once the TTL
+  expires. Here, if the upstream fetch fails AFTER a value was previously
+  cached, we return the stale value rather than empty list — a momentary
+  Plex outage should not erase the operator's "who is watching" picture.
+  Cold-start failure (no cache + fetch fails) still returns empty list so
+  callers always get a list, never ``None``.
+* **Thundering-herd guard.** Concurrent callers during a cache-miss could
+  each independently fire ``PlexClient.get_sessions()`` and stampede the
+  upstream Plex server. An ``asyncio.Lock`` collapses concurrent misses
+  into exactly one upstream call; the other waiters receive the freshly
+  cached value once the holder finishes.
+* **Settings gate.** When the operator has not configured Plex (the
+  ``plex_enabled`` setting is False, or no base URL is set) we return
+  ``[]`` immediately without touching the cache or constructing a
+  ``PlexClient`` — there is no upstream to call, and the empty list is
+  the correct "no Plex sessions" answer for downstream resolvers.
+
+This module is intentionally narrow and stateless across imports — the
+cache lives in module-level globals so a single process shares one cache
+across all callers (BandwidthTracker, resolver, future surfaces). The
+generic :mod:`cache` helper is not reused here because it lacks both the
+stale-fallback and the async-lock primitives this surface needs; rolling
+a small purpose-built cache keeps the contract obvious without growing
+the generic helper's surface area.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+
+from config import get_settings
+from plex_client import PlexClient, PlexClientError, PlexSession
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration constants
+# ---------------------------------------------------------------------------
+
+# Cache key. Single-string namespace per the bead spec — no per-user or
+# per-server fan-out (Plex is a single configured upstream per ECM install).
+CACHE_KEY = "plex:sessions"
+
+# Time-to-live in seconds. Matches the Dispatcharr poll cadence so the
+# BandwidthTracker enrichment path sees a fresh Plex snapshot each cycle
+# but intermediate callers (resolver, future MCP tools) hit cache.
+CACHE_TTL_SECONDS = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Module-level state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Entry:
+    """Cached Plex session list with the wall-clock time it was fetched.
+
+    Kept module-private — callers should not introspect cache internals.
+    """
+
+    sessions: list[PlexSession]
+    cached_at: float
+
+
+# Single-slot cache (one key, so a dict would be overkill — keep the
+# storage shape obvious). ``None`` means "no value ever cached"; a populated
+# entry with ``cached_at`` older than ``CACHE_TTL_SECONDS`` is "stale" and
+# eligible for refresh but still returnable on fetch failure.
+_cached_entry: _Entry | None = None
+
+# Thundering-herd guard. Constructed lazily on first call so importing
+# this module does not bind to the (possibly not-yet-running) event loop.
+# A single module-level lock is sufficient because the cache is single-key.
+_fetch_lock: asyncio.Lock | None = None
+
+
+def _get_lock() -> asyncio.Lock:
+    """Return the module-level fetch lock, constructing it on first use.
+
+    Lazy construction matters because ``asyncio.Lock()`` binds to the
+    running event loop on first ``acquire()``. Constructing the lock at
+    import time would either bind to a loop that no longer exists (test
+    isolation: pytest-asyncio creates a fresh loop per function) or fail
+    outright when this module is imported outside a running loop.
+    """
+    global _fetch_lock
+    if _fetch_lock is None:
+        _fetch_lock = asyncio.Lock()
+    return _fetch_lock
+
+
+def _reset_for_tests() -> None:
+    """Clear the module-level cache and lock — tests only.
+
+    Tests share the same module instance across test functions; without
+    this reset, a test that populates the cache would leak that state into
+    subsequent tests and produce false cache-hit assertions. Production
+    code paths do not call this.
+    """
+    global _cached_entry, _fetch_lock
+    _cached_entry = None
+    _fetch_lock = None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def get_cached_plex_sessions() -> list[PlexSession]:
+    """Return the live Plex session list, served from cache when fresh.
+
+    Behavior matrix:
+
+    * **Plex disabled** (``settings.plex_enabled`` is False OR
+      ``settings.plex_base_url`` is empty) → return ``[]`` immediately;
+      no cache access, no client construction, no log line beyond the
+      DEBUG-level "disabled" trace.
+    * **Cache hit** (entry exists AND age < TTL) → return the cached
+      sessions; no upstream call.
+    * **Cache miss** (no entry OR entry expired) → acquire the fetch
+      lock, re-check the cache under the lock (another coroutine may
+      have populated it while we waited), then call
+      ``PlexClient.get_sessions()``, store the result, return.
+    * **Cache miss + fetch failure with prior cache** → log a WARN and
+      return the stale cached value rather than the empty list. A
+      transient Plex blip shouldn't erase the "who is watching" picture
+      mid-resolver.
+    * **Cache miss + fetch failure + no prior cache** (cold-start
+      failure) → log a WARN and return ``[]`` so callers always receive
+      a list.
+
+    Always returns a list — never raises. Upstream errors are absorbed
+    and logged so the BandwidthTracker poll loop can continue under all
+    failure modes.
+    """
+    settings = get_settings()
+
+    # Settings gate — Plex disabled or unconfigured short-circuits before
+    # any cache or client interaction. Use ``getattr`` defensively because
+    # the ``plex_*`` settings fields are owned by W4 which may not be on
+    # the ``dev`` tip at the moment this module ships. Once W4 lands the
+    # ``DispatcharrSettings`` model will expose these as real fields and
+    # the ``getattr`` defaults will become inert defensive code.
+    plex_enabled = getattr(settings, "plex_enabled", False)
+    plex_base_url = getattr(settings, "plex_base_url", "") or ""
+    plex_token = getattr(settings, "plex_token", "") or ""
+
+    if not plex_enabled or not plex_base_url:
+        logger.debug("[PLEX] Plex disabled or unconfigured; returning []")
+        return []
+
+    # Fast-path: cache hit without lock acquisition. ``time.monotonic`` is
+    # used over ``time.time`` because we only care about elapsed time
+    # (TTL comparison) and monotonic is wall-clock-jump safe.
+    entry = _cached_entry
+    if entry is not None:
+        age = time.monotonic() - entry.cached_at
+        if age < CACHE_TTL_SECONDS:
+            logger.debug(
+                "[PLEX] Cache hit for %s (age=%.2fs, ttl=%.1fs)",
+                CACHE_KEY, age, CACHE_TTL_SECONDS,
+            )
+            return entry.sessions
+
+    # Cache miss path. Acquire the lock so concurrent misses collapse to
+    # one upstream call. The double-checked locking pattern below is
+    # essential — without the re-check inside the lock, every waiter
+    # that arrived during the miss would still fire its own fetch once
+    # it got the lock, defeating the thundering-herd guard entirely.
+    lock = _get_lock()
+    async with lock:
+        # Re-check under lock. The first waiter to acquire the lock does
+        # the fetch; subsequent waiters see the just-populated cache and
+        # return without firing their own upstream call.
+        entry = _cached_entry
+        if entry is not None:
+            age = time.monotonic() - entry.cached_at
+            if age < CACHE_TTL_SECONDS:
+                logger.debug(
+                    "[PLEX] Cache hit under lock for %s (age=%.2fs); "
+                    "another waiter populated it",
+                    CACHE_KEY,
+                )
+                return entry.sessions
+
+        # Holder of the lock — do the upstream fetch.
+        client = PlexClient(base_url=plex_base_url, api_key=plex_token)
+        try:
+            try:
+                sessions = await client.get_sessions()
+            finally:
+                # Always release the httpx connection pool even on
+                # error. Without this every failure leaks a socket pool
+                # for the lifetime of the process.
+                await client.close()
+        except PlexClientError as exc:
+            # Stale-fallback decision branches on whether a prior cache
+            # value exists. Re-read ``_cached_entry`` here (not the
+            # ``entry`` local from above) so we see the latest module
+            # state — though under the lock no other coroutine can be
+            # writing, so the two are equivalent in this code path.
+            if _cached_entry is not None:
+                logger.warning(
+                    "[PLEX] Fetch failed (%s); returning stale cached "
+                    "sessions (age=%.2fs)",
+                    exc,
+                    time.monotonic() - _cached_entry.cached_at,
+                )
+                return _cached_entry.sessions
+            logger.warning(
+                "[PLEX] Fetch failed with no prior cache (%s); "
+                "returning empty list",
+                exc,
+            )
+            return []
+
+        # Success — populate the cache and return.
+        _store_entry(sessions)
+        logger.debug(
+            "[PLEX] Cache miss for %s; fetched %d sessions and stored",
+            CACHE_KEY, len(sessions),
+        )
+        return sessions
+
+
+def _store_entry(sessions: list[PlexSession]) -> None:
+    """Replace the module-level cache entry with a fresh fetch result.
+
+    Pulled out so the test ``_reset_for_tests`` helper can share the
+    same "globals are write-protected behind one assignment" discipline.
+    """
+    global _cached_entry
+    _cached_entry = _Entry(sessions=sessions, cached_at=time.monotonic())

--- a/backend/services/plex_resolver.py
+++ b/backend/services/plex_resolver.py
@@ -1,0 +1,541 @@
+"""Plex cross-ref resolver (bd-r5f0c.2, epic bd-r5f0c).
+
+Given a single ECM stream session (client IP + stream name), this
+module answers one question: which Plex user — if any — is the actual
+viewer? When operators watch ECM-mediated streams through Plex,
+ECM only sees the Plex server's IP (every Plex viewer's pull comes
+from the same proxy IP), so without this cross-reference Stats
+collapses every Plex viewer into a single 'Plex server' identity.
+
+Data flow (cross-references the cache, NEVER calls PlexClient directly):
+
+    BandwidthTracker (W4, future) → resolve_plex_user(ip, name)
+       → get_cached_plex_sessions()                [plex_cache]
+            → cache hit OR PlexClient.get_sessions  [plex_client]
+       → match stream_name against now-playing
+       → return user_name | None
+
+Match algorithm:
+
+1. Extract the Plex server's IP from ``settings.plex_base_url``.
+   For IP-literal URLs (``http://192.168.1.20:32400``) we compare
+   directly. For hostname URLs (``https://plex.local:32400``) we resolve
+   via :func:`socket.gethostbyname` ONCE per process and cache the
+   result — repeated polls (every ~5s) must not thrash DNS.
+2. If the ECM session's client IP does NOT equal the Plex server IP,
+   short-circuit with ``None`` BEFORE calling the cache. Every poll
+   cycle visits this branch for every non-Plex-mediated session, so the
+   short-circuit is the load-bearing optimization.
+3. Fetch cached Plex sessions. The cache transparently handles the
+   "Plex disabled" case (returns ``[]``) so the resolver does not need
+   to inspect ``settings.plex_enabled``.
+4. For each session, score ``now_playing_item_name`` via three tiers:
+   * Tier 1 — exact (NFC + lowercase + strip) match on channel_name
+     parsed from pipe-suffix format ``"<number> | <name>"``;
+   * Tier 2 — channel_number exact string compare;
+   * Tier 3 — RapidFuzz ``token_set_ratio / 100`` against 0.85 floor.
+5. Multiple matches (rare — same channel on multiple Plex clients):
+   pick the most-recent ``last_activity_date`` datetime. ``None``
+   always loses to any populated datetime.
+
+Design constraints:
+
+* **Never instantiate PlexClient directly.** The cache owns the upstream
+  contract — going around it would defeat the thundering-herd guard,
+  the stale-fallback policy, and the settings gate all at once.
+* **DNS resolution is cached module-level.** A failed resolution is also
+  cached (as the sentinel ``_UNRESOLVED``) so we log the WARN once and
+  return ``None`` cheaply on every subsequent poll until the process
+  restarts. Operators fixing DNS will restart ECM anyway.
+* **Logging is DEBUG-default.** This is on the BandwidthTracker poll
+  loop hot path; INFO-level chatter per resolve call would drown the
+  log. WARN is reserved for unresolvable hostnames (operator action
+  required).
+* **Never raises.** Return None on any failure path; the bandwidth
+  tracker depends on this guarantee.
+"""
+from __future__ import annotations
+
+import logging
+import socket
+import unicodedata
+from datetime import datetime
+from urllib.parse import urlparse
+
+from rapidfuzz import fuzz
+
+from config import get_settings
+from plex_client import PlexSession
+from services.plex_cache import get_cached_plex_sessions
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration constants
+# ---------------------------------------------------------------------------
+
+
+# Fuzzy match threshold per the bead spec. Operators do NOT tune this —
+# Plex's now-playing names are typically clean enough that 0.85 gives
+# very few false positives, and a per-deployment knob here would only
+# encourage attribution drift in Stats. If experience proves it
+# needs tuning, that's a follow-up bead, not a settings field.
+FUZZY_MATCH_THRESHOLD: float = 0.85
+
+
+# Sentinel for "we tried to resolve this hostname and it failed". Cached
+# in ``_dns_cache`` so the WARN is logged once and subsequent polls
+# return ``None`` cheaply without re-attempting the DNS lookup.
+_UNRESOLVED = object()
+
+# Rate-limit the resolver WARN for multiple-candidate disambiguation
+# so noisy Plex setups don't flood the log. Module-level timestamp.
+_plex_resolver_last_warn_at: float | None = None
+_WARN_RATE_LIMIT_SECONDS: float = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Module-level state
+# ---------------------------------------------------------------------------
+
+
+# Map of hostname → resolved IP (or ``_UNRESOLVED`` sentinel). The
+# resolver consults this BEFORE calling ``socket.gethostbyname`` so we
+# never resolve the same hostname twice in one process lifetime.
+_dns_cache: dict[str, str | object] = {}
+
+
+def _reset_for_tests() -> None:
+    """Clear the DNS cache and warn rate-limit — tests only.
+
+    Tests share the same module instance across test functions; without
+    this reset, a hostname-resolution result from one test would leak
+    into the next and produce false matches. Production code paths do
+    not call this.
+    """
+    global _plex_resolver_last_warn_at
+    _dns_cache.clear()
+    _plex_resolver_last_warn_at = None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def resolve_plex_user(
+    ecm_session_ip: str,
+    ecm_stream_name: str,
+    ecm_channel_name: str | None = None,
+    ecm_channel_number: str | int | None = None,
+) -> str | None:
+    """Cross-reference one ECM stream against the live Plex session list.
+
+    Returns the matching Plex user's name when exactly one Plex session
+    is playing this stream, else ``None``. Multiple matches (rare — same
+    channel on multiple Plex clients) tie-break on most-recent
+    ``last_activity_date``.
+
+    Matching is tiered (mirrors the Emby resolver's bd-zldrq fix-forward
+    approach for live TV where Dispatcharr stream names like
+    ``"US: ESPN FHD"`` do not fuzzy-match Plex now-playing names like
+    ``"408 | ESPN"`` at the 0.85 floor):
+
+    1. **Tier 1 — channel_name exact.** Parse each Plex session's
+       ``now_playing_item_name`` as ``"<number> | <name>"`` and compare
+       the right-hand part case-insensitively to ``ecm_channel_name``.
+       Whole-string equal also counts (some Plex installs surface live
+       TV without the ``"<number> | "`` prefix).
+    2. **Tier 2 — channel_number exact.** When both ``ecm_channel_number``
+       and the session's item name prefix are present, string-compare.
+       Defensive against name divergence between ECM and Plex.
+    3. **Tier 3 — fuzzy stream_name fallback.** Score
+       ``ecm_stream_name`` against ``now_playing_item_name`` via
+       RapidFuzz ``token_set_ratio / 100`` against
+       ``FUZZY_MATCH_THRESHOLD``. Still the right behavior for
+       non-live-TV Plex content (movies, episodes, music).
+
+    Args:
+        ecm_session_ip: The client IP of the Dispatcharr stream session
+            ECM is trying to attribute. For Plex-mediated streams this
+            will be the Plex server's IP; for everything else it will
+            not, and the resolver short-circuits.
+        ecm_stream_name: The Dispatcharr stream name (e.g. "CNN HD") —
+            matched case-insensitively against each Plex session's
+            ``now_playing_item_name`` in the tier-3 fallback. Required
+            for back-compat.
+        ecm_channel_name: ECM channel name (e.g. "ESPN"). When
+            populated, the resolver tries tier 1 first. Optional.
+        ecm_channel_number: ECM channel number (e.g. ``408`` or
+            ``"408"``). When populated, the resolver tries tier 2.
+            Accepts ``int`` or ``str`` and casts to ``str`` for compare.
+
+    Returns:
+        The resolved Plex user_name string, or ``None`` when the IP
+        does not match the Plex server, no Plex session matches across
+        any tier, or any defensive failure (DNS resolution failure,
+        malformed base URL).
+
+    Notes:
+        Never raises. The BandwidthTracker poll loop calls this on every
+        active session every ~5 seconds; raising would either kill the
+        loop or force the caller to wrap every call. A top-level
+        ``except Exception`` guard backstops any unexpected failure path
+        and returns ``None`` with a DEBUG log so the caller always gets
+        a result.
+    """
+    try:
+        return await _resolve_plex_user_inner(
+            ecm_session_ip=ecm_session_ip,
+            ecm_stream_name=ecm_stream_name,
+            ecm_channel_name=ecm_channel_name,
+            ecm_channel_number=ecm_channel_number,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[PLEX] Unexpected resolver error: %s", exc)
+        return None
+
+
+async def _resolve_plex_user_inner(
+    ecm_session_ip: str,
+    ecm_stream_name: str,
+    ecm_channel_name: str | None,
+    ecm_channel_number: str | int | None,
+) -> str | None:
+    """Inner implementation of :func:`resolve_plex_user` — may raise.
+
+    Wrapped by ``resolve_plex_user`` which catches all exceptions so the
+    BandwidthTracker poll loop never sees a raised exception from this path.
+    """
+    settings = get_settings()
+    base_url = getattr(settings, "plex_base_url", "") or ""
+
+    plex_server_ip = _resolve_plex_server_ip(base_url)
+    if plex_server_ip is None:
+        # Could not determine the Plex server IP (empty/malformed URL or
+        # DNS failure). Fail safe — no attribution possible.
+        return None
+
+    if ecm_session_ip != plex_server_ip:
+        # Hot path: the vast majority of ECM sessions are NOT
+        # Plex-mediated. Short-circuit before the cache call.
+        return None
+
+    try:
+        sessions = await get_cached_plex_sessions()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[PLEX] Unexpected error fetching cached sessions: %s", exc)
+        return None
+
+    if not sessions:
+        # Cache empty (Plex disabled, idle server, or fetch failure with
+        # no prior cache). Nothing to match.
+        return None
+
+    matches = _find_matching_sessions(
+        ecm_stream_name=ecm_stream_name,
+        ecm_channel_name=ecm_channel_name,
+        ecm_channel_number=ecm_channel_number,
+        sessions=sessions,
+    )
+    if not matches:
+        logger.debug(
+            "[PLEX] No match for stream=%r channel=%r number=%r "
+            "against %d Plex session(s)",
+            ecm_stream_name, ecm_channel_name, ecm_channel_number,
+            len(sessions),
+        )
+        return None
+
+    winner = _tiebreak_most_recent(matches)
+    if len(matches) > 1:
+        # Surface disambiguation so operators can see the tie-break in
+        # trace. Warn-rate-limited so noisy setups don't flood the log.
+        _log_disambiguation_warn(
+            count=len(matches),
+            ecm_session_ip=ecm_session_ip,
+            name=ecm_channel_name or ecm_stream_name,
+            winner_name=winner.user_name,
+        )
+    else:
+        logger.debug(
+            "[PLEX] Resolved stream=%r → user=%s from 1 match",
+            ecm_stream_name, winner.user_name,
+        )
+    return winner.user_name
+
+
+# ---------------------------------------------------------------------------
+# Internals: server IP resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_plex_server_ip(base_url: str) -> str | None:
+    """Extract the Plex server's IP from the configured base URL.
+
+    For IP-literal URLs (``http://192.168.1.20:32400``) the hostname
+    component IS the IP — return it directly. For hostname URLs
+    (``https://plex.local:32400``) resolve via :func:`socket.gethostbyname`
+    and cache the result module-level so the next ~5-second poll cycle
+    reuses it.
+
+    Returns ``None`` on any failure (empty URL, malformed URL,
+    unresolvable hostname). Each failure mode logs once at the
+    appropriate level — operators need to know about DNS failures, but
+    not on every poll cycle.
+    """
+    if not base_url:
+        # Empty base_url indicates Plex is unconfigured. The cache layer
+        # would also return [] in this state; we just exit early.
+        return None
+
+    try:
+        parsed = urlparse(base_url)
+    except ValueError:
+        logger.warning("[PLEX] Could not parse plex_base_url=%r", base_url)
+        return None
+
+    host = parsed.hostname
+    if not host:
+        logger.warning(
+            "[PLEX] plex_base_url=%r has no extractable hostname", base_url,
+        )
+        return None
+
+    if _looks_like_ip_literal(host):
+        # Hostname IS already an IP — no DNS needed.
+        return host
+
+    # Hostname case: consult the DNS cache before calling out.
+    cached = _dns_cache.get(host)
+    if cached is _UNRESOLVED:
+        # Prior call failed and we've already WARN'd. Stay silent now.
+        return None
+    if isinstance(cached, str):
+        return cached
+
+    try:
+        resolved = socket.gethostbyname(host)
+    except socket.gaierror as exc:
+        # DNS failure. WARN once (the cache prevents repeat WARNs) and
+        # poison the cache with the sentinel so subsequent polls short
+        # circuit cheaply.
+        logger.warning(
+            "[PLEX] Could not resolve plex_base_url hostname %r: %s. "
+            "Plex attribution will be disabled until ECM restarts and "
+            "DNS resolves successfully.",
+            host, exc,
+        )
+        _dns_cache[host] = _UNRESOLVED
+        return None
+
+    _dns_cache[host] = resolved
+    logger.debug("[PLEX] Resolved %s → %s (cached)", host, resolved)
+    return resolved
+
+
+def _looks_like_ip_literal(host: str) -> bool:
+    """True when ``host`` is an IPv4/IPv6 literal, not a hostname.
+
+    Use :func:`socket.inet_pton` for both families — it returns a packed
+    address on success and raises ``OSError`` otherwise.
+    """
+    for family in (socket.AF_INET, socket.AF_INET6):
+        try:
+            socket.inet_pton(family, host)
+            return True
+        except OSError:
+            continue
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Internals: matching
+# ---------------------------------------------------------------------------
+
+
+def _normalize(value: str) -> str:
+    """NFC + lowercase + strip — same normalization as emby_resolver."""
+    return unicodedata.normalize("NFC", value).lower().strip()
+
+
+def _find_matching_sessions(
+    *,
+    ecm_stream_name: str,
+    ecm_channel_name: str | None,
+    ecm_channel_number: str | int | None,
+    sessions: list[PlexSession],
+) -> list[PlexSession]:
+    """Return every Plex session that matches across any of the three tiers.
+
+    Tiered match (mirrors emby_resolver's bd-zldrq approach):
+
+    * **Tier 1** — channel name primary. Parse ``item_name`` as
+      ``"<number> | <name>"``; the right-hand part (or the whole
+      string when there's no ``"|"`` separator) must equal
+      ``ecm_channel_name`` after normalization.
+    * **Tier 2** — channel number exact (string compare against the
+      left-hand side of ``"<number> | <name>"``). Skipped when either
+      side is missing.
+    * **Tier 3** — RapidFuzz ``token_set_ratio`` on
+      ``ecm_stream_name`` against ``item_name`` with the bead-spec
+      0.85 floor. Back-compat for movies / VOD where neither channel
+      argument is available.
+
+    A session matches if ANY tier accepts it. The list is the union of
+    tier hits — duplicates are de-duped by session identity so the same
+    physical session is not double-counted in the tie-break.
+    """
+    # Pre-normalize Plex session strings ONCE — hot-path performance.
+    prepared: list[tuple[PlexSession, str, str, str]] = []
+    for session in sessions:
+        normalized_item = _normalize(session.now_playing_item_name or "")
+        # The right-hand side of "<number> | <name>" (or empty when
+        # there's no pipe). Tier 1 compares this to ecm_channel_name.
+        suffix = _parse_pipe_suffix(normalized_item)
+        # The left-hand side of "<number> | <name>" — used for tier 2.
+        prefix = _parse_pipe_prefix(normalized_item)
+        prepared.append((session, normalized_item, suffix, prefix))
+
+    # Track matched sessions by identity to avoid double-counting when
+    # two tiers both accept the same physical session.
+    matched_ids: set[str] = set()
+    matches: list[PlexSession] = []
+
+    def _accept(session: PlexSession) -> None:
+        if session.session_id in matched_ids:
+            return
+        matched_ids.add(session.session_id)
+        matches.append(session)
+
+    # ----- Tier 1: channel name primary match
+    normalized_ecm_channel = _normalize(ecm_channel_name or "")
+    if normalized_ecm_channel:
+        for session, normalized_item, suffix, _prefix in prepared:
+            # Right-hand side of "<number> | <name>" matches (the
+            # primary live-TV path), OR the whole item_name matches
+            # (some Plex installs have no "<number> | " prefix).
+            if suffix and suffix == normalized_ecm_channel:
+                _accept(session)
+                continue
+            if normalized_item and normalized_item == normalized_ecm_channel:
+                _accept(session)
+
+    # ----- Tier 2: channel number exact (string compare against prefix)
+    if ecm_channel_number is not None:
+        ecm_number_str = str(ecm_channel_number).strip()
+        if ecm_number_str:
+            for session, _it, _sfx, prefix in prepared:
+                # Match the numeric prefix of "<number> | <name>"
+                if prefix and prefix.strip() == ecm_number_str:
+                    _accept(session)
+
+    # ----- Tier 3: legacy fuzzy fallback on stream_name
+    normalized_stream = _normalize(ecm_stream_name or "")
+    if normalized_stream:
+        for session, normalized_item, _sfx, _pfx in prepared:
+            if _fuzzy_or_exact_match(normalized_stream, normalized_item):
+                _accept(session)
+
+    return matches
+
+
+def _parse_pipe_suffix(normalized_item_name: str) -> str:
+    """Return the right-hand side of a ``"<number> | <name>"`` string.
+
+    Plex renders live-TV ``title`` as e.g. ``"408 | ESPN"``;
+    the operator-visible channel name is the part after the pipe. When
+    there's no pipe (VOD / movies / episodes), return the empty string.
+
+    Input is assumed already normalized (NFC + lowercase + strip).
+    """
+    if "|" not in normalized_item_name:
+        return ""
+    _prefix, _sep, suffix = normalized_item_name.partition("|")
+    return suffix.strip()
+
+
+def _parse_pipe_prefix(normalized_item_name: str) -> str:
+    """Return the left-hand side of a ``"<number> | <name>"`` string.
+
+    Used by tier 2 to extract the channel number prefix for direct
+    comparison against ``ecm_channel_number``.
+
+    Input is assumed already normalized (NFC + lowercase + strip).
+    """
+    if "|" not in normalized_item_name:
+        return ""
+    prefix, _sep, _suffix = normalized_item_name.partition("|")
+    return prefix.strip()
+
+
+def _fuzzy_or_exact_match(normalized_stream: str, normalized_candidate: str) -> bool:
+    """True iff the normalized stream and candidate exact-match OR fuzzy-score
+    above ``FUZZY_MATCH_THRESHOLD``.
+
+    Empty candidate cannot match.
+    """
+    if not normalized_candidate:
+        return False
+    if normalized_stream == normalized_candidate:
+        return True
+    # token_set_ratio returns 0–100; normalize to 0–1 to match the
+    # threshold semantics in the bead spec.
+    score = fuzz.token_set_ratio(normalized_stream, normalized_candidate) / 100.0
+    return score >= FUZZY_MATCH_THRESHOLD
+
+
+def _tiebreak_most_recent(sessions: list[PlexSession]) -> PlexSession:
+    """Pick the session with the most-recent ``last_activity_date``.
+
+    Plex timestamps are ``datetime`` objects. A session with
+    ``last_activity_date is None`` should never beat one with a real
+    datetime — we map ``None`` to ``float("-inf")`` (epoch seconds) so
+    populated timestamps always sort higher regardless of timezone
+    awareness.
+
+    Returns the input verbatim when there is only one session.
+    """
+    if len(sessions) == 1:
+        return sessions[0]
+
+    def _sort_key(s: PlexSession) -> float:
+        if s.last_activity_date is None:
+            return float("-inf")
+        # Use POSIX timestamp (float seconds since epoch) for comparison
+        # so both timezone-aware and naive datetimes are handled uniformly.
+        try:
+            return s.last_activity_date.timestamp()
+        except (OSError, OverflowError, ValueError):
+            return float("-inf")
+
+    return max(sessions, key=_sort_key)
+
+
+def _log_disambiguation_warn(
+    count: int,
+    ecm_session_ip: str,
+    name: str,
+    winner_name: str,
+) -> None:
+    """Log a rate-limited DEBUG line when multiple candidates are found.
+
+    Using DEBUG (not WARN) because this is on the hot path — multiple
+    matches are rare but not operator-actionable. The rate-limit prevents
+    flooding when a noisy Plex setup repeatedly matches multiple sessions.
+    """
+    global _plex_resolver_last_warn_at
+    import time as _time
+
+    now = _time.monotonic()
+    if (
+        _plex_resolver_last_warn_at is None
+        or now - _plex_resolver_last_warn_at >= _WARN_RATE_LIMIT_SECONDS
+    ):
+        logger.debug(
+            "[PLEX] resolver: %d candidates for ip=%s name=%s, "
+            "picked %s by recency",
+            count, ecm_session_ip, name, winner_name,
+        )
+        _plex_resolver_last_warn_at = now

--- a/backend/tests/fixtures/plex/sessions_idle_only.xml
+++ b/backend/tests/fixtures/plex/sessions_idle_only.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Empty MediaContainer — no active sessions (server is idle). -->
+<MediaContainer size="0"/>

--- a/backend/tests/fixtures/plex/sessions_multi_user_same_channel.xml
+++ b/backend/tests/fixtures/plex/sessions_multi_user_same_channel.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Two users watching the same live TV channel (ESPN, channel 408).
+     Regression target for bd-g03fi (multiple-match tiebreak).
+     alice has a more recent lastViewedAt and should win in a tiebreak.
+     lastViewedAt epoch values:
+       alice: 1747396800 = 2025-05-16T12:00:00Z  (more recent)
+       bob:   1747393200 = 2025-05-16T11:00:00Z  (older) -->
+<MediaContainer size="2">
+  <Video ratingKey="12345" title="408 | ESPN" type="episode"
+         grandparentTitle="ESPN" lastViewedAt="1747396800">
+    <User id="user-alice-1" title="alice"/>
+    <Player address="192.168.1.50" state="playing" platform="Plex for iOS"/>
+  </Video>
+  <Video ratingKey="12346" title="408 | ESPN" type="episode"
+         grandparentTitle="ESPN" lastViewedAt="1747393200">
+    <User id="user-bob-2" title="bob"/>
+    <Player address="192.168.1.51" state="playing" platform="Plex Web"/>
+  </Video>
+</MediaContainer>

--- a/backend/tests/fixtures/plex/sessions_one_active.xml
+++ b/backend/tests/fixtures/plex/sessions_one_active.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- One active live TV session. User alice is watching ESPN (channel 408).
+     lastViewedAt is epoch seconds (UTC): 1747396800 = 2025-05-16T12:00:00Z -->
+<MediaContainer size="1">
+  <Video ratingKey="12345" title="408 | ESPN" type="episode"
+         grandparentTitle="ESPN" lastViewedAt="1747396800">
+    <User id="user-alice-1" title="alice"/>
+    <Player address="192.168.1.50" state="playing" platform="Plex for iOS"/>
+  </Video>
+</MediaContainer>

--- a/backend/tests/fixtures/plex/sessions_vod.xml
+++ b/backend/tests/fixtures/plex/sessions_vod.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- VOD (movie) session — no channel number, no pipe-suffix format.
+     User carol is watching The Matrix.
+     lastViewedAt: 1747400400 = 2025-05-16T13:00:00Z -->
+<MediaContainer size="1">
+  <Video ratingKey="99999" title="The Matrix" type="movie"
+         year="1999" lastViewedAt="1747400400">
+    <User id="user-carol-3" title="carol"/>
+    <Player address="192.168.1.52" state="playing" platform="Plex for Android"/>
+  </Video>
+</MediaContainer>

--- a/backend/tests/services/test_plex_cache.py
+++ b/backend/tests/services/test_plex_cache.py
@@ -1,0 +1,354 @@
+"""Unit tests for :mod:`services.plex_cache` (bd-r5f0c.2, epic bd-r5f0c).
+
+The cache module sits between :mod:`plex_client` and any downstream
+consumer (BandwidthTracker, resolver). The tests below lock the six
+behavioral guarantees the bead enumerates:
+
+1. Cache hit — second call within TTL does not call PlexClient.
+2. Cache miss — first call calls PlexClient; subsequent within TTL
+   returns the same cached list without firing again.
+3. Stale fallback — populated cache + subsequent fetch failure returns
+   the stale list, not empty.
+4. Cold-start failure — empty cache + fetch failure returns empty list
+   and logs a WARN.
+5. Plex disabled — settings gate short-circuits before any cache or
+   client interaction.
+6. Thundering-herd — concurrent cache-miss callers result in exactly
+   one upstream call thanks to the ``asyncio.Lock``.
+
+All tests reset the module-level cache via ``_reset_for_tests`` so state
+does not bleed between tests in the same process.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from plex_client import PlexClientError, PlexSession
+from services import plex_cache
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session(user_name: str = "alice") -> PlexSession:
+    """Build a representative :class:`PlexSession` for assertions."""
+    return PlexSession(
+        session_id=f"sess-{user_name}",
+        user_id=f"uid-{user_name}",
+        user_name=user_name,
+        remote_endpoint="10.0.0.5",
+        now_playing_item_name="408 | ESPN",
+        last_activity_date=datetime(2025, 5, 16, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+def _enabled_settings(base_url: str = "http://plex.example:32400") -> MagicMock:
+    """Settings stub representing a fully-configured, enabled Plex."""
+    settings = MagicMock()
+    settings.plex_enabled = True
+    settings.plex_base_url = base_url
+    settings.plex_token = "token-123"
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def reset_cache_state():
+    """Ensure each test starts with a clean module-level cache.
+
+    Without this, a test that populates the cache would leak that state
+    into the next test and produce false cache-hit assertions.
+    """
+    plex_cache._reset_for_tests()
+    yield
+    plex_cache._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Behavior 1 + 2: cache hit / cache miss
+# ---------------------------------------------------------------------------
+
+
+class TestCacheHitAndMiss:
+    """First call fetches; subsequent calls within the TTL window do not."""
+
+    async def test_first_call_invokes_plex_client_once(self):
+        """Cache miss path constructs PlexClient and calls get_sessions."""
+        session = _make_session()
+        mock_client = AsyncMock()
+        mock_client.get_sessions = AsyncMock(return_value=[session])
+        mock_client.close = AsyncMock()
+
+        with patch.object(plex_cache, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_cache, "PlexClient", return_value=mock_client) as client_cls:
+            result = await plex_cache.get_cached_plex_sessions()
+
+        assert result == [session]
+        assert client_cls.call_count == 1
+        mock_client.get_sessions.assert_awaited_once()
+        # The client pool must always be closed, including on success.
+        mock_client.close.assert_awaited_once()
+
+    async def test_second_call_within_ttl_hits_cache(self):
+        """Within TTL, a second call returns cached data without refetching."""
+        session = _make_session()
+        mock_client = AsyncMock()
+        mock_client.get_sessions = AsyncMock(return_value=[session])
+        mock_client.close = AsyncMock()
+
+        with patch.object(plex_cache, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_cache, "PlexClient", return_value=mock_client) as client_cls:
+            first = await plex_cache.get_cached_plex_sessions()
+            second = await plex_cache.get_cached_plex_sessions()
+
+        assert first == [session]
+        assert second == [session]
+        # Exactly one client constructed and one fetch fired across two calls.
+        assert client_cls.call_count == 1
+        mock_client.get_sessions.assert_awaited_once()
+
+    async def test_call_after_ttl_expiry_refetches(self):
+        """After the TTL elapses, the next call hits Plex again.
+
+        We monkey-patch ``time.monotonic`` to jump forward past the TTL
+        boundary, which is the same outcome the production code observes.
+        """
+        session_v1 = _make_session("alice")
+        session_v2 = _make_session("bob")
+        mock_client = AsyncMock()
+        mock_client.get_sessions = AsyncMock(side_effect=[[session_v1], [session_v2]])
+        mock_client.close = AsyncMock()
+
+        clock = [1000.0]
+
+        def _fake_monotonic():
+            return clock[0]
+
+        with patch.object(plex_cache, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_cache, "PlexClient", return_value=mock_client), \
+             patch.object(plex_cache.time, "monotonic", side_effect=_fake_monotonic):
+            first = await plex_cache.get_cached_plex_sessions()
+            clock[0] += plex_cache.CACHE_TTL_SECONDS + 0.1
+            second = await plex_cache.get_cached_plex_sessions()
+
+        assert first == [session_v1]
+        assert second == [session_v2]
+        assert mock_client.get_sessions.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Behavior 3: stale fallback on subsequent failure
+# ---------------------------------------------------------------------------
+
+
+class TestStaleFallback:
+    """Once a value is cached, a later fetch failure surfaces the stale value."""
+
+    async def test_subsequent_failure_returns_stale_cache(self, caplog):
+        """A populated cache + later fetch failure returns the stale list."""
+        session = _make_session()
+        mock_client = AsyncMock()
+        mock_client.get_sessions = AsyncMock(
+            side_effect=[[session], PlexClientError("network down")]
+        )
+        mock_client.close = AsyncMock()
+
+        clock = [1000.0]
+
+        def _fake_monotonic():
+            return clock[0]
+
+        with patch.object(plex_cache, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_cache, "PlexClient", return_value=mock_client), \
+             patch.object(plex_cache.time, "monotonic", side_effect=_fake_monotonic):
+            first = await plex_cache.get_cached_plex_sessions()
+            clock[0] += plex_cache.CACHE_TTL_SECONDS + 0.1
+            with caplog.at_level(logging.WARNING, logger=plex_cache.logger.name):
+                second = await plex_cache.get_cached_plex_sessions()
+
+        assert first == [session]
+        # Stale-fallback: same list contents, not an empty list.
+        assert second == [session]
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("stale" in r.getMessage().lower() for r in warnings), warnings
+
+
+# ---------------------------------------------------------------------------
+# Behavior 4: cold-start fetch failure
+# ---------------------------------------------------------------------------
+
+
+class TestColdStartFailure:
+    """No prior cache + fetch failure returns empty list + WARN."""
+
+    async def test_cold_start_failure_returns_empty_list(self, caplog):
+        mock_client = AsyncMock()
+        mock_client.get_sessions = AsyncMock(
+            side_effect=PlexClientError("connect refused")
+        )
+        mock_client.close = AsyncMock()
+
+        with patch.object(plex_cache, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_cache, "PlexClient", return_value=mock_client):
+            with caplog.at_level(logging.WARNING, logger=plex_cache.logger.name):
+                result = await plex_cache.get_cached_plex_sessions()
+
+        assert result == []
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("no prior cache" in r.getMessage().lower() for r in warnings), warnings
+
+    async def test_cold_start_failure_does_not_populate_cache(self):
+        """A failed cold-start fetch must not poison the cache with [].
+
+        Otherwise the next call would silently cache-hit empty list for
+        the TTL window, masking a recovered Plex for up to 5s.
+        """
+        mock_client = AsyncMock()
+        session = _make_session()
+        mock_client.get_sessions = AsyncMock(
+            side_effect=[PlexClientError("boom"), [session]]
+        )
+        mock_client.close = AsyncMock()
+
+        with patch.object(plex_cache, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_cache, "PlexClient", return_value=mock_client):
+            first = await plex_cache.get_cached_plex_sessions()
+            # Second call should fire a new fetch because the cold-start
+            # failure left the cache empty.
+            second = await plex_cache.get_cached_plex_sessions()
+
+        assert first == []
+        assert second == [session]
+        assert mock_client.get_sessions.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Behavior 5: settings gate
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsGate:
+    """When Plex is disabled or unconfigured, no cache or client interaction."""
+
+    async def test_plex_disabled_returns_empty_without_client(self):
+        settings = _enabled_settings()
+        settings.plex_enabled = False
+
+        with patch.object(plex_cache, "get_settings", return_value=settings), \
+             patch.object(plex_cache, "PlexClient") as client_cls:
+            result = await plex_cache.get_cached_plex_sessions()
+
+        assert result == []
+        client_cls.assert_not_called()
+
+    async def test_empty_base_url_treated_as_disabled(self):
+        """An empty base_url means "Plex not configured" — same short-circuit."""
+        settings = _enabled_settings()
+        settings.plex_base_url = ""
+
+        with patch.object(plex_cache, "get_settings", return_value=settings), \
+             patch.object(plex_cache, "PlexClient") as client_cls:
+            result = await plex_cache.get_cached_plex_sessions()
+
+        assert result == []
+        client_cls.assert_not_called()
+
+    async def test_missing_plex_attributes_treated_as_disabled(self):
+        """Settings model without plex_* fields (pre-W4) → disabled.
+
+        Defends the current state of ``dev``: ``DispatcharrSettings`` may
+        not yet declare ``plex_enabled`` / ``plex_base_url`` / ``plex_token``
+        at the moment this module ships. The ``getattr`` default in the
+        cache function should treat that as "Plex disabled".
+        """
+        class BareSettings:
+            pass
+
+        with patch.object(plex_cache, "get_settings", return_value=BareSettings()), \
+             patch.object(plex_cache, "PlexClient") as client_cls:
+            result = await plex_cache.get_cached_plex_sessions()
+
+        assert result == []
+        client_cls.assert_not_called()
+
+    async def test_disabled_does_not_touch_cache(self):
+        """Disabled short-circuit returns [] even when a stale cache exists.
+
+        If the operator disables Plex after a cache was populated, the
+        disabled response must win — we should not surface stale Plex
+        data after the operator explicitly turned the feature off.
+        """
+        # Seed the cache directly via the internal helper.
+        plex_cache._store_entry([_make_session("ghost")])
+
+        settings = _enabled_settings()
+        settings.plex_enabled = False
+
+        with patch.object(plex_cache, "get_settings", return_value=settings), \
+             patch.object(plex_cache, "PlexClient") as client_cls:
+            result = await plex_cache.get_cached_plex_sessions()
+
+        assert result == []
+        client_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Behavior 6: thundering-herd prevention
+# ---------------------------------------------------------------------------
+
+
+class TestThunderingHerdPrevention:
+    """Concurrent cache-miss callers must collapse to one upstream fetch."""
+
+    async def test_concurrent_misses_share_a_single_fetch(self):
+        """10 concurrent calls during cold-start fire PlexClient exactly once.
+
+        The lock + double-checked re-read inside the lock is what makes
+        this work — without the re-check, every waiter would still fire
+        a fetch after acquiring the lock, defeating the guard.
+        """
+        session = _make_session()
+        gate = asyncio.Event()
+        construct_count = 0
+        fetch_count = 0
+
+        class CountingClient:
+            """Minimal stand-in for PlexClient that counts constructions and fetches."""
+
+            def __init__(self, *, base_url: str, api_key: str):
+                nonlocal construct_count
+                construct_count += 1
+
+            async def get_sessions(self):
+                nonlocal fetch_count
+                fetch_count += 1
+                await gate.wait()
+                return [session]
+
+            async def close(self):
+                pass
+
+        async def _launch_all_then_release():
+            with patch.object(plex_cache, "get_settings", return_value=_enabled_settings()), \
+                 patch.object(plex_cache, "PlexClient", CountingClient):
+                tasks = [
+                    asyncio.create_task(plex_cache.get_cached_plex_sessions())
+                    for _ in range(10)
+                ]
+                await asyncio.sleep(0.05)
+                gate.set()
+                results = await asyncio.gather(*tasks)
+                return results
+
+        results = await _launch_all_then_release()
+
+        assert len(results) == 10
+        assert all(r == [session] for r in results), results
+        assert construct_count == 1, f"expected 1 client construction, got {construct_count}"
+        assert fetch_count == 1, f"expected 1 fetch, got {fetch_count}"

--- a/backend/tests/services/test_plex_resolver.py
+++ b/backend/tests/services/test_plex_resolver.py
@@ -1,0 +1,664 @@
+"""Unit tests for :mod:`services.plex_resolver` (bd-r5f0c.2, epic bd-r5f0c).
+
+The resolver answers one question: given an ECM stream session (client
+IP + stream name), is there exactly one matching Plex session, and if
+so, which Plex user owns it?
+
+Algorithm under test:
+
+1. If the ECM session's client IP does NOT match the configured Plex
+   server's IP (extracted from ``settings.plex_base_url``), return
+   ``None`` immediately — the stream is going somewhere other than the
+   Plex server, so no Plex attribution is possible. Do NOT call the
+   cache in this branch.
+2. Otherwise, fetch cached Plex sessions via
+   :func:`plex_cache.get_cached_plex_sessions`.
+3. Tiered matching across 3 tiers (mirrors emby_resolver bd-zldrq):
+   - Tier 1: channel_name pipe-suffix match
+   - Tier 2: channel_number match against pipe-prefix
+   - Tier 3: fuzzy stream_name match (RapidFuzz token_set_ratio ≥ 0.85)
+4. Zero matches → return ``None``.
+5. One or more matches → most-recent ``last_activity_date`` wins.
+   Returns user_name as a string (not a dataclass).
+
+Test isolation note: the resolver caches DNS resolution results
+module-level. :func:`plex_resolver._reset_for_tests` clears that cache
+between tests.
+"""
+from __future__ import annotations
+
+import logging
+import socket
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from plex_client import PlexSession
+from services import plex_resolver
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_SENTINEL = object()  # distinct from None to allow explicit None last_activity
+
+
+def _make_session(
+    *,
+    session_id: str | None = None,
+    user_id: str = "uid-alice",
+    user_name: str = "alice",
+    item_name: str | None = "408 | ESPN",
+    last_activity: object = _SENTINEL,
+    remote_endpoint: str = "10.0.0.99",
+) -> PlexSession:
+    """Build a representative :class:`PlexSession` for assertions.
+
+    Pass ``last_activity=None`` explicitly to get ``last_activity_date=None``.
+    Omit the argument to get a sensible default datetime (avoids accidental
+    None tiebreak in tests that don't care about the timestamp).
+    """
+    if last_activity is _SENTINEL:
+        last_activity = datetime(2025, 5, 16, 12, 0, 0, tzinfo=timezone.utc)
+    return PlexSession(
+        session_id=session_id or f"sess-{user_name}",
+        user_id=user_id,
+        user_name=user_name,
+        remote_endpoint=remote_endpoint,
+        now_playing_item_name=item_name,
+        last_activity_date=last_activity,  # type: ignore[arg-type]
+    )
+
+
+def _enabled_settings(base_url: str = "http://192.168.1.20:32400") -> MagicMock:
+    """Settings stub for a fully-configured, enabled Plex.
+
+    Default base URL is an IP literal so tests of the resolver's
+    happy-path do not need to mock ``socket.gethostbyname``.
+    """
+    settings = MagicMock()
+    settings.plex_enabled = True
+    settings.plex_base_url = base_url
+    settings.plex_token = "token-123"
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def reset_resolver_state():
+    """Reset the module-level DNS cache around every test."""
+    plex_resolver._reset_for_tests()
+    yield
+    plex_resolver._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Behavior: IP mismatch short-circuit (no cache call)
+# ---------------------------------------------------------------------------
+
+
+class TestIpMismatch:
+    """When the ECM session's IP is not the Plex server's IP, the resolver
+    must return ``None`` without ever touching the cache."""
+
+    async def test_ip_mismatch_returns_none_without_cache_call(self):
+        """IP mismatch on an IP-literal base URL skips the cache entirely."""
+        cache_mock = AsyncMock(return_value=[_make_session()])
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions", cache_mock):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="10.0.0.5",  # NOT the Plex server (192.168.1.20)
+                ecm_stream_name="ESPN",
+            )
+        assert result is None
+        cache_mock.assert_not_awaited()
+
+    async def test_ip_match_proceeds_to_cache_call(self):
+        """When the session IP matches the Plex server IP, the cache is called."""
+        cache_mock = AsyncMock(return_value=[])
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions", cache_mock):
+            await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ESPN",
+            )
+        cache_mock.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Behavior: Tier 1 — channel name pipe-suffix match
+# ---------------------------------------------------------------------------
+
+
+class TestTier1ChannelNameMatch:
+    """Tier 1: parse item_name as ``"<number> | <name>"`` and match the
+    right-hand part against ``ecm_channel_name`` case-insensitively."""
+
+    async def test_channel_name_matches_pipe_suffix(self):
+        """item_name "408 | ESPN" matches ecm_channel_name "ESPN"."""
+        session = _make_session(
+            user_id="uid-mw", user_name="MotWakorb",
+            item_name="408 | ESPN",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: ESPN FHD",
+                ecm_channel_name="ESPN",
+                ecm_channel_number=408,
+            )
+        assert result == "MotWakorb"
+
+    async def test_channel_name_matches_whole_name_without_prefix(self):
+        """item_name is just "ESPN" (no pipe prefix) — whole-string match."""
+        session = _make_session(
+            user_name="MotWakorb",
+            item_name="ESPN",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: ESPN FHD",
+                ecm_channel_name="ESPN",
+            )
+        assert result is not None
+        assert result == "MotWakorb"
+
+    async def test_channel_name_match_is_case_insensitive(self):
+        """``espn`` matches ``"408 | ESPN"`` — normalization applied."""
+        session = _make_session(
+            user_name="case_user",
+            item_name="408 | ESPN",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ignored — tier 1 wins first",
+                ecm_channel_name="espn",
+            )
+        assert result is not None
+        assert result == "case_user"
+
+    async def test_no_channel_name_arg_skips_tier1(self):
+        """When ecm_channel_name is None, tier 1 is skipped entirely."""
+        # Session only has pipe-suffix item name; without channel_name arg
+        # tier 1 cannot match but tier 3 might.
+        session = _make_session(
+            user_name="sports_fan",
+            item_name="CNN HD",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            # No ecm_channel_name; stream_name exact-matches item_name
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="CNN HD",
+            )
+        assert result == "sports_fan"
+
+
+# ---------------------------------------------------------------------------
+# Behavior: Tier 2 — channel number match
+# ---------------------------------------------------------------------------
+
+
+class TestTier2ChannelNumberMatch:
+    """Tier 2: match channel number against the left-hand prefix of
+    ``"<number> | <name>"``."""
+
+    async def test_channel_number_string_match(self):
+        """ecm_channel_number=408 matches "408 | ESPN" prefix "408"."""
+        session = _make_session(
+            user_id="uid-num", user_name="num_user",
+            item_name="408 | Some unrelated channel",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: ESPN FHD",
+                ecm_channel_name="Sports Channel A",  # won't tier-1 match
+                ecm_channel_number=408,
+            )
+        assert result == "num_user"
+
+    async def test_channel_number_int_cast_to_string(self):
+        """ecm_channel_number can be int or str — both should match."""
+        session = _make_session(
+            user_name="int_user",
+            item_name="200 | CNN",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result_int = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ignore",
+                ecm_channel_name="XYZ",  # no match
+                ecm_channel_number=200,
+            )
+        assert result_int == "int_user"
+
+    async def test_no_pipe_in_item_name_skips_tier2(self):
+        """VOD session (no pipe format) cannot match via channel number."""
+        session = _make_session(
+            user_name="vod_user",
+            item_name="The Matrix",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: ESPN FHD",
+                ecm_channel_name="ESPN",  # won't match "The Matrix"
+                ecm_channel_number=408,    # prefix would be empty
+            )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Behavior: Tier 3 — fuzzy stream_name fallback
+# ---------------------------------------------------------------------------
+
+
+class TestTier3FuzzyFallback:
+    """Tier 3: RapidFuzz token_set_ratio on ecm_stream_name against
+    now_playing_item_name with the 0.85 threshold."""
+
+    async def test_fuzzy_match_above_threshold_returns_user(self):
+        """Stream name "CNN HD" vs item "CNN HD 1080p" — above 0.85."""
+        session = _make_session(user_name="dan", item_name="CNN HD 1080p")
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="CNN HD",
+            )
+        assert result == "dan"
+
+    async def test_fuzzy_match_below_threshold_returns_none(self):
+        """Unrelated item name scores below 0.85 — no match."""
+        session = _make_session(item_name="The Office Season 3 Episode 14")
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="CNN HD",
+            )
+        assert result is None
+
+    async def test_fuzzy_match_on_vod_when_no_channel_args(self):
+        """Movie session: no channel args, stream name fuzzy-matches title."""
+        session = _make_session(
+            user_name="movie_viewer",
+            item_name="The Matrix 1999",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="The Matrix",
+            )
+        assert result == "movie_viewer"
+
+    async def test_empty_item_name_cannot_match(self):
+        """Session with None item_name cannot match any tier."""
+        session = _make_session(item_name=None)
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="CNN HD",
+            )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Behavior: no-match conditions
+# ---------------------------------------------------------------------------
+
+
+class TestNoMatch:
+    """The resolver returns ``None`` whenever the cache is empty, every
+    session is below the fuzzy threshold, or no sessions exist."""
+
+    async def test_empty_cache_returns_none(self):
+        """An empty cache produces no match."""
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="CNN HD",
+            )
+        assert result is None
+
+    async def test_all_sessions_idle_returns_none(self):
+        """Sessions with item_name None cannot match anything."""
+        idle = _make_session(item_name=None)
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[idle, idle])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="CNN HD",
+            )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Behavior: tiebreak by most-recent last_activity_date
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleMatchTiebreak:
+    """Multiple matches → most-recent last_activity_date wins."""
+
+    async def test_picks_most_recent_last_activity(self):
+        """Two sessions playing the same channel; newer last_activity wins."""
+        older = _make_session(
+            session_id="sess-old",
+            user_id="uid-old", user_name="old_viewer",
+            item_name="408 | ESPN",
+            last_activity=datetime(2025, 5, 16, 10, 0, 0, tzinfo=timezone.utc),
+        )
+        newer = _make_session(
+            session_id="sess-new",
+            user_id="uid-new", user_name="new_viewer",
+            item_name="408 | ESPN",
+            last_activity=datetime(2025, 5, 16, 14, 0, 0, tzinfo=timezone.utc),
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[older, newer])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: ESPN FHD",
+                ecm_channel_name="ESPN",
+                ecm_channel_number=408,
+            )
+        assert result == "new_viewer"
+
+    async def test_null_last_activity_loses_to_populated(self):
+        """A session with last_activity_date=None should never beat one
+        with an actual datetime."""
+        no_ts = _make_session(
+            session_id="sess-null",
+            user_id="uid-null", user_name="null_viewer",
+            item_name="408 | ESPN",
+            last_activity=None,
+        )
+        with_ts = _make_session(
+            session_id="sess-ts",
+            user_id="uid-ts", user_name="ts_viewer",
+            item_name="408 | ESPN",
+            last_activity=datetime(2025, 5, 16, 10, 0, 0, tzinfo=timezone.utc),
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[no_ts, with_ts])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: ESPN FHD",
+                ecm_channel_name="ESPN",
+            )
+        assert result == "ts_viewer"
+
+    async def test_debug_log_fires_when_multiple_candidates(self, caplog):
+        """When N > 1 candidates match, the resolver must log a DEBUG line
+        surfacing the disambiguation."""
+        older = _make_session(
+            session_id="sess-old",
+            user_name="old_user",
+            item_name="408 | ESPN",
+            last_activity=datetime(2025, 5, 16, 10, 0, 0, tzinfo=timezone.utc),
+        )
+        newer = _make_session(
+            session_id="sess-new",
+            user_name="new_user",
+            item_name="408 | ESPN",
+            last_activity=datetime(2025, 5, 16, 14, 0, 0, tzinfo=timezone.utc),
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[older, newer])):
+            with caplog.at_level(logging.DEBUG, logger="services.plex_resolver"):
+                await plex_resolver.resolve_plex_user(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="US: ESPN FHD",
+                    ecm_channel_name="ESPN",
+                    ecm_channel_number=408,
+                )
+        assert any(
+            "[PLEX]" in rec.getMessage()
+            and "resolver" in rec.getMessage()
+            and "candidates" in rec.getMessage()
+            for rec in caplog.records
+        ), f"expected disambiguation DEBUG; got {[r.getMessage() for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# Behavior: hostname-based base URL DNS resolution
+# ---------------------------------------------------------------------------
+
+
+class TestHostnameBaseUrl:
+    """When ``plex_base_url`` uses a hostname rather than an IP literal,
+    the resolver falls back to ``socket.gethostbyname``."""
+
+    async def test_hostname_resolves_to_matching_ip_attributes(self):
+        """``plex.local`` resolves to ``192.168.1.20`` — matches the ECM
+        session IP and the resolver proceeds to look up the session."""
+        session = _make_session(user_name="eve", item_name="CNN HD")
+        settings = _enabled_settings(base_url="https://plex.local:32400")
+
+        with patch.object(plex_resolver, "get_settings", return_value=settings), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver.socket, "gethostbyname",
+                          return_value="192.168.1.20"):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="CNN HD",
+            )
+        assert result == "eve"
+
+    async def test_hostname_resolves_to_non_matching_ip_returns_none(self):
+        """``plex.local`` resolves to ``10.0.0.1`` — does NOT match."""
+        cache_mock = AsyncMock(return_value=[_make_session(item_name="CNN HD")])
+        settings = _enabled_settings(base_url="https://plex.local:32400")
+
+        with patch.object(plex_resolver, "get_settings", return_value=settings), \
+             patch.object(plex_resolver, "get_cached_plex_sessions", cache_mock), \
+             patch.object(plex_resolver.socket, "gethostbyname",
+                          return_value="10.0.0.1"):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="CNN HD",
+            )
+        assert result is None
+        cache_mock.assert_not_awaited()
+
+    async def test_hostname_resolution_failure_logs_warn_and_returns_none(self, caplog):
+        """Unresolvable hostname logs WARN with [PLEX] prefix and returns None."""
+        settings = _enabled_settings(base_url="https://does-not-exist.invalid:32400")
+
+        with patch.object(plex_resolver, "get_settings", return_value=settings), \
+             patch.object(plex_resolver, "get_cached_plex_sessions", AsyncMock()) as cache_mock, \
+             patch.object(plex_resolver.socket, "gethostbyname",
+                          side_effect=socket.gaierror("Name resolution failed")):
+            with caplog.at_level(logging.WARNING, logger="services.plex_resolver"):
+                result = await plex_resolver.resolve_plex_user(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CNN HD",
+                )
+        assert result is None
+        cache_mock.assert_not_awaited()
+        assert any(
+            "[PLEX]" in rec.getMessage() and "does-not-exist.invalid" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    async def test_hostname_resolution_result_is_cached(self):
+        """``socket.gethostbyname`` should be called at most once per
+        process — the resolver caches the resolution."""
+        session = _make_session(item_name="CNN HD")
+        settings = _enabled_settings(base_url="https://plex.local:32400")
+
+        with patch.object(plex_resolver, "get_settings", return_value=settings), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver.socket, "gethostbyname",
+                          return_value="192.168.1.20") as gethost:
+            await plex_resolver.resolve_plex_user("192.168.1.20", "CNN HD")
+            await plex_resolver.resolve_plex_user("192.168.1.20", "CNN HD")
+            await plex_resolver.resolve_plex_user("192.168.1.20", "CNN HD")
+        assert gethost.call_count == 1
+
+    async def test_ip_literal_bypasses_dns(self):
+        """IP literal in base URL bypasses ``socket.gethostbyname`` entirely."""
+        session = _make_session(item_name="CNN HD")
+        settings = _enabled_settings(base_url="http://192.168.1.20:32400")
+
+        with patch.object(plex_resolver, "get_settings", return_value=settings), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver.socket, "gethostbyname") as gethost:
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="CNN HD",
+            )
+        assert result == "alice"
+        gethost.assert_not_called()
+
+    async def test_failed_dns_poisons_cache_so_next_poll_skips_lookup(self):
+        """After a DNS failure, subsequent polls return None without
+        re-attempting the DNS lookup."""
+        settings = _enabled_settings(base_url="https://bad.host.invalid:32400")
+
+        with patch.object(plex_resolver, "get_settings", return_value=settings), \
+             patch.object(plex_resolver, "get_cached_plex_sessions", AsyncMock(return_value=[])), \
+             patch.object(plex_resolver.socket, "gethostbyname",
+                          side_effect=socket.gaierror("NXDOMAIN")) as gethost:
+            await plex_resolver.resolve_plex_user("192.168.1.20", "CNN HD")
+            await plex_resolver.resolve_plex_user("192.168.1.20", "CNN HD")
+
+        # DNS was only attempted once; the sentinel poisoned the cache.
+        assert gethost.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Behavior: empty / malformed configuration
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyOrMalformedConfig:
+    """Defensive coverage for misconfiguration."""
+
+    async def test_empty_base_url_returns_none(self):
+        """Empty ``plex_base_url`` cannot extract a hostname — returns None."""
+        settings = _enabled_settings(base_url="")
+        cache_mock = AsyncMock(return_value=[_make_session()])
+        with patch.object(plex_resolver, "get_settings", return_value=settings), \
+             patch.object(plex_resolver, "get_cached_plex_sessions", cache_mock):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="CNN HD",
+            )
+        assert result is None
+        cache_mock.assert_not_awaited()
+
+    async def test_malformed_base_url_returns_none(self):
+        """A base URL that ``urlparse`` cannot extract a hostname from
+        (e.g. only a scheme) returns ``None`` without raising."""
+        settings = _enabled_settings(base_url="http://")
+        cache_mock = AsyncMock(return_value=[_make_session()])
+        with patch.object(plex_resolver, "get_settings", return_value=settings), \
+             patch.object(plex_resolver, "get_cached_plex_sessions", cache_mock):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="CNN HD",
+            )
+        assert result is None
+        cache_mock.assert_not_awaited()
+
+    async def test_never_raises_on_exception(self):
+        """The resolver must swallow exceptions and return None — the
+        BandwidthTracker poll loop depends on this guarantee.
+
+        We make ``get_settings`` raise to exercise the top-level catch-all
+        without needing to reach inside the inner function.
+        """
+        with patch.object(plex_resolver, "get_settings", side_effect=RuntimeError("settings exploded")):
+            # Must not raise; the top-level guard catches Exception
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="CNN HD",
+            )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Behavior: back-compat two-positional-arg call shape
+# ---------------------------------------------------------------------------
+
+
+class TestBackCompatCallShape:
+    """Existing callers pass only (ip, stream_name) — must still work."""
+
+    async def test_two_positional_args_still_works(self):
+        """Pre-fix callers pass only (ip, stream_name) — fuzzy match
+        must still function with no channel args."""
+        session = _make_session(user_name="alice", item_name="CNN HD")
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                "192.168.1.20", "CNN HD",
+            )
+        assert result == "alice"
+
+
+# ---------------------------------------------------------------------------
+# Behavior: multi-tier dedup (same session matched by multiple tiers)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTierDedup:
+    """A session that matches both tier 1 and tier 2 should only appear
+    once in the candidate list (no double-counting in tiebreak)."""
+
+    async def test_session_matched_by_two_tiers_counted_once(self):
+        """Session matches both tier 1 (channel name) and tier 2 (channel
+        number). Should appear exactly once in the result, not twice."""
+        session = _make_session(
+            session_id="sess-dedup",
+            user_name="dedup_user",
+            item_name="408 | ESPN",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: ESPN FHD",
+                ecm_channel_name="ESPN",
+                ecm_channel_number=408,
+            )
+        # Single match — no tiebreak needed, and result is the user_name.
+        assert result == "dedup_user"

--- a/backend/tests/unit/test_plex_client.py
+++ b/backend/tests/unit/test_plex_client.py
@@ -1,0 +1,343 @@
+"""Unit tests for the Plex API client (bd-r5f0c.2).
+
+The Plex client mirrors the emby_client structure (async httpx, ``[PLEX]``
+log prefix, dataclass session shape, ``PlexClientError`` on any
+auth/network/non-2xx/XML failure) but is purpose-built for reading the
+operator's Plex ``/status/sessions`` feed used downstream by the
+user-attribution resolver (epic bd-r5f0c).
+
+Key Plex-specific differences from Emby:
+- Auth header: ``X-Plex-Token`` (not ``X-Emby-Token``)
+- Endpoint: ``/status/sessions`` (not ``/Sessions``)
+- Response format: XML (not JSON)
+- ``PlexSession.last_activity_date`` is a ``datetime`` (not ISO string)
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from plex_client import PlexClient, PlexClientError, PlexSession
+
+# Path to disk fixtures per project convention (docs/pytest_conventions.md).
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "plex"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _xml_response(status_code: int, xml_body: str = "") -> AsyncMock:
+    """Build a mock ``httpx.Response`` with the given status + XML text."""
+    resp = AsyncMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.text = xml_body
+    return resp
+
+
+def _load_fixture(name: str) -> str:
+    """Load an XML fixture from the plex fixtures directory."""
+    return (FIXTURES_DIR / name).read_text()
+
+
+# ---------------------------------------------------------------------------
+# Construction & URL normalization
+# ---------------------------------------------------------------------------
+
+
+def test_base_url_trailing_slash_is_stripped():
+    """The client must normalize ``http://plex/`` and ``http://plex`` to the
+    same canonical form so downstream string concat
+    (``base + "/status/sessions"``) never produces double slashes."""
+    client_with_slash = PlexClient(base_url="http://plex.local:32400/", api_key="token")
+    client_without_slash = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    assert client_with_slash.base_url == "http://plex.local:32400"
+    assert client_without_slash.base_url == "http://plex.local:32400"
+
+
+def test_base_url_strips_only_trailing_slash_not_path():
+    """If the operator configures a sub-path (reverse-proxy setups),
+    only the trailing slash gets stripped — the path itself is preserved."""
+    client = PlexClient(base_url="http://proxy.example.com/plex/", api_key="token")
+    assert client.base_url == "http://proxy.example.com/plex"
+
+
+# ---------------------------------------------------------------------------
+# get_sessions — success path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_maps_xml_to_dataclass():
+    """The Plex XML response is mapped to the PlexSession dataclass
+    correctly, including parsing lastViewedAt epoch seconds into datetime."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token-xyz")
+    xml = _load_fixture("sessions_one_active.xml")
+    try:
+        fake_resp = _xml_response(200, xml)
+        request_mock = AsyncMock(return_value=fake_resp)
+        with patch.object(client._client, "request", request_mock):
+            sessions = await client.get_sessions()
+
+        assert len(sessions) == 1
+        alice = sessions[0]
+        assert isinstance(alice, PlexSession)
+        assert alice.session_id == "12345"
+        assert alice.user_id == "user-alice-1"
+        assert alice.user_name == "alice"
+        assert alice.remote_endpoint == "192.168.1.50"
+        assert alice.now_playing_item_name == "408 | ESPN"
+        # lastViewedAt epoch 1747396800 → 2025-05-16T12:00:00+00:00
+        assert isinstance(alice.last_activity_date, datetime)
+        assert alice.last_activity_date == datetime(2025, 5, 16, 12, 0, 0, tzinfo=timezone.utc)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_multi_user_fixture():
+    """Two-user fixture yields two PlexSession instances."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    xml = _load_fixture("sessions_multi_user_same_channel.xml")
+    try:
+        fake_resp = _xml_response(200, xml)
+        request_mock = AsyncMock(return_value=fake_resp)
+        with patch.object(client._client, "request", request_mock):
+            sessions = await client.get_sessions()
+
+        assert len(sessions) == 2
+        names = {s.user_name for s in sessions}
+        assert names == {"alice", "bob"}
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_sends_x_plex_token_header_and_hits_correct_path():
+    """The outbound request must carry ``X-Plex-Token: <api_key>`` and
+    target ``<base>/status/sessions`` — the contract the Plex server enforces."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="my-token")
+    try:
+        fake_resp = _xml_response(200, "<MediaContainer size=\"0\"/>")
+        request_mock = AsyncMock(return_value=fake_resp)
+        with patch.object(client._client, "request", request_mock):
+            await client.get_sessions()
+
+        call = request_mock.await_args
+        assert call.args[0] == "GET"
+        assert call.args[1] == "http://plex.local:32400/status/sessions"
+        sent_headers = call.kwargs["headers"]
+        assert sent_headers["X-Plex-Token"] == "my-token"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_empty_mediascontainer_returns_empty_list():
+    """An empty ``<MediaContainer/>`` (no active sessions) must produce ``[]``,
+    not raise — downstream resolver code expects an iterable."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    xml = _load_fixture("sessions_idle_only.xml")
+    try:
+        fake_resp = _xml_response(200, xml)
+        request_mock = AsyncMock(return_value=fake_resp)
+        with patch.object(client._client, "request", request_mock):
+            sessions = await client.get_sessions()
+        assert sessions == []
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_vod_session_parsed():
+    """VOD session (movie title, no pipe-suffix) is parsed correctly.
+    ``now_playing_item_name`` captures the movie title."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    xml = _load_fixture("sessions_vod.xml")
+    try:
+        fake_resp = _xml_response(200, xml)
+        request_mock = AsyncMock(return_value=fake_resp)
+        with patch.object(client._client, "request", request_mock):
+            sessions = await client.get_sessions()
+        assert len(sessions) == 1
+        assert sessions[0].now_playing_item_name == "The Matrix"
+        assert sessions[0].user_name == "carol"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_skips_element_without_user_child():
+    """A ``<Video>`` without a ``<User>`` child (anonymous local session) must
+    be skipped — the resolver cannot attribute an anonymous session."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    xml = """<MediaContainer size="1">
+      <Video ratingKey="1" title="ESPN" lastViewedAt="1747396800">
+        <Player address="192.168.1.50" state="playing"/>
+      </Video>
+    </MediaContainer>"""
+    try:
+        fake_resp = _xml_response(200, xml)
+        request_mock = AsyncMock(return_value=fake_resp)
+        with patch.object(client._client, "request", request_mock):
+            sessions = await client.get_sessions()
+        assert sessions == []
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_missing_last_viewed_at_yields_none_datetime():
+    """A ``<Video>`` without ``lastViewedAt`` attribute produces
+    ``PlexSession.last_activity_date is None`` — tiebreak still works
+    (None loses to any populated datetime)."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    xml = """<MediaContainer size="1">
+      <Video ratingKey="2" title="CNN HD">
+        <User id="uid-1" title="dave"/>
+        <Player address="192.168.1.55" state="playing"/>
+      </Video>
+    </MediaContainer>"""
+    try:
+        fake_resp = _xml_response(200, xml)
+        request_mock = AsyncMock(return_value=fake_resp)
+        with patch.object(client._client, "request", request_mock):
+            sessions = await client.get_sessions()
+        assert len(sessions) == 1
+        assert sessions[0].last_activity_date is None
+    finally:
+        await client.close()
+
+
+# ---------------------------------------------------------------------------
+# get_sessions — error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_raises_on_401_unauthorized():
+    """A 401 from Plex (bad/expired token) must surface as
+    ``PlexClientError`` so the caller can flag the connection as broken."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="bad-token")
+    try:
+        fake_resp = _xml_response(401, "")
+        request_mock = AsyncMock(return_value=fake_resp)
+        with patch.object(client._client, "request", request_mock):
+            with pytest.raises(PlexClientError) as exc_info:
+                await client.get_sessions()
+        assert "401" in str(exc_info.value)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_raises_on_non_2xx_response():
+    """Non-2xx responses other than 401 (e.g. 500 from Plex) must also
+    surface as ``PlexClientError`` — the client never silently returns
+    empty on a server error."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        fake_resp = _xml_response(500, "")
+        request_mock = AsyncMock(return_value=fake_resp)
+        with patch.object(client._client, "request", request_mock):
+            with pytest.raises(PlexClientError) as exc_info:
+                await client.get_sessions()
+        assert "500" in str(exc_info.value)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_raises_on_network_error():
+    """Network-level failures (httpx.ConnectError, ReadTimeout, etc.) must
+    be wrapped as ``PlexClientError`` with the original exception preserved
+    in the cause chain."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        underlying = httpx.ConnectError("connection refused")
+        request_mock = AsyncMock(side_effect=underlying)
+        with patch.object(client._client, "request", request_mock):
+            with pytest.raises(PlexClientError) as exc_info:
+                await client.get_sessions()
+        assert exc_info.value.__cause__ is underlying
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_raises_on_malformed_xml():
+    """A response that is not valid XML must surface as
+    ``PlexClientError`` — the Plex server can return error pages as HTML."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        fake_resp = _xml_response(200, "<not valid xml <<<<")
+        request_mock = AsyncMock(return_value=fake_resp)
+        with patch.object(client._client, "request", request_mock):
+            with pytest.raises(PlexClientError) as exc_info:
+                await client.get_sessions()
+        assert "malformed" in str(exc_info.value).lower() or "xml" in str(exc_info.value).lower()
+    finally:
+        await client.close()
+
+
+# ---------------------------------------------------------------------------
+# test_connection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_test_connection_returns_true_on_success():
+    """The Settings UI 'Test Connection' button calls this — True means
+    'token works', False means 'something is wrong, show error'."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        fake_resp = _xml_response(200, "<MediaContainer size=\"0\"/>")
+        request_mock = AsyncMock(return_value=fake_resp)
+        with patch.object(client._client, "request", request_mock):
+            ok = await client.test_connection()
+        assert ok is True
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_test_connection_returns_false_on_plex_client_error():
+    """Any failure that ``get_sessions`` raises must be swallowed by
+    ``test_connection`` and reported as ``False``."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="bad-token")
+    try:
+        fake_resp = _xml_response(401, "")
+        request_mock = AsyncMock(return_value=fake_resp)
+        with patch.object(client._client, "request", request_mock):
+            ok = await client.test_connection()
+        assert ok is False
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_test_connection_returns_false_on_network_error():
+    """Network-error path also collapses to ``False`` for the Settings UI."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        request_mock = AsyncMock(side_effect=httpx.ConnectError("nope"))
+        with patch.object(client._client, "request", request_mock):
+            ok = await client.test_connection()
+        assert ok is False
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_close_releases_pool():
+    """``close()`` must call ``aclose()`` on the underlying httpx client
+    to release the connection pool."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    with patch.object(client._client, "aclose", new_callable=AsyncMock) as aclose_mock:
+        await client.close()
+    aclose_mock.assert_awaited_once()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0038",
+  "version": "0.17.1-0039",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Plex backend modules mirroring the Emby trio. W4 will wire bandwidth_tracker + stats.py against these.

- `backend/plex_client.py` — async httpx + X-Plex-Token + XML parsed via stdlib `xml.etree`
- `backend/services/plex_cache.py` — TTL 5s + thundering-herd lock + stale-fallback + settings gate
- `backend/services/plex_resolver.py` — IP short-circuit + DNS cache + tiered match (pipe-suffix → channel_number → fuzzy); never raises

## Test plan
- [x] `pytest tests/unit/test_plex_client.py tests/services/test_plex_cache.py tests/services/test_plex_resolver.py` — 57 tests green
- [x] Existing Emby tests still green — 50 tests, no regression
- [x] Full backend suite green — 4147 passed, 1 skipped (volume test)
- [x] Disk fixtures under `tests/fixtures/plex/` (4 XML files)
- [x] Version bump `0.17.1-0036` → `0.17.1-0037`

Closes bd-r5f0c.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)