### PR TITLE
v0.17.1-0048: resolver no-match forensic logging (bd-r5f0c.10)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0047",
+    version="0.17.1-0048",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0047"
+APP_VERSION = "0.17.1-0048"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/services/emby_resolver.py
+++ b/backend/services/emby_resolver.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import logging
 import socket
+import time
 import unicodedata
 from dataclasses import dataclass
 from urllib.parse import urlparse
@@ -104,17 +105,43 @@ _UNRESOLVED = object()
 _dns_cache: dict[str, str | object] = {}
 
 
+# bd-r5f0c.10: per-(client_ip, normalized_channel_name) rate-limit
+# timestamps for the no-match forensic WARN. A dict (not a single global
+# timestamp) so a noisy problem channel does not silence diagnosis for
+# other channels the same operator is also having trouble with. Keys are
+# ``(client_ip, normalized_ecm_channel_name)`` and values are
+# ``time.monotonic()`` snapshots of the last emission for that pair.
+_emby_resolver_no_match_last_warn_at: dict[tuple[str, str], float] = {}
+
+
+# Minimum interval between WARN emissions for the same (ip, channel)
+# pair. 60 s is short enough that an operator actively diagnosing sees
+# fresh data on every reload but long enough to keep the log readable
+# under sustained polling at ~5 s cadence.
+_EMBY_NO_MATCH_WARN_INTERVAL: float = 60.0
+
+
+# Max number of sessions to enumerate in the forensic log line. Operators
+# with 50+ active Emby sessions would otherwise blow out the WARN line;
+# 10 is enough to surface the candidates that actually matter without
+# log-bloat.
+_EMBY_NO_MATCH_MAX_SESSIONS: int = 10
+
+
 def _reset_for_tests() -> None:
