### PR TITLE
feat(stats): multi-viewer UI + Plex/Jellyfin Settings + AttributionBadge (bd-r5f0c.5, v0.17.1-0044)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0046",
+    version="0.17.1-0047",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0046"
+APP_VERSION = "0.17.1-0047"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0046",
+  "version": "0.17.1-0047",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/AttributionBadge.css
+++ b/frontend/src/components/AttributionBadge.css
@@ -1,0 +1,47 @@
+/* AttributionBadge.css (bd-r5f0c.5 / W5)
+ *
+ * Mirrors .attribution-source-badge (StatsTab.css) for visual consistency.
+ * Each source variant uses a distinct icon + text — no color-only
+ * differentiation — to satisfy the a11y requirement from the bead spec.
+ */
+
+.attribution-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 10px;
+  background: var(--bg-elevated, rgba(255, 255, 255, 0.06));
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+  border: 1px solid var(--border-primary, rgba(255, 255, 255, 0.1));
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.attribution-badge__icon {
+  font-size: 12px;
+  line-height: 1;
+}
+
+.attribution-badge__text {
+  /* text is always present — no color-only differentiation */
+}
+
+/* Per-source accent colours are supplementary (icon+text are the primary
+   differentiators). Using very subtle tints so they don't overwhelm. */
+.attribution-badge--emby {
+  border-color: rgba(82, 197, 183, 0.3);
+  color: var(--text-primary, rgba(255, 255, 255, 0.9));
+}
+
+.attribution-badge--plex {
+  border-color: rgba(229, 160, 13, 0.3);
+  color: var(--text-primary, rgba(255, 255, 255, 0.9));
+}
+
+.attribution-badge--jellyfin {
+  border-color: rgba(0, 164, 220, 0.3);
+  color: var(--text-primary, rgba(255, 255, 255, 0.9));
+}

