### PR TITLE
fix(settings): align Plex test-connection wire key with backend schema (bd-8zi93)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0054",
+    version="0.17.1-0055",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0054"
+APP_VERSION = "0.17.1-0055"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0054",
+  "version": "0.17.1-0055",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -36,6 +36,10 @@ import {
   updateAlertMethod,
   // Logos (bd-nh50y debug-logging contract)
   getAllLogos,
+  // Integration test-connection wire-format guards (bd-8zi93)
+  testEmbyConnection,
+  testPlexConnection,
+  testJellyfinConnection,
 } from './api';
 import { logger } from '../utils/logger';
 
@@ -1291,6 +1295,68 @@ describe('API Service', () => {
         errSpy.mockRestore();
         logger.setLevel(prevLevel);
       }
+    });
+  });
+
+  // Wire-format guards for the Settings → Integrations test-connection
+  // endpoints (bd-8zi93). The backend Pydantic schemas pick specific field
+  // names per integration:
+  //   - Emby:     { base_url, api_key }
+  //   - Plex:     { base_url, token }       — X-Plex-Token nomenclature
+  //   - Jellyfin: { base_url, api_key }
+  // A mismatch surfaces as a 422 "Field required" inline error in the UI
+  // (the original Plex symptom). These tests lock the exact JSON shape sent
+  // over the wire so a future rename can't silently break it again.
+  describe('integration test-connection wire format', () => {
+    it('testEmbyConnection sends { base_url, api_key }', async () => {
+      let requestBody: unknown;
+      server.use(
+        http.post('/api/settings/emby/test-connection', async ({ request }) => {
+          requestBody = await request.json();
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      await testEmbyConnection('http://emby.local:8096', 'emby-api-key');
+
+      expect(requestBody).toEqual({
+        base_url: 'http://emby.local:8096',
+        api_key: 'emby-api-key',
+      });
+    });
+
+    it('testPlexConnection sends { base_url, token }', async () => {
+      let requestBody: unknown;
+      server.use(
+        http.post('/api/settings/plex/test-connection', async ({ request }) => {
+          requestBody = await request.json();
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      await testPlexConnection('http://plex.local:32400', 'plex-token-value');
+
+      expect(requestBody).toEqual({
+        base_url: 'http://plex.local:32400',
+        token: 'plex-token-value',
+      });
+    });
+
+    it('testJellyfinConnection sends { base_url, api_key }', async () => {
+      let requestBody: unknown;
+      server.use(
+        http.post('/api/settings/jellyfin/test-connection', async ({ request }) => {
+          requestBody = await request.json();
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      await testJellyfinConnection('http://jellyfin.local:8096', 'jellyfin-api-key');
+
+      expect(requestBody).toEqual({
+        base_url: 'http://jellyfin.local:8096',
+        api_key: 'jellyfin-api-key',
+      });
     });
   });
 });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1183,9 +1183,12 @@ export async function testPlexConnection(
   baseUrl: string,
   plexToken: string,
 ): Promise<PlexTestConnectionResult> {
+  // Wire key is `token` to match the backend PlexTestConnectionRequest schema
+  // (X-Plex-Token ecosystem nomenclature). The JS parameter stays `plexToken`
+  // for readability at call sites. See bd-8zi93.
   return fetchJson(`${API_BASE}/settings/plex/test-connection`, {
     method: 'POST',
-    body: JSON.stringify({ base_url: baseUrl, plex_token: plexToken }),
+    body: JSON.stringify({ base_url: baseUrl, token: plexToken }),
   });
 }
 


### PR DESCRIPTION
## Symptom

PO reported: Settings → Integrations → Plex section. URL + token filled, "Enable Plex user attribution" checked, click "Test connection" → inline error region beneath the button shows "Field Required". Same UI patterns for Emby and Jellyfin work — only Plex was broken.

## Root cause

API contract mismatch between frontend and backend for the Plex test-connection endpoint:

- Frontend `frontend/src/services/api.ts` (`testPlexConnection`) was sending:
  ```json
  { "base_url": "...", "plex_token": "..." }
  ```
- Backend `backend/routers/settings.py` `PlexTestConnectionRequest` Pydantic model expects:
  ```json
  { "base_url": "...", "token": "..." }
  ```

The backend field is named `token` to match the `X-Plex-Token` ecosystem nomenclature (and the backend tests at `backend/tests/routers/test_plex_settings.py` already use `token`). Pydantic saw `token` missing and returned a 422 `{"detail":[{"loc":["body","token"],"msg":"Field required"}]}`, which the frontend httpClient surfaces inline as "Field required".

Emby and Jellyfin both use `api_key` on both sides, so they happened to be correct.

## Fix

- `frontend/src/services/api.ts` — change the wire key in `testPlexConnection` from `plex_token` to `token`. The JS-side function parameter stays `plexToken` for readability at call sites; only the JSON key changes.
- Added a one-line comment at the call site noting the wire-key match with the backend schema and the bd-8zi93 reference.

## Regression guard

Added a new `integration test-connection wire format` describe block at the end of `frontend/src/services/api.test.ts`. It uses MSW `http.post` handlers to capture the actual request body and `expect(body).toEqual({...})` the exact wire shape for all three integrations:

- `testEmbyConnection` → `{ base_url, api_key }`
- `testPlexConnection` → `{ base_url, token }`
- `testJellyfinConnection` → `{ base_url, api_key }`

A future rename of any of these wire keys will fail these tests, preventing a silent recurrence.

## Scope

Surgical. Two files changed (one fix, one new test block) plus the three version-bump touchpoints (v0.17.1-0054 → v0.17.1-0055).

- `frontend/src/services/api.ts` — 5 lines (1 fix + 3 comment lines + version-unrelated)
- `frontend/src/services/api.test.ts` — 66 lines added (imports + new describe block)
- `frontend/package.json`, `backend/main.py`, `backend/routers/backup.py` — version bump

The existing `PlexIntegrationSection.test.tsx` mocks `api.testPlexConnection` at the function level and asserts only on its arguments, so it did NOT need changes and remains green.

## Test plan

- [x] `vitest run --configLoader runner src/services/api.test.ts src/components/settings/{PlexIntegrationSection,EmbyIntegrationSection,JellyfinIntegrationSection}.test.tsx` — all targeted files green (94 tests)
- [x] `vitest run --configLoader runner` — full frontend suite green (1488 tests, 74 files)
- [x] `tsc --noEmit` — clean
- [x] `eslint src --max-warnings 0` — clean
- [x] `vite build --configLoader runner` — bundle builds cleanly
- [x] `scripts/check_version_consistency.py` — all 3 version touchpoints at 0.17.1-0055
- [ ] PO verifies on container after merge: Plex test-connection with valid + invalid creds

Closes bd-8zi93.