-    """Clear the DNS cache — tests only.
+    """Clear the DNS cache and the no-match WARN rate-limit state — tests only.
 
     Tests share the same module instance across test functions; without
     this reset, a hostname-resolution result from one test would leak
     into the next and produce false matches (e.g. a test that mocks
     ``gethostbyname`` to return one IP would still see that IP in a
-    later test that expects to fail). Production code paths do not call
-    this.
+    later test that expects to fail). The bd-r5f0c.10 no-match WARN
+    timestamps also leak across tests if not cleared — a test exercising
+    rate-limit behaviour would prevent the next test from seeing its own
+    WARN. Production code paths do not call this.
     """
     _dns_cache.clear()
+    _emby_resolver_no_match_last_warn_at.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +255,18 @@ async def resolve_emby_users(
             ecm_stream_name, ecm_channel_name, ecm_channel_number,
             len(sessions),
         )
+        # bd-r5f0c.10: forensic logging — IP matched, sessions exist,
+        # but no tier produced a match. Rate-limited per (ip, channel)
+        # per 60 s. Guarded on ``sessions`` so an empty session cache
+        # (the normal idle state) does NOT generate noise.
+        if sessions:
+            _log_emby_resolver_no_match(
+                client_ip=ecm_session_ip,
+                ecm_channel_name=ecm_channel_name,
+                ecm_channel_number=ecm_channel_number,
+                ecm_stream_name=ecm_stream_name,
+                sessions=sessions,
+            )
         observability.get_metric("user_attribution_unresolved_total").labels(source="emby").inc()
         return []
 
@@ -567,6 +606,74 @@ def _tiebreak_most_recent(sessions: list[EmbySession]) -> EmbySession:
     if len(sessions) == 1:
         return sessions[0]
     return max(sessions, key=lambda s: s.last_activity_date or "")
+
+
+def _log_emby_resolver_no_match(
+    *,
+    client_ip: str,
+    ecm_channel_name: str | None,
+    ecm_channel_number: str | int | None,
+    ecm_stream_name: str,
+    sessions: list[EmbySession],
+) -> None:
+    """Emit a structured WARN once per (client_ip, channel_name) per 60 s
+    when the resolver had sessions to compare against and the IP
+    short-circuit passed, but no tier produced a match.
+
+    bd-r5f0c.10 forensic logging for the PO-reported v0.17.1 cut-blocker:
+    two Emby viewers watching different channels (CBS resolves, CNN
+    surfaces as ``"User #0"``) configured identically in ECM. We cannot
+    fix the resolver mismatch without forensic data on what each tier
+    compared and rejected; this helper emits one WARN per problem
+    (ip, channel) per 60 s carrying raw and NFC-lower-stripped forms of
+    every comparison input plus every cached session so the mismatch is
+    visible at a glance in the operator's log.
+
+    The helper is intentionally suppressive: callers MUST only invoke it
+    when ``sessions`` is non-empty (an empty cache is a normal idle
+    state) and no tier matched. Calling on every poll cycle without
+    those guards would flood the log.
+
+    The session list in the payload is truncated at
+    ``_EMBY_NO_MATCH_MAX_SESSIONS`` (10) entries — defensive against
+    operators with very large Emby session counts.
+    """
+    rate_key = (client_ip, _normalize(ecm_channel_name or ""))
+    now = time.monotonic()
+    last = _emby_resolver_no_match_last_warn_at.get(rate_key, 0.0)
+    if now - last < _EMBY_NO_MATCH_WARN_INTERVAL:
+        return
+    _emby_resolver_no_match_last_warn_at[rate_key] = now
+
+    truncated = sessions[:_EMBY_NO_MATCH_MAX_SESSIONS]
+    session_payload = [
+        {
+            "session_id": (s.session_id[:8] if s.session_id else None),
+            "item_name": s.now_playing_item_name,
+            "item_name_norm": _normalize(s.now_playing_item_name or ""),
+            "item_name_pipe_suffix": _parse_pipe_suffix(
+                _normalize(s.now_playing_item_name or "")
+            ),
+            "channel_name": s.now_playing_channel_name,
+            "channel_name_norm": _normalize(s.now_playing_channel_name or ""),
+            "channel_number": s.channel_number,
+            "last_activity": s.last_activity_date,
+        }
+        for s in truncated
+    ]
+    logger.warning(
+        "[EMBY-RESOLVER] no-match diagnostic: ip=%s ecm_channel=%r "
+        "ecm_channel_norm=%r ecm_channel_number=%r ecm_stream=%r "
+        "ecm_stream_norm=%r sessions_count=%d sessions=%s",
+        client_ip,
+        ecm_channel_name,
+        _normalize(ecm_channel_name or ""),
+        ecm_channel_number,
+        ecm_stream_name,
+        _normalize(ecm_stream_name or ""),
+        len(sessions),
+        session_payload,
+    )
 
 
 def _sort_by_recency_descending(sessions: list[EmbySession]) -> list[EmbySession]:

--- a/backend/services/jellyfin_resolver.py
+++ b/backend/services/jellyfin_resolver.py
@@ -110,16 +110,37 @@ _dns_cache: dict[str, str | object] = {}
 _jellyfin_resolver_last_warn_at: float | None = None
 
 
+# bd-r5f0c.10: per-(client_ip, normalized_channel_name) rate-limit
+# timestamps for the no-match forensic WARN. A dict (not a single global
+# timestamp) so a noisy problem channel does not silence diagnosis for
+# other channels the same operator is also having trouble with.
+_jellyfin_resolver_no_match_last_warn_at: dict[tuple[str, str], float] = {}
+
+
+# Minimum interval between WARN emissions for the same (ip, channel)
+# pair. Same 60 s as the existing disambiguation WARN above and as the
+# Emby/Plex no-match WARNs.
+_JELLYFIN_NO_MATCH_WARN_INTERVAL: float = 60.0
+
+
+# Max sessions in the forensic log line — defensive against log-bloat
+# on operators with very large Jellyfin session counts.
+_JELLYFIN_NO_MATCH_MAX_SESSIONS: int = 10
+
+
 def _reset_for_tests() -> None:
-    """Clear the DNS cache and warn timestamp — tests only.
+    """Clear the DNS cache, warn timestamp, and no-match rate-limit — tests only.
 
     Tests share the same module instance across test functions; without
     this reset, a hostname-resolution result from one test would leak
-    into the next and produce false matches.
+    into the next and produce false matches. bd-r5f0c.10 also added a
+    per-(ip, channel) no-match WARN timestamp dict that must be cleared
+    so rate-limit tests are isolated.
     """
     global _jellyfin_resolver_last_warn_at
     _dns_cache.clear()
     _jellyfin_resolver_last_warn_at = None
+    _jellyfin_resolver_no_match_last_warn_at.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -220,6 +241,17 @@ async def resolve_jellyfin_users(
             ecm_stream_name, ecm_channel_name, ecm_channel_number,
             len(sessions),
         )
