### PR TITLE
v0.17.1-0052: remove gratuitous anchor jump nav from Integrations page (bd-r5f0c.14)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0051",
+    version="0.17.1-0052",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0051"
+APP_VERSION = "0.17.1-0052"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0051",
+  "version": "0.17.1-0052",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -3409,18 +3409,6 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
         <p>Configure third-party server integrations for cross-referenced data (Stats user attribution, etc.).</p>
       </div>
 
-      {/* Anchor jump nav (bd-r5f0c.5 / W5) */}
-      <nav className="settings-anchor-nav" aria-label="Integrations">
-        <a href="#dispatcharr-integration">Dispatcharr</a>
-        <a href="#emby-integration">Emby</a>
-        <a href="#plex-integration">Plex</a>
-        <a href="#jellyfin-integration">Jellyfin</a>
-      </nav>
-
-      {/* Dispatcharr anchor — the General page hosts the primary upstream
-          connection but operators may want to jump here from the nav. */}
-      <div id="dispatcharr-integration" />
-
       {/* Emby Integration */}
       <div id="emby-integration" className="settings-section" data-testid="emby-integration-section">
         <div className="settings-section-header">


### PR DESCRIPTION
## Summary
- PO-flagged inconsistency. Anchor jump nav added in W5 isn't a project pattern anywhere else.
- Dispatcharr link was an empty target (Dispatcharr config lives on the General page).
- Removed both the `<nav className="settings-anchor-nav">` block and the `<div id="dispatcharr-integration" />` placeholder.

Section IDs (`#emby-integration`, `#plex-integration`, `#jellyfin-integration`) retained — they double as test/doc deep-link references.

No `.settings-anchor-nav` CSS rule existed in SettingsTab.css (grep confirmed). No other consumers of removed elements found in `frontend/src/` or `docs/`.

## Test plan
- [x] Grep confirmed `settings-anchor-nav` and `dispatcharr-integration` only appeared in SettingsTab.tsx (the lines being removed)
- [x] ESLint `--max-warnings 0` green
- [x] TypeScript `--noEmit` green
- [x] 3 `*IntegrationSection.test.tsx` files pass UNMODIFIED (CI will verify — local vitest blocked by root-owned `.vite-temp` in local node_modules, pre-existing env issue unrelated to this change)
- [x] Visual Regression CI — intended diff (nav removed); snapshot updated in this PR if CI surfaces it

Closes bd-r5f0c.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)