### PR TITLE
v0.17.1-0041: media-session attribution metrics + warn alerts (bd-r5f0c.6)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0039",
+    version="0.17.1-0041",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -877,6 +877,127 @@ def _build_metrics(registry: CollectorRegistry) -> Dict[str, Any]:
             ["status"],
             registry=registry,
         ),
+        # ----------------------------------------------------------------
+        # Media-session attribution observability (bd-r5f0c.6).
+        #
+        # Six metrics cover the cache + resolver hot path for Emby /
+        # Plex / Jellyfin user attribution. All share a single bounded
+        # ``source`` label with three values: "emby", "plex",
+        # "jellyfin". Attribution is best-effort (SLO-8 posture) — the
+        # alert rules that wire on these are warn-only, never paging.
+        #
+        # Cache metrics (incremented by services/<source>_cache.py):
+        #
+        #   * ``media_session_cache_hits_total`` — cache hit before any
+        #     upstream call (fast-path and under-lock re-check). One
+        #     increment per cache-hit return, not per caller if multiple
+        #     waiters share a just-populated entry.
+        #   * ``media_session_fetch_duration_seconds`` — wall time of
+        #     the upstream ``get_sessions()`` HTTP call. Cache hits are
+        #     NOT counted — the histogram tracks upstream latency only.
+        #     Buckets match ``_HTTP_LATENCY_BUCKETS`` (LAN requests, the
+        #     same regime as other ECM upstream calls).
+        #   * ``media_session_fetch_errors_total`` — upstream fetch raised
+        #     an exception (network error, auth failure, server error).
+        #     The stale-fallback and cold-start paths both increment this
+        #     counter so the denominator is "all failed fetch attempts",
+        #     not just the ones that had a stale entry to fall back on.
+        #   * ``media_session_stale_fallback_total`` — stale cache entry
+        #     returned after a fetch failure. Subset of fetch_errors_total
+        #     (only those where a prior cache existed). Non-zero rate means
+        #     ECM is serving stale data to the resolver.
+        #
+        # Resolver metrics (incremented by services/<source>_resolver.py):
+        #
+        #   * ``user_attribution_resolved_total`` — resolver matched a
+        #     session to a user (returned a non-None attribution).
+        #     Incremented AFTER the IP match succeeds and a session match
+        #     is found — the IP short-circuit (not our session) does NOT
+        #     increment this counter.
+        #   * ``user_attribution_unresolved_total`` — resolver had an IP
+        #     match (the session came from the right source server) but
+        #     found no matching Emby/Plex/Jellyfin session. Incremented
+        #     after the IP-match succeeds and the session match loop
+        #     returns empty. The IP short-circuit does NOT increment.
+        #
+        # The ratio resolved / (resolved + unresolved) is the attribution
+        # quality SLI for the r5f0c epic — target ≥ 80% steady state
+        # (operators who configure all three sources should see most
+        # sessions attributed). Below 50% for > 30m → investigate.
+        # ----------------------------------------------------------------
+        "media_session_cache_hits_total": Counter(
+            "ecm_media_session_cache_hits_total",
+            "Count of per-source session-cache hits (returned without an "
+            "upstream fetch). source ∈ {emby, plex, jellyfin}. "
+            "Incremented on both the fast-path hit (before lock) and the "
+            "under-lock re-check hit (another waiter populated the cache "
+            "while we waited). Does NOT count cache misses that went to "
+            "the upstream and succeeded.",
+            ["source"],
+            registry=registry,
+        ),
+        "media_session_fetch_duration_seconds": Histogram(
+            "ecm_media_session_fetch_duration_seconds",
+            "Wall time of the upstream get_sessions() HTTP call, in "
+            "seconds. source ∈ {emby, plex, jellyfin}. Cache hits are "
+            "NOT counted — this histogram tracks upstream latency only. "
+            "Recorded on every fetch attempt regardless of outcome "
+            "(success or exception); the _count gives total fetch "
+            "attempts, the _sum gives total latency across all fetches.",
+            ["source"],
+            buckets=_HTTP_LATENCY_BUCKETS,
+            registry=registry,
+        ),
+        "media_session_fetch_errors_total": Counter(
+            "ecm_media_session_fetch_errors_total",
+            "Count of upstream session-fetch failures (exception raised "
+            "by the upstream client). source ∈ {emby, plex, jellyfin}. "
+            "Incremented on every exception from get_sessions(), "
+            "regardless of whether a stale cache exists to fall back on. "
+            "Alert rule MediaSessionFetchErrorsSustained fires when this "
+            "counter has a non-zero rate for > 10m (warn-only, SLO-8 "
+            "posture — attribution is best-effort).",
+            ["source"],
+            registry=registry,
+        ),
+        "media_session_stale_fallback_total": Counter(
+            "ecm_media_session_stale_fallback_total",
+            "Count of stale-cache returns after an upstream fetch failure. "
+            "source ∈ {emby, plex, jellyfin}. Incremented when "
+            "fetch_errors_total fires AND a prior cache entry exists to "
+            "return. A non-zero rate means ECM is serving stale session "
+            "data to resolvers; attribution quality degrades but does not "
+            "go dark (the stale entry is still returned). Alert rule "
+            "MediaSessionStaleFallbackRising fires when rate > 0.01 for "
+            "> 30m (warn-only, SLO-8 posture).",
+            ["source"],
+            registry=registry,
+        ),
+        "user_attribution_resolved_total": Counter(
+            "ecm_user_attribution_resolved_total",
+            "Count of successful user-attribution resolutions per source. "
+            "source ∈ {emby, plex, jellyfin}. Incremented by the "
+            "resolver when the ECM session IP matches the source server IP "
+            "AND a session match is found across the three match tiers. "
+            "The IP-short-circuit case (session is not from this source's "
+            "server) is NOT counted. Numerator of the attribution quality "
+            "SLI: resolved / (resolved + unresolved).",
+            ["source"],
+            registry=registry,
+        ),
+        "user_attribution_unresolved_total": Counter(
+            "ecm_user_attribution_unresolved_total",
+            "Count of attribution failures for sessions whose IP matched "
+            "the source server but no session match was found. "
+            "source ∈ {emby, plex, jellyfin}. Incremented when the IP "
+            "matches the configured source server but the three-tier "
+            "session-match loop returns empty. Does NOT increment on "
+            "IP-short-circuit (session is not from this source). "
+            "Denominator complement: resolved / (resolved + unresolved) "
+            "is the attribution quality SLI.",
+            ["source"],
+            registry=registry,
+        ),
     }
 
 

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0039"
+APP_VERSION = "0.17.1-0041"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/services/emby_cache.py
+++ b/backend/services/emby_cache.py
@@ -49,6 +49,7 @@ from dataclasses import dataclass
 
 from config import get_settings
 from emby_client import EmbyClient, EmbyClientError, EmbySession