--- a/frontend/src/components/AttributionBadge.test.tsx
+++ b/frontend/src/components/AttributionBadge.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Tests for <AttributionBadge> (bd-r5f0c.5 / W5).
+ *
+ * Contracts under test:
+ *   - Each source variant renders the correct icon name.
+ *   - Each source variant renders the correct "via <Source>" text.
+ *   - Icon span has an aria-label of "Attributed via <Source>".
+ *   - The outer span carries the source-specific CSS modifier class.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AttributionBadge } from './AttributionBadge';
+
+describe('AttributionBadge', () => {
+  // --- Emby variant ---
+
+  it('renders live_tv icon for emby source', () => {
+    const { container } = render(<AttributionBadge source="emby" />);
+    const icon = container.querySelector('.attribution-badge__icon');
+    expect(icon?.textContent).toBe('live_tv');
+  });
+
+  it('renders "via Emby" text for emby source', () => {
+    render(<AttributionBadge source="emby" />);
+    expect(screen.getByText('via Emby')).toBeInTheDocument();
+  });
+
+  it('has aria-label "Attributed via Emby" on the icon span for emby source', () => {
+    const { container } = render(<AttributionBadge source="emby" />);
+    const icon = container.querySelector('.attribution-badge__icon');
+    expect(icon?.getAttribute('aria-label')).toBe('Attributed via Emby');
+  });
+
+  it('applies emby CSS modifier class for emby source', () => {
+    const { container } = render(<AttributionBadge source="emby" />);
+    expect(container.querySelector('.attribution-badge--emby')).toBeInTheDocument();
+  });
+
+  // --- Plex variant ---
+
+  it('renders smart_display icon for plex source', () => {
+    const { container } = render(<AttributionBadge source="plex" />);
+    const icon = container.querySelector('.attribution-badge__icon');
+    expect(icon?.textContent).toBe('smart_display');
+  });
+
+  it('renders "via Plex" text for plex source', () => {
+    render(<AttributionBadge source="plex" />);
+    expect(screen.getByText('via Plex')).toBeInTheDocument();
+  });
+
+  it('has aria-label "Attributed via Plex" on the icon span for plex source', () => {
+    const { container } = render(<AttributionBadge source="plex" />);
+    const icon = container.querySelector('.attribution-badge__icon');
+    expect(icon?.getAttribute('aria-label')).toBe('Attributed via Plex');
+  });
+
+  it('applies plex CSS modifier class for plex source', () => {
+    const { container } = render(<AttributionBadge source="plex" />);
+    expect(container.querySelector('.attribution-badge--plex')).toBeInTheDocument();
+  });
+
+  // --- Jellyfin variant ---
+
+  it('renders play_circle icon for jellyfin source', () => {
+    const { container } = render(<AttributionBadge source="jellyfin" />);
+    const icon = container.querySelector('.attribution-badge__icon');
+    expect(icon?.textContent).toBe('play_circle');
+  });
+
+  it('renders "via Jellyfin" text for jellyfin source', () => {
+    render(<AttributionBadge source="jellyfin" />);
+    expect(screen.getByText('via Jellyfin')).toBeInTheDocument();
+  });
+
+  it('has aria-label "Attributed via Jellyfin" on the icon span for jellyfin source', () => {
+    const { container } = render(<AttributionBadge source="jellyfin" />);
+    const icon = container.querySelector('.attribution-badge__icon');
+    expect(icon?.getAttribute('aria-label')).toBe('Attributed via Jellyfin');
+  });
+
+  it('applies jellyfin CSS modifier class for jellyfin source', () => {
+    const { container } = render(<AttributionBadge source="jellyfin" />);
+    expect(container.querySelector('.attribution-badge--jellyfin')).toBeInTheDocument();
+  });
+
+  // --- Extra className pass-through ---
+
+  it('appends additional className to the outer span', () => {
+    const { container } = render(<AttributionBadge source="emby" className="my-extra-class" />);
+    expect(container.querySelector('.my-extra-class')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/AttributionBadge.tsx
+++ b/frontend/src/components/AttributionBadge.tsx
@@ -1,0 +1,51 @@
+/**
+ * AttributionBadge (bd-r5f0c.5 / W5).
+ *
+ * Reusable badge for media-server attribution. Renders a Material Icon +
+ * "via <Source>" text in a styled <span>. A11y-correct: icon + text, NOT
+ * color-only differentiation. The icon span carries an aria-label so
+ * screen-reader users hear the source name from the icon alone.
+ *
+ * Usage:
+ *   <AttributionBadge source="emby" />
+ *   <AttributionBadge source="plex" />
+ *   <AttributionBadge source="jellyfin" />
+ *
+ * Icon mapping (Material Icons):
+ *   emby     → live_tv
+ *   plex     → smart_display
+ *   jellyfin → play_circle
+ */
+import './AttributionBadge.css';
+
+export type AttributionBadgeSource = 'emby' | 'plex' | 'jellyfin';
+
+const SOURCE_CONFIG: Record<AttributionBadgeSource, { icon: string; label: string }> = {
+  emby: { icon: 'live_tv', label: 'Emby' },
+  plex: { icon: 'smart_display', label: 'Plex' },
+  jellyfin: { icon: 'play_circle', label: 'Jellyfin' },
+};
+
+export interface AttributionBadgeProps {
+  source: AttributionBadgeSource;
+  /** Additional CSS class names on the outer <span>. */
+  className?: string;
+}
+
+export function AttributionBadge({ source, className }: AttributionBadgeProps) {
+  const { icon, label } = SOURCE_CONFIG[source];
+  const classes = ['attribution-badge', `attribution-badge--${source}`, className]
+    .filter(Boolean)
+    .join(' ');
+  return (
+    <span className={classes}>
+      <span
+        className="material-icons attribution-badge__icon"
+        aria-label={`Attributed via ${label}`}
+      >
+        {icon}
+      </span>
+      <span className="attribution-badge__text">via {label}</span>
+    </span>
+  );
+}

--- a/frontend/src/components/settings/EmbyIntegrationSection.test.tsx
+++ b/frontend/src/components/settings/EmbyIntegrationSection.test.tsx
@@ -35,6 +35,8 @@ vi.mock('../../services/api', () => ({
   getExportSections: vi.fn(),
   listSavedBackups: vi.fn(),
   testEmbyConnection: vi.fn(),
+  testPlexConnection: vi.fn(),
+  testJellyfinConnection: vi.fn(),
 }));
 
 vi.mock('../../services/autoCreationApi', () => ({
@@ -201,6 +203,13 @@ const settingsBase = {
   emby_enabled: false,
   emby_base_url: '',
   emby_api_key_configured: false,
+  // Plex/Jellyfin fields (added by bd-r5f0c.5 / W5; SettingsTab reads them)
+  plex_enabled: false,
+  plex_base_url: '',
+  plex_token_configured: false,
+  jellyfin_enabled: false,
+  jellyfin_base_url: '',
+  jellyfin_api_key_configured: false,
 };
 
 function renderOnIntegrations() {

--- a/frontend/src/components/settings/JellyfinIntegrationSection.test.tsx
+++ b/frontend/src/components/settings/JellyfinIntegrationSection.test.tsx
@@ -1,20 +1,20 @@
 /**
- * Tests for the Stream Deduplication settings controls (BD-K / bd-ugzn4).
+ * Tests for the Jellyfin Integration Settings subsection (bd-r5f0c.5 / W5).
  *
- * The controls live directly in SettingsTab.tsx (Channel Defaults → Stream
- * Deduplication section). This test file exercises the dedup-specific
- * rendering, load, save, and clamping behaviour without full SettingsTab
- * integration — it mocks the api module and renders SettingsTab in isolation.
+ * Mirrors EmbyIntegrationSection.test.tsx.
  *
- * ADR-008 §D2: dedup_threshold stored as float 0.60-1.00; UI displays and
- * edits as integer percent 60-100. Hard floor 60 (server enforces; UI
- * clamps as convenience).
+ * Contracts under test:
+ *   - Section renders with the three fields (enabled, base_url, api_key).
+ *   - Fields populate from loaded settings (key itself is masked).
+ *   - "Test Connection" button calls api.testJellyfinConnection with
+ *     form-state values and renders ok/error inline.
+ *   - Save persists jellyfin_enabled and jellyfin_base_url always, and
+ *     jellyfin_api_key only when the operator entered a fresh value
+ *     (preserve-on-omit).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-// SettingsTab has many nested imports — mock the heavyweight ones so the
-// unit test stays fast and does not hit missing module boundaries.
 vi.mock('../../services/api', () => ({
   getSettings: vi.fn(),
   saveSettings: vi.fn(),
@@ -26,6 +26,9 @@ vi.mock('../../services/api', () => ({
   getM3UAccounts: vi.fn(),
   getExportSections: vi.fn(),
   listSavedBackups: vi.fn(),
+  testEmbyConnection: vi.fn(),
+  testPlexConnection: vi.fn(),
+  testJellyfinConnection: vi.fn(),
 }));
 
 vi.mock('../../services/autoCreationApi', () => ({
@@ -49,7 +52,6 @@ vi.mock('../../hooks/useAuth', () => ({
   useAuth: () => ({ user: { is_admin: true, username: 'admin' } }),
 }));
 
-// Stub sub-components that pull in DnD context or heavy deps
 vi.mock('../settings/NormalizationEngineSection', () => ({
   NormalizationEngineSection: () => <div data-testid="stub-normalization" />,
 }));
@@ -106,7 +108,6 @@ vi.mock('../CustomSelect', () => ({
 import * as api from '../../services/api';
 import { SettingsTab } from '../tabs/SettingsTab';
 
-// Minimal settings fixture — only the fields SettingsTab actually reads.
 function makeSettings(overrides: Partial<typeof settingsBase> = {}): Awaited<ReturnType<typeof api.getSettings>> {
   return { ...settingsBase, ...overrides } as Awaited<ReturnType<typeof api.getSettings>>;
 }
@@ -186,32 +187,30 @@ const settingsBase = {
   telegram_chat_id: '',
   mcp_api_key_configured: false,
   telemetry_client_errors_enabled: true,
-  // Dedup fields under test (BD-K / bd-ugzn4)
   dedup_threshold: 0.80,
   dedup_m3u_toast_suppressed: false,
-  // Emby integration (bd-8wc6q). Defaults disabled — not under test here.
   emby_enabled: false,
   emby_base_url: '',
   emby_api_key_configured: false,
-  // Plex/Jellyfin integration (bd-r5f0c.5). Defaults disabled — not under test here.
   plex_enabled: false,
   plex_base_url: '',
   plex_token_configured: false,
+  // Jellyfin fields under test (bd-r5f0c.5 / W5)
   jellyfin_enabled: false,
   jellyfin_base_url: '',
   jellyfin_api_key_configured: false,
 };
 
-function renderOnChannelDefaults() {
+function renderOnIntegrations() {
   return render(
     <SettingsTab
       onSaved={vi.fn()}
-      initialSettingsPage="channel-defaults"
+      initialSettingsPage="integrations"
     />
   );
 }
 
-describe('DeduplicationSettingsSection (BD-K / bd-ugzn4)', () => {
+describe('JellyfinIntegrationSection (bd-r5f0c.5 / W5)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(api.getSettings).mockResolvedValue(makeSettings());
@@ -223,174 +222,191 @@ describe('DeduplicationSettingsSection (BD-K / bd-ugzn4)', () => {
 
   // --- Rendering ---
 
-  it('renders the dedup threshold input with the operator\'s current value', async () => {
-    vi.mocked(api.getSettings).mockResolvedValue(makeSettings({ dedup_threshold: 0.75 }));
-    renderOnChannelDefaults();
+  it('renders the Jellyfin Integration section on the Integrations page', async () => {
+    renderOnIntegrations();
+    await waitFor(() => {
+      expect(screen.getByTestId('jellyfin-integration-section')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('jellyfin-enabled-checkbox')).toBeInTheDocument();
+    expect(screen.getByTestId('jellyfin-base-url-input')).toBeInTheDocument();
+    expect(screen.getByTestId('jellyfin-api-key-input')).toBeInTheDocument();
+    expect(screen.getByTestId('jellyfin-test-connection-btn')).toBeInTheDocument();
+  });
+
+  it('populates form fields from loaded settings', async () => {
+    vi.mocked(api.getSettings).mockResolvedValue(makeSettings({
+      jellyfin_enabled: true,
+      jellyfin_base_url: 'http://jellyfin.local:8096',
+      jellyfin_api_key_configured: true,
+    }));
+
+    renderOnIntegrations();
 
     await waitFor(() => {
-      const input = screen.getByTestId('dedup-threshold-input') as HTMLInputElement;
-      expect(input.value).toBe('75');
+      const enabled = screen.getByTestId('jellyfin-enabled-checkbox') as HTMLInputElement;
+      const baseUrl = screen.getByTestId('jellyfin-base-url-input') as HTMLInputElement;
+      const apiKey = screen.getByTestId('jellyfin-api-key-input') as HTMLInputElement;
+      expect(enabled.checked).toBe(true);
+      expect(baseUrl.value).toBe('http://jellyfin.local:8096');
+      expect(apiKey.value).toBe('');
+      expect(apiKey.placeholder).toBe('••••••••');
     });
   });
 
-  it('renders the dedup threshold input with default 80 when field is absent from settings', async () => {
-    const withoutDedup = { ...settingsBase } as Partial<typeof settingsBase>;
-    delete (withoutDedup as Record<string, unknown>)['dedup_threshold'];
-    vi.mocked(api.getSettings).mockResolvedValue(withoutDedup as Awaited<ReturnType<typeof api.getSettings>>);
-
-    renderOnChannelDefaults();
-
+  it('uses a password-type input for the API key field', async () => {
+    renderOnIntegrations();
     await waitFor(() => {
-      const input = screen.getByTestId('dedup-threshold-input') as HTMLInputElement;
-      expect(input.value).toBe('80');
+      const apiKey = screen.getByTestId('jellyfin-api-key-input') as HTMLInputElement;
+      expect(apiKey.type).toBe('password');
     });
   });
 
-  it('renders the toast-suppressor checkbox reflecting the operator\'s current value (false)', async () => {
-    vi.mocked(api.getSettings).mockResolvedValue(makeSettings({ dedup_m3u_toast_suppressed: false }));
-    renderOnChannelDefaults();
+  // --- Test Connection ---
+
+  it('calls api.testJellyfinConnection with form-state values when Test is clicked', async () => {
+    vi.mocked(api.testJellyfinConnection).mockResolvedValue({ ok: true });
+    renderOnIntegrations();
 
     await waitFor(() => {
-      const checkbox = screen.getByTestId('dedup-toast-suppressed-checkbox') as HTMLInputElement;
-      expect(checkbox.checked).toBe(false);
+      expect(screen.getByTestId('jellyfin-base-url-input')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('jellyfin-base-url-input'), {
+      target: { value: 'http://jellyfin.local:8096' },
+    });
+    fireEvent.change(screen.getByTestId('jellyfin-api-key-input'), {
+      target: { value: 'fresh-jf-key' },
+    });
+
+    fireEvent.click(screen.getByTestId('jellyfin-test-connection-btn'));
+
+    await waitFor(() => {
+      expect(api.testJellyfinConnection).toHaveBeenCalledWith(
+        'http://jellyfin.local:8096',
+        'fresh-jf-key',
+      );
     });
   });
 
-  it('renders the toast-suppressor checkbox as checked when operator has suppressed the toast', async () => {
-    vi.mocked(api.getSettings).mockResolvedValue(makeSettings({ dedup_m3u_toast_suppressed: true }));
-    renderOnChannelDefaults();
+  it('shows a success message inline when the test succeeds', async () => {
+    vi.mocked(api.testJellyfinConnection).mockResolvedValue({ ok: true });
+    renderOnIntegrations();
 
     await waitFor(() => {
-      const checkbox = screen.getByTestId('dedup-toast-suppressed-checkbox') as HTMLInputElement;
-      expect(checkbox.checked).toBe(true);
+      expect(screen.getByTestId('jellyfin-base-url-input')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('jellyfin-base-url-input'), {
+      target: { value: 'http://jellyfin.local:8096' },
+    });
+    fireEvent.change(screen.getByTestId('jellyfin-api-key-input'), {
+      target: { value: 'jf-key' },
+    });
+    fireEvent.click(screen.getByTestId('jellyfin-test-connection-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('jellyfin-test-result-success')).toBeInTheDocument();
     });
   });
 
-  it('toast suppressor starts unchecked by default (field absent)', async () => {
-    const withoutToast = { ...settingsBase } as Partial<typeof settingsBase>;
-    delete (withoutToast as Record<string, unknown>)['dedup_m3u_toast_suppressed'];
-    vi.mocked(api.getSettings).mockResolvedValue(withoutToast as Awaited<ReturnType<typeof api.getSettings>>);
-
-    renderOnChannelDefaults();
+  it('shows the backend error message inline when the test fails', async () => {
+    vi.mocked(api.testJellyfinConnection).mockResolvedValue({
+      ok: false,
+      error: 'Jellyfin /Sessions returned 401 unauthorized — check API key',
+    });
+    renderOnIntegrations();
 
     await waitFor(() => {
-      const checkbox = screen.getByTestId('dedup-toast-suppressed-checkbox') as HTMLInputElement;
-      expect(checkbox.checked).toBe(false);
+      expect(screen.getByTestId('jellyfin-base-url-input')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('jellyfin-base-url-input'), {
+      target: { value: 'http://jellyfin.local:8096' },
+    });
+    fireEvent.change(screen.getByTestId('jellyfin-api-key-input'), {
+      target: { value: 'bad-key' },
+    });
+    fireEvent.click(screen.getByTestId('jellyfin-test-connection-btn'));
+
+    await waitFor(() => {
+      const errEl = screen.getByTestId('jellyfin-test-result-error');
+      expect(errEl).toBeInTheDocument();
+      expect(errEl.textContent).toContain('401');
     });
   });
 
-  // --- Save: threshold ---
+  it('rejects the test click with an inline error when base URL is empty', async () => {
+    renderOnIntegrations();
 
-  it('POSTs the new dedup_threshold as a float when the operator edits and saves', async () => {
-    renderOnChannelDefaults();
-
-    // Wait for the settings to load
     await waitFor(() => {
-      expect(screen.getByTestId('dedup-threshold-input')).toBeInTheDocument();
+      expect(screen.getByTestId('jellyfin-test-connection-btn')).toBeInTheDocument();
     });
 
-    // Change the threshold from 80 to 90
-    const input = screen.getByTestId('dedup-threshold-input') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: '90' } });
+    fireEvent.click(screen.getByTestId('jellyfin-test-connection-btn'));
 
-    // Click the Save button
+    await waitFor(() => {
+      const err = screen.getByTestId('jellyfin-test-result-error');
+      expect(err.textContent?.toLowerCase()).toContain('base url');
+    });
+    expect(api.testJellyfinConnection).not.toHaveBeenCalled();
+  });
+
+  // --- Save ---
+
+  it('saves jellyfin_enabled and jellyfin_base_url on save', async () => {
+    renderOnIntegrations();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('jellyfin-enabled-checkbox')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('jellyfin-enabled-checkbox'));
+    fireEvent.change(screen.getByTestId('jellyfin-base-url-input'), {
+      target: { value: 'http://jellyfin.local:8096' },
+    });
+    fireEvent.change(screen.getByTestId('jellyfin-api-key-input'), {
+      target: { value: 'fresh-jf-key' },
+    });
+
     const saveBtn = screen.getByRole('button', { name: /save settings/i });
     fireEvent.click(saveBtn);
 
     await waitFor(() => {
       expect(api.saveSettings).toHaveBeenCalledWith(
-        expect.objectContaining({ dedup_threshold: 0.90 })
+        expect.objectContaining({
+          jellyfin_enabled: true,
+          jellyfin_base_url: 'http://jellyfin.local:8096',
+          jellyfin_api_key: 'fresh-jf-key',
+        }),
       );
     });
   });
 
-  // --- Save: toast suppressor ---
+  it('omits jellyfin_api_key from the save payload when the field is blank (preserve-on-omit)', async () => {
+    vi.mocked(api.getSettings).mockResolvedValue(makeSettings({
+      jellyfin_enabled: true,
+      jellyfin_base_url: 'http://old-jellyfin:8096',
+      jellyfin_api_key_configured: true,
+    }));
 
-  it('POSTs the toggled dedup_m3u_toast_suppressed value when operator checks and saves', async () => {
-    renderOnChannelDefaults();
-
-    await waitFor(() => {
-      expect(screen.getByTestId('dedup-toast-suppressed-checkbox')).toBeInTheDocument();
-    });
-
-    const checkbox = screen.getByTestId('dedup-toast-suppressed-checkbox') as HTMLInputElement;
-    fireEvent.click(checkbox); // toggle from false → true
-
-    const saveBtn = screen.getByRole('button', { name: /save settings/i });
-    fireEvent.click(saveBtn);
+    renderOnIntegrations();
 
     await waitFor(() => {
-      expect(api.saveSettings).toHaveBeenCalledWith(
-        expect.objectContaining({ dedup_m3u_toast_suppressed: true })
-      );
+      expect(screen.getByTestId('jellyfin-base-url-input')).toBeInTheDocument();
     });
-  });
 
-  // --- Clamping ---
+    fireEvent.change(screen.getByTestId('jellyfin-base-url-input'), {
+      target: { value: 'http://new-jellyfin:8096' },
+    });
 
-  it('clamps threshold to 60 when operator enters a value below the floor', async () => {
-    renderOnChannelDefaults();
+    fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
 
     await waitFor(() => {
-      expect(screen.getByTestId('dedup-threshold-input')).toBeInTheDocument();
+      expect(api.saveSettings).toHaveBeenCalled();
     });
 
-    const input = screen.getByTestId('dedup-threshold-input') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: '30' } });
-
-    // Value should be clamped to 60 immediately on change
-    expect(input.value).toBe('60');
-  });
-
-  it('clamps threshold to 100 when operator enters a value above the ceiling', async () => {
-    renderOnChannelDefaults();
-
-    await waitFor(() => {
-      expect(screen.getByTestId('dedup-threshold-input')).toBeInTheDocument();
-    });
-
-    const input = screen.getByTestId('dedup-threshold-input') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: '150' } });
-
-    expect(input.value).toBe('100');
-  });
-
-  it('saves threshold clamped to 0.60 when operator somehow bypasses UI validation', async () => {
-    renderOnChannelDefaults();
-
-    await waitFor(() => {
-      expect(screen.getByTestId('dedup-threshold-input')).toBeInTheDocument();
-    });
-
-    // Simulate a value below floor reaching the onChange handler (e.g. direct prop manipulation)
-    const input = screen.getByTestId('dedup-threshold-input') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: '10' } });
-    // After clamp, value is 60 → save sends 0.60
-    const saveBtn = screen.getByRole('button', { name: /save settings/i });
-    fireEvent.click(saveBtn);
-
-    await waitFor(() => {
-      expect(api.saveSettings).toHaveBeenCalledWith(
-        expect.objectContaining({ dedup_threshold: 0.60 })
-      );
-    });
-  });
-
-  // --- Hint text ---
-
-  it('shows the ADR-008 hard floor hint text below the threshold input', async () => {
-    renderOnChannelDefaults();
-
-    await waitFor(() => {
-      expect(screen.getByText(/ADR-008 hard floor/i)).toBeInTheDocument();
-    });
-  });
-
-  it('shows the hint that pending merges are still queued when toast is suppressed', async () => {
-    renderOnChannelDefaults();
-
-    await waitFor(() => {
-      expect(screen.getByText(/Pending merges are still queued/i)).toBeInTheDocument();
-    });
+    const callArgs = vi.mocked(api.saveSettings).mock.calls[0][0];
+    expect(callArgs.jellyfin_base_url).toBe('http://new-jellyfin:8096');
+    expect(callArgs).not.toHaveProperty('jellyfin_api_key');
   });
 });

--- a/frontend/src/components/settings/PlexIntegrationSection.test.tsx
+++ b/frontend/src/components/settings/PlexIntegrationSection.test.tsx
@@ -1,20 +1,24 @@
 /**
- * Tests for the Stream Deduplication settings controls (BD-K / bd-ugzn4).
+ * Tests for the Plex Integration Settings subsection (bd-r5f0c.5 / W5).
  *
- * The controls live directly in SettingsTab.tsx (Channel Defaults → Stream
- * Deduplication section). This test file exercises the dedup-specific
- * rendering, load, save, and clamping behaviour without full SettingsTab
- * integration — it mocks the api module and renders SettingsTab in isolation.
+ * Mirrors EmbyIntegrationSection.test.tsx. Additional contract:
+ *   - The token field MUST show the SEC-1 helper text ("Use a server-local
+ *     Plex token, not your plex.tv account token.") directly below the
+ *     input field. This is a security requirement — do not remove the test.
  *
- * ADR-008 §D2: dedup_threshold stored as float 0.60-1.00; UI displays and
- * edits as integer percent 60-100. Hard floor 60 (server enforces; UI
- * clamps as convenience).
+ * Contracts under test:
+ *   - Section renders with the three fields (enabled, base_url, token).
+ *   - Fields populate from loaded settings (token itself is masked —
+ *     only ``plex_token_configured`` is surfaced).
+ *   - "Test Connection" button calls api.testPlexConnection with form-state
+ *     values and renders ok/error inline.
+ *   - Save persists plex_enabled and plex_base_url always, and plex_token
+ *     only when the operator entered a fresh value (preserve-on-omit).
+ *   - Token helper text is present and visible (SEC-1).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-// SettingsTab has many nested imports — mock the heavyweight ones so the
-// unit test stays fast and does not hit missing module boundaries.
 vi.mock('../../services/api', () => ({
   getSettings: vi.fn(),
   saveSettings: vi.fn(),
@@ -26,6 +30,9 @@ vi.mock('../../services/api', () => ({
   getM3UAccounts: vi.fn(),
   getExportSections: vi.fn(),
   listSavedBackups: vi.fn(),
+  testEmbyConnection: vi.fn(),
+  testPlexConnection: vi.fn(),
+  testJellyfinConnection: vi.fn(),
 }));
 
 vi.mock('../../services/autoCreationApi', () => ({
@@ -49,7 +56,6 @@ vi.mock('../../hooks/useAuth', () => ({
   useAuth: () => ({ user: { is_admin: true, username: 'admin' } }),
 }));
 
-// Stub sub-components that pull in DnD context or heavy deps
 vi.mock('../settings/NormalizationEngineSection', () => ({
   NormalizationEngineSection: () => <div data-testid="stub-normalization" />,
 }));
@@ -106,7 +112,6 @@ vi.mock('../CustomSelect', () => ({
 import * as api from '../../services/api';
 import { SettingsTab } from '../tabs/SettingsTab';
 
-// Minimal settings fixture — only the fields SettingsTab actually reads.
 function makeSettings(overrides: Partial<typeof settingsBase> = {}): Awaited<ReturnType<typeof api.getSettings>> {
   return { ...settingsBase, ...overrides } as Awaited<ReturnType<typeof api.getSettings>>;
 }
@@ -186,14 +191,12 @@ const settingsBase = {
   telegram_chat_id: '',
   mcp_api_key_configured: false,
   telemetry_client_errors_enabled: true,
-  // Dedup fields under test (BD-K / bd-ugzn4)
   dedup_threshold: 0.80,
   dedup_m3u_toast_suppressed: false,
-  // Emby integration (bd-8wc6q). Defaults disabled — not under test here.
   emby_enabled: false,
   emby_base_url: '',
   emby_api_key_configured: false,
-  // Plex/Jellyfin integration (bd-r5f0c.5). Defaults disabled — not under test here.
+  // Plex fields under test (bd-r5f0c.5 / W5)
   plex_enabled: false,
   plex_base_url: '',
   plex_token_configured: false,
@@ -202,16 +205,16 @@ const settingsBase = {
   jellyfin_api_key_configured: false,
 };
 
-function renderOnChannelDefaults() {
+function renderOnIntegrations() {
   return render(
     <SettingsTab
       onSaved={vi.fn()}
-      initialSettingsPage="channel-defaults"
+      initialSettingsPage="integrations"
     />
   );
 }
 
-describe('DeduplicationSettingsSection (BD-K / bd-ugzn4)', () => {
+describe('PlexIntegrationSection (bd-r5f0c.5 / W5)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(api.getSettings).mockResolvedValue(makeSettings());
@@ -223,174 +226,204 @@ describe('DeduplicationSettingsSection (BD-K / bd-ugzn4)', () => {
 
   // --- Rendering ---
 
-  it('renders the dedup threshold input with the operator\'s current value', async () => {
-    vi.mocked(api.getSettings).mockResolvedValue(makeSettings({ dedup_threshold: 0.75 }));
-    renderOnChannelDefaults();
+  it('renders the Plex Integration section on the Integrations page', async () => {
+    renderOnIntegrations();
+    await waitFor(() => {
+      expect(screen.getByTestId('plex-integration-section')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('plex-enabled-checkbox')).toBeInTheDocument();
+    expect(screen.getByTestId('plex-base-url-input')).toBeInTheDocument();
+    expect(screen.getByTestId('plex-token-input')).toBeInTheDocument();
+    expect(screen.getByTestId('plex-test-connection-btn')).toBeInTheDocument();
+  });
+
+  it('populates form fields from loaded settings', async () => {
+    vi.mocked(api.getSettings).mockResolvedValue(makeSettings({
+      plex_enabled: true,
+      plex_base_url: 'http://plex.local:32400',
+      plex_token_configured: true,
+    }));
+
+    renderOnIntegrations();
 
     await waitFor(() => {
-      const input = screen.getByTestId('dedup-threshold-input') as HTMLInputElement;
-      expect(input.value).toBe('75');
+      const enabled = screen.getByTestId('plex-enabled-checkbox') as HTMLInputElement;
+      const baseUrl = screen.getByTestId('plex-base-url-input') as HTMLInputElement;
+      const token = screen.getByTestId('plex-token-input') as HTMLInputElement;
+      expect(enabled.checked).toBe(true);
+      expect(baseUrl.value).toBe('http://plex.local:32400');
+      // Token field is intentionally blank on load
+      expect(token.value).toBe('');
+      expect(token.placeholder).toBe('••••••••');
     });
   });
 
-  it('renders the dedup threshold input with default 80 when field is absent from settings', async () => {
-    const withoutDedup = { ...settingsBase } as Partial<typeof settingsBase>;
-    delete (withoutDedup as Record<string, unknown>)['dedup_threshold'];
-    vi.mocked(api.getSettings).mockResolvedValue(withoutDedup as Awaited<ReturnType<typeof api.getSettings>>);
-
-    renderOnChannelDefaults();
-
+  it('uses a password-type input for the token field', async () => {
+    renderOnIntegrations();
     await waitFor(() => {
-      const input = screen.getByTestId('dedup-threshold-input') as HTMLInputElement;
-      expect(input.value).toBe('80');
+      const token = screen.getByTestId('plex-token-input') as HTMLInputElement;
+      expect(token.type).toBe('password');
     });
   });
 
-  it('renders the toast-suppressor checkbox reflecting the operator\'s current value (false)', async () => {
-    vi.mocked(api.getSettings).mockResolvedValue(makeSettings({ dedup_m3u_toast_suppressed: false }));
-    renderOnChannelDefaults();
+  // --- SEC-1: Token helper text ---
 
+  it('shows server-local token helper text (SEC-1 requirement)', async () => {
+    renderOnIntegrations();
     await waitFor(() => {
-      const checkbox = screen.getByTestId('dedup-toast-suppressed-checkbox') as HTMLInputElement;
-      expect(checkbox.checked).toBe(false);
+      const helperEl = screen.getByTestId('plex-token-helper-text');
+      expect(helperEl).toBeInTheDocument();
+      expect(helperEl.textContent).toContain('server-local Plex token');
+      expect(helperEl.textContent).toContain('plex.tv account token');
     });
   });
 
-  it('renders the toast-suppressor checkbox as checked when operator has suppressed the toast', async () => {
-    vi.mocked(api.getSettings).mockResolvedValue(makeSettings({ dedup_m3u_toast_suppressed: true }));
-    renderOnChannelDefaults();
+  // --- Test Connection ---
+
+  it('calls api.testPlexConnection with form-state values when Test is clicked', async () => {
+    vi.mocked(api.testPlexConnection).mockResolvedValue({ ok: true });
+    renderOnIntegrations();
 
     await waitFor(() => {
-      const checkbox = screen.getByTestId('dedup-toast-suppressed-checkbox') as HTMLInputElement;
-      expect(checkbox.checked).toBe(true);
+      expect(screen.getByTestId('plex-base-url-input')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('plex-base-url-input'), {
+      target: { value: 'http://plex.local:32400' },
+    });
+    fireEvent.change(screen.getByTestId('plex-token-input'), {
+      target: { value: 'my-plex-token' },
+    });
+
+    fireEvent.click(screen.getByTestId('plex-test-connection-btn'));
+
+    await waitFor(() => {
+      expect(api.testPlexConnection).toHaveBeenCalledWith(
+        'http://plex.local:32400',
+        'my-plex-token',
+      );
     });
   });
 
-  it('toast suppressor starts unchecked by default (field absent)', async () => {
-    const withoutToast = { ...settingsBase } as Partial<typeof settingsBase>;
-    delete (withoutToast as Record<string, unknown>)['dedup_m3u_toast_suppressed'];
-    vi.mocked(api.getSettings).mockResolvedValue(withoutToast as Awaited<ReturnType<typeof api.getSettings>>);
-
-    renderOnChannelDefaults();
+  it('shows a success message inline when the test succeeds', async () => {
+    vi.mocked(api.testPlexConnection).mockResolvedValue({ ok: true });
+    renderOnIntegrations();
 
     await waitFor(() => {
-      const checkbox = screen.getByTestId('dedup-toast-suppressed-checkbox') as HTMLInputElement;
-      expect(checkbox.checked).toBe(false);
+      expect(screen.getByTestId('plex-base-url-input')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('plex-base-url-input'), {
+      target: { value: 'http://plex.local:32400' },
+    });
+    fireEvent.change(screen.getByTestId('plex-token-input'), {
+      target: { value: 'my-plex-token' },
+    });
+    fireEvent.click(screen.getByTestId('plex-test-connection-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plex-test-result-success')).toBeInTheDocument();
     });
   });
 
-  // --- Save: threshold ---
+  it('shows the backend error message inline when the test fails', async () => {
+    vi.mocked(api.testPlexConnection).mockResolvedValue({
+      ok: false,
+      error: 'Plex returned 401 unauthorized — check token',
+    });
+    renderOnIntegrations();
 
-  it('POSTs the new dedup_threshold as a float when the operator edits and saves', async () => {
-    renderOnChannelDefaults();
-
-    // Wait for the settings to load
     await waitFor(() => {
-      expect(screen.getByTestId('dedup-threshold-input')).toBeInTheDocument();
+      expect(screen.getByTestId('plex-base-url-input')).toBeInTheDocument();
     });
 
-    // Change the threshold from 80 to 90
-    const input = screen.getByTestId('dedup-threshold-input') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: '90' } });
+    fireEvent.change(screen.getByTestId('plex-base-url-input'), {
+      target: { value: 'http://plex.local:32400' },
+    });
+    fireEvent.change(screen.getByTestId('plex-token-input'), {
+      target: { value: 'bad-token' },
+    });
+    fireEvent.click(screen.getByTestId('plex-test-connection-btn'));
 
-    // Click the Save button
+    await waitFor(() => {
+      const errEl = screen.getByTestId('plex-test-result-error');
+      expect(errEl).toBeInTheDocument();
+      expect(errEl.textContent).toContain('401');
+    });
+  });
+
+  it('rejects the test click with an inline error when base URL is empty', async () => {
+    renderOnIntegrations();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plex-test-connection-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('plex-test-connection-btn'));
+
+    await waitFor(() => {
+      const err = screen.getByTestId('plex-test-result-error');
+      expect(err.textContent?.toLowerCase()).toContain('base url');
+    });
+    expect(api.testPlexConnection).not.toHaveBeenCalled();
+  });
+
+  // --- Save ---
+
+  it('saves plex_enabled and plex_base_url on save', async () => {
+    renderOnIntegrations();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plex-enabled-checkbox')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('plex-enabled-checkbox'));
+    fireEvent.change(screen.getByTestId('plex-base-url-input'), {
+      target: { value: 'http://plex.local:32400' },
+    });
+    fireEvent.change(screen.getByTestId('plex-token-input'), {
+      target: { value: 'fresh-token' },
+    });
+
     const saveBtn = screen.getByRole('button', { name: /save settings/i });
     fireEvent.click(saveBtn);
 
     await waitFor(() => {
       expect(api.saveSettings).toHaveBeenCalledWith(
-        expect.objectContaining({ dedup_threshold: 0.90 })
+        expect.objectContaining({
+          plex_enabled: true,
+          plex_base_url: 'http://plex.local:32400',
+          plex_token: 'fresh-token',
+        }),
       );
     });
   });
 
-  // --- Save: toast suppressor ---
+  it('omits plex_token from the save payload when the field is blank (preserve-on-omit)', async () => {
+    vi.mocked(api.getSettings).mockResolvedValue(makeSettings({
+      plex_enabled: true,
+      plex_base_url: 'http://old-plex:32400',
+      plex_token_configured: true,
+    }));
 
-  it('POSTs the toggled dedup_m3u_toast_suppressed value when operator checks and saves', async () => {
-    renderOnChannelDefaults();
-
-    await waitFor(() => {
-      expect(screen.getByTestId('dedup-toast-suppressed-checkbox')).toBeInTheDocument();
-    });
-
-    const checkbox = screen.getByTestId('dedup-toast-suppressed-checkbox') as HTMLInputElement;
-    fireEvent.click(checkbox); // toggle from false → true
-
-    const saveBtn = screen.getByRole('button', { name: /save settings/i });
-    fireEvent.click(saveBtn);
+    renderOnIntegrations();
 
     await waitFor(() => {
-      expect(api.saveSettings).toHaveBeenCalledWith(
-        expect.objectContaining({ dedup_m3u_toast_suppressed: true })
-      );
+      expect(screen.getByTestId('plex-base-url-input')).toBeInTheDocument();
     });
-  });
 
-  // --- Clamping ---
+    fireEvent.change(screen.getByTestId('plex-base-url-input'), {
+      target: { value: 'http://new-plex:32400' },
+    });
 
-  it('clamps threshold to 60 when operator enters a value below the floor', async () => {
-    renderOnChannelDefaults();
+    fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
 
     await waitFor(() => {
-      expect(screen.getByTestId('dedup-threshold-input')).toBeInTheDocument();
+      expect(api.saveSettings).toHaveBeenCalled();
     });
 
-    const input = screen.getByTestId('dedup-threshold-input') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: '30' } });
-
-    // Value should be clamped to 60 immediately on change
-    expect(input.value).toBe('60');
-  });
-
-  it('clamps threshold to 100 when operator enters a value above the ceiling', async () => {
-    renderOnChannelDefaults();
-
-    await waitFor(() => {
-      expect(screen.getByTestId('dedup-threshold-input')).toBeInTheDocument();
-    });
-
-    const input = screen.getByTestId('dedup-threshold-input') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: '150' } });
-
-    expect(input.value).toBe('100');
-  });
-
-  it('saves threshold clamped to 0.60 when operator somehow bypasses UI validation', async () => {
-    renderOnChannelDefaults();
-
-    await waitFor(() => {
-      expect(screen.getByTestId('dedup-threshold-input')).toBeInTheDocument();
-    });
-
-    // Simulate a value below floor reaching the onChange handler (e.g. direct prop manipulation)
-    const input = screen.getByTestId('dedup-threshold-input') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: '10' } });
-    // After clamp, value is 60 → save sends 0.60
-    const saveBtn = screen.getByRole('button', { name: /save settings/i });
-    fireEvent.click(saveBtn);
-
-    await waitFor(() => {
-      expect(api.saveSettings).toHaveBeenCalledWith(
-        expect.objectContaining({ dedup_threshold: 0.60 })
-      );
-    });
-  });
-
-  // --- Hint text ---
-
-  it('shows the ADR-008 hard floor hint text below the threshold input', async () => {
-    renderOnChannelDefaults();
-
-    await waitFor(() => {
-      expect(screen.getByText(/ADR-008 hard floor/i)).toBeInTheDocument();
-    });
-  });
-
-  it('shows the hint that pending merges are still queued when toast is suppressed', async () => {
-    renderOnChannelDefaults();
-
-    await waitFor(() => {
-      expect(screen.getByText(/Pending merges are still queued/i)).toBeInTheDocument();
-    });
+    const callArgs = vi.mocked(api.saveSettings).mock.calls[0][0];
+    expect(callArgs.plex_base_url).toBe('http://new-plex:32400');
+    expect(callArgs).not.toHaveProperty('plex_token');
   });
 });

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -366,6 +366,22 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
   const [embyTestStatus, setEmbyTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
   const [embyTestMessage, setEmbyTestMessage] = useState('');
 
+  // Plex integration (bd-r5f0c.5 / W5). plex_token uses preserve-on-omit.
+  const [plexEnabled, setPlexEnabled] = useState(false);
+  const [plexBaseUrl, setPlexBaseUrl] = useState('');
+  const [plexToken, setPlexToken] = useState('');
+  const [plexTokenConfigured, setPlexTokenConfigured] = useState(false);
+  const [plexTestStatus, setPlexTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
+  const [plexTestMessage, setPlexTestMessage] = useState('');
+
+  // Jellyfin integration (bd-r5f0c.5 / W5). jellyfin_api_key uses preserve-on-omit.
+  const [jellyfinEnabled, setJellyfinEnabled] = useState(false);
+  const [jellyfinBaseUrl, setJellyfinBaseUrl] = useState('');
+  const [jellyfinApiKey, setJellyfinApiKey] = useState('');
+  const [jellyfinApiKeyConfigured, setJellyfinApiKeyConfigured] = useState(false);
+  const [jellyfinTestStatus, setJellyfinTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
+  const [jellyfinTestMessage, setJellyfinTestMessage] = useState('');
+
   const [streamSortPriority, setStreamSortPriority] = useState<SortCriterion[]>(['resolution', 'bitrate', 'framerate', 'video_codec', 'm3u_priority', 'audio_channels']);
   const [streamSortEnabled, setStreamSortEnabled] = useState<SortEnabledMap>({ resolution: true, bitrate: true, framerate: true, video_codec: false, m3u_priority: false, audio_channels: false });
   const [m3uAccountPriorities, setM3uAccountPriorities] = useState<Record<string, number>>({});
@@ -808,6 +824,20 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
       setEmbyApiKeyConfigured(settings.emby_api_key_configured ?? false);
       setEmbyTestStatus('idle');
       setEmbyTestMessage('');
+      // Plex integration (bd-r5f0c.5 / W5)
+      setPlexEnabled(settings.plex_enabled ?? false);
+      setPlexBaseUrl(settings.plex_base_url ?? '');
+      setPlexToken('');
+      setPlexTokenConfigured(settings.plex_token_configured ?? false);
+      setPlexTestStatus('idle');
+      setPlexTestMessage('');
+      // Jellyfin integration (bd-r5f0c.5 / W5)
+      setJellyfinEnabled(settings.jellyfin_enabled ?? false);
+      setJellyfinBaseUrl(settings.jellyfin_base_url ?? '');
+      setJellyfinApiKey('');
+      setJellyfinApiKeyConfigured(settings.jellyfin_api_key_configured ?? false);
+      setJellyfinTestStatus('idle');
+      setJellyfinTestMessage('');
       setStatsPollInterval(settings.stats_poll_interval ?? 10);
       setOriginalPollInterval(settings.stats_poll_interval ?? 10);
       setUserTimezone(settings.user_timezone ?? '');
@@ -1033,6 +1063,77 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
     }
   };
 
+  // Plex test-connection (bd-r5f0c.5 / W5). Mirrors Emby pattern.
+  // SEC-1: uses server-local Plex token (operator-entered), not plex.tv account token.
+  const handleTestPlexConnection = async () => {
+    if (!plexBaseUrl) {
+      setPlexTestStatus('error');
+      setPlexTestMessage('Base URL is required');
+      return;
+    }
+    if (!plexToken && !plexTokenConfigured) {
+      setPlexTestStatus('error');
+      setPlexTestMessage('Plex token is required');
+      return;
+    }
+    if (!plexToken) {
+      setPlexTestStatus('error');
+      setPlexTestMessage('Re-enter the token to test the connection');
+      return;
+    }
+    setPlexTestStatus('testing');
+    setPlexTestMessage('');
+    try {
+      const result = await api.testPlexConnection(plexBaseUrl, plexToken);
+      if (result.ok) {
+        setPlexTestStatus('success');
+        setPlexTestMessage('Connection successful');
+      } else {
+        setPlexTestStatus('error');
+        setPlexTestMessage(result.error || 'Connection failed');
+      }
+    } catch (err) {
+      logger.error('Failed to test Plex connection', err);
+      setPlexTestStatus('error');
+      setPlexTestMessage(err instanceof Error ? err.message : 'Connection failed');
+    }
+  };
+
+  // Jellyfin test-connection (bd-r5f0c.5 / W5). Mirrors Emby pattern.
+  const handleTestJellyfinConnection = async () => {
+    if (!jellyfinBaseUrl) {
+      setJellyfinTestStatus('error');
+      setJellyfinTestMessage('Base URL is required');
+      return;
+    }
+    if (!jellyfinApiKey && !jellyfinApiKeyConfigured) {
+      setJellyfinTestStatus('error');
+      setJellyfinTestMessage('API key is required');
+      return;
+    }
+    if (!jellyfinApiKey) {
+      setJellyfinTestStatus('error');
+      setJellyfinTestMessage('Re-enter the API key to test the connection');
+      return;
+    }
+    setJellyfinTestStatus('testing');
+    setJellyfinTestMessage('');
+    try {
+      const result = await api.testJellyfinConnection(jellyfinBaseUrl, jellyfinApiKey);
+      if (result.ok) {
+        setJellyfinTestStatus('success');
+        setJellyfinTestMessage('Connection successful');
+      } else {
+        setJellyfinTestStatus('error');
+        setJellyfinTestMessage(result.error || 'Connection failed');
+      }
+    } catch (err) {
+      logger.error('Failed to test Jellyfin connection', err);
+      setJellyfinTestStatus('error');
+      setJellyfinTestMessage(err instanceof Error ? err.message : 'Connection failed');
+    }
+  };
+
   const handleResetStats = async () => {
     if (!confirm('This will clear all channel/stream statistics, watch history, and hidden groups. Use this when switching Dispatcharr servers. Continue?')) {
       return;
@@ -1113,6 +1214,14 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
         emby_enabled: embyEnabled,
         emby_base_url: embyBaseUrl,
         ...(embyApiKey ? { emby_api_key: embyApiKey } : {}),
+        // Plex integration (bd-r5f0c.5 / W5). preserve-on-omit for token.
+        plex_enabled: plexEnabled,
+        plex_base_url: plexBaseUrl,
+        ...(plexToken ? { plex_token: plexToken } : {}),
+        // Jellyfin integration (bd-r5f0c.5 / W5). preserve-on-omit for key.
+        jellyfin_enabled: jellyfinEnabled,
+        jellyfin_base_url: jellyfinBaseUrl,
+        ...(jellyfinApiKey ? { jellyfin_api_key: jellyfinApiKey } : {}),
         stats_poll_interval: statsPollInterval,
         user_timezone: userTimezone,
         backend_log_level: backendLogLevel,
@@ -3289,11 +3398,10 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
     </div>
   );
 
-  // Integrations page (bd-8wc6q, epic bd-2cenq). Third-party server
-  // integrations — Emby today, room for Plex/Jellyfin/etc. as the epic
-  // grows. Distinct from "Linked Accounts" (which is ECM-internal M3U
-  // account linking) and from the Dispatcharr connection on the General
-  // page (which is the primary upstream, not a side integration).
+  // Integrations page (bd-8wc6q / bd-r5f0c.5, epic bd-2cenq). Third-party
+  // server integrations: Emby, Plex, Jellyfin. Distinct from "Linked
+  // Accounts" (ECM-internal M3U account linking) and from the Dispatcharr
+  // connection on the General page (the primary upstream).
   const renderIntegrationsPage = () => (
     <div className="settings-page">
       <div className="settings-page-header">
@@ -3301,7 +3409,20 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
         <p>Configure third-party server integrations for cross-referenced data (Stats user attribution, etc.).</p>
       </div>
 
-      <div className="settings-section" data-testid="emby-integration-section">
+      {/* Anchor jump nav (bd-r5f0c.5 / W5) */}
+      <nav className="settings-anchor-nav" aria-label="Integrations">
+        <a href="#dispatcharr-integration">Dispatcharr</a>
+        <a href="#emby-integration">Emby</a>
+        <a href="#plex-integration">Plex</a>
+        <a href="#jellyfin-integration">Jellyfin</a>
+      </nav>
+
+      {/* Dispatcharr anchor — the General page hosts the primary upstream
+          connection but operators may want to jump here from the nav. */}
+      <div id="dispatcharr-integration" />
+
+      {/* Emby Integration */}
+      <div id="emby-integration" className="settings-section" data-testid="emby-integration-section">
         <div className="settings-section-header">
           <span className="material-icons">live_tv</span>
           <h3>Emby Integration</h3>
@@ -3395,6 +3516,209 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
               style={{ color: 'var(--accent-error, #ef4444)' }}
             >
               ✗ {embyTestMessage}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Plex Integration (bd-r5f0c.5 / W5) */}
+      <div id="plex-integration" className="settings-section" data-testid="plex-integration-section">
+        <div className="settings-section-header">
+          <span className="material-icons">smart_display</span>
+          <h3>Plex Integration</h3>
+          <span className={`badge badge-sm ${plexEnabled && plexTokenConfigured ? 'badge-success' : ''}`}>
+            {plexEnabled && plexTokenConfigured ? 'Configured' : 'Unconfigured'}
+          </span>
+        </div>
+
+        <p className="form-hint">
+          When enabled, ECM cross-references active stream sessions against the operator's Plex
+          <code> /status/sessions </code>feed so Stats can attribute real Plex usernames.
+        </p>
+
+        <div className="checkbox-group">
+          <input
+            id="plexEnabled"
+            type="checkbox"
+            checked={plexEnabled}
+            onChange={(e) => setPlexEnabled(e.target.checked)}
+            data-testid="plex-enabled-checkbox"
+          />
+          <div className="checkbox-content">
+            <label htmlFor="plexEnabled">Enable Plex user attribution</label>
+            <p>Requires base URL and token below. Disabling stops the cross-reference but does not clear stored values.</p>
+          </div>
+        </div>
+
+        <div className="form-group-vertical">
+          <label htmlFor="plexBaseUrl">Plex base URL</label>
+          <span className="form-description">
+            Full URL to your Plex Media Server (e.g. <code>http://plex.local:32400</code>). Sub-paths are
+            preserved for reverse-proxy setups.
+          </span>
+          <input
+            id="plexBaseUrl"
+            type="text"
+            value={plexBaseUrl}
+            onChange={(e) => setPlexBaseUrl(e.target.value)}
+            placeholder="http://plex.local:32400"
+            data-testid="plex-base-url-input"
+            className="settings-text-input"
+          />
+        </div>
+
+        <div className="form-group-vertical">
+          <label htmlFor="plexToken">Plex token</label>
+          <span className="form-description">
+            {plexTokenConfigured ? 'A token is currently stored — leave blank to keep it.' : 'No token stored.'}
+          </span>
+          {/* SEC-1: Server-local Plex token warning. plex.tv account tokens have
+              full account scope; server-local tokens are scoped to the server.
+              This text is a security requirement — do not remove it. */}
+          <span className="form-description form-description--warning" data-testid="plex-token-helper-text">
+            Use a server-local Plex token, not your plex.tv account token. See Integrations docs for guidance.
+          </span>
+          <input
+            id="plexToken"
+            type="password"
+            value={plexToken}
+            onChange={(e) => setPlexToken(e.target.value)}
+            placeholder={plexTokenConfigured ? '••••••••' : 'Paste your server-local Plex token'}
+            data-testid="plex-token-input"
+            className="settings-text-input"
+            autoComplete="new-password"
+          />
+        </div>
+
+        <div className="form-group-vertical">
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={handleTestPlexConnection}
+            disabled={plexTestStatus === 'testing'}
+            data-testid="plex-test-connection-btn"
+            style={{ alignSelf: 'flex-start' }}
+          >
+            <span className="material-icons">
+              {plexTestStatus === 'testing' ? 'sync' : 'cable'}
+            </span>
+            {plexTestStatus === 'testing' ? 'Testing...' : 'Test Connection'}
+          </button>
+          {plexTestStatus === 'success' && (
+            <span
+              className="form-hint"
+              data-testid="plex-test-result-success"
+              style={{ color: 'var(--accent-success, #22C55E)' }}
+            >
+              ✓ {plexTestMessage}
+            </span>
+          )}
+          {plexTestStatus === 'error' && (
+            <span
+              className="form-hint"
+              data-testid="plex-test-result-error"
+              style={{ color: 'var(--accent-error, #ef4444)' }}
+            >
+              ✗ {plexTestMessage}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Jellyfin Integration (bd-r5f0c.5 / W5) */}
+      <div id="jellyfin-integration" className="settings-section" data-testid="jellyfin-integration-section">
+        <div className="settings-section-header">
+          <span className="material-icons">play_circle</span>
+          <h3>Jellyfin Integration</h3>
+          <span className={`badge badge-sm ${jellyfinEnabled && jellyfinApiKeyConfigured ? 'badge-success' : ''}`}>
+            {jellyfinEnabled && jellyfinApiKeyConfigured ? 'Configured' : 'Unconfigured'}
+          </span>
+        </div>
+
+        <p className="form-hint">
+          When enabled, ECM cross-references active stream sessions against the operator's Jellyfin
+          <code> /Sessions </code>feed so Stats can attribute real Jellyfin usernames.
+        </p>
+
+        <div className="checkbox-group">
+          <input
+            id="jellyfinEnabled"
+            type="checkbox"
+            checked={jellyfinEnabled}
+            onChange={(e) => setJellyfinEnabled(e.target.checked)}
+            data-testid="jellyfin-enabled-checkbox"
+          />
+          <div className="checkbox-content">
+            <label htmlFor="jellyfinEnabled">Enable Jellyfin user attribution</label>
+            <p>Requires base URL and API key below. Disabling stops the cross-reference but does not clear stored values.</p>
+          </div>
+        </div>
+
+        <div className="form-group-vertical">
+          <label htmlFor="jellyfinBaseUrl">Jellyfin base URL</label>
+          <span className="form-description">
+            Full URL to your Jellyfin server (e.g. <code>http://jellyfin.local:8096</code>). Sub-paths are
+            preserved for reverse-proxy setups.
+          </span>
+          <input
+            id="jellyfinBaseUrl"
+            type="text"
+            value={jellyfinBaseUrl}
+            onChange={(e) => setJellyfinBaseUrl(e.target.value)}
+            placeholder="http://jellyfin.local:8096"
+            data-testid="jellyfin-base-url-input"
+            className="settings-text-input"
+          />
+        </div>
+
+        <div className="form-group-vertical">
+          <label htmlFor="jellyfinApiKey">Jellyfin API key</label>
+          <span className="form-description">
+            Generate in Jellyfin: Dashboard → API Keys → New API Key. Stored plaintext at rest.
+            {jellyfinApiKeyConfigured ? ' A key is currently stored — leave blank to keep it.' : ' No key stored.'}
+          </span>
+          <input
+            id="jellyfinApiKey"
+            type="password"
+            value={jellyfinApiKey}
+            onChange={(e) => setJellyfinApiKey(e.target.value)}
+            placeholder={jellyfinApiKeyConfigured ? '••••••••' : 'Paste your Jellyfin API key'}
+            data-testid="jellyfin-api-key-input"
+            className="settings-text-input"
+            autoComplete="new-password"
+          />
+        </div>
+
+        <div className="form-group-vertical">
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={handleTestJellyfinConnection}
+            disabled={jellyfinTestStatus === 'testing'}
+            data-testid="jellyfin-test-connection-btn"
+            style={{ alignSelf: 'flex-start' }}
+          >
+            <span className="material-icons">
+              {jellyfinTestStatus === 'testing' ? 'sync' : 'cable'}
+            </span>
+            {jellyfinTestStatus === 'testing' ? 'Testing...' : 'Test Connection'}
+          </button>
+          {jellyfinTestStatus === 'success' && (
+            <span
+              className="form-hint"
+              data-testid="jellyfin-test-result-success"
+              style={{ color: 'var(--accent-success, #22C55E)' }}
+            >
+              ✓ {jellyfinTestMessage}
+            </span>
+          )}
+          {jellyfinTestStatus === 'error' && (
+            <span
+              className="form-hint"
+              data-testid="jellyfin-test-result-error"
+              style={{ color: 'var(--accent-error, #ef4444)' }}
+            >
+              ✗ {jellyfinTestMessage}
             </span>
           )}
         </div>

--- a/frontend/src/components/tabs/StatsTab.test.tsx
+++ b/frontend/src/components/tabs/StatsTab.test.tsx
@@ -572,3 +572,334 @@ describe('StatsTab — per-client Emby attribution badge (bd-5kbyf)', () => {
     expect(screen.queryByText('via Emby')).not.toBeInTheDocument();
   });
 });
+
+// bd-r5f0c.5 (W5): Multi-viewer rendering in Connected Clients.
+// The W9 backend now surfaces *_viewers[] lists per source on each client.
+// These tests verify the new rendering paths WITHOUT disturbing the
+// existing bd-5kbyf back-compat tests above.
+
+const baseMultiViewerChannel = {
+  channel_id: 'uuid-mv',
+  channel_name: '200 | CNN',
+  channel_number: 200,
+  state: 'streaming',
+  client_count: 1,
+  stream_name: 'US: CNN FHD',
+  m3u_account_id: 6,
+  stream_id: 9002,
+  emby_user_name: null,
+  plex_user_name: null,
+  jellyfin_user_name: null,
+};
+
+describe('StatsTab — multi-viewer per-client rendering (bd-r5f0c.5 / W5)', () => {
+  // --- Single viewer via emby_viewers[] (W9 path) ---
+
+  it('renders a single Emby viewer from emby_viewers[] list', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue({
+      count: 1,
+      channels: [
+        {
+          ...baseMultiViewerChannel,
+          clients: [
+            {
+              client_id: 'cid-mv1',
+              ip_address: '10.0.0.1',
+              user_agent: 'Emby/1.0',
+              connected_at: '2026-05-17T00:00:00Z',
+              last_active: '2026-05-17T00:01:00Z',
+              emby_viewers: [{ user_id: 'emby-uid-1', user_name: 'Alice' }],
+            },
+          ],
+        },
+      ],
+    } as unknown as ChannelStatsResponse);
+
+    render(<StatsTab />);
+
+    await waitFor(() => {
+      // Name from the viewers list
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+    // AttributionBadge renders "via Emby"
+    expect(screen.getByText('via Emby')).toBeInTheDocument();
+  });
+
+  // --- 2 viewers comma-separated ---
+
+  it('renders two Emby viewers as comma-separated names', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue({
+      count: 1,
+      channels: [
+        {
+          ...baseMultiViewerChannel,
+          clients: [
+            {
+              client_id: 'cid-mv2',
+              ip_address: '10.0.0.2',
+              user_agent: 'Emby/1.0',
+              connected_at: '2026-05-17T00:00:00Z',
+              last_active: '2026-05-17T00:01:00Z',
+              emby_viewers: [
+                { user_id: null, user_name: 'Alice' },
+                { user_id: null, user_name: 'Bob' },
+              ],
+            },
+          ],
+        },
+      ],
+    } as unknown as ChannelStatsResponse);
+
+    render(<StatsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice, Bob')).toBeInTheDocument();
+    });
+    expect(screen.getByText('via Emby')).toBeInTheDocument();
+  });
+
+  // --- 3 viewers comma-separated (up to 3 shown inline per spec) ---
+
+  it('renders three Emby viewers as comma-separated names', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue({
+      count: 1,
+      channels: [
+        {
+          ...baseMultiViewerChannel,
+          clients: [
+            {
+              client_id: 'cid-mv3',
+              ip_address: '10.0.0.3',
+              user_agent: 'Emby/1.0',
+              connected_at: '2026-05-17T00:00:00Z',
+              last_active: '2026-05-17T00:01:00Z',
+              emby_viewers: [
+                { user_id: null, user_name: 'Alice' },
+                { user_id: null, user_name: 'Bob' },
+                { user_id: null, user_name: 'Carol' },
+              ],
+            },
+          ],
+        },
+      ],
+    } as unknown as ChannelStatsResponse);
+
+    render(<StatsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice, Bob, Carol')).toBeInTheDocument();
+    });
+  });
+
+  // --- 4+ viewers → rollup summary ---
+
+  it('renders "(N viewers)" summary for 4+ Emby viewers in a details element', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue({
+      count: 1,
+      channels: [
+        {
+          ...baseMultiViewerChannel,
+          clients: [
+            {
+              client_id: 'cid-mv4',
+              ip_address: '10.0.0.4',
+              user_agent: 'Emby/1.0',
+              connected_at: '2026-05-17T00:00:00Z',
+              last_active: '2026-05-17T00:01:00Z',
+              emby_viewers: [
+                { user_id: null, user_name: 'Alice' },
+                { user_id: null, user_name: 'Bob' },
+                { user_id: null, user_name: 'Carol' },
+                { user_id: null, user_name: 'Dave' },
+              ],
+            },
+          ],
+        },
+      ],
+    } as unknown as ChannelStatsResponse);
+
+    const { container } = render(<StatsTab />);
+
+    await waitFor(() => {
+      // The summary element shows "(4 viewers)"
+      expect(screen.getByText('4 viewers')).toBeInTheDocument();
+    });
+    // Names hidden inside a <details> element
+    expect(container.querySelector('details.viewer-details')).toBeInTheDocument();
+  });
+
+  // --- Plex single viewer ---
+
+  it('renders a single Plex viewer from plex_viewers[] list', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue({
+      count: 1,
+      channels: [
+        {
+          ...baseMultiViewerChannel,
+          clients: [
+            {
+              client_id: 'cid-plex1',
+              ip_address: '10.0.0.5',
+              user_agent: 'Plex/2.0',
+              connected_at: '2026-05-17T00:00:00Z',
+              last_active: '2026-05-17T00:01:00Z',
+              plex_viewers: [{ user_id: null, user_name: 'PlexUser' }],
+            },
+          ],
+        },
+      ],
+    } as unknown as ChannelStatsResponse);
+
+    render(<StatsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('PlexUser')).toBeInTheDocument();
+    });
+    expect(screen.getByText('via Plex')).toBeInTheDocument();
+  });
+
+  // --- Jellyfin single viewer ---
+
+  it('renders a single Jellyfin viewer from jellyfin_viewers[] list', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue({
+      count: 1,
+      channels: [
+        {
+          ...baseMultiViewerChannel,
+          clients: [
+            {
+              client_id: 'cid-jf1',
+              ip_address: '10.0.0.6',
+              user_agent: 'Jellyfin/10.0',
+              connected_at: '2026-05-17T00:00:00Z',
+              last_active: '2026-05-17T00:01:00Z',
+              jellyfin_viewers: [{ user_id: 'jf-uid-1', user_name: 'JellyUser' }],
+            },
+          ],
+        },
+      ],
+    } as unknown as ChannelStatsResponse);
+
+    render(<StatsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('JellyUser')).toBeInTheDocument();
+    });
+    expect(screen.getByText('via Jellyfin')).toBeInTheDocument();
+  });
+
+  // --- Mixed-source rendering ---
+
+  it('renders separate attribution rows for Emby and Plex viewers on the same client', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue({
+      count: 1,
+      channels: [
+        {
+          ...baseMultiViewerChannel,
+          clients: [
+            {
+              client_id: 'cid-mixed',
+              ip_address: '10.0.0.7',
+              user_agent: 'Proxy/1.0',
+              connected_at: '2026-05-17T00:00:00Z',
+              last_active: '2026-05-17T00:01:00Z',
+              emby_viewers: [{ user_id: null, user_name: 'EmbyUser' }],
+              plex_viewers: [{ user_id: null, user_name: 'PlexUser' }],
+            },
+          ],
+        },
+      ],
+    } as unknown as ChannelStatsResponse);
+
+    render(<StatsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('EmbyUser')).toBeInTheDocument();
+    });
+    expect(screen.getByText('PlexUser')).toBeInTheDocument();
+    // Both badges present
+    expect(screen.getByText('via Emby')).toBeInTheDocument();
+    expect(screen.getByText('via Plex')).toBeInTheDocument();
+    // Attribution rows wrapper
+    const { container } = render(<StatsTab />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="client-attribution-rows"]')).toBeInTheDocument();
+    });
+  });
+});
+
+// bd-r5f0c.5 (W5) / bd-g03fi: Channel-header viewer rollup.
+// When total_viewers > 1 across all sources, the header shows "(N viewers)"
+// instead of a single user's name.
+
+describe('StatsTab — channel-header viewer rollup (bd-g03fi)', () => {
+  it('shows "(2 viewers)" rollup when emby_viewers has 2 entries', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue({
+      count: 1,
+      channels: [
+        {
+          ...baseMultiViewerChannel,
+          emby_viewers: [
+            { user_id: null, user_name: 'Alice' },
+            { user_id: null, user_name: 'Bob' },
+          ],
+          clients: [],
+        },
+      ],
+    } as unknown as ChannelStatsResponse);
+
+    const { container } = render(<StatsTab />);
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="channel-header-viewer-rollup"]')).toBeInTheDocument();
+    });
+    expect(screen.getByText('(2 viewers)')).toBeInTheDocument();
+  });
+
+  it('shows "(3 viewers)" rollup when viewers span Emby and Plex', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue({
+      count: 1,
+      channels: [
+        {
+          ...baseMultiViewerChannel,
+          emby_viewers: [
+            { user_id: null, user_name: 'Alice' },
+            { user_id: null, user_name: 'Bob' },
+          ],
+          plex_viewers: [
+            { user_id: null, user_name: 'Carol' },
+          ],
+          clients: [],
+        },
+      ],
+    } as unknown as ChannelStatsResponse);
+
+    render(<StatsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('(3 viewers)')).toBeInTheDocument();
+    });
+  });
+
+  it('shows single viewer name when only 1 viewer total (back-compat)', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue({
+      count: 1,
+      channels: [
+        {
+          ...baseMultiViewerChannel,
+          emby_viewers: [{ user_id: null, user_name: 'OnlyUser' }],
+          clients: [],
+        },
+      ],
+    } as unknown as ChannelStatsResponse);
+
+    const { container } = render(<StatsTab />);
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="channel-header-single-viewer"]')).toBeInTheDocument();
+    });
+    expect(screen.getByText('(watching: OnlyUser)')).toBeInTheDocument();
+    // Should NOT show rollup
+    expect(screen.queryByTestId('channel-header-viewer-rollup')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/tabs/StatsTab.tsx
+++ b/frontend/src/components/tabs/StatsTab.tsx
@@ -22,6 +22,8 @@ import { WatchHistoryPanel } from './WatchHistoryPanel';
 import { BandwidthPanel } from './BandwidthPanel';
 import { UserStatsPanel } from './UserStatsPanel';
 import { ProvidersPanel } from './ProvidersPanel';
+import { AttributionBadge } from '../AttributionBadge';
+import type { Viewer } from '../../types';
 import './StatsTab.css';
 
 // Historical data point for charts
@@ -897,23 +899,67 @@ export function StatsTab() {
                         {streamBadgeText}
                       </span>
                     )}