+        # bd-r5f0c.10: forensic WARN — IP matched, sessions exist, no
+        # tier produced a match. Guarded on ``sessions`` non-empty so
+        # the normal idle state stays silent.
+        if sessions:
+            _log_jellyfin_resolver_no_match(
+                client_ip=ecm_session_ip,
+                ecm_channel_name=ecm_channel_name,
+                ecm_channel_number=ecm_channel_number,
+                ecm_stream_name=ecm_stream_name,
+                sessions=sessions,
+            )
         observability.get_metric("user_attribution_unresolved_total").labels(source="jellyfin").inc()
         return []
 
@@ -529,6 +561,66 @@ def _sort_by_recency_descending(
         sessions,
         key=lambda s: s.last_activity_date or "",
         reverse=True,
+    )
+
+
+def _log_jellyfin_resolver_no_match(
+    *,
+    client_ip: str,
+    ecm_channel_name: str | None,
+    ecm_channel_number: str | int | None,
+    ecm_stream_name: str,
+    sessions: list[JellyfinSession],
+) -> None:
+    """Emit a structured WARN once per (client_ip, channel_name) per 60 s
+    when the Jellyfin resolver had sessions to compare against and the
+    IP short-circuit passed, but no tier produced a match.
+
+    bd-r5f0c.10 forensic logging — mirrors the Emby resolver helper.
+    See :func:`emby_resolver._log_emby_resolver_no_match` for the full
+    rationale. JellyfinSession's field shape matches EmbySession (same
+    upstream Sessions API ancestry), so the per-session payload is
+    identical: raw + normalized item_name, parsed pipe suffix,
+    channel_name (raw + normalized), channel_number, last_activity.
+
+    Callers MUST guard on non-empty ``sessions`` — an empty session list
+    is a normal state and would spam the log with useless lines.
+    """
+    rate_key = (client_ip, _normalize(ecm_channel_name or ""))
+    now = time.monotonic()
+    last = _jellyfin_resolver_no_match_last_warn_at.get(rate_key, 0.0)
+    if now - last < _JELLYFIN_NO_MATCH_WARN_INTERVAL:
+        return
+    _jellyfin_resolver_no_match_last_warn_at[rate_key] = now
+
+    truncated = sessions[:_JELLYFIN_NO_MATCH_MAX_SESSIONS]
+    session_payload = [
+        {
+            "session_id": (s.session_id[:8] if s.session_id else None),
+            "item_name": s.now_playing_item_name,
+            "item_name_norm": _normalize(s.now_playing_item_name or ""),
+            "item_name_pipe_suffix": _parse_pipe_suffix(
+                _normalize(s.now_playing_item_name or "")
+            ),
+            "channel_name": s.now_playing_channel_name,
+            "channel_name_norm": _normalize(s.now_playing_channel_name or ""),
+            "channel_number": s.channel_number,
+            "last_activity": s.last_activity_date,
+        }
+        for s in truncated
+    ]
+    logger.warning(
+        "[JELLYFIN-RESOLVER] no-match diagnostic: ip=%s ecm_channel=%r "
+        "ecm_channel_norm=%r ecm_channel_number=%r ecm_stream=%r "
+        "ecm_stream_norm=%r sessions_count=%d sessions=%s",
+        client_ip,
+        ecm_channel_name,
+        _normalize(ecm_channel_name or ""),
+        ecm_channel_number,
+        ecm_stream_name,
+        _normalize(ecm_stream_name or ""),
+        len(sessions),
+        session_payload,
     )
 
 

--- a/backend/services/plex_resolver.py
+++ b/backend/services/plex_resolver.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import logging
 import socket
+import time
 import unicodedata
 from dataclasses import dataclass
 from datetime import datetime
@@ -134,17 +135,37 @@ _WARN_RATE_LIMIT_SECONDS: float = 60.0
 _dns_cache: dict[str, str | object] = {}
 
 