+import observability
 
 logger = logging.getLogger(__name__)
 
@@ -187,6 +188,7 @@ async def get_cached_emby_sessions() -> list[EmbySession]:
                 "[EMBY] Cache hit for %s (age=%.2fs, ttl=%.1fs)",
                 CACHE_KEY, age, CACHE_TTL_SECONDS,
             )
+            observability.get_metric("media_session_cache_hits_total").labels(source="emby").inc()
             return entry.sessions
 
     # Cache miss path. Acquire the lock so concurrent misses collapse to
@@ -208,19 +210,22 @@ async def get_cached_emby_sessions() -> list[EmbySession]:
                     "another waiter populated it",
                     CACHE_KEY,
                 )
+                observability.get_metric("media_session_cache_hits_total").labels(source="emby").inc()
                 return entry.sessions
 
         # Holder of the lock — do the upstream fetch.
         client = EmbyClient(base_url=emby_base_url, api_key=emby_api_key)
         try:
             try:
-                sessions = await client.get_sessions()
+                with observability.get_metric("media_session_fetch_duration_seconds").labels(source="emby").time():
+                    sessions = await client.get_sessions()
             finally:
                 # Always release the httpx connection pool even on
                 # error. Without this every failure leaks a socket pool
                 # for the lifetime of the process.
                 await client.close()
         except EmbyClientError as exc:
+            observability.get_metric("media_session_fetch_errors_total").labels(source="emby").inc()
             # Stale-fallback decision branches on whether a prior cache
             # value exists. Re-read ``_cached_entry`` here (not the
             # ``entry`` local from above) so we see the latest module
@@ -233,6 +238,7 @@ async def get_cached_emby_sessions() -> list[EmbySession]:
                     exc,
                     time.monotonic() - _cached_entry.cached_at,
                 )
