### PR TITLE
v0.17.1-0049: resolver pipe-prefix tolerance + diagnostic truncation bump (bd-r5f0c.11)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0048",
+    version="0.17.1-0049",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0048"
+APP_VERSION = "0.17.1-0049"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/services/emby_resolver.py
+++ b/backend/services/emby_resolver.py
@@ -121,11 +121,14 @@ _emby_resolver_no_match_last_warn_at: dict[tuple[str, str], float] = {}
 _EMBY_NO_MATCH_WARN_INTERVAL: float = 60.0
 
 
-# Max number of sessions to enumerate in the forensic log line. Operators
-# with 50+ active Emby sessions would otherwise blow out the WARN line;
-# 10 is enough to surface the candidates that actually matter without
-# log-bloat.
-_EMBY_NO_MATCH_MAX_SESSIONS: int = 10
+# Max number of sessions to enumerate in the forensic log line.
+# bd-r5f0c.11: bumped 10 → 30 after the PO-reported v0.17.1 cut-blocker
+# (CBS vs CNN attribution asymmetry) showed an instance with 17 live
+# sessions where the cap of 10 truncated the CNN session out of the
+# forensic payload. 30 covers typical operator scale without log-bloat;
+# operators with >30 sessions are exceptional and the head 30 still
+# carries enough signal for diagnosis.
+_EMBY_NO_MATCH_MAX_SESSIONS: int = 30
 
 
 def _reset_for_tests() -> None:
@@ -514,6 +517,13 @@ def _find_matching_sessions(
 
     # ----- Tier 1: channel name primary match
     normalized_ecm_channel = _normalize(ecm_channel_name or "")
+    # bd-r5f0c.11: when an operator imports channels with the Emby/M3U
+    # pipe-prefix display format leaked into the ECM channel_name itself
+    # (e.g. "109 | CNN"), tier-1 must also parse the ECM side so the
+    # right-hand suffix can be compared against the session forms.
+    # Reuses _parse_pipe_suffix as-is — it returns "" when the input
+    # has no pipe, so this is a no-op for clean ECM names.
+    ecm_channel_suffix = _parse_pipe_suffix(normalized_ecm_channel)
     if normalized_ecm_channel:
         for session, normalized_item, _ch, suffix in prepared:
             # Right-hand side of "<number> | <name>" matches (the
@@ -524,6 +534,19 @@ def _find_matching_sessions(
                 continue
             if normalized_item and normalized_item == normalized_ecm_channel:
                 _accept(session)
+                continue
+            # bd-r5f0c.11: ECM-side pipe-prefix tolerance. When ECM's
+            # channel_name itself carries "<number> | <name>" (M3U
+            # import leak), compare the parsed ECM suffix against the
+            # session's parsed suffix and its whole item_name. Two new
+            # compares; additive — gated on ecm_channel_suffix being
+            # non-empty so clean ECM names are unaffected.
+            if ecm_channel_suffix:
+                if suffix and suffix == ecm_channel_suffix:
+                    _accept(session)
+                    continue
+                if normalized_item and normalized_item == ecm_channel_suffix:
+                    _accept(session)
 
     # ----- Tier 2: channel number exact (string compare)
     if ecm_channel_number is not None:
@@ -635,7 +658,7 @@ def _log_emby_resolver_no_match(
     those guards would flood the log.
 
     The session list in the payload is truncated at
-    ``_EMBY_NO_MATCH_MAX_SESSIONS`` (10) entries — defensive against
+    ``_EMBY_NO_MATCH_MAX_SESSIONS`` (30) entries — defensive against
     operators with very large Emby session counts.
     """
     rate_key = (client_ip, _normalize(ecm_channel_name or ""))

--- a/backend/services/jellyfin_resolver.py
+++ b/backend/services/jellyfin_resolver.py
@@ -125,7 +125,10 @@ _JELLYFIN_NO_MATCH_WARN_INTERVAL: float = 60.0
 
 # Max sessions in the forensic log line — defensive against log-bloat
 # on operators with very large Jellyfin session counts.
-_JELLYFIN_NO_MATCH_MAX_SESSIONS: int = 10
+# bd-r5f0c.11: bumped 10 → 30 to match emby_resolver after the PO's
+# v0.17.1 forensic showed 17 live sessions and the cap-of-10 hid the
+# session that mattered. 30 covers typical operator scale.
+_JELLYFIN_NO_MATCH_MAX_SESSIONS: int = 30
 
 
 def _reset_for_tests() -> None:
@@ -454,6 +457,13 @@ def _find_matching_sessions(
 
     # ----- Tier 1: channel name primary match (Jellyfin-tolerant)
     normalized_ecm_channel = _normalize(ecm_channel_name or "")
+    # bd-r5f0c.11: when an operator imports channels with the Emby/M3U
+    # pipe-prefix display format leaked into the ECM channel_name itself
+    # (e.g. "109 | CNN"), tier-1 must also parse the ECM side so the
+    # right-hand suffix can be compared against the session forms.
+    # Reuses _parse_pipe_suffix as-is — it returns "" when the input
+    # has no pipe, so this is a no-op for clean ECM names.
+    ecm_channel_suffix = _parse_pipe_suffix(normalized_ecm_channel)
     if normalized_ecm_channel:
         for session, normalized_item, _ch, suffix in prepared:
             # Sub-case A: pipe-suffix exists and matches (e.g. "408 | ESPN"
@@ -467,6 +477,19 @@ def _find_matching_sessions(
             # whole string happens to equal the channel name.
             if normalized_item and normalized_item == normalized_ecm_channel:
                 _accept(session)
+                continue
+            # bd-r5f0c.11: ECM-side pipe-prefix tolerance. When ECM's
+            # channel_name itself carries "<number> | <name>" (M3U
+            # import leak), compare the parsed ECM suffix against the
+            # session's parsed suffix and its whole item_name. Two new
+            # compares; additive — gated on ecm_channel_suffix being
+            # non-empty so clean ECM names are unaffected.
+            if ecm_channel_suffix:
+                if suffix and suffix == ecm_channel_suffix:
+                    _accept(session)
+                    continue
+                if normalized_item and normalized_item == ecm_channel_suffix:
+                    _accept(session)
 
     # ----- Tier 2: channel number exact (string compare)
     if ecm_channel_number is not None:

--- a/backend/services/plex_resolver.py
+++ b/backend/services/plex_resolver.py
@@ -149,7 +149,10 @@ _PLEX_NO_MATCH_WARN_INTERVAL: float = 60.0
 
 # Max sessions in the forensic log line — defensive against log-bloat
 # on operators with very large Plex session counts.
-_PLEX_NO_MATCH_MAX_SESSIONS: int = 10
+# bd-r5f0c.11: bumped 10 → 30 to match emby_resolver after the PO's
+# v0.17.1 forensic showed 17 live sessions and the cap-of-10 hid the
+# session that mattered. 30 covers typical operator scale.
+_PLEX_NO_MATCH_MAX_SESSIONS: int = 30
 
 
 def _reset_for_tests() -> None:
@@ -494,6 +497,13 @@ def _find_matching_sessions(
 
     # ----- Tier 1: channel name primary match
     normalized_ecm_channel = _normalize(ecm_channel_name or "")
+    # bd-r5f0c.11: when an operator imports channels with the Emby/M3U
+    # pipe-prefix display format leaked into the ECM channel_name itself
+    # (e.g. "109 | CNN"), tier-1 must also parse the ECM side so the
+    # right-hand suffix can be compared against the session forms.
+    # Reuses _parse_pipe_suffix as-is — it returns "" when the input
+    # has no pipe, so this is a no-op for clean ECM names.
+    ecm_channel_suffix = _parse_pipe_suffix(normalized_ecm_channel)
     if normalized_ecm_channel:
         for session, normalized_item, suffix, _prefix in prepared:
             # Right-hand side of "<number> | <name>" matches (the
@@ -504,6 +514,19 @@ def _find_matching_sessions(
                 continue
             if normalized_item and normalized_item == normalized_ecm_channel:
                 _accept(session)
+                continue
+            # bd-r5f0c.11: ECM-side pipe-prefix tolerance. When ECM's
+            # channel_name itself carries "<number> | <name>" (M3U
+            # import leak), compare the parsed ECM suffix against the
+            # session's parsed suffix and its whole item_name. Two new
+            # compares; additive — gated on ecm_channel_suffix being
+            # non-empty so clean ECM names are unaffected.
+            if ecm_channel_suffix:
+                if suffix and suffix == ecm_channel_suffix:
+                    _accept(session)
+                    continue
+                if normalized_item and normalized_item == ecm_channel_suffix:
+                    _accept(session)
 
     # ----- Tier 2: channel number exact (string compare against prefix)
     if ecm_channel_number is not None:

--- a/backend/tests/services/test_emby_resolver.py
+++ b/backend/tests/services/test_emby_resolver.py
@@ -1113,3 +1113,185 @@ class TestNoMatchDiagnostic:
         assert len(warns) == 2, (
             f"window-expiry broken: expected 2 WARNs, got {len(warns)}"
         )
+
+    async def test_truncation_cap_thirty(self, caplog):
+        """bd-r5f0c.11: 35 sessions in cache → forensic payload includes
+        exactly 30 entries (the bumped cap), not the original 10 and
+        not the full 35. The cap protects log size on operators with
+        very large session counts while still capturing enough breadth
+        for diagnosis.
+        """
+        sessions = [
+            _make_session(
+                user_id=f"uid-{idx:02d}",
+                user_name=f"user{idx:02d}",
+                item_name=f"{900 + idx} | NotTheChannel{idx}",
+                channel_number=str(900 + idx),
+            )
+            for idx in range(35)
+        ]
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=sessions)):
+            with caplog.at_level(logging.WARNING, logger="services.emby_resolver"):
+                users = await emby_resolver.resolve_emby_users(
+                    ecm_session_ip="192.168.1.10",
+                    ecm_stream_name="US: CNN FHD",
+                    ecm_channel_name="CNN",
+                    ecm_channel_number=200,
+                )
+        assert users == []
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 1
+        # Count distinct session_id markers in the payload. Each entry
+        # carries an 8-char session_id prefix derived from "sess-userNN".
+        msg = warns[0].getMessage()
+        # The payload renders dicts with "'session_id':" — count occurrences.
+        assert msg.count("'session_id':") == 30, (
+            f"expected truncation cap of 30 session entries, "
+            f"got {msg.count(chr(39) + 'session_id' + chr(39) + ':')}"
+        )
+        # The header sessions_count reports the full 35 (untruncated).
+        assert "sessions_count=35" in msg
+
+
+# ---------------------------------------------------------------------------
+# Behavior: bd-r5f0c.11 — ECM-side pipe-prefix tolerance in Tier-1
+# ---------------------------------------------------------------------------
+
+
+class TestECMPipePrefixTolerance:
+    """bd-r5f0c.11: when an operator imports channels with the Emby/M3U
+    pipe-prefix display format leaked into the ECM channel_name itself
+    (e.g. "109 | CNN"), tier-1 must match against Emby sessions even
+    though ECM is carrying the upstream's display format. The fix adds
+    two compares against the parsed ECM suffix (alongside the existing
+    compares against ecm_channel_name as a whole), gated on the ECM
+    name actually containing a pipe so clean ECM names are unaffected.
+    """
+
+    async def test_ecm_prefix_emby_prefix(self):
+        """ECM channel_name "109 | CNN" vs Emby item_name "109 | CNN".
+        Existing tier-1 (ecm_full vs item_name) would have matched this
+        already; the new compares (ecm_suffix vs pipe_suffix) also
+        succeed. Either path is acceptable — the assertion is that the
+        session resolves.
+        """
+        session = _make_session(
+            user_id="uid-mw", user_name="MotWakorb",
+            item_name="109 | CNN", channel_number="109",
+        )
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await emby_resolver.resolve_emby_user(
+                ecm_session_ip="192.168.1.10",
+                ecm_stream_name="US: CNN HD",
+                ecm_channel_name="109 | CNN",
+                ecm_channel_number=None,
+            )
+        assert result == emby_resolver.EmbyAttribution(
+            user_id="uid-mw", user_name="MotWakorb",
+        )
+
+    async def test_ecm_prefix_emby_clean(self):
+        """ECM channel_name "109 | CNN" vs Emby item_name "CNN" (no
+        pipe prefix on the Emby side). This is the case neither existing
+        compare can reach — only the new compare (ecm_suffix vs whole
+        item_name) succeeds.
+        """
+        session = _make_session(
+            user_id="uid-mw", user_name="MotWakorb",
+            item_name="CNN",
+        )
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await emby_resolver.resolve_emby_user(
+                ecm_session_ip="192.168.1.10",
+                ecm_stream_name="US: CNN HD",
+                ecm_channel_name="109 | CNN",
+            )
+        assert result is not None
+        assert result.user_name == "MotWakorb"
+
+    async def test_ecm_clean_emby_prefix(self):
+        """ECM channel_name "CNN" (clean) vs Emby item_name "109 | CNN".
+        Regression check — this is the original CBS-style case that
+        worked before bd-r5f0c.11 (matched via existing ecm_full vs
+        pipe_suffix) and must continue to work after.
+        """
+        session = _make_session(
+            user_id="uid-mw", user_name="MotWakorb",
+            item_name="109 | CNN", channel_number="109",
+        )
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await emby_resolver.resolve_emby_user(
+                ecm_session_ip="192.168.1.10",
+                ecm_stream_name="US: CNN HD",
+                ecm_channel_name="CNN",
+            )
+        assert result is not None
+        assert result.user_name == "MotWakorb"
+
+    async def test_ecm_clean_emby_clean(self):
+        """ECM channel_name "CNN" vs Emby item_name "CNN". The trivial
+        whole-string match path (existing) — regression check that the
+        new compares don't perturb it.
+        """
+        session = _make_session(
+            user_id="uid-mw", user_name="MotWakorb",
+            item_name="CNN",
+        )
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await emby_resolver.resolve_emby_user(
+                ecm_session_ip="192.168.1.10",
+                ecm_stream_name="US: CNN HD",
+                ecm_channel_name="CNN",
+            )
+        assert result is not None
+        assert result.user_name == "MotWakorb"
+
+    async def test_ecm_prefix_no_match(self):
+        """ECM channel_name "109 | CNN" vs Emby item_name "NESN".
+        Tolerance must NOT cause false positives — the ECM suffix
+        "cnn" does not equal "nesn", no tier matches. The stream_name
+        is unrelated so tier-3 fuzzy also cannot rescue.
+        """
+        session = _make_session(
+            user_name="alice",
+            item_name="NESN",
+        )
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await emby_resolver.resolve_emby_user(
+                ecm_session_ip="192.168.1.10",
+                ecm_stream_name="totally unrelated stream name",
+                ecm_channel_name="109 | CNN",
+            )
+        assert result is None
+
+    async def test_ecm_prefix_case_insensitive(self):
+        """ECM channel_name "109 | cnn" (lowercased prefix form) vs
+        Emby item_name "109 | CNN". Normalization (NFC + lower + strip)
+        applies to both sides before the new compares fire.
+        """
+        session = _make_session(
+            user_name="case_user",
+            item_name="109 | CNN",
+        )
+        with patch.object(emby_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(emby_resolver, "get_cached_emby_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await emby_resolver.resolve_emby_user(
+                ecm_session_ip="192.168.1.10",
+                ecm_stream_name="ignored — tier 1 wins",
+                ecm_channel_name="109 | cnn",
+            )
+        assert result is not None
+        assert result.user_name == "case_user"

--- a/backend/tests/services/test_jellyfin_resolver.py
+++ b/backend/tests/services/test_jellyfin_resolver.py
@@ -1041,3 +1041,166 @@ class TestNoMatchDiagnostic:
                 )
         warns = self._no_match_records(caplog.records)
         assert len(warns) == 2
+
+    async def test_truncation_cap_thirty(self, caplog):
+        """bd-r5f0c.11: 35 sessions in cache → forensic payload includes
+        exactly 30 entries (the bumped cap), not the original 10 and
+        not the full 35.
+        """
+        sessions = [
+            _make_session(
+                user_id=f"jf-uid-{idx:02d}",
+                user_name=f"user{idx:02d}",
+                item_name=f"{900 + idx} | NotTheChannel{idx}",
+                channel_number=str(900 + idx),
+            )
+            for idx in range(35)
+        ]
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=sessions)):
+            with caplog.at_level(logging.WARNING, logger="services.jellyfin_resolver"):
+                users = await jellyfin_resolver.resolve_jellyfin_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="US: CNN FHD",
+                    ecm_channel_name="CNN",
+                    ecm_channel_number=200,
+                )
+        assert users == []
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 1
+        msg = warns[0].getMessage()
+        assert msg.count("'session_id':") == 30, (
+            f"expected truncation cap of 30 session entries, "
+            f"got {msg.count(chr(39) + 'session_id' + chr(39) + ':')}"
+        )
+        assert "sessions_count=35" in msg
+
+
+# ---------------------------------------------------------------------------
+# Behavior: bd-r5f0c.11 — ECM-side pipe-prefix tolerance in Tier-1
+# ---------------------------------------------------------------------------
+
+
+class TestECMPipePrefixTolerance:
+    """bd-r5f0c.11: when an operator imports channels with the pipe-prefix
+    display format leaked into the ECM channel_name itself (e.g.
+    "109 | CNN"), tier-1 must match against Jellyfin sessions even
+    though ECM is carrying the upstream's display format. The fix adds
+    two compares against the parsed ECM suffix (alongside the existing
+    compares against ecm_channel_name as a whole), gated on the ECM
+    name actually containing a pipe so clean ECM names are unaffected.
+    """
+
+    async def test_ecm_prefix_jellyfin_prefix(self):
+        """ECM channel_name "109 | CNN" vs Jellyfin item_name "109 | CNN"."""
+        session = _make_session(
+            user_id="jf-uid-mw", user_name="MotWakorb",
+            item_name="109 | CNN", channel_number="109",
+        )
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await jellyfin_resolver.resolve_jellyfin_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: CNN HD",
+                ecm_channel_name="109 | CNN",
+            )
+        assert result == jellyfin_resolver.JellyfinAttribution(
+            user_id="jf-uid-mw", user_name="MotWakorb",
+        )
+
+    async def test_ecm_prefix_jellyfin_clean(self):
+        """ECM channel_name "109 | CNN" vs Jellyfin item_name "CNN"
+        (the canonical Jellyfin-style bare channel name). Only the new
+        compare (ecm_suffix vs whole item_name) reaches this case.
+        """
+        session = _make_session(
+            user_id="jf-uid-mw", user_name="MotWakorb",
+            item_name="CNN",
+        )
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await jellyfin_resolver.resolve_jellyfin_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: CNN HD",
+                ecm_channel_name="109 | CNN",
+            )
+        assert result is not None
+        assert result.user_name == "MotWakorb"
+
+    async def test_ecm_clean_jellyfin_prefix(self):
+        """ECM channel_name "CNN" vs Jellyfin item_name "109 | CNN".
+        Regression — existing pre-bd-r5f0c.11 path.
+        """
+        session = _make_session(
+            user_id="jf-uid-mw", user_name="MotWakorb",
+            item_name="109 | CNN", channel_number="109",
+        )
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await jellyfin_resolver.resolve_jellyfin_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: CNN HD",
+                ecm_channel_name="CNN",
+            )
+        assert result is not None
+        assert result.user_name == "MotWakorb"
+
+    async def test_ecm_clean_jellyfin_clean(self):
+        """ECM channel_name "CNN" vs Jellyfin item_name "CNN".
+        Trivial whole-string regression check.
+        """
+        session = _make_session(
+            user_id="jf-uid-mw", user_name="MotWakorb",
+            item_name="CNN",
+        )
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await jellyfin_resolver.resolve_jellyfin_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: CNN HD",
+                ecm_channel_name="CNN",
+            )
+        assert result is not None
+        assert result.user_name == "MotWakorb"
+
+    async def test_ecm_prefix_no_match(self):
+        """ECM channel_name "109 | CNN" vs Jellyfin item_name "NESN".
+        Tolerance must NOT cause false positives.
+        """
+        session = _make_session(
+            user_name="alice",
+            item_name="NESN",
+        )
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await jellyfin_resolver.resolve_jellyfin_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="totally unrelated stream name",
+                ecm_channel_name="109 | CNN",
+            )
+        assert result is None
+
+    async def test_ecm_prefix_case_insensitive(self):
+        """ECM channel_name "109 | cnn" (lowercase) vs Jellyfin
+        item_name "109 | CNN". NFC + lower + strip on both sides.
+        """
+        session = _make_session(
+            user_name="case_user",
+            item_name="109 | CNN",
+        )
+        with patch.object(jellyfin_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(jellyfin_resolver, "get_cached_jellyfin_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await jellyfin_resolver.resolve_jellyfin_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ignored — tier 1 wins",
+                ecm_channel_name="109 | cnn",
+            )
+        assert result is not None
+        assert result.user_name == "case_user"

--- a/backend/tests/services/test_plex_resolver.py
+++ b/backend/tests/services/test_plex_resolver.py
@@ -1003,3 +1003,160 @@ class TestNoMatchDiagnostic:
                 )
         warns = self._no_match_records(caplog.records)
         assert len(warns) == 2
+
+    async def test_truncation_cap_thirty(self, caplog):
+        """bd-r5f0c.11: 35 sessions in cache → forensic payload includes
+        exactly 30 entries (the bumped cap), not the original 10 and
+        not the full 35.
+        """
+        sessions = [
+            _make_session(
+                session_id=f"sess-{idx:02d}",
+                user_id=f"uid-{idx:02d}",
+                user_name=f"user{idx:02d}",
+                item_name=f"{900 + idx} | NotTheChannel{idx}",
+            )
+            for idx in range(35)
+        ]
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=sessions)):
+            with caplog.at_level(logging.WARNING, logger="services.plex_resolver"):
+                users = await plex_resolver.resolve_plex_users(
+                    ecm_session_ip="192.168.1.20",
+                    ecm_stream_name="US: CNN FHD",
+                    ecm_channel_name="CNN",
+                    ecm_channel_number=200,
+                )
+        assert users == []
+        warns = self._no_match_records(caplog.records)
+        assert len(warns) == 1
+        msg = warns[0].getMessage()
+        assert msg.count("'session_id':") == 30, (
+            f"expected truncation cap of 30 session entries, "
+            f"got {msg.count(chr(39) + 'session_id' + chr(39) + ':')}"
+        )
+        assert "sessions_count=35" in msg
+
+
+# ---------------------------------------------------------------------------
+# Behavior: bd-r5f0c.11 — ECM-side pipe-prefix tolerance in Tier-1
+# ---------------------------------------------------------------------------
+
+
+class TestECMPipePrefixTolerance:
+    """bd-r5f0c.11: when an operator imports channels with the pipe-prefix
+    display format leaked into the ECM channel_name itself (e.g.
+    "109 | CNN"), tier-1 must match against Plex sessions even though
+    ECM is carrying the upstream's display format. The fix adds two
+    compares against the parsed ECM suffix (alongside the existing
+    compares against ecm_channel_name as a whole), gated on the ECM
+    name actually containing a pipe so clean ECM names are unaffected.
+    """
+
+    async def test_ecm_prefix_plex_prefix(self):
+        """ECM channel_name "109 | CNN" vs Plex item_name "109 | CNN"."""
+        session = _make_session(
+            user_id="uid-mw", user_name="MotWakorb",
+            item_name="109 | CNN",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: CNN HD",
+                ecm_channel_name="109 | CNN",
+            )
+        assert result == "MotWakorb"
+
+    async def test_ecm_prefix_plex_clean(self):
+        """ECM channel_name "109 | CNN" vs Plex item_name "CNN".
+        Only the new compare (ecm_suffix vs whole item_name) reaches
+        this case.
+        """
+        session = _make_session(
+            user_name="MotWakorb",
+            item_name="CNN",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: CNN HD",
+                ecm_channel_name="109 | CNN",
+            )
+        assert result == "MotWakorb"
+
+    async def test_ecm_clean_plex_prefix(self):
+        """ECM channel_name "CNN" vs Plex item_name "109 | CNN".
+        Regression — existing pre-bd-r5f0c.11 path.
+        """
+        session = _make_session(
+            user_name="MotWakorb",
+            item_name="109 | CNN",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: CNN HD",
+                ecm_channel_name="CNN",
+            )
+        assert result == "MotWakorb"
+
+    async def test_ecm_clean_plex_clean(self):
+        """ECM channel_name "CNN" vs Plex item_name "CNN". Trivial
+        whole-string regression check.
+        """
+        session = _make_session(
+            user_name="MotWakorb",
+            item_name="CNN",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: CNN HD",
+                ecm_channel_name="CNN",
+            )
+        assert result == "MotWakorb"
+
+    async def test_ecm_prefix_no_match(self):
+        """ECM channel_name "109 | CNN" vs Plex item_name "NESN".
+        Tolerance must NOT cause false positives.
+        """
+        session = _make_session(
+            user_name="alice",
+            item_name="NESN",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="totally unrelated stream name",
+                ecm_channel_name="109 | CNN",
+            )
+        assert result is None
+
+    async def test_ecm_prefix_case_insensitive(self):
+        """ECM channel_name "109 | cnn" (lowercase) vs Plex item_name
+        "109 | CNN". NFC + lower + strip normalization on both sides.
+        """
+        session = _make_session(
+            user_name="case_user",
+            item_name="109 | CNN",
+        )
+        with patch.object(plex_resolver, "get_settings", return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ignored — tier 1 wins",
+                ecm_channel_name="109 | cnn",
+            )
+        assert result == "case_user"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0048",
+  "version": "0.17.1-0049",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Fixes PO-reported CBS-vs-CNN attribution asymmetry. ECM had CNN as '109 | CNN' (M3U pipe-prefix leak); tier-1 was only parsing the Emby side. Fix adds two more compares using the existing _parse_pipe_suffix helper on the ECM side too.

Also bumps W10's no-match diagnostic per-session truncation 10 → 30 so future forensics covers the full typical session cache.

## Test plan
- [x] TestECMPipePrefixTolerance — 6 cases per resolver (3 resolvers, 18 new tests)
- [x] TestNoMatchDiagnostic truncation cap test (3 resolvers, 3 new tests)
- [x] Existing resolver / bandwidth_tracker tests pass unmodified
- [x] Full backend suite green (4357 passed, 1 skipped — the volume test)

Closes bd-r5f0c.11. PO will separately fix the CNN row's channel_name + channel_number in ECM (option C: code + data both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)