+# bd-r5f0c.10: per-(client_ip, normalized_channel_name) rate-limit
+# timestamps for the no-match forensic WARN. A dict (not a single global
+# timestamp) so a noisy problem channel does not silence diagnosis for
+# other channels the same operator is also having trouble with.
+_plex_resolver_no_match_last_warn_at: dict[tuple[str, str], float] = {}
+
+
+# Minimum interval between WARN emissions for the same (ip, channel)
+# pair. 60 s mirrors the Emby resolver helper for shape symmetry.
+_PLEX_NO_MATCH_WARN_INTERVAL: float = 60.0
+
+
+# Max sessions in the forensic log line — defensive against log-bloat
+# on operators with very large Plex session counts.
+_PLEX_NO_MATCH_MAX_SESSIONS: int = 10
+
+
 def _reset_for_tests() -> None:
-    """Clear the DNS cache and warn rate-limit — tests only.
+    """Clear the DNS cache, warn rate-limit, and no-match rate-limit — tests only.
 
     Tests share the same module instance across test functions; without
     this reset, a hostname-resolution result from one test would leak
-    into the next and produce false matches. Production code paths do
-    not call this.
+    into the next and produce false matches. bd-r5f0c.10 also added a
+    per-(ip, channel) no-match WARN timestamp dict that must be cleared
+    so rate-limit tests are isolated. Production code paths do not call
+    this.
     """
     global _plex_resolver_last_warn_at
     _dns_cache.clear()
     _plex_resolver_last_warn_at = None
+    _plex_resolver_no_match_last_warn_at.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -251,6 +272,17 @@ async def _resolve_plex_users_inner(
             ecm_stream_name, ecm_channel_name, ecm_channel_number,
             len(sessions),
         )
+        # bd-r5f0c.10: forensic WARN — IP matched, sessions exist, no
+        # tier produced a match. Guarded on ``sessions`` non-empty so
+        # the normal idle state stays silent.
+        if sessions:
+            _log_plex_resolver_no_match(
+                client_ip=ecm_session_ip,
+                ecm_channel_name=ecm_channel_name,
+                ecm_channel_number=ecm_channel_number,
+                ecm_stream_name=ecm_stream_name,
+                sessions=sessions,
+            )
         observability.get_metric("user_attribution_unresolved_total").labels(source="plex").inc()
         return []
 
@@ -579,6 +611,73 @@ def _sort_by_recency_descending(sessions: list[PlexSession]) -> list[PlexSession
     the input order is preserved for ties.
     """
     return sorted(sessions, key=_plex_recency_key, reverse=True)
+
+
+def _log_plex_resolver_no_match(
+    *,
+    client_ip: str,
+    ecm_channel_name: str | None,
+    ecm_channel_number: str | int | None,
+    ecm_stream_name: str,
+    sessions: list[PlexSession],
+) -> None:
+    """Emit a structured WARN once per (client_ip, channel_name) per 60 s
+    when the Plex resolver had sessions to compare against and the IP
+    short-circuit passed, but no tier produced a match.
+
+    bd-r5f0c.10 forensic logging — mirrors the Emby resolver helper.
+    See :func:`emby_resolver._log_emby_resolver_no_match` for the full
+    rationale. PlexSession exposes a smaller field set
+    (no separate ``now_playing_channel_name`` or ``channel_number`` — Plex
+    encodes both as the ``<number> | <name>`` pipe form on
+    ``now_playing_item_name``) so the per-session payload surfaces the
+    parsed pipe prefix and suffix alongside the raw item name. The
+    ``last_activity_date`` is a ``datetime`` here (vs an ISO string for
+    Emby/Jellyfin), serialized as ``isoformat()`` for readability.
+
+    Callers MUST guard on non-empty ``sessions`` — an empty session list
+    is a normal state and would spam the log with useless lines.
+    """
+    rate_key = (client_ip, _normalize(ecm_channel_name or ""))
+    now = time.monotonic()
+    last = _plex_resolver_no_match_last_warn_at.get(rate_key, 0.0)
+    if now - last < _PLEX_NO_MATCH_WARN_INTERVAL:
+        return
+    _plex_resolver_no_match_last_warn_at[rate_key] = now
+
+    truncated = sessions[:_PLEX_NO_MATCH_MAX_SESSIONS]
+    session_payload = [
+        {
+            "session_id": (s.session_id[:8] if s.session_id else None),
+            "item_name": s.now_playing_item_name,
+            "item_name_norm": _normalize(s.now_playing_item_name or ""),
+            "item_name_pipe_prefix": _parse_pipe_prefix(
+                _normalize(s.now_playing_item_name or "")
+            ),
+            "item_name_pipe_suffix": _parse_pipe_suffix(
+                _normalize(s.now_playing_item_name or "")
+            ),
+            "last_activity": (
+                s.last_activity_date.isoformat()
+                if s.last_activity_date is not None
+                else None
+            ),
+        }
+        for s in truncated
+    ]
+    logger.warning(
+        "[PLEX-RESOLVER] no-match diagnostic: ip=%s ecm_channel=%r "
+        "ecm_channel_norm=%r ecm_channel_number=%r ecm_stream=%r "
+        "ecm_stream_norm=%r sessions_count=%d sessions=%s",
+        client_ip,
+        ecm_channel_name,
+        _normalize(ecm_channel_name or ""),
+        ecm_channel_number,
+        ecm_stream_name,
+        _normalize(ecm_stream_name or ""),
+        len(sessions),
+        session_payload,
+    )
 
 
 def _log_disambiguation_warn(

--- a/backend/tests/services/test_emby_resolver.py
+++ b/backend/tests/services/test_emby_resolver.py
@@ -932,3 +932,184 @@ class TestMultiViewer:
             )
         assert len(users) == 3
         assert _get_counter_value("user_attribution_resolved_total", "emby") == 3.0