+                observability.get_metric("media_session_stale_fallback_total").labels(source="emby").inc()
                 return _cached_entry.sessions
             logger.warning(
                 "[EMBY] Fetch failed with no prior cache (%s); "

--- a/backend/services/emby_resolver.py
+++ b/backend/services/emby_resolver.py
@@ -67,6 +67,7 @@ from rapidfuzz import fuzz
 from config import get_settings
 from emby_client import EmbySession
 from services.emby_cache import get_cached_emby_sessions
+import observability
 
 logger = logging.getLogger(__name__)
 
@@ -249,6 +250,7 @@ async def resolve_emby_user(
             ecm_stream_name, ecm_channel_name, ecm_channel_number,
             len(sessions),
         )
+        observability.get_metric("user_attribution_unresolved_total").labels(source="emby").inc()
         return None
 
     winner = _tiebreak_most_recent(matches)
@@ -267,6 +269,7 @@ async def resolve_emby_user(
             "[EMBY] Resolved stream=%r → user=%s (uid=%s) from 1 match",
             ecm_stream_name, winner.user_name, winner.user_id,
         )
+    observability.get_metric("user_attribution_resolved_total").labels(source="emby").inc()
     return EmbyAttribution(user_id=winner.user_id, user_name=winner.user_name)
 
 

--- a/backend/services/jellyfin_cache.py
+++ b/backend/services/jellyfin_cache.py
@@ -46,6 +46,7 @@ from dataclasses import dataclass
 
 from config import get_settings
 from jellyfin_client import JellyfinClient, JellyfinClientError, JellyfinSession
+import observability
 
 logger = logging.getLogger(__name__)
 
@@ -179,6 +180,7 @@ async def get_cached_jellyfin_sessions() -> list[JellyfinSession]:
                 "[JELLYFIN] Cache hit for %s (age=%.2fs, ttl=%.1fs)",
                 CACHE_KEY, age, CACHE_TTL_SECONDS,
             )
+            observability.get_metric("media_session_cache_hits_total").labels(source="jellyfin").inc()
             return entry.sessions
 
     # Cache miss path. Acquire the lock so concurrent misses collapse to
@@ -200,19 +202,22 @@ async def get_cached_jellyfin_sessions() -> list[JellyfinSession]:
                     "another waiter populated it",
                     CACHE_KEY,
                 )
+                observability.get_metric("media_session_cache_hits_total").labels(source="jellyfin").inc()
                 return entry.sessions
 
         # Holder of the lock — do the upstream fetch.
         client = JellyfinClient(base_url=jellyfin_base_url, api_key=jellyfin_api_key)
         try:
             try:
-                sessions = await client.get_sessions()
+                with observability.get_metric("media_session_fetch_duration_seconds").labels(source="jellyfin").time():
+                    sessions = await client.get_sessions()
             finally:
                 # Always release the httpx connection pool even on
                 # error. Without this every failure leaks a socket pool
                 # for the lifetime of the process.
                 await client.close()
         except JellyfinClientError as exc:
+            observability.get_metric("media_session_fetch_errors_total").labels(source="jellyfin").inc()
             # Stale-fallback decision branches on whether a prior cache
             # value exists.
             if _cached_entry is not None:
@@ -222,6 +227,7 @@ async def get_cached_jellyfin_sessions() -> list[JellyfinSession]:
                     exc,
                     time.monotonic() - _cached_entry.cached_at,
                 )
+                observability.get_metric("media_session_stale_fallback_total").labels(source="jellyfin").inc()
                 return _cached_entry.sessions
             logger.warning(
                 "[JELLYFIN] Fetch failed with no prior cache (%s); "

--- a/backend/services/jellyfin_resolver.py
+++ b/backend/services/jellyfin_resolver.py
@@ -75,6 +75,7 @@ from rapidfuzz import fuzz
 from config import get_settings
 from jellyfin_client import JellyfinSession
 from services.jellyfin_cache import get_cached_jellyfin_sessions
+import observability
 
 logger = logging.getLogger(__name__)
 
@@ -229,6 +230,7 @@ async def resolve_jellyfin_user(
             ecm_stream_name, ecm_channel_name, ecm_channel_number,
             len(sessions),
         )
+        observability.get_metric("user_attribution_unresolved_total").labels(source="jellyfin").inc()
         return None
 
     winner = _tiebreak_most_recent(matches)
@@ -252,6 +254,7 @@ async def resolve_jellyfin_user(
             "[JELLYFIN] Resolved stream=%r → user=%s (uid=%s) from 1 match",
             ecm_stream_name, winner.user_name, winner.user_id,
         )
+    observability.get_metric("user_attribution_resolved_total").labels(source="jellyfin").inc()
     return JellyfinAttribution(user_id=winner.user_id, user_name=winner.user_name)
 
 

--- a/backend/services/plex_cache.py
+++ b/backend/services/plex_cache.py
@@ -51,6 +51,7 @@ from dataclasses import dataclass
 
 from config import get_settings
 from plex_client import PlexClient, PlexClientError, PlexSession
+import observability
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +185,7 @@ async def get_cached_plex_sessions() -> list[PlexSession]:
                 "[PLEX] Cache hit for %s (age=%.2fs, ttl=%.1fs)",
                 CACHE_KEY, age, CACHE_TTL_SECONDS,
             )
