### PR TITLE
v0.17.1-0050: dedup same-user multi-stream in per-client viewer list (bd-r5f0c.12)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0049",
+    version="0.17.1-0050",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0049"
+APP_VERSION = "0.17.1-0050"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0049",
+  "version": "0.17.1-0050",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/tabs/StatsTab.test.tsx
+++ b/frontend/src/components/tabs/StatsTab.test.tsx
@@ -903,3 +903,162 @@ describe('StatsTab — channel-header viewer rollup (bd-g03fi)', () => {
     expect(screen.queryByTestId('channel-header-viewer-rollup')).not.toBeInTheDocument();
   });
 });
+
+// bd-r5f0c.12 (W12): Per-client viewer dedup — same-user multi-stream.
+// When a single user has multiple concurrent streams from the same source,
+// the per-client viewer list renders "name (N)" instead of repeating the name.
+// Grouping is by user_id (primary) with user_name fallback when user_id is null.
+
+describe('StatsTab — per-client viewer dedup display (bd-r5f0c.12 / W12)', () => {
+  // Helper to build a mock response with a single channel + single client
+  const makeViewerMockResponse = (
+    viewers: { user_id: string | null; user_name: string }[],
+  ) => ({
+    count: 1,
+    channels: [
+      {
+        ...baseMultiViewerChannel,
+        clients: [
+          {
+            client_id: 'cid-dedup',
+            ip_address: '10.0.1.1',
+            user_agent: 'Emby/1.0',
+            connected_at: '2026-05-17T00:00:00Z',
+            last_active: '2026-05-17T00:01:00Z',
+            emby_viewers: viewers,
+          },
+        ],
+      },
+    ],
+  });
+
+  // Test 1: same user_id → "name (N)" suffix
+  it('renders "name (N)" for same-user multi-stream', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue(
+      makeViewerMockResponse([
+        { user_id: '1', user_name: 'jkaisersoze' },
+        { user_id: '1', user_name: 'jkaisersoze' },
+      ]) as unknown as ChannelStatsResponse,
+    );
+
+    render(<StatsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('jkaisersoze (2)')).toBeInTheDocument();
+    });
+    // Must NOT repeat the plain name twice separated by a comma
+    expect(screen.queryByText('jkaisersoze, jkaisersoze')).not.toBeInTheDocument();
+  });
+
+  // Test 2: two same-user streams + one distinct user → "name (N), other"
+  it('renders mixed users with one duplicate as "name (N), other"', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue(
+      makeViewerMockResponse([
+        { user_id: '1', user_name: 'jkaisersoze' },
+        { user_id: '1', user_name: 'jkaisersoze' },
+        { user_id: '2', user_name: 'alice' },
+      ]) as unknown as ChannelStatsResponse,
+    );
+
+    render(<StatsTab />);
+
+    await waitFor(() => {
+      // Map preserves insertion order, so jkaisersoze first
+      expect(screen.getByText('jkaisersoze (2), alice')).toBeInTheDocument();
+    });
+  });
+
+  // Test 3: distinct users → comma-separated, no count suffixes (W5 regression)
+  it('renders distinct users as comma-separated list without count suffixes', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue(
+      makeViewerMockResponse([
+        { user_id: '1', user_name: 'alice' },
+        { user_id: '2', user_name: 'bob' },
+      ]) as unknown as ChannelStatsResponse,
+    );
+
+    render(<StatsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('alice, bob')).toBeInTheDocument();
+    });
+  });
+
+  // Test 4: 4 unique users → "(N viewers)" rollup (W5 regression)
+  it('renders 4 unique users as "(N viewers)" rollup with details expansion', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue(
+      makeViewerMockResponse([
+        { user_id: '1', user_name: 'alice' },
+        { user_id: '2', user_name: 'bob' },
+        { user_id: '3', user_name: 'carol' },
+        { user_id: '4', user_name: 'dave' },
+      ]) as unknown as ChannelStatsResponse,
+    );
+
+    const { container } = render(<StatsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('4 viewers')).toBeInTheDocument();
+    });
+    // Names hidden inside a <details> element
+    expect(container.querySelector('details.viewer-details')).toBeInTheDocument();
+  });
+
+  // Test 5: 4 streams from same user → "name (4)" inline, NOT rollup
+  // (group count = 1, below the rollup threshold of 4 groups)
+  it('renders 4 streams from the same user as "name (4)" inline (not rollup)', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue(
+      makeViewerMockResponse([
+        { user_id: '1', user_name: 'jkaisersoze' },
+        { user_id: '1', user_name: 'jkaisersoze' },
+        { user_id: '1', user_name: 'jkaisersoze' },
+        { user_id: '1', user_name: 'jkaisersoze' },
+      ]) as unknown as ChannelStatsResponse,
+    );
+
+    const { container } = render(<StatsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('jkaisersoze (4)')).toBeInTheDocument();
+    });
+    // Only 1 group — must NOT use the rollup <details> element
+    expect(container.querySelector('details.viewer-details')).not.toBeInTheDocument();
+  });
+
+  // Test 6: user_id null → group by user_name fallback (Plex edge case from W9)
+  it('groups by user_name fallback when user_id is null', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue(
+      makeViewerMockResponse([
+        { user_id: null, user_name: 'alice' },
+        { user_id: null, user_name: 'alice' },
+      ]) as unknown as ChannelStatsResponse,
+    );
+
+    render(<StatsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('alice (2)')).toBeInTheDocument();
+    });
+  });
+
+  // Test 7: same user_id with differing user_name (e.g., Emby mid-session rename).
+  // Implementation choice: first-seen user_name wins (Map insertion order).
+  // The second entry increments the count but the first name is kept.
+  it('groups by user_id even when user_name differs (first-seen name wins)', async () => {
+    vi.mocked(api.getChannelStats).mockResolvedValue(
+      makeViewerMockResponse([
+        { user_id: '1', user_name: 'jkaisersoze' },
+        { user_id: '1', user_name: 'jkaisersoze (alt)' }, // same user_id, different display name
+      ]) as unknown as ChannelStatsResponse,
+    );
+
+    render(<StatsTab />);
+
+    await waitFor(() => {
+      // Only 1 group total — first-seen name 'jkaisersoze' kept, count = 2
+      expect(screen.getByText('jkaisersoze (2)')).toBeInTheDocument();
+    });
+    // The alternate name string must not appear as a standalone rendered item
+    expect(screen.queryByText('jkaisersoze (alt)')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/tabs/StatsTab.tsx
+++ b/frontend/src/components/tabs/StatsTab.tsx
@@ -1213,14 +1213,6 @@ export function StatsTab() {
                         <div key={client.client_id || idx} className="client-item">
                           <div className="client-info">
                             {/* bd-r5f0c.5 (W5): Multi-viewer rendering.
-                                Priority order:
-                                  1. *_viewers[] (W9 multi-viewer lists)
-                                  2. *_user_name singular (back-compat fallback)
-                                  3. dispatcharr username / user_id
-                                For each source that has viewers, render an
-                                AttributionBadge row. If a client has viewers
-                                from multiple sources, each gets its own line. */}
-                            {/* bd-r5f0c.5 (W5): Multi-viewer rendering.
                                 Priority order per source:
                                   1. *_viewers[] (W9 multi-viewer lists) → AttributionBadge
                                   2. *_user_name singular (back-compat) → old inline badge
@@ -1228,6 +1220,10 @@ export function StatsTab() {
                                   3. dispatcharr username / user_id
                                 If a client has viewers from multiple sources,
                                 each gets its own <span className="client-user"> row. */}
+                            {/* bd-r5f0c.12: per-client display groups same-user multi-stream into
+                                "name (N)". The channel-header viewer rollup intentionally still
+                                counts raw streams (each concurrent stream is its own operational
+                                event at the channel level). */}
                             {(() => {
                               // --- Multi-viewer path (W9 emby_viewers / plex_viewers / jellyfin_viewers) ---
                               type ViewerRow = { source: 'emby' | 'plex' | 'jellyfin'; viewers: Viewer[] };
@@ -1247,19 +1243,46 @@ export function StatsTab() {
                                 return (
                                   <div className="client-attribution-rows" data-testid="client-attribution-rows">
                                     {viewerRows.map(row => {
-                                      const count = row.viewers.length;
+                                      // bd-r5f0c.12: Group viewers by (user_id, user_name) — same user
+                                      // with multiple concurrent streams collapses into "name (N)"
+                                      // instead of repeating the name. user_id is the primary key;
+                                      // user_name is the fallback when user_id is null (e.g., Plex's
+                                      // PlexAttribution.user_id can be None per W9 report — same-name
+                                      // viewers still group via name fallback).
+                                      type ViewerGroup = { user_id: string | null; user_name: string; count: number };
+                                      const groupKey = (v: Viewer): string =>
+                                        v.user_id != null ? `id:${v.user_id}` : `name:${v.user_name}`;
+
+                                      const groupMap = new Map<string, ViewerGroup>();
+                                      for (const v of row.viewers) {
+                                        const key = groupKey(v);
+                                        const existing = groupMap.get(key);
+                                        if (existing) {
+                                          existing.count += 1;
+                                        } else {
+                                          groupMap.set(key, { user_id: v.user_id, user_name: v.user_name, count: 1 });
+                                        }
+                                      }
+                                      const groups = Array.from(groupMap.values());
+
+                                      // Format each group: "<name>" when count==1, "<name> (<count>)" otherwise
+                                      const formatGroup = (g: ViewerGroup): string =>
+                                        g.count === 1 ? g.user_name : `${g.user_name} (${g.count})`;
+
+                                      // Threshold for rollup is now group count, not raw viewer count
+                                      const isRollup = groups.length > 3;
                                       let nameText: string;
-                                      if (count === 1) {
-                                        nameText = row.viewers[0].user_name;
-                                      } else if (count <= 3) {
-                                        nameText = row.viewers.map(v => v.user_name).join(', ');
+                                      if (groups.length === 1) {
+                                        nameText = formatGroup(groups[0]);
+                                      } else if (groups.length <= 3) {
+                                        nameText = groups.map(formatGroup).join(', ');
                                       } else {
-                                        nameText = `${count} viewers`;
+                                        nameText = `${row.viewers.length} viewers`;
                                       }
                                       return (
                                         <span key={row.source} className="client-user">
                                           <AttributionBadge source={row.source} />
-                                          {count > 3 ? (
+                                          {isRollup ? (
                                             <details className="viewer-details">
                                               <summary>{nameText}</summary>
                                               <ul className="viewer-list">


### PR DESCRIPTION
## Summary

- PO UX tweak: per-client viewer list now groups same-user multi-stream into `name (N)` instead of repeating the name
- Grouping by `(user_id, user_name)`: user_id primary key, user_name fallback for null user_id (Plex edge case)
- Channel-header rollup intentionally unchanged — raw stream count is the correct operational signal at channel level

## Test plan

- [x] 7 new W12 dedup tests: same-user 2x, mixed users with duplicate, distinct users regression, 4-unique rollup regression, 4x same user inline, null user_id fallback, same user_id differing name
- [x] 23 existing W5/W11 multi-viewer tests pass unmodified
- [x] vitest: 1479/1479 passed (74 files)
- [x] eslint: 0 warnings
- [x] tsc: 0 errors
- [x] vite build: clean

Closes bd-r5f0c.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)