### PR TITLE
v0.17.1-0054: assert SEC-1 caveat on modal — remove visually-hidden span (bd-r5f0c.16)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0053",
+    version="0.17.1-0054",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0053"
+APP_VERSION = "0.17.1-0054"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0053",
+  "version": "0.17.1-0054",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/settings/PlexIntegrationSection.test.tsx
+++ b/frontend/src/components/settings/PlexIntegrationSection.test.tsx
@@ -1,10 +1,12 @@
 /**
  * Tests for the Plex Integration Settings subsection (bd-r5f0c.5 / W5).
  *
- * Mirrors EmbyIntegrationSection.test.tsx. Additional contract:
- *   - The token field MUST show the SEC-1 helper text ("Use a server-local
- *     Plex token, not your plex.tv account token.") directly below the
- *     input field. This is a security requirement — do not remove the test.
+ * Mirrors EmbyIntegrationSection.test.tsx. Additional contract (SEC-1):
+ *   - The Plex token help modal MUST surface the account-vs-server-local
+ *     security caveat ("use the server-local token … NOT your plex.tv
+ *     account token") via data-testid="plex-token-security-callout".
+ *     bd-r5f0c.16 / W16: test updated to assert on the modal callout;
+ *     the visually-hidden DOM span was removed.
  *
  * Contracts under test:
  *   - Section renders with the three fields (enabled, base_url, token).
@@ -14,7 +16,7 @@
  *     values and renders ok/error inline.
  *   - Save persists plex_enabled and plex_base_url always, and plex_token
  *     only when the operator entered a fresh value (preserve-on-omit).
- *   - Token helper text is present and visible (SEC-1).
+ *   - SEC-1 security callout is present in the help modal (SEC-1).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -282,16 +284,18 @@ describe('PlexIntegrationSection (bd-r5f0c.5 / W5)', () => {
     });
   });
 
-  // --- SEC-1: Token helper text ---
+  // --- SEC-1: Modal security callout ---
 
-  it('shows server-local token helper text (SEC-1 requirement)', async () => {
+  it('shows server-local-token security caveat inside the help modal (SEC-1 requirement)', async () => {
     renderOnIntegrations();
-    await waitFor(() => {
-      const helperEl = screen.getByTestId('plex-token-helper-text');
-      expect(helperEl).toBeInTheDocument();
-      expect(helperEl.textContent).toContain('server-local Plex token');
-      expect(helperEl.textContent).toContain('plex.tv account token');
-    });
+    await waitFor(() => screen.getByTestId('plex-token-help-link'));
+    fireEvent.click(screen.getByTestId('plex-token-help-link'));
+    await waitFor(() => screen.getByTestId('plex-token-security-callout'));
+    const callout = screen.getByTestId('plex-token-security-callout');
+    expect(callout).toBeInTheDocument();
+    expect(callout.textContent).toContain('use the server-local token');
+    expect(callout.textContent).toContain('NOT');
+    expect(callout.textContent).toContain('plex.tv account token');
   });
 
   // --- Test Connection ---

--- a/frontend/src/components/tabs/SettingsTab.css
+++ b/frontend/src/components/tabs/SettingsTab.css
@@ -985,19 +985,6 @@
   text-decoration: none;
 }
 
-/* SEC-1 text kept in DOM for test contract; visually hidden so only the modal surfaces it */
-.plex-token-sec1-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 /* Plex token discovery modal */
 .plex-token-modal .plex-token-steps {
   padding-left: 1.25rem;

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -3563,11 +3563,9 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
 
           <div className="form-group-vertical">
             <label htmlFor="plexToken">Plex token</label>
-            {/* SEC-1: Server-local Plex token security requirement.
-                The account-vs-server-local distinction is surfaced in the discovery modal
-                (bd-r5f0c.15 / W15) as a prominent callout. The visually-hidden span below
-                keeps that content in the DOM so the SEC-1 test contract still passes without
-                modification. */}
+            {/* SEC-1: The account-vs-server-local security requirement is surfaced in the
+                discovery modal (bd-r5f0c.15 / W15) as a prominent callout. The SEC-1 test
+                asserts on the modal callout directly (bd-r5f0c.16 / W16). */}
             <span className="form-description" data-testid="plex-token-helper-text">
               {plexTokenConfigured ? 'A token is currently stored — leave blank to keep it.' : 'No token stored.'}
               {' '}
@@ -3579,11 +3577,6 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
               >
                 How to find your Plex token
               </button>
-              {/* Visually hidden — keeps the SEC-1 test assertion (textContent check) passing.
-                  Full instructions + context live in the modal opened by the link above. */}
-              <span className="plex-token-sec1-hidden">
-                {' '}Use a server-local Plex token, not your plex.tv account token.
-              </span>
             </span>
             <input
               id="plexToken"


### PR DESCRIPTION
## Summary
- W15 follow-up cleanup. SEC-1 test refactored to assert on the modal callout (`data-testid="plex-token-security-callout"`); the visually-hidden `.plex-token-sec1-hidden` span + CSS rule removed entirely.
- Emby and Jellyfin integration tests unmodified.

## Test plan
- [x] SEC-1 test refactored — opens modal, asserts `plex-token-security-callout` callout presence and textContent contains 'use the server-local token', 'NOT', 'plex.tv account token'
- [x] Emby/Jellyfin IntegrationSection tests UNMODIFIED (9+9 = 18 tests pass)
- [x] Full vitest suite: 1485 tests / 74 files green
- [x] eslint: no warnings
- [x] tsc: no errors
- [x] vite build: successful

Closes bd-r5f0c.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)