+            observability.get_metric("media_session_cache_hits_total").labels(source="plex").inc()
             return entry.sessions
 
     # Cache miss path. Acquire the lock so concurrent misses collapse to
@@ -205,19 +207,22 @@ async def get_cached_plex_sessions() -> list[PlexSession]:
                     "another waiter populated it",
                     CACHE_KEY,
                 )
+                observability.get_metric("media_session_cache_hits_total").labels(source="plex").inc()
                 return entry.sessions
 
         # Holder of the lock — do the upstream fetch.
         client = PlexClient(base_url=plex_base_url, api_key=plex_token)
         try:
             try:
-                sessions = await client.get_sessions()
+                with observability.get_metric("media_session_fetch_duration_seconds").labels(source="plex").time():
+                    sessions = await client.get_sessions()
             finally:
                 # Always release the httpx connection pool even on
                 # error. Without this every failure leaks a socket pool
                 # for the lifetime of the process.
                 await client.close()
         except PlexClientError as exc:
+            observability.get_metric("media_session_fetch_errors_total").labels(source="plex").inc()
             # Stale-fallback decision branches on whether a prior cache
             # value exists. Re-read ``_cached_entry`` here (not the
             # ``entry`` local from above) so we see the latest module
@@ -230,6 +235,7 @@ async def get_cached_plex_sessions() -> list[PlexSession]:
                     exc,
                     time.monotonic() - _cached_entry.cached_at,
                 )
+                observability.get_metric("media_session_stale_fallback_total").labels(source="plex").inc()
                 return _cached_entry.sessions
             logger.warning(
                 "[PLEX] Fetch failed with no prior cache (%s); "

--- a/backend/services/plex_resolver.py
+++ b/backend/services/plex_resolver.py
@@ -67,6 +67,7 @@ from rapidfuzz import fuzz
 from config import get_settings
 from plex_client import PlexSession
 from services.plex_cache import get_cached_plex_sessions
+import observability
 
 logger = logging.getLogger(__name__)
 
@@ -246,6 +247,7 @@ async def _resolve_plex_user_inner(
             ecm_stream_name, ecm_channel_name, ecm_channel_number,
             len(sessions),
         )
+        observability.get_metric("user_attribution_unresolved_total").labels(source="plex").inc()
         return None
 
     winner = _tiebreak_most_recent(matches)
@@ -263,6 +265,7 @@ async def _resolve_plex_user_inner(
             "[PLEX] Resolved stream=%r → user=%s from 1 match",
             ecm_stream_name, winner.user_name,
         )
+    observability.get_metric("user_attribution_resolved_total").labels(source="plex").inc()
     return winner.user_name
 
 

--- a/backend/tests/services/test_emby_cache.py
+++ b/backend/tests/services/test_emby_cache.py
@@ -27,6 +27,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import observability
 from emby_client import EmbyClientError, EmbySession
 from services import emby_cache
 
@@ -72,8 +73,42 @@ def reset_cache_state():
     test cannot corrupt the next one's setup.
     """
     emby_cache._reset_for_tests()
+    observability.reset_for_tests()
+    observability.install_metrics()
     yield
     emby_cache._reset_for_tests()
+    observability.reset_for_tests()
+
+
+def _get_counter_value(metric_key: str, source: str) -> float:
+    """Return the current value of a labeled counter from the live registry.
+
+    ``metric_key`` is the key in observability._METRICS (e.g.
+    ``"media_session_cache_hits_total"``). The prometheus metric name is
+    ``"ecm_" + metric_key``.
+    """
+    metric = observability.get_metric(metric_key)
+    prom_name = f"ecm_{metric_key}"
+    for mf in metric.collect():
+        for sample in mf.samples:
+            if sample.name == prom_name and sample.labels.get("source") == source:
+                return sample.value
+    return 0.0
+
+
+def _get_histogram_count(metric_key: str, source: str) -> float:
+    """Return the _count value of a labeled histogram from the live registry.
+
+    ``metric_key`` is the key in observability._METRICS (e.g.
+    ``"media_session_fetch_duration_seconds"``).
+    """
+    metric = observability.get_metric(metric_key)
+    prom_count_name = f"ecm_{metric_key}_count"
+    for mf in metric.collect():
+        for sample in mf.samples:
+            if sample.name == prom_count_name and sample.labels.get("source") == source:
+                return sample.value
+    return 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +153,21 @@ class TestCacheHitAndMiss:
         # Exactly one client constructed and one fetch fired across two calls.
         assert client_cls.call_count == 1
         mock_client.get_sessions.assert_awaited_once()
+        # The second call was a cache hit — counter must be 1.
+        assert _get_counter_value("media_session_cache_hits_total", "emby") == 1.0
+
+    async def test_first_call_records_fetch_duration(self):
+        """Cache miss path records exactly one histogram observation."""
+        session = _make_session()
+        mock_client = AsyncMock()
+        mock_client.get_sessions = AsyncMock(return_value=[session])
+        mock_client.close = AsyncMock()
+
+        with patch.object(emby_cache, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_cache, "EmbyClient", return_value=mock_client):
+            await emby_cache.get_cached_emby_sessions()
+
+        assert _get_histogram_count("media_session_fetch_duration_seconds", "emby") >= 1.0
 
     async def test_call_after_ttl_expiry_refetches(self):
         """After the TTL elapses, the next call hits Emby again.
@@ -190,6 +240,9 @@ class TestStaleFallback:
         # is being returned so operators can correlate.
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert any("stale" in r.getMessage().lower() for r in warnings), warnings
+        # Metric assertions: fetch error and stale fallback both incremented.
+        assert _get_counter_value("media_session_fetch_errors_total", "emby") == 1.0
+        assert _get_counter_value("media_session_stale_fallback_total", "emby") == 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -219,6 +272,9 @@ class TestColdStartFailure:
         # [EMBY] prefix convention (logger name is module name; the
         # [EMBY] text appears in the formatted message body).
         assert any("no prior cache" in r.getMessage().lower() for r in warnings), warnings
+        # Metric assertion: fetch error incremented; stale fallback NOT (no prior cache).
+        assert _get_counter_value("media_session_fetch_errors_total", "emby") == 1.0
+        assert _get_counter_value("media_session_stale_fallback_total", "emby") == 0.0
 
     async def test_cold_start_failure_does_not_populate_cache(self):
         """A failed cold-start fetch must not poison the cache with [].

--- a/backend/tests/services/test_emby_resolver.py
+++ b/backend/tests/services/test_emby_resolver.py
@@ -37,6 +37,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import observability
 from emby_client import EmbySession
 from services import emby_resolver
 
@@ -96,8 +97,27 @@ def reset_resolver_state():
     both pre- and post-test so a failing assertion cannot leak state.
     """
     emby_resolver._reset_for_tests()
+    observability.reset_for_tests()
+    observability.install_metrics()
     yield
     emby_resolver._reset_for_tests()
+    observability.reset_for_tests()
+
+
+def _get_counter_value(metric_key: str, source: str) -> float:
+    """Return the current value of a labeled counter from the live registry.
+
+    ``metric_key`` is the key in observability._METRICS (e.g.
+    ``"user_attribution_resolved_total"``). The prometheus metric name is
+    ``"ecm_" + metric_key``.
+    """
+    metric = observability.get_metric(metric_key)
+    prom_name = f"ecm_{metric_key}"
+    for mf in metric.collect():
+        for sample in mf.samples:
+            if sample.name == prom_name and sample.labels.get("source") == source:
+                return sample.value
+    return 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -145,6 +165,9 @@ class TestExactMatch:
                 ecm_stream_name="CNN HD",
             )
         assert result == emby_resolver.EmbyAttribution(user_id="uid-bob", user_name="bob")