+
+
+# ---------------------------------------------------------------------------
+# bd-r5f0c.10: forensic no-match WARN. When the resolver has the
+# preconditions for a match (IP short-circuit passed + sessions present)
+# but no tier accepts any session, emit one WARN per (ip, channel) per
+# 60 s carrying enough raw + normalized data to see why the tiers missed.
+# Suppressed cases: empty cache, IP mismatch, successful match.
+# ---------------------------------------------------------------------------
+
+
+class TestNoMatchDiagnostic:
+    """The forensic WARN fires once per (ip, channel) per 60 s when the
+    resolver entered the matching path with non-empty sessions but no
+    tier produced a match. All other cases stay silent."""
+
+    @staticmethod
+    def _no_match_records(records):
+        """Filter caplog records to just our no-match diagnostic lines."""
+        return [
+            r for r in records
+            if "[EMBY-RESOLVER] no-match diagnostic" in r.getMessage()
+        ]
+
+    async def test_emits_warn_when_sessions_exist_and_no_tier_matches(self, caplog):
+        """Sessions in cache but no tier accepts any of them → one WARN."""
+        session = _make_session(
+            user_name="alice",
+            item_name="999 | NotTheChannel",
+            channel_name="NotTheChannel",
+            channel_number="999",
+        )
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.emby_resolver"):
+                users = await emby_resolver.resolve_emby_users(
+                    ecm_session_ip="192.168.1.10",
+                    ecm_stream_name="US: CNN FHD",
+                    ecm_channel_name="CNN",
+                    ecm_channel_number=200,
+                )
+        assert users == []
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 1, (
+            f"expected exactly one no-match WARN; got {len(warns)}: "
+            f"{[r.getMessage() for r in warns]}"
+        )
+        msg = warns[0].getMessage()
+        # Channel + session info must be present for forensic value.
+        assert "CNN" in msg
+        assert "NotTheChannel" in msg
+
+    async def test_no_emit_when_sessions_empty(self, caplog):
+        """Empty session cache (idle Emby) is the normal state — no WARN."""
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=[])):
+            with caplog.at_level(logging.WARNING, logger="services.emby_resolver"):
+                users = await emby_resolver.resolve_emby_users(
+                    ecm_session_ip="192.168.1.10",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+        assert users == []
+        assert self._no_match_records(caplog.records) == []
+
+    async def test_no_emit_when_match_succeeds(self, caplog):
+        """A successful resolve must not emit the no-match WARN."""
+        session = _make_session(user_name="alice", item_name="CNN HD")
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.emby_resolver"):
+                users = await emby_resolver.resolve_emby_users(
+                    ecm_session_ip="192.168.1.10",
+                    ecm_stream_name="CNN HD",
+                )
+        assert len(users) == 1
+        assert self._no_match_records(caplog.records) == []
+
+    async def test_no_emit_when_ip_short_circuit_fails(self, caplog):
+        """IP mismatch short-circuits before the session compare → no WARN."""
+        session = _make_session(
+            item_name="NotTheChannel", channel_number="999",
+        )
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.emby_resolver"):
+                users = await emby_resolver.resolve_emby_users(
+                    ecm_session_ip="10.0.0.99",  # NOT the Emby server
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+        assert users == []
+        assert self._no_match_records(caplog.records) == []
+
+    async def test_rate_limit_within_window(self, caplog):
+        """Two no-match calls in quick succession for the same (ip, channel)
+        → one WARN only. The second call should be suppressed by the
+        60 s rate-limit."""
+        session = _make_session(item_name="UnrelatedShow")
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.emby_resolver"):
+                await emby_resolver.resolve_emby_users(
+                    ecm_session_ip="192.168.1.10",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+                await emby_resolver.resolve_emby_users(
+                    ecm_session_ip="192.168.1.10",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 1, (
+            f"rate-limit broken: expected 1 WARN, got {len(warns)}"
+        )
+
+    async def test_rate_limit_per_channel_independence(self, caplog):
+        """Two different problem channels for the same IP each get their
+        own WARN — the rate-limit is keyed by (ip, channel), not by ip
+        alone. This is the load-bearing assertion: one noisy channel
+        must NOT silence diagnosis for a sibling channel."""
+        session = _make_session(item_name="UnrelatedShow")
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.emby_resolver"):
+                await emby_resolver.resolve_emby_users(
+                    ecm_session_ip="192.168.1.10",
+                    ecm_stream_name="CBS",
+                    ecm_channel_name="CBS",
+                )
+                await emby_resolver.resolve_emby_users(
+                    ecm_session_ip="192.168.1.10",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 2, (
+            f"expected one WARN per channel; got {len(warns)}"
+        )
+        messages = " ".join(r.getMessage() for r in warns)
+        assert "CBS" in messages and "CNN" in messages
+
+    async def test_rate_limit_window_expiry(self, caplog, monkeypatch):
+        """Advance the monotonic clock past 60 s and a second call for
+        the same (ip, channel) emits a fresh WARN."""
+        session = _make_session(item_name="UnrelatedShow")
+        # Step the clock manually so we don't sleep in tests.
+        fake_now = [1000.0]
+
+        def fake_monotonic():
+            return fake_now[0]
+
+        monkeypatch.setattr(emby_resolver.time, "monotonic", fake_monotonic)
+
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.emby_resolver"):
+                await emby_resolver.resolve_emby_users(
+                    ecm_session_ip="192.168.1.10",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+                # Bump clock past the 60 s window.
+                fake_now[0] += 61.0
+                await emby_resolver.resolve_emby_users(
+                    ecm_session_ip="192.168.1.10",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 2, (
+            f"window-expiry broken: expected 2 WARNs, got {len(warns)}"
+        )

--- a/backend/tests/services/test_jellyfin_resolver.py
+++ b/backend/tests/services/test_jellyfin_resolver.py
@@ -880,3 +880,164 @@ class TestMultiViewer:
             )
         assert len(users) == 3
         assert _get_counter_value("user_attribution_resolved_total", "jellyfin") == 3.0
+
+
+# ---------------------------------------------------------------------------
+# bd-r5f0c.10: forensic no-match WARN. Same shape as the Emby resolver
+# helper — see TestNoMatchDiagnostic in test_emby_resolver.py for the
+# rationale. Fires once per (ip, channel) per 60 s when sessions exist
+# and the IP short-circuit passed but no tier accepted any session.
+# ---------------------------------------------------------------------------
+
+
+class TestNoMatchDiagnostic:
+    """Jellyfin forensic no-match WARN. Same suppression semantics as
+    the Emby helper — only fires when IP matched + sessions non-empty +
+    no tier matched."""
+
+    @staticmethod
+    def _no_match_records(records):
+        return [
+            r for r in records
+            if "[JELLYFIN-RESOLVER] no-match diagnostic" in r.getMessage()
+        ]
+
+    async def test_emits_warn_when_sessions_exist_and_no_tier_matches(self, caplog):
+        """Sessions in cache but no tier accepts any of them → one WARN."""
+        session = _make_session(
+            user_name="alice",
+            item_name="NotTheChannel",  # bare Jellyfin style
+            channel_number="999",
+        )
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.jellyfin_resolver"):
+                users = await jellyfin_resolver.resolve_jellyfin_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="US: CNN FHD",
+                    ecm_channel_name="CNN",
+                    ecm_channel_number=200,
+                )
+        assert users == []
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 1, (
+            f"expected exactly one no-match WARN; got {len(warns)}: "
+            f"{[r.getMessage() for r in warns]}"
+        )
+        msg = warns[0].getMessage()
+        assert "CNN" in msg
+        assert "NotTheChannel" in msg
+
+    async def test_no_emit_when_sessions_empty(self, caplog):
+        """Empty session cache is the normal state — no WARN."""
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=[])):
+            with caplog.at_level(logging.WARNING, logger="services.jellyfin_resolver"):
+                users = await jellyfin_resolver.resolve_jellyfin_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+        assert users == []
+        assert self._no_match_records(caplog.records) == []
+
+    async def test_no_emit_when_match_succeeds(self, caplog):
+        """A successful resolve must not emit the no-match WARN."""
+        session = _make_session(user_name="alice", item_name="CNN HD")
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.jellyfin_resolver"):
+                users = await jellyfin_resolver.resolve_jellyfin_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CNN HD",
+                )
+        assert len(users) == 1
+        assert self._no_match_records(caplog.records) == []
+
+    async def test_no_emit_when_ip_short_circuit_fails(self, caplog):
+        """IP mismatch short-circuits before the session compare → no WARN."""
+        session = _make_session(item_name="UnrelatedShow")
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.jellyfin_resolver"):
+                users = await jellyfin_resolver.resolve_jellyfin_users(
+                    ecm_session_ip="10.0.0.99",  # NOT the Jellyfin server
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+        assert users == []
+        assert self._no_match_records(caplog.records) == []
+
+    async def test_rate_limit_within_window(self, caplog):
+        """Two no-match calls for same (ip, channel) within 60 s → one WARN."""
+        session = _make_session(item_name="UnrelatedShow")
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.jellyfin_resolver"):
+                await jellyfin_resolver.resolve_jellyfin_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+                await jellyfin_resolver.resolve_jellyfin_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 1
+
+    async def test_rate_limit_per_channel_independence(self, caplog):
+        """Different channels for the same IP each get their own WARN."""
+        session = _make_session(item_name="UnrelatedShow")
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.jellyfin_resolver"):
+                await jellyfin_resolver.resolve_jellyfin_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CBS",
+                    ecm_channel_name="CBS",
+                )
+                await jellyfin_resolver.resolve_jellyfin_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 2
+        messages = " ".join(r.getMessage() for r in warns)
+        assert "CBS" in messages and "CNN" in messages
+
+    async def test_rate_limit_window_expiry(self, caplog, monkeypatch):
+        """Advancing the monotonic clock past 60 s permits a fresh WARN."""
+        session = _make_session(item_name="UnrelatedShow")
+        fake_now = [1000.0]
+
+        def fake_monotonic():
+            return fake_now[0]
+
+        monkeypatch.setattr(jellyfin_resolver.time, "monotonic", fake_monotonic)
+
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.jellyfin_resolver"):
+                await jellyfin_resolver.resolve_jellyfin_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+                fake_now[0] += 61.0
+                await jellyfin_resolver.resolve_jellyfin_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 2

--- a/backend/tests/services/test_plex_resolver.py
+++ b/backend/tests/services/test_plex_resolver.py
@@ -843,3 +843,163 @@ class TestMultiViewer:
             )
         assert len(users) == 3
         assert _get_counter_value("user_attribution_resolved_total", "plex") == 3.0
+
+
+# ---------------------------------------------------------------------------
+# bd-r5f0c.10: forensic no-match WARN. Same shape as the Emby resolver
+# helper — see TestNoMatchDiagnostic in test_emby_resolver.py for the
+# rationale. Fires once per (ip, channel) per 60 s when sessions exist
+# and the IP short-circuit passed but no tier accepted any session.
+# ---------------------------------------------------------------------------
+
+
+class TestNoMatchDiagnostic:
+    """Plex forensic no-match WARN. Mirrors the Emby resolver semantics:
+    only fires when IP matched + sessions non-empty + no tier matched."""
+
+    @staticmethod
+    def _no_match_records(records):
+        return [
+            r for r in records
+            if "[PLEX-RESOLVER] no-match diagnostic" in r.getMessage()
+        ]
+
+    async def test_emits_warn_when_sessions_exist_and_no_tier_matches(self, caplog):
+        """Sessions in cache but no tier accepts any of them → one WARN."""
+        session = _make_session(
+            user_name="alice",
+            item_name="999 | NotTheChannel",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.plex_resolver"):
+                users = await plex_resolver.resolve_plex_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="US: CNN FHD",
+                    ecm_channel_name="CNN",
+                    ecm_channel_number=200,
+                )
+        assert users == []
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 1, (
+            f"expected exactly one no-match WARN; got {len(warns)}: "
+            f"{[r.getMessage() for r in warns]}"
+        )
+        msg = warns[0].getMessage()
+        assert "CNN" in msg
+        assert "NotTheChannel" in msg
+
+    async def test_no_emit_when_sessions_empty(self, caplog):
+        """Empty session cache is the normal state — no WARN."""
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[])):
+            with caplog.at_level(logging.WARNING, logger="services.plex_resolver"):
+                users = await plex_resolver.resolve_plex_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="ESPN",
+                    ecm_channel_name="ESPN",
+                )
+        assert users == []
+        assert self._no_match_records(caplog.records) == []
+
+    async def test_no_emit_when_match_succeeds(self, caplog):
+        """A successful resolve must not emit the no-match WARN."""
+        session = _make_session(user_name="alice", item_name="408 | ESPN")
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.plex_resolver"):
+                users = await plex_resolver.resolve_plex_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="ESPN",
+                    ecm_channel_name="ESPN",
+                )
+        assert len(users) == 1
+        assert self._no_match_records(caplog.records) == []
+
+    async def test_no_emit_when_ip_short_circuit_fails(self, caplog):
+        """IP mismatch short-circuits before the session compare → no WARN."""
+        session = _make_session(item_name="UnrelatedShow")
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.plex_resolver"):
+                users = await plex_resolver.resolve_plex_users(
+                    ecm_session_ip="10.0.0.99",  # NOT the Plex server
+                    ecm_stream_name="ESPN",
+                    ecm_channel_name="ESPN",
+                )
+        assert users == []
+        assert self._no_match_records(caplog.records) == []
+
+    async def test_rate_limit_within_window(self, caplog):
+        """Two no-match calls for same (ip, channel) within 60 s → one WARN."""
+        session = _make_session(item_name="UnrelatedShow")
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.plex_resolver"):
+                await plex_resolver.resolve_plex_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+                await plex_resolver.resolve_plex_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 1
+
+    async def test_rate_limit_per_channel_independence(self, caplog):
+        """Different channels for the same IP each get their own WARN."""
+        session = _make_session(item_name="UnrelatedShow")
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.plex_resolver"):
+                await plex_resolver.resolve_plex_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CBS",
+                    ecm_channel_name="CBS",
+                )
+                await plex_resolver.resolve_plex_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 2
+        messages = " ".join(r.getMessage() for r in warns)
+        assert "CBS" in messages and "CNN" in messages
+
+    async def test_rate_limit_window_expiry(self, caplog, monkeypatch):
+        """Advancing the monotonic clock past 60 s permits a fresh WARN."""
+        session = _make_session(item_name="UnrelatedShow")
+        fake_now = [1000.0]
+
+        def fake_monotonic():
+            return fake_now[0]
+
+        monkeypatch.setattr(plex_resolver.time, "monotonic", fake_monotonic)
+
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            with caplog.at_level(logging.WARNING, logger="services.plex_resolver"):
+                await plex_resolver.resolve_plex_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+                fake_now[0] += 61.0
+                await plex_resolver.resolve_plex_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="CNN",
+                    ecm_channel_name="CNN",
+                )
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 2

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0047",
+  "version": "0.17.1-0048",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
PO-reported cut-blocker: identical-config CBS/CNN streams attribute differently. Adds WARN-rate-limited forensic logging to all 3 resolvers (Emby/Plex/Jellyfin) for the specific case worth diagnosing: integration enabled + sessions present + IP matched + no tier produced a match.

Log line includes raw and normalized forms of every comparison input + every cached session so operator can spot the mismatch at a glance.

Rate-limit: per (client_ip, ecm_channel_name) per 60s.

## Test plan
- [x] New `TestNoMatchDiagnostic` class on each resolver (~7 tests each, 3 resolvers)
- [x] Rate-limit-per-channel-independence test
- [x] Existing resolver tests pass unmodified
- [x] bandwidth_tracker integration tests pass
- [x] Full backend suite green (4336 passed)

Closes bd-r5f0c.10. Pure observability - no matching-logic changes.

Generated with [Claude Code](https://claude.com/claude-code)