### PR TITLE
v0.17.1-0045: integrations docs + multi-viewer API/architecture docs (bd-r5f0c.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Bulk channel merge: pre-validate source IDs to return 422 instead of silently producing DELETE 404 noise on stale rows (bd-ozhkf — follow-up to bd-ct9wl).** The `bulk_merge_channels` endpoint had the same bare-`except` footgun as the single-channel `merge_channels` endpoint before bd-ct9wl: a `get_channel` 404 was swallowed and execution fell through to `delete_channel`, generating `[DISPATCHARR] API request failed: DELETE 404` log noise for every stale source ID. The fix mirrors the bd-ct9wl pattern exactly: catch `httpx.HTTPStatusError` with `status_code == 404`, collect missing IDs, raise HTTP 422 with the same detail string (`"Source channels [...] no longer exist — refresh the channels list and try again"`) before any mutations. Two regression tests in `TestBulkMergeChannelsStaleSourceIds` assert the 422 path and that `delete_channel` is not called on stale IDs.
 - **Channel merge UX: surface backend 422 detail to operator instead of swallowing into generic "Merge failed" error (bd-7j6v1 — follow-up to bd-ct9wl).** The `httpClient.ts` `fetchJson` function already extracts the FastAPI `detail` field from non-2xx responses and throws it as `HttpError.message`, so `MergeChannelsModal` and `FindDuplicatesModal` already propagate the 422 detail string to the error banner through their `setError` catch handlers — no code change required. Added regression tests to lock this contract: `MergeChannelsModal.test.tsx` and `FindDuplicatesModal.test.tsx` each assert 422 detail renders verbatim in the error banner, a non-422 `HttpError` renders its message, and a non-`Error` thrown value falls back to the generic copy.
 
+- **Plex user attribution (bd-r5f0c.2/r5f0c.4).** Connected Clients and User Stats now show Plex usernames for sessions routed through a Plex Media Server. Configure under Settings → Integrations → Plex Integration. Uses a server-local Plex token (not a plex.tv account token) scoped to a single server.
+- **Jellyfin user attribution (bd-r5f0c.3/r5f0c.4).** Connected Clients and User Stats now show Jellyfin usernames for sessions routed through a Jellyfin server. Configure under Settings → Integrations → Jellyfin Integration.
+- **Multi-viewer attribution display (bd-r5f0c.9).** When multiple users watch the same channel through the same media server simultaneously, all their names are listed in Connected Clients. The previous behaviour surfaced only the most-recent user's name; the new `*_viewers` JSON arrays capture every concurrent viewer. The legacy `*_user_name` singular fields remain for back-compat.
+- **`AttributionBadge` UI component (bd-r5f0c.5).** Renders "via Emby" / "via Plex" / "via Jellyfin" badges in the Connected Clients list, keying on the `attribution_source` field in the stats API response.
+- **Operator integrations documentation (bd-r5f0c.7).** `docs/user_guide/integrations/index.md` — side-by-side setup guide for all three media-server integrations, including Plex server-local token guidance, multi-viewer behaviour, privacy posture, and troubleshooting. Partially addresses bd-jn30g (Emby docs gap).
+
+### Security
+
+- **SSRF mitigation on test-connection endpoints (bd-r5f0c.4).** `POST /api/settings/test_emby_connection`, `POST /api/settings/test_plex_connection`, and `POST /api/settings/test_jellyfin_connection` now apply a scheme allowlist (`http`, `https`) and reconstruct URLs using netloc-only (no path interpolation), preventing SSRF via operator-supplied base URLs.
+
+### Changed
+
+- **`_resolve_emby_attributions` → `_resolve_attributions` (bd-r5f0c.4).** Multi-source `asyncio.gather` replacing the Emby-only implementation. The old name is preserved as an alias.
+- **`_enrich_channels_with_emby` → `_enrich_channels_with_attribution` (bd-r5f0c.4).** The Active Channels endpoint now calls the unified multi-source helper. Legacy alias `_enrich_channels_with_emby` preserved for any external callers.
+
 ## [0.17.0] — 2026-05-16
 
 ### Added

--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0043",
+    version="0.17.1-0045",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0043"
+APP_VERSION = "0.17.1-0045"
 
 REDACTED = "***REDACTED***"
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -441,6 +441,24 @@ curl -X POST "http://localhost:6100/api/channel-merges/42/dismiss" \
 | `GET /api/stats/unique-viewers-by-channel` | Get unique viewers per channel |
 | `GET /api/stats/watch-history` | Get watch history log (paginated, filterable by channel/IP/days, includes user attribution) |
 
+**Per-channel attribution fields**:
+
+Each channel object — and each entry in `channel.clients[]` — carries
+per-source attribution fields when an integration is enabled and the
+session matches:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `emby_viewers` | `[{user_id, user_name}] \| null` | All Emby users watching this channel via this client. Null if Emby integration disabled or no match. |
+| `plex_viewers` | `[{user_id, user_name}] \| null` | All Plex users watching this channel via this client. Null if Plex integration disabled or no match. |
+| `jellyfin_viewers` | `[{user_id, user_name}] \| null` | All Jellyfin users watching this channel via this client. Null if Jellyfin integration disabled or no match. |
+| `emby_user_name` | `string \| null` | The most-recent Emby user's name. Provided for back-compat; prefer `emby_viewers`. |
+| `plex_user_name` | `string \| null` | Most-recent Plex user. Prefer `plex_viewers`. |
+| `jellyfin_user_name` | `string \| null` | Most-recent Jellyfin user. Prefer `jellyfin_viewers`. |
+| `attribution_source` | `'emby' \| 'plex' \| 'jellyfin' \| 'dispatcharr' \| null` | The source that wins display precedence (Emby > Plex > Jellyfin > Dispatcharr). |
+
+Operator setup: see [`docs/user_guide/integrations/index.md`](user_guide/integrations/index.md).
+
 ## Popularity
 
 | Endpoint | Description |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -429,6 +429,67 @@ The rename in v0.17.1 (`api_key` → `dispatcharr_api_key`) eliminates the field
 
 **Deployment:** `ECM_URL=http://ecm:6100` (internal Docker network); shares the `/config/` volume with the ECM backend for the API key file. The key is generated in ECM's UI under *Settings → MCP Integration*.
 
+## User Attribution Pipeline
+
+On each bandwidth poll (~5s cadence), the `BandwidthTracker`
+cross-references active stream sessions against the live-sessions API of
+each configured media server (Emby, Plex, Jellyfin). For each
+`(channel, client_ip)` pair, the per-source resolver:
+
+1. Short-circuits if the client IP doesn't match the upstream media
+   server's IP — non-Emby/Plex/Jellyfin sessions bypass the resolver
+   entirely.
+2. Calls a tiered match against the cached session list: channel-name
+   match → channel-number match → fuzzy stream-name match. All sessions
+   that match across the tiers are pooled into the viewer list.
+3. Returns the viewer list sorted most-recent first.
+
+The bandwidth tracker writes the viewer list (JSON-encoded) to
+`session_telemetry.<source>_viewers`, and the most-recent viewer's name
+to the legacy `session_telemetry.<source>_user_name` column. The
+`/api/stats/channels` endpoint surfaces both; prefer the array form.
+
+Caching: each source has a 5-second TTL cache of upstream sessions with
+thundering-herd lock + stale-fallback on upstream failure. The resolver
+never raises — upstream failures degrade the row's attribution to NULL
+without affecting the telemetry write.
+
+Failure isolation: the three resolvers run via `asyncio.gather` with
+per-source 2s timeouts. A slow Plex does not stall Emby or Jellyfin
+attribution.
+
+Multi-viewer model: ECM media-server integrations are transcoding
+proxies — N upstream users share one ECM-client (the media server's
+IP). The viewer list captures all matched users; the legacy singular
+`*_user_name` column captures the most-recent for back-compat.
+
+```
+BandwidthTracker (poll ~5s)
+  ├─ _enrich_channels_with_attribution()
+  │    ├─ emby_enabled?  → services/emby_resolver.py
+  │    │    └─ resolve_emby_users(ip, stream_name, channel_name, channel_number)
+  │    │         → [{user_id, user_name}, ...] (tiered match, sorted recent-first)
+  │    ├─ plex_enabled?  → services/plex_resolver.py  (same shape)
+  │    └─ jellyfin_enabled? → services/jellyfin_resolver.py  (same shape)
+  │
+  └─ writes to session_telemetry:
+       emby_viewers     (TEXT, JSON-encoded list)
+       plex_viewers     (TEXT, JSON-encoded list)
+       jellyfin_viewers (TEXT, JSON-encoded list)
+       emby_user_name   (TEXT, legacy — most-recent viewer)
+       plex_user_name   (TEXT, legacy)
+       jellyfin_user_name (TEXT, legacy)
+
+GET /api/stats/channels  →  _enrich_channels_with_attribution (live, on-demand)
+                         →  surfaces *_viewers arrays + *_user_name fields
+                         →  attribution_source: Emby > Plex > Jellyfin > Dispatcharr
+```
+
+Operator setup: see [`docs/user_guide/integrations/index.md`](user_guide/integrations/index.md).
+API field reference: see [Enhanced Stats § Per-channel attribution fields](api.md).
+
+---
+
 ## External API Contract — Dispatcharr
 
 `backend/dispatcharr_client.py` makes **73 named calls** into Dispatcharr's HTTP API, covering **4 of Dispatcharr's 13 Django apps**. The table below maps each ECM domain to the Dispatcharr app that serves it.

--- a/docs/discord_release_notes.md
+++ b/docs/discord_release_notes.md
@@ -52,3 +52,27 @@
 - ⚡ Performance
 - 🔒 Security
 - 💥 Breaking changes
+
+---
+
+## Pending release notes (copy-paste to Discord when cutting the release)
+
+### v0.17.1
+
+```
+@here
+
+## 🚀 ECM v0.17.1
+
+**🆕 Plex + Jellyfin User Attribution + Multi-Viewer**
+• Connected Clients now shows usernames for Plex and Jellyfin streams (was: Emby only)
+• When multiple users watch the same channel through the same media server, all their names are listed (was: only the most-recent user's name)
+• Configure under Settings → Integrations → Plex Integration / Jellyfin Integration
+• No re-migration required; new columns in session_telemetry are populated as new sessions arrive
+
+**🔒 Security**
+• SSRF mitigation on test-connection endpoints for Emby, Plex, and Jellyfin (scheme allowlist + netloc-only URL reconstruction)
+
+**📝 Documentation**
+• New Integrations operator guide covering Emby, Plex, and Jellyfin side-by-side (Settings → Integrations)
+```

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -42,11 +42,18 @@ The Stats tab, including the Stats v2 features shipped in v0.17.0.
 - **[Metric glossary](stats/metric-glossary.md)** — definitions for every Stats v2 number: watch time, session count, last watched, buffer events, provider attribution, bytes delta, and bitrate.
 - **[History cutover note](stats/stats-v2-history-cutover.md)** — what happens to historical stats data at the v0.17.0 cutover; why metrics start on deploy day.
 
-### 8. [Backup & Restore](backup-restore/index.md) — Placeholder
+### 8. [Integrations](integrations/index.md) — Media Server Integrations (v0.17.1)
+
+Connect ECM to Emby, Plex, and/or Jellyfin so the Stats tab shows viewer
+usernames instead of raw IP addresses. Covers setup for all three sources,
+the Plex server-local token (vs. plex.tv account token), multi-viewer
+behaviour, and troubleshooting.
+
+### 9. [Backup & Restore](backup-restore/index.md) — Placeholder
 
 Backing up your ECM configuration and restoring it on a new install. Currently a placeholder; the v0.18.0 epic (bd-0i2vt) and the immediate import work (bd-gb5r5.3) will fill in the operator workflow.
 
-### 9. [Troubleshooting](troubleshooting/index.md) — Stub
+### 10. [Troubleshooting](troubleshooting/index.md) — Stub
 
 Common problems, how to read ECM's logs, and what to gather before asking for help.
 

--- a/docs/user_guide/integrations/index.md
+++ b/docs/user_guide/integrations/index.md
@@ -1,0 +1,96 @@
+# Media Server Integrations
+
+> **Audience:** Operator who wants to see viewer usernames (e.g., "Alice via Emby") instead of raw IP addresses in the Stats tab.
+
+ECM cross-references its bandwidth telemetry against your media server's
+live-session API to surface WHO is watching WHAT in the Stats tab. You can
+enable one or more of Emby, Plex, and Jellyfin. Each integration is
+independent — enabling one does not require the others.
+
+## Why enable an integration?
+
+Without an integration, the Stats tab Connected Clients list shows your
+viewers by IP address only (e.g., `192.168.1.42`). With an integration
+enabled, it shows usernames (e.g., `Alice via Emby`).
+
+## What you see when it's working
+
+- **Connected Clients**: each viewer-row shows a username + a "via Emby" /
+  "via Plex" / "via Jellyfin" badge. When multiple users share a channel
+  through the same media server, all their names are listed. (Example: if
+  Alice and Bob are both watching ESPN via Emby, you'll see both names on
+  the ESPN row.)
+- **User Stats panel**: per-user watch-time aggregated across whichever
+  integration attributed each session.
+
+## Setup — Emby
+
+1. In ECM: Settings → Integrations → Emby
+2. Enable the toggle
+3. Base URL: the URL of your Emby server (e.g., `http://emby:8096`)
+4. API Key: get this from your Emby Dashboard → API Keys (top-right menu) → "+" to create a new key
+5. Click "Test Connection" to verify
+6. Save
+
+## Setup — Plex
+
+1. In ECM: Settings → Integrations → Plex
+2. Enable the toggle
+3. Base URL: the URL of your Plex Media Server (e.g., `http://plex:32400`)
+4. Plex Token: **use a server-local token, NOT your plex.tv account token**.
+   The server-local token has scope limited to your specific Plex server;
+   the plex.tv account token has full account scope and is a more sensitive
+   credential. To find your server-local token:
+   - Open Plex Web (`http://plex:32400/web`)
+   - Play any item (movie, episode, channel)
+   - Right-click the playing item → "Get Info" → "View XML"
+   - In the URL bar of the XML page, look for `X-Plex-Token=...` — that's
+     your token
+   - Alternatively, see [the official Plex support article on finding tokens](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/)
+5. Click "Test Connection" to verify
+6. Save
+
+## Setup — Jellyfin
+
+1. In ECM: Settings → Integrations → Jellyfin
+2. Enable the toggle
+3. Base URL: the URL of your Jellyfin server (e.g., `http://jellyfin:8096`)
+4. API Key: get this from your Jellyfin Dashboard → API Keys → "+" to
+   create a new key
+5. Click "Test Connection" to verify
+6. Save
+
+## Known limitations
+
+**Multi-client disambiguation is best-effort.** When two viewers from the
+same source (e.g., Alice and Bob both via Emby) are watching the SAME
+channel, ECM matches by IP address and session activity timestamp. In rare
+cases involving identical channel names, identical timestamps, or
+multi-source overlap, the attribution may surface viewers in a
+non-deterministic order. The username list is accurate; the row ordering
+within the list is best-effort.
+
+## Privacy posture
+
+API keys and Plex tokens are stored plaintext in ECM's settings file. The
+container-resident settings file is operator-owned filesystem. ECM does
+not transmit these credentials anywhere except to the configured media
+server.
+
+## Troubleshooting
+
+- **"Connection refused" on Test Connection**: verify your media server is
+  reachable from the ECM container. Try `docker exec ecm-ecm-1 wget -qO- <base_url>` to confirm network reach.
+- **"Unauthorized" on Test Connection**: regenerate the API key in your
+  media server. For Plex, confirm you're using a server-local token.
+- **No usernames in Connected Clients**: confirm the integration is
+  enabled and Test Connection succeeded. The Connected Clients list
+  updates within 5 seconds of a session starting (per the session cache
+  TTL).
+
+---
+
+## Going deeper
+
+- API response fields: [`docs/api.md` — Enhanced Stats § Per-channel attribution fields](../../api.md)
+- Pipeline internals: [`docs/architecture.md` — User Attribution Pipeline](../../architecture.md)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0043",
+  "version": "0.17.1-0045",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Don't repeat the Emby-zero-docs pattern. Ships unified Integrations operator guide + API field annotations + architecture pipeline subsection + release notes for the bd-r5f0c epic.

- `docs/user_guide/integrations/index.md` (NEW) — operator setup for Emby/Plex/Jellyfin, with server-local Plex token guidance (SEC-1) and multi-viewer behavior
- `docs/api.md` — channel/client `*_viewers` array fields documented; legacy `*_user_name` back-compat noted; `attribution_source` enum documented
- `docs/architecture.md` — 'User Attribution Pipeline' subsection (poll cycle, tiered resolver, asyncio.gather failure-isolation, multi-viewer model)
- `docs/discord_release_notes.md` — v0.17.1 pending release entry
- `docs/user_guide/index.md` — Integrations entry added to section list (now section 8; Troubleshooting renumbered to 10)
- `CHANGELOG.md` — [Unreleased] Added / Security / Changed entries

## Test plan

- [x] Backend suite green: 4305 passed, 1 skipped (volume test)
- [x] No broken internal markdown links (verified manually; no link checker in CI)
- [x] Version Consistency: all three version strings bumped to `0.17.1-0045` (main.py, backup.py, package.json)
- [x] docs-only-pass CI check will pass (no backend/frontend source changes)

Closes bd-r5f0c.7. Partially addresses bd-jn30g (Emby docs gap — reassess closure post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)