+        # Metric assertion: resolved counter incremented; unresolved is zero.
+        assert _get_counter_value("user_attribution_resolved_total", "emby") == 1.0
+        assert _get_counter_value("user_attribution_unresolved_total", "emby") == 0.0
 
     async def test_case_insensitive_match(self):
         """Case differences do not prevent an exact match — "cnn" matches "CNN"."""
@@ -214,6 +237,9 @@ class TestFuzzyMatch:
                 ecm_stream_name="CNN HD",
             )
         assert result is None
+        # IP matched but no session matched — unresolved counter incremented.
+        assert _get_counter_value("user_attribution_unresolved_total", "emby") == 1.0
+        assert _get_counter_value("user_attribution_resolved_total", "emby") == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_jellyfin_cache.py
+++ b/backend/tests/services/test_jellyfin_cache.py
@@ -27,6 +27,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import observability
 from jellyfin_client import JellyfinClientError, JellyfinSession
 from services import jellyfin_cache
 
@@ -62,8 +63,42 @@ def _make_jellyfin_enabled_settings(base_url: str = "http://jellyfin.example") -
 def reset_cache_state():
     """Ensure each test starts with a clean module-level cache."""
     jellyfin_cache._reset_for_tests()
+    observability.reset_for_tests()
+    observability.install_metrics()
     yield
     jellyfin_cache._reset_for_tests()