-                    {/* bd-fm23o (final bead of EPIC bd-2cenq — Emby user
-                        attribution): "(watching: <emby_user>)" badge for
-                        Emby-mediated streams. Backend's
-                        ``_enrich_channels_with_emby`` populates
-                        ``emby_user_name`` when the live resolver
-                        attributes any client of this channel to an Emby
-                        user. Rendered alongside the stream-name badge
-                        for visual continuity — operator can see
-                        provider + stream + Emby viewer in one line. */}
-                    {channel.emby_user_name && (
-                      <span
-                        className="stream-name-badge channel-emby-viewer"
-                        title={`Watching via Emby: ${channel.emby_user_name}`}
-                      >
-                        (watching: {channel.emby_user_name})
-                      </span>
-                    )}
+                    {/* bd-r5f0c.5 / W5 (bd-g03fi): channel-header viewer
+                        rollup. Counts total viewers across all sources
+                        (emby + plex + jellyfin + dispatcharr fallback).
+                        - total == 1: show single name (back-compat)
+                        - total > 1: show "(N viewers)" rollup
+                        - total == 0: fall back to legacy emby_user_name
+                        singular for any old DB rows that pre-date W9.
+                        The per-client breakdown in the expanded section
+                        below shows the full breakdown by source. */}
+                    {(() => {
+                      const embyCount = channel.emby_viewers?.length ?? 0;
+                      const plexCount = channel.plex_viewers?.length ?? 0;
+                      const jellyfinCount = channel.jellyfin_viewers?.length ?? 0;
+                      const totalViewers = embyCount + plexCount + jellyfinCount;
+
+                      if (totalViewers > 1) {
+                        // bd-g03fi closure: rollup to "(N viewers)"
+                        return (
+                          <span
+                            className="stream-name-badge channel-emby-viewer"
+                            title={`${totalViewers} viewers across all media servers`}
+                            data-testid="channel-header-viewer-rollup"
+                          >
+                            ({totalViewers} viewers)
+                          </span>
+                        );
+                      }
+
+                      if (totalViewers === 1) {
+                        // Single viewer: show their name with badge
+                        const singleViewer =
+                          channel.emby_viewers?.[0] ??
+                          channel.plex_viewers?.[0] ??
+                          channel.jellyfin_viewers?.[0];
+                        if (singleViewer) {
+                          return (
+                            <span
+                              className="stream-name-badge channel-emby-viewer"
+                              title={`Watching: ${singleViewer.user_name}`}
+                              data-testid="channel-header-single-viewer"
+                            >
+                              (watching: {singleViewer.user_name})
+                            </span>
+                          );
+                        }
+                      }
+
+                      // Fallback: legacy emby_user_name for pre-W9 DB rows
+                      if (channel.emby_user_name) {
+                        return (
+                          <span
+                            className="stream-name-badge channel-emby-viewer"
+                            title={`Watching via Emby: ${channel.emby_user_name}`}
+                          >
+                            (watching: {channel.emby_user_name})
+                          </span>
+                        );
+                      }
+
+                      return null;
+                    })()}
                     {m3uSource && (
                       <span className="m3u-source" title={`M3U Source: ${m3uSource}`}>
                         {m3uSource}
@@ -1166,26 +1212,120 @@ export function StatsTab() {
                       {channel.clients.map((client, idx) => (
                         <div key={client.client_id || idx} className="client-item">
                           <div className="client-info">
-                            {/* bd-5kbyf: prefer emby_user_name (propagated
-                                from channel-level resolver) over dispatcharr
-                                username; fall back to User #id when neither
-                                is set. "via Emby" badge mirrors the
-                                attribution-source-badge from UserStatsPanel
-                                (bd-fm23o). */}
-                            {(client.emby_user_name || client.username || client.user_id) && (
-                              <span className="client-user">
-                                <span className="material-icons" style={{ fontSize: '14px' }}>person</span>
-                                {client.emby_user_name || client.username || `User #${client.user_id}`}
-                                {client.emby_user_name && (
-                                  <span
-                                    className="badge attribution-source-badge"
-                                    title="Identity resolved via Emby /Sessions cross-reference"
-                                  >
-                                    via Emby
+                            {/* bd-r5f0c.5 (W5): Multi-viewer rendering.
+                                Priority order:
+                                  1. *_viewers[] (W9 multi-viewer lists)
+                                  2. *_user_name singular (back-compat fallback)
+                                  3. dispatcharr username / user_id
+                                For each source that has viewers, render an
+                                AttributionBadge row. If a client has viewers
+                                from multiple sources, each gets its own line. */}
+                            {/* bd-r5f0c.5 (W5): Multi-viewer rendering.
+                                Priority order per source:
+                                  1. *_viewers[] (W9 multi-viewer lists) → AttributionBadge
+                                  2. *_user_name singular (back-compat) → old inline badge
+                                     to preserve existing test contracts (bd-5kbyf)
+                                  3. dispatcharr username / user_id
+                                If a client has viewers from multiple sources,
+                                each gets its own <span className="client-user"> row. */}
+                            {(() => {
+                              // --- Multi-viewer path (W9 emby_viewers / plex_viewers / jellyfin_viewers) ---
+                              type ViewerRow = { source: 'emby' | 'plex' | 'jellyfin'; viewers: Viewer[] };
+                              const viewerRows: ViewerRow[] = [];
+
+                              if (client.emby_viewers && client.emby_viewers.length > 0) {
+                                viewerRows.push({ source: 'emby', viewers: client.emby_viewers });
+                              }
+                              if (client.plex_viewers && client.plex_viewers.length > 0) {
+                                viewerRows.push({ source: 'plex', viewers: client.plex_viewers });
+                              }
+                              if (client.jellyfin_viewers && client.jellyfin_viewers.length > 0) {
+                                viewerRows.push({ source: 'jellyfin', viewers: client.jellyfin_viewers });
+                              }
+
+                              if (viewerRows.length > 0) {
+                                return (
+                                  <div className="client-attribution-rows" data-testid="client-attribution-rows">
+                                    {viewerRows.map(row => {
+                                      const count = row.viewers.length;
+                                      let nameText: string;
+                                      if (count === 1) {
+                                        nameText = row.viewers[0].user_name;
+                                      } else if (count <= 3) {
+                                        nameText = row.viewers.map(v => v.user_name).join(', ');
+                                      } else {
+                                        nameText = `${count} viewers`;
+                                      }
+                                      return (
+                                        <span key={row.source} className="client-user">
+                                          <AttributionBadge source={row.source} />
+                                          {count > 3 ? (
+                                            <details className="viewer-details">
+                                              <summary>{nameText}</summary>
+                                              <ul className="viewer-list">
+                                                {row.viewers.map((v, i) => (
+                                                  <li key={i}>{v.user_name}</li>
+                                                ))}
+                                              </ul>
+                                            </details>
+                                          ) : (
+                                            <span className="viewer-names">{nameText}</span>
+                                          )}
+                                        </span>
+                                      );
+                                    })}
+                                  </div>
+                                );
+                              }
+
+                              // --- Back-compat singular path (bd-5kbyf contract preserved) ---
+                              // When emby_viewers is absent/null but emby_user_name is set
+                              // (pre-W9 DB rows), render the original markup so existing
+                              // tests pass unmodified. Same for plex / jellyfin.
+                              if (client.emby_user_name) {
+                                return (
+                                  <span className="client-user">
+                                    <span className="material-icons" style={{ fontSize: '14px' }}>person</span>
+                                    {client.emby_user_name}
+                                    <span
+                                      className="badge attribution-source-badge"
+                                      title="Identity resolved via Emby /Sessions cross-reference"
+                                    >
+                                      via Emby
+                                    </span>
                                   </span>
-                                )}
-                              </span>
-                            )}
+                                );
+                              }
+                              if (client.plex_user_name) {
+                                return (
+                                  <span className="client-user">
+                                    <span className="material-icons" style={{ fontSize: '14px' }}>person</span>
+                                    {client.plex_user_name}
+                                    <span className="badge attribution-source-badge">via Plex</span>
+                                  </span>
+                                );
+                              }
+                              if (client.jellyfin_user_name) {
+                                return (
+                                  <span className="client-user">
+                                    <span className="material-icons" style={{ fontSize: '14px' }}>person</span>
+                                    {client.jellyfin_user_name}
+                                    <span className="badge attribution-source-badge">via Jellyfin</span>
+                                  </span>
+                                );
+                              }
+
+                              // --- Dispatcharr username / user_id fallback ---
+                              if (client.username || client.user_id) {
+                                return (
+                                  <span className="client-user">
+                                    <span className="material-icons" style={{ fontSize: '14px' }}>person</span>
+                                    {client.username || `User #${client.user_id}`}
+                                  </span>
+                                );
+                              }
+                              return null;
+                            })()}
                             <span className="client-ip">{client.ip_address || 'Unknown'}</span>
                             <span className="client-ua">{parseUserAgent(client.user_agent)}</span>
                           </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1024,6 +1024,14 @@ export interface SettingsResponse {
   emby_enabled: boolean;
   emby_base_url: string;
   emby_api_key_configured: boolean;
+  // Plex integration (bd-r5f0c.2 / W2). Token uses preserve-on-omit.
+  plex_enabled: boolean;
+  plex_base_url: string;
+  plex_token_configured: boolean;
+  // Jellyfin integration (bd-r5f0c.3 / W3). Key uses preserve-on-omit.
+  jellyfin_enabled: boolean;
+  jellyfin_base_url: string;
+  jellyfin_api_key_configured: boolean;
 }
 
 // Stream preview mode for browser playback
@@ -1128,6 +1136,14 @@ export async function saveSettings(settings: {
   emby_enabled?: boolean;
   emby_base_url?: string;
   emby_api_key?: string;
+  // Plex integration (bd-r5f0c.2 / W2). plex_token uses preserve-on-omit.
+  plex_enabled?: boolean;
+  plex_base_url?: string;
+  plex_token?: string;
+  // Jellyfin integration (bd-r5f0c.3 / W3). jellyfin_api_key uses preserve-on-omit.
+  jellyfin_enabled?: boolean;
+  jellyfin_base_url?: string;
+  jellyfin_api_key?: string;
 }): Promise<{ status: string; configured: boolean; server_changed: boolean }> {
   return fetchJson(`${API_BASE}/settings`, {
     method: 'POST',
@@ -1152,6 +1168,38 @@ export async function testEmbyConnection(
   apiKey: string,
 ): Promise<EmbyTestConnectionResult> {
   return fetchJson(`${API_BASE}/settings/emby/test-connection`, {
+    method: 'POST',
+    body: JSON.stringify({ base_url: baseUrl, api_key: apiKey }),
+  });
+}
+
+// Plex Settings UI test-connection (bd-r5f0c.5 / W5). Same shape as Emby.
+export interface PlexTestConnectionResult {
+  ok: boolean;
+  error?: string;
+}
+
+export async function testPlexConnection(
+  baseUrl: string,
+  plexToken: string,
+): Promise<PlexTestConnectionResult> {
+  return fetchJson(`${API_BASE}/settings/plex/test-connection`, {
+    method: 'POST',
+    body: JSON.stringify({ base_url: baseUrl, plex_token: plexToken }),
+  });
+}
+
+// Jellyfin Settings UI test-connection (bd-r5f0c.5 / W5). Same shape as Emby.
+export interface JellyfinTestConnectionResult {
+  ok: boolean;
+  error?: string;
+}
+
+export async function testJellyfinConnection(
+  baseUrl: string,
+  apiKey: string,
+): Promise<JellyfinTestConnectionResult> {
+  return fetchJson(`${API_BASE}/settings/jellyfin/test-connection`, {
     method: 'POST',
     body: JSON.stringify({ base_url: baseUrl, api_key: apiKey }),
   });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -357,6 +357,19 @@ export * from './journal';
 // Stats & Monitoring Types
 // =============================================================================
 
+// Multi-viewer attribution (bd-r5f0c.9 / W9). Each entry represents one
+// upstream user observed in a media-server session that corresponds to an
+// ECM stream. The ``user_id`` may be null when the resolver doesn't surface
+// a stable server-side identifier (e.g. Plex today).
+export interface Viewer {
+  user_id: string | null;
+  user_name: string;
+}
+
+// Attribution source for a given client or channel. Drives badge icon +
+// label in <AttributionBadge>. Null = no source resolved.
+export type AttributionSource = 'emby' | 'plex' | 'jellyfin' | 'dispatcharr' | null;
+
 // Client connection info for an active stream
 export interface StreamClient {
   client_id: string;
@@ -370,9 +383,19 @@ export interface StreamClient {
   current_rate_KBps?: number;
   user_id?: string;
   username?: string;
-  /** bd-5kbyf: Emby user resolved via cross-reference when this channel is
+  /** Legacy singular attribution (back-compat; most-recent viewer's name).
+   * bd-5kbyf: Emby user resolved via cross-reference when this channel is
    * Emby-mediated. Null when Emby is disabled or no attribution matched. */
   emby_user_name?: string | null;
+  // Plex/Jellyfin legacy singular (W4 / bd-r5f0c.4)
+  plex_user_name?: string | null;
+  jellyfin_user_name?: string | null;
+  // Multi-viewer lists (W9 / bd-r5f0c.9). Null = no attribution from that source.
+  emby_viewers?: Viewer[] | null;
+  plex_viewers?: Viewer[] | null;
+  jellyfin_viewers?: Viewer[] | null;
+  // Most-recent viewer's attribution source (drives badge selection)
+  attribution_source?: AttributionSource;
 }
 
 // Active channel stats from /proxy/ts/status
@@ -437,6 +460,15 @@ export interface ChannelStats {
   // stream name. The Active Channels view renders this as a
   // "(watching: <emby_user>)" suffix on the stream-identity badge.
   emby_user_name?: string | null;
+  // Plex / Jellyfin legacy singular (W4 / bd-r5f0c.4)
+  plex_user_name?: string | null;
+  jellyfin_user_name?: string | null;
+  // Multi-viewer lists (W9 / bd-r5f0c.9). Null = no attribution from that source.
+  emby_viewers?: Viewer[] | null;
+  plex_viewers?: Viewer[] | null;
+  jellyfin_viewers?: Viewer[] | null;
+  // Most-recent viewer's attribution source (drives badge selection)
+  attribution_source?: AttributionSource;
 }
 
 // Response from /proxy/ts/status
@@ -1160,7 +1192,8 @@ export interface WatchHistoryResponse {
 // account that ECM would otherwise see) and the UI renders a "via Emby"
 // badge so the operator knows the attribution path. ``"dispatcharr"`` is
 // the pre-bd-fm23o default for sessions with no Emby attribution.
-export type AttributionSource = 'emby' | 'dispatcharr';
+// Extended by bd-r5f0c.5 to include 'plex' and 'jellyfin' variants.
+// The canonical definition is at the top of this file (line ~371).
 
 // Row shape for /watch-time with group_by=total
 export interface WatchTimeUserTotalRow {


### PR DESCRIPTION
## Summary

- New `<AttributionBadge>` component: icon + "via Source" text, 3 sources (emby/plex/jellyfin), BEM CSS, a11y-correct `aria-label` on icon span
- **StatsTab Connected Clients**: multi-viewer rendering from `*_viewers[]` arrays (W9 backend path); back-compat for legacy `emby_user_name` singular path (preserves bd-5kbyf test contracts unmodified)
- **Channel-header viewer rollup** (bd-g03fi): shows "(N viewers)" when total > 1 across all sources
- **Settings Integrations page**: Plex + Jellyfin sections with anchor jump nav, SEC-1 Plex token helper text (`data-testid="plex-token-helper-text"`)
- **TypeScript types**: `Viewer` interface, `AttributionSource` expanded to `emby|plex|jellyfin|dispatcharr|null`, extended `StreamClient` + `ChannelStats`; removed duplicate narrower `AttributionSource` declaration
- **api.ts**: `SettingsResponse` Plex/Jellyfin fields + `testPlexConnection` / `testJellyfinConnection` endpoints
- **Version bump**: 0.17.1-0043 → 0.17.1-0044 (frontend/package.json, backend/main.py, backend/routers/backup.py)

## Test plan

- [ ] All 1472 frontend tests pass (74 files): `vitest run`
- [ ] ESLint clean: `eslint src --max-warnings 0`
- [ ] TypeScript clean: `tsc --noEmit`
- [ ] Vite build succeeds
- [ ] Existing bd-5kbyf tests (Emby singular back-compat) pass unmodified
- [ ] New `AttributionBadge.test.tsx`: 13 tests for emby/plex/jellyfin variants
- [ ] New `PlexIntegrationSection.test.tsx` + `JellyfinIntegrationSection.test.tsx`: settings section render/save/test-connection
- [ ] `StatsTab.test.tsx`: multi-viewer tests (single, 2-3 comma-list, 4+ rollup, mixed-source, channel-header rollup)
- [ ] `DeduplicationSettingsSection.test.tsx`: SettingsResponse fixture updated with Plex/Jellyfin fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)