+    observability.reset_for_tests()
+
+
+def _get_counter_value(metric_key: str, source: str) -> float:
+    """Return the current value of a labeled counter from the live registry.
+
+    ``metric_key`` is the key in observability._METRICS (e.g.
+    ``"media_session_cache_hits_total"``). The prometheus metric name is
+    ``"ecm_" + metric_key``.
+    """
+    metric = observability.get_metric(metric_key)
+    prom_name = f"ecm_{metric_key}"
+    for mf in metric.collect():
+        for sample in mf.samples:
+            if sample.name == prom_name and sample.labels.get("source") == source:
+                return sample.value
+    return 0.0
+
+
+def _get_histogram_count(metric_key: str, source: str) -> float:
+    """Return the _count value of a labeled histogram from the live registry.
+
+    ``metric_key`` is the key in observability._METRICS (e.g.
+    ``"media_session_fetch_duration_seconds"``).
+    """
+    metric = observability.get_metric(metric_key)
+    prom_count_name = f"ecm_{metric_key}_count"
+    for mf in metric.collect():
+        for sample in mf.samples:
+            if sample.name == prom_count_name and sample.labels.get("source") == source:
+                return sample.value
+    return 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -106,6 +141,21 @@ class TestCacheHitAndMiss:
         assert second == [session]
         assert client_cls.call_count == 1
         mock_client.get_sessions.assert_awaited_once()
+        # The second call was a cache hit — counter must be 1.
+        assert _get_counter_value("media_session_cache_hits_total", "jellyfin") == 1.0
+
+    async def test_first_call_records_fetch_duration(self):
+        """Cache miss path records exactly one histogram observation."""
+        session = _make_session()
+        mock_client = AsyncMock()
+        mock_client.get_sessions = AsyncMock(return_value=[session])
+        mock_client.close = AsyncMock()
+
+        with patch.object(jellyfin_cache, "get_settings", return_value=_make_jellyfin_enabled_settings()), \
+             patch.object(jellyfin_cache, "JellyfinClient", return_value=mock_client):
+            await jellyfin_cache.get_cached_jellyfin_sessions()
+
+        assert _get_histogram_count("media_session_fetch_duration_seconds", "jellyfin") >= 1.0
 
     async def test_call_after_ttl_expiry_refetches(self):
         """After the TTL elapses, the next call hits Jellyfin again.
@@ -170,6 +220,9 @@ class TestStaleFallback:
         assert second == [session]
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert any("stale" in r.getMessage().lower() for r in warnings), warnings
+        # Metric assertions: fetch error and stale fallback both incremented.
+        assert _get_counter_value("media_session_fetch_errors_total", "jellyfin") == 1.0
+        assert _get_counter_value("media_session_stale_fallback_total", "jellyfin") == 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +248,9 @@ class TestColdStartFailure:
         assert result == []
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert any("no prior cache" in r.getMessage().lower() for r in warnings), warnings
+        # Metric assertion: fetch error incremented; stale fallback NOT (no prior cache).
+        assert _get_counter_value("media_session_fetch_errors_total", "jellyfin") == 1.0
+        assert _get_counter_value("media_session_stale_fallback_total", "jellyfin") == 0.0
 
     async def test_cold_start_failure_does_not_populate_cache(self):
         """A failed cold-start fetch must not poison the cache with []."""

--- a/backend/tests/services/test_jellyfin_resolver.py
+++ b/backend/tests/services/test_jellyfin_resolver.py
@@ -36,6 +36,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import observability
 from jellyfin_client import JellyfinSession
 from services import jellyfin_resolver
 
@@ -84,8 +85,27 @@ def _enabled_settings(base_url: str = "http://192.168.1.20:8096") -> MagicMock:
 def reset_resolver_state():
     """Reset the module-level DNS cache and warn timestamp around every test."""
     jellyfin_resolver._reset_for_tests()
+    observability.reset_for_tests()
+    observability.install_metrics()
     yield
     jellyfin_resolver._reset_for_tests()
+    observability.reset_for_tests()
+
+
+def _get_counter_value(metric_key: str, source: str) -> float:
+    """Return the current value of a labeled counter from the live registry.
+
+    ``metric_key`` is the key in observability._METRICS (e.g.
+    ``"user_attribution_resolved_total"``). The prometheus metric name is
+    ``"ecm_" + metric_key``.
+    """
+    metric = observability.get_metric(metric_key)
+    prom_name = f"ecm_{metric_key}"
+    for mf in metric.collect():
+        for sample in mf.samples:
+            if sample.name == prom_name and sample.labels.get("source") == source:
+                return sample.value
+    return 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -145,6 +165,9 @@ class TestNoPipeSuffixTolerance:
         assert result == jellyfin_resolver.JellyfinAttribution(
             user_id="jf-uid-mw", user_name="MotWakorb",
         )
+        # Metric assertion: resolved counter incremented; unresolved is zero.
+        assert _get_counter_value("user_attribution_resolved_total", "jellyfin") == 1.0
+        assert _get_counter_value("user_attribution_unresolved_total", "jellyfin") == 0.0
 
     async def test_pipe_format_also_works(self):
         """Jellyfin installs that DO use the pipe format (e.g. Emby-migrated
@@ -199,6 +222,9 @@ class TestNoPipeSuffixTolerance:
                 ecm_channel_name="CNN",
             )
         assert result is None
+        # IP matched but no session matched — unresolved counter incremented.
+        assert _get_counter_value("user_attribution_unresolved_total", "jellyfin") == 1.0
+        assert _get_counter_value("user_attribution_resolved_total", "jellyfin") == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_plex_cache.py
+++ b/backend/tests/services/test_plex_cache.py
@@ -28,6 +28,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import observability
 from plex_client import PlexClientError, PlexSession
 from services import plex_cache
 
@@ -66,8 +67,42 @@ def reset_cache_state():
     into the next test and produce false cache-hit assertions.
     """
     plex_cache._reset_for_tests()
+    observability.reset_for_tests()
+    observability.install_metrics()
     yield
     plex_cache._reset_for_tests()
+    observability.reset_for_tests()
+
+
+def _get_counter_value(metric_key: str, source: str) -> float:
+    """Return the current value of a labeled counter from the live registry.
+
+    ``metric_key`` is the key in observability._METRICS (e.g.
+    ``"media_session_cache_hits_total"``). The prometheus metric name is
+    ``"ecm_" + metric_key``.
+    """
+    metric = observability.get_metric(metric_key)
+    prom_name = f"ecm_{metric_key}"
+    for mf in metric.collect():
+        for sample in mf.samples:
+            if sample.name == prom_name and sample.labels.get("source") == source:
+                return sample.value
+    return 0.0
+
+
+def _get_histogram_count(metric_key: str, source: str) -> float:
+    """Return the _count value of a labeled histogram from the live registry.
+
+    ``metric_key`` is the key in observability._METRICS (e.g.
+    ``"media_session_fetch_duration_seconds"``).
+    """
+    metric = observability.get_metric(metric_key)
+    prom_count_name = f"ecm_{metric_key}_count"
+    for mf in metric.collect():
+        for sample in mf.samples:
+            if sample.name == prom_count_name and sample.labels.get("source") == source:
+                return sample.value
+    return 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +147,21 @@ class TestCacheHitAndMiss:
         # Exactly one client constructed and one fetch fired across two calls.
         assert client_cls.call_count == 1
         mock_client.get_sessions.assert_awaited_once()
+        # The second call was a cache hit — counter must be 1.
+        assert _get_counter_value("media_session_cache_hits_total", "plex") == 1.0
+
+    async def test_first_call_records_fetch_duration(self):
+        """Cache miss path records exactly one histogram observation."""
+        session = _make_session()
+        mock_client = AsyncMock()
+        mock_client.get_sessions = AsyncMock(return_value=[session])
+        mock_client.close = AsyncMock()
+
+        with patch.object(plex_cache, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_cache, "PlexClient", return_value=mock_client):
+            await plex_cache.get_cached_plex_sessions()
+
+        assert _get_histogram_count("media_session_fetch_duration_seconds", "plex") >= 1.0
 
     async def test_call_after_ttl_expiry_refetches(self):
         """After the TTL elapses, the next call hits Plex again.
@@ -177,6 +227,9 @@ class TestStaleFallback:
         assert second == [session]
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert any("stale" in r.getMessage().lower() for r in warnings), warnings
+        # Metric assertions: fetch error and stale fallback both incremented.
+        assert _get_counter_value("media_session_fetch_errors_total", "plex") == 1.0
+        assert _get_counter_value("media_session_stale_fallback_total", "plex") == 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -202,6 +255,9 @@ class TestColdStartFailure:
         assert result == []
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert any("no prior cache" in r.getMessage().lower() for r in warnings), warnings
+        # Metric assertion: fetch error incremented; stale fallback NOT (no prior cache).
+        assert _get_counter_value("media_session_fetch_errors_total", "plex") == 1.0
+        assert _get_counter_value("media_session_stale_fallback_total", "plex") == 0.0
 
     async def test_cold_start_failure_does_not_populate_cache(self):
         """A failed cold-start fetch must not poison the cache with [].

--- a/backend/tests/services/test_plex_resolver.py
+++ b/backend/tests/services/test_plex_resolver.py
@@ -34,6 +34,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import observability
 from plex_client import PlexSession
 from services import plex_resolver
 
@@ -90,8 +91,27 @@ def _enabled_settings(base_url: str = "http://192.168.1.20:32400") -> MagicMock:
 def reset_resolver_state():
     """Reset the module-level DNS cache around every test."""
     plex_resolver._reset_for_tests()
+    observability.reset_for_tests()
+    observability.install_metrics()
     yield
     plex_resolver._reset_for_tests()
+    observability.reset_for_tests()
+
+
+def _get_counter_value(metric_key: str, source: str) -> float:
+    """Return the current value of a labeled counter from the live registry.
+
+    ``metric_key`` is the key in observability._METRICS (e.g.
+    ``"user_attribution_resolved_total"``). The prometheus metric name is
+    ``"ecm_" + metric_key``.
+    """
+    metric = observability.get_metric(metric_key)
+    prom_name = f"ecm_{metric_key}"
+    for mf in metric.collect():
+        for sample in mf.samples:
+            if sample.name == prom_name and sample.labels.get("source") == source:
+                return sample.value
+    return 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -152,6 +172,9 @@ class TestTier1ChannelNameMatch:
                 ecm_channel_number=408,
             )
         assert result == "MotWakorb"
+        # Metric assertion: resolved counter incremented; unresolved is zero.
+        assert _get_counter_value("user_attribution_resolved_total", "plex") == 1.0
+        assert _get_counter_value("user_attribution_unresolved_total", "plex") == 0.0
 
     async def test_channel_name_matches_whole_name_without_prefix(self):
         """item_name is just "ESPN" (no pipe prefix) — whole-string match."""
@@ -359,6 +382,9 @@ class TestNoMatch:
                 ecm_stream_name="CNN HD",
             )
         assert result is None
+        # IP matched but no session matched — unresolved counter incremented.
+        assert _get_counter_value("user_attribution_unresolved_total", "plex") == 1.0
+        assert _get_counter_value("user_attribution_resolved_total", "plex") == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/docs/sre/prometheus_rules.yaml
+++ b/docs/sre/prometheus_rules.yaml
@@ -1070,3 +1070,34 @@ groups:
             on-call. The runbook covers the half-merge recovery
             procedure and the half-state diagnostic query.
           runbook_url: docs/runbooks/dedup-merge-api-error-rate-high.md
+
+  # =====================================================================
+  # Media-session attribution observability (bd-r5f0c.6)
+  #
+  # Warn-only, no paging — attribution is best-effort (SLO-8 posture).
+  # These alerts surface degraded upstream connectivity so operators can
+  # investigate without being woken up. A source that is down for > 10m
+  # means attribution for that source is dark; > 30m stale-fallback
+  # means the operator's "who is watching" picture is stale.
+  # =====================================================================
+  - name: ecm_media_session_attribution
+    rules:
+      - alert: MediaSessionFetchErrorsSustained
+        expr: rate(ecm_media_session_fetch_errors_total[5m]) > 0
+        for: 10m
+        labels:
+          severity: warning
+          service: ecm
+        annotations:
+          summary: "Upstream {{ $labels.source }} session fetch failing sustained 10m"
+          description: "ECM has been unable to fetch sessions from {{ $labels.source }} for over 10 minutes. User attribution for this source is degraded."
+
+      - alert: MediaSessionStaleFallbackRising
+        expr: rate(ecm_media_session_stale_fallback_total[10m]) > 0.01
+        for: 30m
+        labels:
+          severity: warning
+          service: ecm
+        annotations:
+          summary: "{{ $labels.source }} session cache serving stale entries sustained 30m"
+          description: "ECM is serving stale {{ $labels.source }} session data because the upstream has been failing. Check upstream connectivity."

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0039",
+  "version": "0.17.1-0041",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Six new Prometheus metrics with `{source}` label (emby/plex/jellyfin) covering the attribution hot path — cache hits, fetch duration, fetch errors, stale fallback, resolved, and unresolved
- Instrumentation folded into existing emby/plex/jellyfin cache and resolver modules (no new files)
- Two warn-only alert rules added to `docs/sre/prometheus_rules.yaml` (no paging — matches SLO-8 best-effort posture for attribution)

## Test plan
- [x] Cache tests green with metric assertions folded in (40 tests)
- [x] Resolver tests green with resolved/unresolved counter assertions (83 tests)
- [x] Full backend suite green (4209 passed, 1 skipped)
- [x] Prometheus rule validation: `promtool` not installed locally; CI yamllint/Semgrep will validate

## Notes
- Part E (dashboard panels) skipped: no `monitoring/grafana/` JSON in repo; metrics are exposed and Grafana UI can build panels
- Cache structural divergence: Plex and Jellyfin cache modules are byte-identical in structure to each other and to the Emby cache — no divergence observed; instrumentation applied uniformly

Closes bd-r5f0c.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)