### PR TITLE
feat(plex): EPG cross-reference resolver tier for Live TV channel attribution (bd-ma6r3)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0057",
+    version="0.17.1-0058",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -882,9 +882,27 @@ def _build_metrics(registry: CollectorRegistry) -> Dict[str, Any]:
         #
         # Six metrics cover the cache + resolver hot path for Emby /
         # Plex / Jellyfin user attribution. All share a single bounded
-        # ``source`` label with three values: "emby", "plex",
-        # "jellyfin". Attribution is best-effort (SLO-8 posture) — the
-        # alert rules that wire on these are warn-only, never paging.
+        # ``source`` label.
+        #
+        # Resolver metrics carry exactly three values: "emby", "plex",
+        # "jellyfin" — one per primary attribution source.
+        #
+        # Cache metrics carry the resolver three values PLUS one
+        # secondary surface introduced by bd-ma6r3:
+        #
+        #   * "plex_epg" — the Plex EPG-airings cache used by the
+        #     :mod:`services.plex_epg_cache` module to cross-reference
+        #     a Live TV session's ``grandparentTitle`` (program name)
+        #     to the airing's ``channelCallSign``. The cache lives
+        #     beside the session cache; same TTL / lock / stale-
+        #     fallback envelope, different upstream surface and
+        #     longer TTL (30 s vs 5 s session). Dashboards that filter
+        #     on ``source=plex`` will see ONLY the session cache —
+        #     filter on ``source=~"plex|plex_epg"`` for full Plex
+        #     attribution-stack visibility.
+        #
+        # Attribution is best-effort (SLO-8 posture) — the alert rules
+        # that wire on these are warn-only, never paging.
         #
         # Cache metrics (incremented by services/<source>_cache.py):
         #
@@ -928,22 +946,27 @@ def _build_metrics(registry: CollectorRegistry) -> Dict[str, Any]:
         "media_session_cache_hits_total": Counter(
             "ecm_media_session_cache_hits_total",
             "Count of per-source session-cache hits (returned without an "
-            "upstream fetch). source ∈ {emby, plex, jellyfin}. "
+            "upstream fetch). source ∈ {emby, plex, jellyfin, plex_epg}. "
             "Incremented on both the fast-path hit (before lock) and the "
             "under-lock re-check hit (another waiter populated the cache "
             "while we waited). Does NOT count cache misses that went to "
-            "the upstream and succeeded.",
+            "the upstream and succeeded. The plex_epg label (bd-ma6r3) "
+            "covers the Plex EPG-airings cache, a secondary surface used "
+            "only by the Plex resolver's Live TV cross-reference tier.",
             ["source"],
             registry=registry,
         ),
         "media_session_fetch_duration_seconds": Histogram(
             "ecm_media_session_fetch_duration_seconds",
             "Wall time of the upstream get_sessions() HTTP call, in "
-            "seconds. source ∈ {emby, plex, jellyfin}. Cache hits are "
-            "NOT counted — this histogram tracks upstream latency only. "
-            "Recorded on every fetch attempt regardless of outcome "
-            "(success or exception); the _count gives total fetch "
-            "attempts, the _sum gives total latency across all fetches.",
+            "seconds. source ∈ {emby, plex, jellyfin, plex_epg}. Cache "
+            "hits are NOT counted — this histogram tracks upstream "
+            "latency only. Recorded on every fetch attempt regardless "
+            "of outcome (success or exception); the _count gives total "
+            "fetch attempts, the _sum gives total latency across all "
+            "fetches. The plex_epg label (bd-ma6r3) measures the full "
+            "DVR/section sweep (multiple sequential HTTP GETs); samples "
+            "will be wider than the single-GET session caches.",
             ["source"],
             buckets=_HTTP_LATENCY_BUCKETS,
             registry=registry,
@@ -951,8 +974,9 @@ def _build_metrics(registry: CollectorRegistry) -> Dict[str, Any]:
         "media_session_fetch_errors_total": Counter(
             "ecm_media_session_fetch_errors_total",
             "Count of upstream session-fetch failures (exception raised "
-            "by the upstream client). source ∈ {emby, plex, jellyfin}. "
-            "Incremented on every exception from get_sessions(), "
+            "by the upstream client). source ∈ {emby, plex, jellyfin, "
+            "plex_epg}. Incremented on every exception from "
+            "get_sessions() / get_current_live_epg_channels(), "
             "regardless of whether a stale cache exists to fall back on. "
             "Alert rule MediaSessionFetchErrorsSustained fires when this "
             "counter has a non-zero rate for > 10m (warn-only, SLO-8 "
@@ -963,7 +987,7 @@ def _build_metrics(registry: CollectorRegistry) -> Dict[str, Any]:
         "media_session_stale_fallback_total": Counter(
             "ecm_media_session_stale_fallback_total",
             "Count of stale-cache returns after an upstream fetch failure. "
-            "source ∈ {emby, plex, jellyfin}. Incremented when "
+            "source ∈ {emby, plex, jellyfin, plex_epg}. Incremented when "
             "fetch_errors_total fires AND a prior cache entry exists to "
             "return. A non-zero rate means ECM is serving stale session "
             "data to resolvers; attribution quality degrades but does not "

--- a/backend/plex_client.py
+++ b/backend/plex_client.py
@@ -1,14 +1,23 @@
-"""Plex API client (bd-r5f0c.2, epic bd-r5f0c).
+"""Plex API client (bd-r5f0c.2, epic bd-r5f0c; bd-ma6r3 EPG cross-reference).
 
-Read-only async client for the operator's Plex Media Server. Single concern:
-fetch the ``/status/sessions`` feed so downstream code (plex_cache,
-plex_resolver, BandwidthTracker enrichment) can cross-reference live
-Plex viewers against ECM's active streams and attribute the real Plex
-username instead of collapsing every Plex-mediated pull to the proxy IP.
+Read-only async client for the operator's Plex Media Server. Two concerns:
+
+1. Fetch ``/status/sessions`` so downstream code (plex_cache,
+   plex_resolver, BandwidthTracker enrichment) can cross-reference live
+   Plex viewers against ECM's active streams and attribute the real Plex
+   username instead of collapsing every Plex-mediated pull to the proxy
+   IP.
+2. (bd-ma6r3) Fetch the EPG-section airings under each DVR so the Plex
+   Live TV resolver tier can cross-reference an unknown ``@grandparentTitle``
+   (the PROGRAM currently airing — NOT the channel) against the EPG entry
+   whose time window contains "now" and pull the ``channelCallSign`` off the
+   ``<Media>`` element. Plex's ``/status/sessions`` XML carries the program
+   name but NOT the channel for Live TV, so the EPG is the only Plex API
+   surface that exposes the channel identity for an active Live TV session.
 
 This module is intentionally narrow:
 
-* No caching here — that lives in plex_cache's wrapper around this client.
+* No caching here — that lives in plex_cache + plex_epg_cache.
 * No resolver / matching logic — plex_resolver owns ``ECM stream → Plex user``.
 * No Settings UI plumbing — W4 wires ``test_connection`` into Settings.
 
@@ -18,11 +27,35 @@ across the two outbound HTTP clients.
 
 Plex-specific differences from Emby:
 * Auth header: ``X-Plex-Token: <token>`` (NOT ``X-Emby-Token``)
-* Endpoint: ``GET /status/sessions`` (NOT ``/Sessions``)
+* Endpoints:
+
+  * ``GET /status/sessions`` — live sessions (NOT ``/Sessions``).
+  * ``GET /livetv/dvrs`` — list of configured DVRs (each with a ``key``
+    we use to address its EPG provider).
+  * ``GET /tv.plex.providers.epg.xmltv:<dvr_key>/sections`` — list of
+    EPG sections (Movies / News / Shows / Sports for the typical
+    Dispatcharr-HDHomeRun-fronted setup the bead targets).
+  * ``GET /tv.plex.providers.epg.xmltv:<dvr_key>/sections/<sid>/all?type=4``
+    — episode airings for that section. Each ``<Video>`` carries one
+    or more ``<Media>`` elements with ``channelCallSign``,
+    ``beginsAt`` / ``endsAt``, and ``protocol="livetv"``. The resolver
+    filters to the airing whose ``beginsAt <= now <= endsAt``.
+
 * Response format: XML (NOT JSON). Parsed via stdlib
   ``xml.etree.ElementTree`` — no additional deps required. Plex is a
   configured-by-operator trusted upstream so the XXE risk of stdlib is
   acceptable (defusedxml is unnecessary here).
+
+bd-ma6r3 sizing notes (observed against PO's running Plex 2026-05-18):
+
+* DVR sweep latency for 4 sections (1793 / 53 / 226 / 0 entries): ~0.43s
+  sequential. Section 2 (Shows) is the long pole at ~3.3 MB and ~0.33s.
+* The Plex API ignores client-side query filters like ``?onAir=1`` —
+  filtering to current airings must be done client-side after the parse.
+* Each ``<Video>`` may have MULTIPLE ``<Media>`` children covering
+  different upcoming airings of the same episode. We emit one
+  :class:`PlexEpgEntry` per ``<Media>`` so the resolver can window-filter
+  on each ``beginsAt``/``endsAt`` pair independently.
 """
 from __future__ import annotations
 
@@ -39,6 +72,65 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Public types
 # ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PlexEpgEntry:
+    """One Plex EPG airing slot for a Live TV channel (bd-ma6r3).
+
+    Each ``<Media>`` element under a ``<Video>`` returned by
+    ``/tv.plex.providers.epg.xmltv:<dvr_key>/sections/<sid>/all?type=4``
+    becomes one entry. A ``<Video>`` (episode) can carry multiple
+    ``<Media>`` elements representing different upcoming airings of the
+    same episode — flattening to one entry per airing is what lets the
+    resolver window-filter on the airing whose time range contains
+    "now" without needing to flatten inside the resolver.
+
+    Fields are a deliberate subset of the upstream XML — only what the
+    resolver tier needs. ``grandparent_title`` is the episode's
+    ``<Video>/@grandparentTitle`` (e.g., ``"MLB Baseball"``) and IS
+    what Plex's ``/status/sessions`` carries on the live session, so
+    the resolver can match a session's ``now_playing_channel_name``
+    (which comes from the same ``@grandparentTitle`` on the session)
+    against this entry's ``grandparent_title``.
+
+    Attributes:
+        grandparent_title: The owning episode's ``@grandparentTitle``
+            (e.g., ``"MLB Baseball"``). The resolver matches this
+            against the session's ``now_playing_channel_name``.
+        channel_call_sign: ``<Media>/@channelCallSign`` — the
+            operator-visible channel name including any pipe-prefix
+            (e.g., ``"8.1 | NBC: KGW Portland"``). This is what the
+            resolver compares against ECM's ``channel_name``; the
+            existing tier-1 pipe-suffix tolerance handles the prefix.
+            ``None`` when the attribute is absent.
+        channel_identifier: ``<Media>/@channelIdentifier`` — short
+            channel key (e.g., ``"8.1"``). Surfaced for forensic
+            logging; not used in matching.
+        channel_title: ``<Media>/@channelTitle`` — Plex's display title
+            for the channel. Surfaced for forensic logging.
+        channel_vcn: ``<Media>/@channelVcn`` — virtual channel number.
+            Surfaced for forensic logging.
+        begins_at: ``<Media>/@beginsAt`` (epoch seconds) parsed into a
+            timezone-aware datetime. ``None`` when the attribute is
+            absent or unparseable; such entries are filtered out by
+            the current-time window check.
+        ends_at: ``<Media>/@endsAt`` (epoch seconds) parsed into a
+            timezone-aware datetime. Same fallback semantics as
+            ``begins_at``.
+        protocol: ``<Media>/@protocol`` — expected to be ``"livetv"``
+            for the bead's target use case. Stored verbatim so the
+            resolver can defensively filter on it.
+    """
+
+    grandparent_title: str
+    channel_call_sign: str | None
+    channel_identifier: str | None
+    channel_title: str | None
+    channel_vcn: str | None
+    begins_at: datetime | None
+    ends_at: datetime | None
+    protocol: str | None
 
 
 @dataclass(frozen=True)
@@ -85,6 +177,14 @@ class PlexSession:
             (epoch seconds). Used to break ties when multiple Plex sessions
             match the same ECM stream (most-recent-wins). ``None`` when the
             attribute is absent or unparseable.
+        is_live: ``True`` when the upstream ``<Video>`` carries ``@live="1"``
+            — Plex flags Live TV (DVR / tuner) sessions distinctly from VOD
+            and personal-library episodes. The bd-ma6r3 EPG resolver tier
+            uses this to gate the EPG cross-reference: VOD sessions have no
+            broadcast schedule to look up, and firing the EPG fetch for them
+            wastes the upstream call. Defaults to ``False`` when the
+            attribute is absent so existing VOD / movie tests are
+            unaffected.
     """
 
     session_id: str
@@ -95,6 +195,7 @@ class PlexSession:
     now_playing_channel_name: str | None
     now_playing_parent_title: str | None
     last_activity_date: datetime | None
+    is_live: bool = False
 
 
 class PlexClientError(Exception):
@@ -156,40 +257,215 @@ class PlexClient:
                 response, network failure, or malformed XML. The original
                 exception is preserved as ``__cause__`` where applicable.
         """
-        url = f"{self.base_url}/status/sessions"
-        headers = {"X-Plex-Token": self.api_key}
-
-        logger.debug("[PLEX] GET %s", url)
-        try:
-            response = await self._client.request("GET", url, headers=headers)
-        except httpx.HTTPError as exc:
-            # ConnectError, ReadTimeout, RemoteProtocolError, etc. — any
-            # transport-level failure. Wrap so callers see one exception
-            # type regardless of whether the failure was DNS, TCP, or TLS.
-            logger.warning("[PLEX] /status/sessions request failed: %s", exc)
-            raise PlexClientError(f"Plex request failed: {exc}") from exc
-
-        if response.status_code == 401:
-            # Surface 401 distinctly — the operator's most common failure
-            # mode is a wrong/revoked token, and the Settings UI surface
-            # will route on this string.
-            logger.warning("[PLEX] /status/sessions returned 401 unauthorized")
-            raise PlexClientError(
-                "Plex /status/sessions returned 401 unauthorized — check token"
-            )
-
-        if response.status_code >= 400:
-            logger.warning(
-                "[PLEX] /status/sessions returned non-2xx: status=%s",
-                response.status_code,
-            )
-            raise PlexClientError(
-                f"Plex /status/sessions returned {response.status_code}"
-            )
-
-        sessions = _parse_sessions_xml(response.text)
-        logger.debug("[PLEX] /status/sessions returned %d sessions", len(sessions))
+        # bd-ma6r3: delegate HTTP plumbing to ``_get_xml`` so the
+        # ``/status/sessions`` path and the new EPG paths share one
+        # error-translation surface (401 / non-2xx / transport).
+        xml_text = await self._get_xml("/status/sessions")
+        sessions = _parse_sessions_xml(xml_text)
+        logger.debug(
+            "[PLEX] /status/sessions returned %d sessions", len(sessions),
+        )
         return sessions
+
+    async def get_current_live_epg_channels(
+        self,
+        *,
+        now: datetime | None = None,
+    ) -> list[PlexEpgEntry]:
+        """Fetch the union of CURRENT Live TV EPG airings across all DVR sections.
+
+        bd-ma6r3 — the composed entry point the resolver calls. Discovers
+        DVRs, walks each DVR's EPG sections, fetches the airings for each
+        section, and returns a flat de-duplicated list of
+        :class:`PlexEpgEntry` filtered to the airings whose
+        ``beginsAt <= now <= endsAt`` AND ``protocol == "livetv"``.
+
+        Design decision (composed vs flat): the bead is silent on whether
+        to expose the DVR/section walk separately or hide it behind a
+        single composed call. Composed wins because (a) every caller —
+        and there is only one, the resolver — wants the union, never a
+        per-DVR breakdown; (b) the cache layer's TTL is whole-snapshot,
+        so partial returns from one DVR are not useful; and (c) hiding
+        the walk inside the client lets the resolver stay focused on
+        matching rather than orchestrating Plex API surfaces. The
+        granular helpers (:meth:`get_dvr_keys`,
+        :meth:`get_dvr_section_keys`, :meth:`get_section_epg_entries`)
+        remain public for tests and future MCP surfaces but are not
+        load-bearing on the production hot path.
+
+        Args:
+            now: Override the current time for testing. Defaults to
+                ``datetime.now(timezone.utc)``. Pass a fixed datetime in
+                tests so the time-window filter is deterministic against
+                a fixed-shape fixture.
+
+        Returns:
+            List of current Live TV airings across all DVRs. Empty list
+            when no DVRs are configured, no sections exist, or no airings
+            cover the current time. Always returns a list — failures are
+            absorbed by the caller-side cache layer; this method raises
+            on any HTTP/XML error so the cache can WARN-log and serve
+            stale data per :mod:`services.plex_epg_cache`.
+
+        Raises:
+            PlexClientError: On any non-2xx response or XML parse failure
+                during the DVR/section discovery OR airing fetch. The
+                cache layer wraps this with stale-fallback semantics.
+        """
+        if now is None:
+            now = datetime.now(timezone.utc)
+
+        dvr_keys = await self.get_dvr_keys()
+        if not dvr_keys:
+            logger.debug("[PLEX] No DVRs configured; EPG sweep returns []")
+            return []
+
+        # bd-ma6r3: walk DVRs sequentially. Operator-typical setup is one
+        # DVR (the bead's probe found exactly one). Even on multi-DVR
+        # setups the sweep latency is bounded by the section count, not
+        # the DVR count, so sequential iteration here keeps the code
+        # readable without adding a parallel-fetch coordinator.
+        current: list[PlexEpgEntry] = []
+        for dvr_key in dvr_keys:
+            try:
+                section_keys = await self.get_dvr_section_keys(dvr_key)
+            except PlexClientError as exc:
+                # One DVR's section listing failed — log + continue so a
+                # broken DVR doesn't disable EPG attribution for the
+                # others. Re-raising would let the cache stale-fallback
+                # absorb it, but partial-success here is friendlier on
+                # multi-DVR operators.
+                logger.warning(
+                    "[PLEX] EPG sweep: section list failed for dvr=%s: %s",
+                    dvr_key, exc,
+                )
+                continue
+            for section_key in section_keys:
+                try:
+                    entries = await self.get_section_epg_entries(
+                        dvr_key=dvr_key, section_key=section_key,
+                    )
+                except PlexClientError as exc:
+                    logger.warning(
+                        "[PLEX] EPG sweep: airings failed for "
+                        "dvr=%s section=%s: %s",
+                        dvr_key, section_key, exc,
+                    )
+                    continue
+                for entry in entries:
+                    if _epg_entry_is_current(entry, now=now):
+                        current.append(entry)
+
+        logger.debug(
+            "[PLEX] EPG sweep: %d current Live TV airing(s) across "
+            "%d DVR(s)",
+            len(current), len(dvr_keys),
+        )
+        return current
+
+    async def get_dvr_keys(self) -> list[str]:
+        """Return the list of DVR ``key`` attributes from ``/livetv/dvrs``.
+
+        bd-ma6r3. Each DVR's ``key`` is the integer Plex assigns when the
+        operator configures a tuner provider; it's the same value baked
+        into the ``tv.plex.providers.epg.xmltv:<key>`` endpoint paths.
+
+        Returns:
+            List of DVR keys (strings). Empty list when no DVRs are
+            configured — a normal state for non-LiveTV Plex installs,
+            not an error.
+
+        Raises:
+            PlexClientError: On any non-2xx / malformed XML.
+        """
+        xml = await self._get_xml("/livetv/dvrs")
+        try:
+            root = ET.fromstring(xml)
+        except ET.ParseError as exc:
+            logger.warning(
+                "[PLEX] /livetv/dvrs returned malformed XML: %s", exc,
+            )
+            raise PlexClientError(
+                f"Plex /livetv/dvrs returned malformed XML: {exc}",
+            ) from exc
+        return [
+            dvr.get("key", "") for dvr in root.iter("Dvr")
+            if dvr.get("key")
+        ]
+
+    async def get_dvr_section_keys(self, dvr_key: str) -> list[str]:
+        """Return the section ``key`` attributes for one DVR.
+
+        bd-ma6r3. Each Plex DVR exposes its EPG under the synthetic
+        provider id ``tv.plex.providers.epg.xmltv:<dvr_key>``, and the
+        airings are organized into sections matching Plex's library
+        categories (Movies, News, Shows, Sports for the typical
+        Dispatcharr-fronted setup the bead targets).
+
+        Args:
+            dvr_key: A DVR key returned by :meth:`get_dvr_keys`.
+
+        Returns:
+            List of section keys (strings). Empty list if the DVR has no
+            sections — unusual, but treated as the "nothing to fetch"
+            answer rather than an error.
+
+        Raises:
+            PlexClientError: On any non-2xx / malformed XML.
+        """
+        path = f"/tv.plex.providers.epg.xmltv:{dvr_key}/sections"
+        xml = await self._get_xml(path)
+        try:
+            root = ET.fromstring(xml)
+        except ET.ParseError as exc:
+            logger.warning("[PLEX] %s returned malformed XML: %s", path, exc)
+            raise PlexClientError(
+                f"Plex {path} returned malformed XML: {exc}",
+            ) from exc
+        return [
+            d.get("key", "") for d in root.iter("Directory")
+            if d.get("key")
+        ]
+
+    async def get_section_epg_entries(
+        self,
+        *,
+        dvr_key: str,
+        section_key: str,
+    ) -> list[PlexEpgEntry]:
+        """Return ALL EPG airings for one DVR section (no time-window filter).
+
+        bd-ma6r3. Calls
+        ``GET /tv.plex.providers.epg.xmltv:<dvr_key>/sections/<sid>/all?type=4``
+        and emits one :class:`PlexEpgEntry` per ``<Media>`` element under
+        every returned ``<Video>``. The ``?type=4`` query is Plex's
+        episode-content-type filter — without it the response also
+        includes show/season directory entries which carry no
+        ``channelCallSign``.
+
+        The caller (typically
+        :meth:`get_current_live_epg_channels`) is responsible for the
+        ``beginsAt <= now <= endsAt`` time-window filter so this helper
+        stays a pure fetch+parse with no clock side effects.
+
+        Args:
+            dvr_key: DVR key from :meth:`get_dvr_keys`.
+            section_key: Section key from :meth:`get_dvr_section_keys`.
+
+        Returns:
+            List of :class:`PlexEpgEntry` (one per ``<Media>``). Empty
+            list when the section has no episodes — normal for unused
+            sections like Movies in PO's all-Dispatcharr setup.
+
+        Raises:
+            PlexClientError: On any non-2xx / malformed XML.
+        """
+        path = (
+            f"/tv.plex.providers.epg.xmltv:{dvr_key}"
+            f"/sections/{section_key}/all"
+        )
+        xml = await self._get_xml(path, params={"type": "4"})
+        return _parse_epg_xml(xml)
 
     async def test_connection(self) -> bool:
         """Verify the configured URL + token reach a working Plex server.
@@ -208,6 +484,58 @@ class PlexClient:
             logger.info("[PLEX] test_connection failed: %s", exc)
             return False
         return True
+
+    # ------------------------------------------------------------------
+    # HTTP plumbing
+    # ------------------------------------------------------------------
+
+    async def _get_xml(
+        self,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+    ) -> str:
+        """Shared GET implementation for the XML endpoints (bd-ma6r3).
+
+        Centralizes the 401 / non-2xx / transport-error handling that
+        the bd-r5f0c.2 :meth:`get_sessions` implementation pioneered so
+        the bd-ma6r3 EPG endpoints inherit the same error-translation
+        contract verbatim. All XML endpoints use the same
+        ``X-Plex-Token`` header and same expected status codes.
+
+        SSRF posture: ``self.base_url`` was sanitized at client
+        construction time (bd-r5f0c.4 test-connection endpoint) — every
+        path concatenation here goes through that same trusted host.
+        We never accept a host override per-call.
+        """
+        url = f"{self.base_url}{path}"
+        headers = {"X-Plex-Token": self.api_key}
+
+        logger.debug("[PLEX] GET %s params=%s", url, params)
+        try:
+            response = await self._client.request(
+                "GET", url, headers=headers, params=params,
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("[PLEX] %s request failed: %s", path, exc)
+            raise PlexClientError(f"Plex request failed: {exc}") from exc
+
+        if response.status_code == 401:
+            logger.warning("[PLEX] %s returned 401 unauthorized", path)
+            raise PlexClientError(
+                f"Plex {path} returned 401 unauthorized — check token",
+            )
+
+        if response.status_code >= 400:
+            logger.warning(
+                "[PLEX] %s returned non-2xx: status=%s",
+                path, response.status_code,
+            )
+            raise PlexClientError(
+                f"Plex {path} returned {response.status_code}",
+            )
+
+        return response.text
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -295,6 +623,15 @@ def _map_item(item: ET.Element) -> PlexSession | None:
     # captured as a secondary channel surface — some Plex DVR setups put
     # the channel name on the parent (the "show" that groups all Live TV
     # episodes by channel) rather than the grandparent.
+    # bd-ma6r3: ``@live="1"`` flags Plex Live TV sessions (DVR / tuner)
+    # distinctly from VOD. The resolver's EPG cross-reference tier only
+    # runs for live sessions — VOD has no broadcast schedule to look up,
+    # and firing the EPG fetch on every VOD-only poll cycle would waste
+    # the upstream call. ``@live`` can be "1", "0", or absent; we coerce
+    # any other value to False so future Plex format changes degrade
+    # gracefully (live sessions still flow through tier-1/2/3 normally).
+    is_live = item.get("live") == "1"
+
     return PlexSession(
         session_id=item.get("ratingKey", ""),
         user_id=user_el.get("id", ""),
@@ -304,4 +641,103 @@ def _map_item(item: ET.Element) -> PlexSession | None:
         now_playing_channel_name=item.get("grandparentTitle"),
         now_playing_parent_title=item.get("parentTitle"),
         last_activity_date=last_activity,
+        is_live=is_live,
     )
+
+
+# ---------------------------------------------------------------------------
+# EPG parsing helpers (bd-ma6r3)
+# ---------------------------------------------------------------------------
+
+
+def _parse_epg_xml(xml_text: str) -> list[PlexEpgEntry]:
+    """Parse one section's EPG response into a list of :class:`PlexEpgEntry`.
+
+    bd-ma6r3. Plex returns a ``<MediaContainer>`` of ``<Video>`` episode
+    elements, each carrying one or more ``<Media>`` children. We emit one
+    entry per ``<Media>`` so the caller's time-window filter can examine
+    each airing's ``beginsAt`` / ``endsAt`` pair independently — a single
+    episode that airs at multiple times produces one entry per airing.
+
+    Raises:
+        PlexClientError: On any XML parse error.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        logger.warning(
+            "[PLEX] Failed to parse EPG section XML: %s", exc,
+        )
+        raise PlexClientError(
+            f"Plex EPG section returned malformed XML: {exc}",
+        ) from exc
+
+    entries: list[PlexEpgEntry] = []
+    for video in root.iter("Video"):
+        # bd-ma6r3: ``@grandparentTitle`` is the field the resolver matches
+        # against ``session.now_playing_channel_name`` (both come from the
+        # same Plex attribute name on different endpoints). Missing
+        # grandparent means we can't match an unknown session to this
+        # airing — skip the whole video.
+        grandparent = video.get("grandparentTitle")
+        if not grandparent:
+            continue
+        for media in video.iter("Media"):
+            entries.append(_map_epg_media(grandparent_title=grandparent, media=media))
+    return entries
+
+
+def _map_epg_media(*, grandparent_title: str, media: ET.Element) -> PlexEpgEntry:
+    """Map one ``<Media>`` element to a :class:`PlexEpgEntry`.
+
+    Time attributes (``beginsAt``, ``endsAt``) are epoch seconds; absent
+    or unparseable values land as ``None`` (the time-window filter
+    treats ``None``-bounded entries as never-current so they drop out
+    of the live-EPG snapshot without raising).
+    """
+    return PlexEpgEntry(
+        grandparent_title=grandparent_title,
+        channel_call_sign=media.get("channelCallSign"),
+        channel_identifier=media.get("channelIdentifier"),
+        channel_title=media.get("channelTitle"),
+        channel_vcn=media.get("channelVcn"),
+        begins_at=_parse_epoch(media.get("beginsAt")),
+        ends_at=_parse_epoch(media.get("endsAt")),
+        protocol=media.get("protocol"),
+    )
+
+
+def _parse_epoch(raw: str | None) -> datetime | None:
+    """Parse a Plex epoch-seconds attribute into a tz-aware ``datetime``.
+
+    Returns ``None`` when the input is absent or malformed — the
+    EPG-current filter handles ``None`` as "not currently airing" so
+    a broken timestamp drops the entry from the snapshot rather than
+    raising.
+    """
+    if raw is None:
+        return None
+    try:
+        return datetime.fromtimestamp(int(raw), tz=timezone.utc)
+    except (ValueError, OSError):
+        return None
+
+
+def _epg_entry_is_current(entry: PlexEpgEntry, *, now: datetime) -> bool:
+    """Return ``True`` iff ``entry`` is a Live TV airing covering ``now``.
+
+    bd-ma6r3. Three constraints all required:
+
+    * ``protocol == "livetv"`` — defensive against EPG entries Plex might
+      surface for non-LiveTV sources in mixed-provider setups.
+    * ``begins_at`` and ``ends_at`` both populated.
+    * ``begins_at <= now <= ends_at``.
+
+    Returning ``False`` simply filters the entry out of the live
+    snapshot; the caller does not need to log or raise.
+    """
+    if entry.protocol != "livetv":
+        return False
+    if entry.begins_at is None or entry.ends_at is None:
+        return False
+    return entry.begins_at <= now <= entry.ends_at

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0057"
+APP_VERSION = "0.17.1-0058"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/services/plex_epg_cache.py
+++ b/backend/services/plex_epg_cache.py
@@ -1,0 +1,266 @@
+"""Plex EPG-airings cache (bd-ma6r3).
+
+Sibling to :mod:`services.plex_cache`. The Plex Live TV resolver tier
+(see :mod:`services.plex_resolver`) cross-references a session's
+``grandparentTitle`` against the current EPG airing on each
+configured DVR section to recover the channel ``channelCallSign`` —
+the field Plex's ``/status/sessions`` does NOT carry for Live TV but
+which IS the operator-visible channel name (e.g.
+``"8.1 | NBC: KGW Portland"``).
+
+Why a sibling cache, not an extension of :mod:`services.plex_cache`:
+
+* **Different TTL.** The session cache TTL (5 s) tracks the
+  Dispatcharr poll cadence so per-poll Plex attribution stays fresh.
+  EPG airings are 30+ minutes long; refreshing them every 5 s would
+  hammer the operator's Plex server with a ~3 MB Shows-section payload
+  for zero practical benefit. 30 s is the bead's recommendation and
+  trades off (a) once-per-half-minute upstream cost (low) against (b)
+  worst-case 30 s lag between a viewer changing channel and ECM
+  picking up the new ``channelCallSign`` (acceptable — that's still an
+  order of magnitude faster than the EPG entries themselves change).
+* **Different fetch shape.** The session cache fires one
+  ``GET /status/sessions`` per refresh. The EPG cache fires one fetch
+  per DVR section (typically 4) and walks them sequentially.
+  Co-housing both behind one ``get_cached_plex_sessions()`` entry
+  point would conflate two fundamentally different upstream contracts.
+* **Different idle-state behavior.** :mod:`services.plex_cache` is
+  unconditionally consulted by the resolver hot path — it's cheap and
+  cached. The EPG cache populates ONLY when the resolver has unmatched
+  live sessions to disambiguate, gated by
+  :func:`maybe_get_cached_plex_epg`. Bundling this gate inside the
+  session-cache would muddy that cache's "always queryable" contract.
+
+The bead's "rate-limit short-circuits when no Plex live sessions
+exist" acceptance criterion is enforced at the resolver layer
+(it calls :func:`maybe_get_cached_plex_epg` only when it has a live
+session that earlier tiers couldn't match). This module's responsibility
+is the TTL + thundering-herd + stale-fallback envelope; the
+gate-on-demand discipline lives in the resolver.
+
+Three deliberate behaviors mirror :mod:`services.plex_cache`:
+
+* **Stale-fallback.** Upstream failure after a successful prior fetch
+  returns the stale entry rather than ``[]`` so a momentary Plex blip
+  does not erase the EPG cross-reference picture mid-resolver.
+* **Thundering-herd guard.** An ``asyncio.Lock`` collapses concurrent
+  cache-misses into exactly one upstream sweep.
+* **Settings gate.** Plex disabled / unconfigured → ``[]`` immediately,
+  no cache access, no client construction.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+
+from config import get_settings
+from plex_client import PlexClient, PlexClientError, PlexEpgEntry
+import observability
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration constants
+# ---------------------------------------------------------------------------
+
+
+# bd-ma6r3: single cache key (same single-upstream design as
+# :mod:`services.plex_cache`). The cached value is the FULL union of
+# current Live TV airings across all DVRs / sections — partial returns
+# from a single section are not useful to the resolver.
+CACHE_KEY = "plex_epg:current_live"
+
+# Time-to-live in seconds. EPG airings change on broadcast boundaries
+# (typically 30+ minutes). A 30 s TTL means:
+#
+#   * Worst-case lag between a viewer changing channel and ECM picking
+#     up the new ``channelCallSign`` is bounded at TTL.
+#   * Steady-state upstream cost is one DVR/section sweep per 30 s
+#     (the bead's probe measured ~0.43 s for PO's 4-section setup).
+#   * Idle Plex deployments incur ZERO cost — the resolver's
+#     gate-on-demand discipline never invokes this cache when there
+#     are no unmatched live sessions to disambiguate.
+CACHE_TTL_SECONDS = 30.0
+
+
+# ---------------------------------------------------------------------------
+# Module-level state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Entry:
+    """Cached EPG snapshot with the wall-clock time it was fetched.
+
+    Kept module-private — callers should not introspect cache internals.
+    """
+
+    entries: list[PlexEpgEntry]
+    cached_at: float
+
+
+# Single-slot cache (same shape as :mod:`services.plex_cache`).
+_cached_entry: _Entry | None = None
+
+# Thundering-herd guard — constructed lazily for the same event-loop
+# binding reasons as :mod:`services.plex_cache`.
+_fetch_lock: asyncio.Lock | None = None
+
+
+def _get_lock() -> asyncio.Lock:
+    """Return the module-level fetch lock, constructing it on first use.
+
+    See :func:`services.plex_cache._get_lock` for the lazy-binding
+    rationale (pytest-asyncio per-function event loop isolation).
+    """
+    global _fetch_lock
+    if _fetch_lock is None:
+        _fetch_lock = asyncio.Lock()
+    return _fetch_lock
+
+
+def _reset_for_tests() -> None:
+    """Clear the module-level cache and lock — tests only.
+
+    Tests share the same module instance across functions; without this
+    reset, a test that populates the EPG cache would leak into the next
+    and produce false cache-hit assertions.
+    """
+    global _cached_entry, _fetch_lock
+    _cached_entry = None
+    _fetch_lock = None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def maybe_get_cached_plex_epg() -> list[PlexEpgEntry]:
+    """Return the current Live TV EPG snapshot, served from cache when fresh.
+
+    Behavior matrix (same shape as
+    :func:`services.plex_cache.get_cached_plex_sessions`):
+
+    * **Plex disabled** (``settings.plex_enabled`` False OR
+      ``settings.plex_base_url`` empty) → return ``[]`` immediately;
+      no cache access, no client construction.
+    * **Cache hit** (entry exists AND age < TTL) → return the cached
+      entries; no upstream call.
+    * **Cache miss** (no entry OR entry expired) → acquire fetch lock,
+      re-check under lock, call
+      :meth:`PlexClient.get_current_live_epg_channels`, store and
+      return.
+    * **Cache miss + fetch failure with prior cache** → log WARN and
+      return the stale cached entries rather than the empty list.
+    * **Cache miss + fetch failure + no prior cache** → log WARN and
+      return ``[]`` so callers always receive a list.
+
+    Always returns a list — never raises. Upstream errors are absorbed
+    and logged so the resolver's poll loop can continue under all
+    failure modes.
+
+    bd-ma6r3 metric note: the existing
+    ``media_session_cache_hits_total`` / ``_fetch_duration_seconds`` /
+    ``_fetch_errors_total`` / ``_stale_fallback_total`` family is reused
+    here with the new ``source`` label value ``"plex_epg"``. This keeps
+    the cache-layer observability symmetry across the three sources +
+    new EPG surface (one dashboard, one alert family). The label enum
+    descriptive text in :mod:`observability` is extended to mention
+    ``plex_epg`` alongside the existing ``emby / plex / jellyfin``.
+    """
+    settings = get_settings()
+
+    plex_enabled = getattr(settings, "plex_enabled", False)
+    plex_base_url = getattr(settings, "plex_base_url", "") or ""
+    plex_token = getattr(settings, "plex_token", "") or ""
+
+    if not plex_enabled or not plex_base_url:
+        logger.debug("[PLEX-EPG] Plex disabled or unconfigured; returning []")
+        return []
+
+    # Fast-path: cache hit without lock acquisition.
+    entry = _cached_entry
+    if entry is not None:
+        age = time.monotonic() - entry.cached_at
+        if age < CACHE_TTL_SECONDS:
+            logger.debug(
+                "[PLEX-EPG] Cache hit for %s (age=%.2fs, ttl=%.1fs)",
+                CACHE_KEY, age, CACHE_TTL_SECONDS,
+            )
+            observability.get_metric(
+                "media_session_cache_hits_total",
+            ).labels(source="plex_epg").inc()
+            return entry.entries
+
+    # Cache miss — acquire lock and double-check.
+    lock = _get_lock()
+    async with lock:
+        entry = _cached_entry
+        if entry is not None:
+            age = time.monotonic() - entry.cached_at
+            if age < CACHE_TTL_SECONDS:
+                logger.debug(
+                    "[PLEX-EPG] Cache hit under lock for %s "
+                    "(age=%.2fs); another waiter populated it",
+                    CACHE_KEY,
+                )
+                observability.get_metric(
+                    "media_session_cache_hits_total",
+                ).labels(source="plex_epg").inc()
+                return entry.entries
+
+        # Holder of the lock — do the upstream sweep.
+        client = PlexClient(base_url=plex_base_url, api_key=plex_token)
+        try:
+            try:
+                with observability.get_metric(
+                    "media_session_fetch_duration_seconds",
+                ).labels(source="plex_epg").time():
+                    entries = await client.get_current_live_epg_channels()
+            finally:
+                # Always release the httpx connection pool, even on
+                # error. Without this every failure leaks a socket
+                # pool for the lifetime of the process.
+                await client.close()
+        except PlexClientError as exc:
+            observability.get_metric(
+                "media_session_fetch_errors_total",
+            ).labels(source="plex_epg").inc()
+            if _cached_entry is not None:
+                logger.warning(
+                    "[PLEX-EPG] Fetch failed (%s); returning stale "
+                    "cached EPG entries (age=%.2fs)",
+                    exc,
+                    time.monotonic() - _cached_entry.cached_at,
+                )
+                observability.get_metric(
+                    "media_session_stale_fallback_total",
+                ).labels(source="plex_epg").inc()
+                return _cached_entry.entries
+            logger.warning(
+                "[PLEX-EPG] Fetch failed with no prior cache (%s); "
+                "returning empty list",
+                exc,
+            )
+            return []
+
+        _store_entry(entries)
+        logger.debug(
+            "[PLEX-EPG] Cache miss for %s; fetched %d current EPG "
+            "airing(s) and stored",
+            CACHE_KEY, len(entries),
+        )
+        return entries
+
+
+def _store_entry(entries: list[PlexEpgEntry]) -> None:
+    """Replace the module-level cache entry with a fresh fetch result.
+
+    Pulled out for symmetry with :func:`services.plex_cache._store_entry`.
+    """
+    global _cached_entry
+    _cached_entry = _Entry(entries=entries, cached_at=time.monotonic())

--- a/backend/services/plex_resolver.py
+++ b/backend/services/plex_resolver.py
@@ -67,8 +67,9 @@ from urllib.parse import urlparse
 from rapidfuzz import fuzz
 
 from config import get_settings
-from plex_client import PlexSession
+from plex_client import PlexEpgEntry, PlexSession
 from services.plex_cache import get_cached_plex_sessions
+from services.plex_epg_cache import maybe_get_cached_plex_epg
 import observability
 
 logger = logging.getLogger(__name__)
@@ -77,6 +78,37 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Public types
 # ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _EpgAttempt:
+    """bd-ma6r3 diagnostic record of an EPG-tier resolution attempt.
+
+    Carries the per-session candidate set the EPG tier built and the
+    subset of sessions it ultimately matched. Surfaced to
+    :func:`_log_plex_resolver_no_match` so a no-match forensic log line
+    can attribute "the EPG tier ran and matched nothing because
+    ``channelCallSign`` was ``foo`` and ECM channel was ``bar``" rather
+    than reporting only the bare session list.
+
+    ``snapshot_count`` is the size of the EPG snapshot the tier
+    consulted (across all DVRs / sections, already time-window
+    filtered). ``snapshot_count == 0`` distinguishes "fetched but
+    nothing currently airing" (operator's Plex EPG is stale or empty)
+    from "tier did not run" (handled by ``epg_attempt is None`` at the
+    call site).
+
+    ``candidates_by_session`` maps the unmatched live session's
+    ``session_id`` to the list of ``channel_call_sign`` strings the EPG
+    tier discovered for that session via ``grandparent_title`` lookup.
+    Empty list means "no EPG entry's grandparent matched this session's
+    grandparentTitle" — usually means the session is playing something
+    not in the current EPG snapshot.
+    """
+
+    snapshot_count: int
+    candidates_by_session: dict[str, list[str]]
+    matched_sessions: list["PlexSession"]
 
 
 @dataclass(frozen=True)
@@ -268,6 +300,53 @@ async def _resolve_plex_users_inner(
         ecm_channel_number=ecm_channel_number,
         sessions=sessions,
     )
+
+    # bd-ma6r3 EPG cross-reference tier. After Tier 1/2/3 in
+    # :func:`_find_matching_sessions` have done their work, check
+    # whether any LIVE TV session went unmatched. Plex's
+    # ``/status/sessions`` does NOT carry the channel name for Live TV
+    # — ``@grandparentTitle`` is the program currently airing, and
+    # ``@title`` is the episode. The channel ``channelCallSign`` lives
+    # only on the Plex EPG endpoints' ``<Media>`` element. The EPG
+    # tier:
+    #
+    # 1. Collects every unmatched live session (``is_live=True``).
+    # 2. Gates on (a) at least one such session AND (b) an
+    #    ``ecm_channel_name`` to match against. No live sessions or no
+    #    channel-name input → skip the EPG fetch entirely (this is the
+    #    bead's "rate-limit short-circuits when no Plex live sessions
+    #    exist" acceptance criterion). Skipping when channel_name is
+    #    absent matches Tier 1's own gate.
+    # 3. Fetches the current EPG snapshot (cached, 30 s TTL).
+    # 4. For each unmatched live session, looks up the EPG entry whose
+    #    ``grandparent_title`` matches the session's
+    #    ``now_playing_channel_name`` and whose time window covers
+    #    "now" (already filtered upstream by
+    #    :meth:`PlexClient.get_current_live_epg_channels`).
+    # 5. Adds the EPG entry's ``channel_call_sign`` as an additional
+    #    Tier-1 candidate for that session and re-tests the same
+    #    pipe-suffix tolerance Tier 1 uses against the existing
+    #    candidates.
+    #
+    # Sessions matched here are unioned into ``matches``. Diagnostic
+    # information about the EPG attempt is fed into
+    # ``_log_plex_resolver_no_match`` so the forensic log captures
+    # whether the EPG tier ran, what it found, and why it didn't help.
+    epg_attempt: _EpgAttempt | None = None
+    if ecm_channel_name and sessions:
+        unmatched_live_sessions = [
+            s for s in sessions
+            if s.is_live and s not in matches
+        ]
+        if unmatched_live_sessions:
+            epg_attempt = await _attempt_epg_match(
+                ecm_channel_name=ecm_channel_name,
+                unmatched_live_sessions=unmatched_live_sessions,
+            )
+            for session in epg_attempt.matched_sessions:
+                if session not in matches:
+                    matches.append(session)
+
     if not matches:
         logger.debug(
             "[PLEX] No match for stream=%r channel=%r number=%r "
@@ -278,6 +357,10 @@ async def _resolve_plex_users_inner(
         # bd-r5f0c.10: forensic WARN — IP matched, sessions exist, no
         # tier produced a match. Guarded on ``sessions`` non-empty so
         # the normal idle state stays silent.
+        # bd-ma6r3: pass through the ``epg_attempt`` so the diagnostic
+        # captures whether the EPG tier ran and what it saw — debugging
+        # a no-match on a Live TV channel needs the EPG snapshot, not
+        # just the session list.
         if sessions:
             _log_plex_resolver_no_match(
                 client_ip=ecm_session_ip,
@@ -285,6 +368,7 @@ async def _resolve_plex_users_inner(
                 ecm_channel_number=ecm_channel_number,
                 ecm_stream_name=ecm_stream_name,
                 sessions=sessions,
+                epg_attempt=epg_attempt,
             )
         observability.get_metric("user_attribution_unresolved_total").labels(source="plex").inc()
         return []
@@ -612,6 +696,119 @@ def _find_matching_sessions(
     return matches
 
 
+async def _attempt_epg_match(
+    *,
+    ecm_channel_name: str,
+    unmatched_live_sessions: list[PlexSession],
+) -> _EpgAttempt:
+    """Run the bd-ma6r3 EPG cross-reference tier.
+
+    For each unmatched live session, look up the current EPG entries
+    whose ``grandparent_title`` matches the session's
+    ``now_playing_channel_name`` (both come from Plex's
+    ``@grandparentTitle`` attribute on different endpoints). For each
+    such entry, treat its ``channel_call_sign`` as an additional
+    Tier-1 candidate and re-test the same pipe-suffix tolerance
+    Tier 1 uses.
+
+    Returns an :class:`_EpgAttempt` describing what the tier did:
+
+    * ``snapshot_count`` — the EPG snapshot size.
+    * ``candidates_by_session`` — per-session list of
+      ``channelCallSign`` values the tier considered.
+    * ``matched_sessions`` — sessions the tier accepted (subset of
+      ``unmatched_live_sessions``).
+
+    Never raises. The cache layer absorbs upstream failures; if the
+    cache returns ``[]``, the tier matches nothing and the diagnostic
+    records ``snapshot_count=0``.
+    """
+    try:
+        epg_entries = await maybe_get_cached_plex_epg()
+    except Exception as exc:  # noqa: BLE001
+        # Defensive: the cache layer is designed never to raise, but
+        # surface any unexpected error as "no EPG available" rather
+        # than letting it propagate up the resolver hot path.
+        logger.debug("[PLEX-EPG] Unexpected error fetching cached EPG: %s", exc)
+        epg_entries = []
+
+    snapshot_count = len(epg_entries)
+    if not epg_entries:
+        return _EpgAttempt(
+            snapshot_count=0,
+            candidates_by_session={},
+            matched_sessions=[],
+        )
+
+    # Index EPG entries by normalized grandparent_title for O(N) lookup
+    # rather than O(N*M) per-session scan. Multiple EPG entries can
+    # share a grandparent_title (same program on different channels —
+    # e.g. ``"MLB Baseball"`` airs on multiple regional sports
+    # networks); we keep all of them as candidates and let the
+    # Tier-1-style comparator pick the one whose ``channel_call_sign``
+    # matches ``ecm_channel_name``.
+    by_grandparent: dict[str, list[PlexEpgEntry]] = {}
+    for entry in epg_entries:
+        key = _normalize(entry.grandparent_title)
+        if not key:
+            continue
+        by_grandparent.setdefault(key, []).append(entry)
+
+    normalized_ecm_channel = _normalize(ecm_channel_name)
+    ecm_channel_suffix = _parse_pipe_suffix(normalized_ecm_channel)
+
+    candidates_by_session: dict[str, list[str]] = {}
+    matched: list[PlexSession] = []
+    for session in unmatched_live_sessions:
+        session_grandparent_norm = _normalize(
+            session.now_playing_channel_name or "",
+        )
+        if not session_grandparent_norm:
+            # bd-ma6r3: when ``@grandparentTitle`` is absent, fall back
+            # to ``@title`` for the EPG lookup — some Plex Live TV
+            # surfaces only populate the title with the program name
+            # and leave the grandparent blank. This is the most-likely
+            # alternate shape; if neither is set we have nothing to
+            # cross-reference.
+            session_grandparent_norm = _normalize(
+                session.now_playing_item_name or "",
+            )
+        if not session_grandparent_norm:
+            candidates_by_session[session.session_id] = []
+            continue
+        matching_epg = by_grandparent.get(session_grandparent_norm, [])
+        # Build the per-session candidate list of ``channelCallSign``
+        # values for diagnostic logging AND comparison.
+        call_signs = [
+            entry.channel_call_sign for entry in matching_epg
+            if entry.channel_call_sign
+        ]
+        candidates_by_session[session.session_id] = list(call_signs)
+        if not call_signs:
+            continue
+        # Tier-1-style comparison: each ``channelCallSign`` becomes a
+        # candidate. Reuse the existing :func:`_match_against_candidates`
+        # so the pipe-suffix / pipe-prefix / ECM-suffix tolerance is
+        # IDENTICAL to the live Tier 1.
+        candidates: list[tuple[str, str]] = []
+        for call_sign in call_signs:
+            normalized_call = _normalize(call_sign)
+            call_suffix = _parse_pipe_suffix(normalized_call)
+            candidates.append((normalized_call, call_suffix))
+        if _match_against_candidates(
+            normalized_ecm_channel,
+            ecm_channel_suffix,
+            tuple(candidates),
+        ):
+            matched.append(session)
+
+    return _EpgAttempt(
+        snapshot_count=snapshot_count,
+        candidates_by_session=candidates_by_session,
+        matched_sessions=matched,
+    )
+
+
 def _match_against_candidates(
     normalized_ecm_channel: str,
     ecm_channel_suffix: str,
@@ -751,6 +948,7 @@ def _log_plex_resolver_no_match(
     ecm_channel_number: str | int | None,
     ecm_stream_name: str,
     sessions: list[PlexSession],
+    epg_attempt: _EpgAttempt | None = None,
 ) -> None:
     """Emit a structured WARN once per (client_ip, channel_name) per 60 s
     when the Plex resolver had sessions to compare against and the IP
@@ -765,6 +963,14 @@ def _log_plex_resolver_no_match(
     parsed pipe prefix and suffix alongside the raw item name. The
     ``last_activity_date`` is a ``datetime`` here (vs an ISO string for
     Emby/Jellyfin), serialized as ``isoformat()`` for readability.
+
+    bd-ma6r3: when the EPG cross-reference tier ran (``epg_attempt`` is
+    not None), include its diagnostic payload so the operator can see
+    whether the EPG snapshot had any current airings, which channelCallSign
+    values the tier considered for each unmatched live session, and why
+    none of them passed the Tier-1-style comparator. Without this
+    surfaced, debugging a Live TV "User #N" symptom requires re-running
+    the EPG probe by hand against the operator's Plex server.
 
     Callers MUST guard on non-empty ``sessions`` — an empty session list
     is a normal state and would spam the log with useless lines.
@@ -813,10 +1019,29 @@ def _log_plex_resolver_no_match(
         }
         for s in truncated
     ]
+    # bd-ma6r3 EPG-tier payload. When the tier ran, surface the snapshot
+    # size and the per-session list of channel callsigns it considered.
+    # When the tier did not run (no live sessions OR no ecm_channel_name)
+    # the value is ``None`` so the log line clearly distinguishes
+    # "tier skipped" from "tier ran and found nothing".
+    if epg_attempt is None:
+        epg_payload: dict | None = None
+    else:
+        epg_payload = {
+            "snapshot_count": epg_attempt.snapshot_count,
+            "candidates_by_session": {
+                # Truncate keys to first 8 chars for log readability — same
+                # discipline as ``session_id`` in ``session_payload``.
+                (sid[:8] if sid else ""): cands
+                for sid, cands in epg_attempt.candidates_by_session.items()
+            },
+            "matched_count": len(epg_attempt.matched_sessions),
+        }
+
     logger.warning(
         "[PLEX-RESOLVER] no-match diagnostic: ip=%s ecm_channel=%r "
         "ecm_channel_norm=%r ecm_channel_number=%r ecm_stream=%r "
-        "ecm_stream_norm=%r sessions_count=%d sessions=%s",
+        "ecm_stream_norm=%r sessions_count=%d sessions=%s epg=%s",
         client_ip,
         ecm_channel_name,
         _normalize(ecm_channel_name or ""),
@@ -825,6 +1050,7 @@ def _log_plex_resolver_no_match(
         _normalize(ecm_stream_name or ""),
         len(sessions),
         session_payload,
+        epg_payload,
     )
 
 

--- a/backend/tests/fixtures/plex/dvr_sections.xml
+++ b/backend/tests/fixtures/plex/dvr_sections.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- bd-ma6r3 fixture for GET /tv.plex.providers.epg.xmltv:7/sections.
+     The typical Dispatcharr-HDHomeRun-fronted EPG provider exposes
+     four library sections: Movies (1), Shows (2), Sports (3), News (4).
+     Captured from PO's running Plex 2026-05-18. -->
+<MediaContainer size="4" title1="Plex Library">
+  <Directory key="1" type="movie" title="Movies" />
+  <Directory key="4" type="show" title="News" />
+  <Directory key="2" type="show" title="Shows" />
+  <Directory key="3" type="show" title="Sports" />
+</MediaContainer>

--- a/backend/tests/fixtures/plex/epg_section_multi_media_per_video.xml
+++ b/backend/tests/fixtures/plex/epg_section_multi_media_per_video.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- bd-ma6r3 EPG fixture: one <Video> with MULTIPLE <Media> elements.
+
+     Plex's real EPG response shape — a single episode that airs at
+     multiple times (or on multiple channels) carries one <Media> per
+     airing slot. The parser must emit one PlexEpgEntry per <Media>;
+     the time-window filter then keeps only the airing currently
+     covering "now".
+
+     Captured from PO's Plex 2026-05-18: Fox 11 News at Five episode
+     with 4 upcoming <Media> elements across consecutive evenings. -->
+<MediaContainer size="1" identifier="tv.plex.providers.epg.xmltv" title1="News" title2="All Shows" viewGroup="show">
+  <Video ratingKey="news-episode" type="episode"
+         title="Episode 09-03"
+         grandparentTitle="Fox 11 News at Five"
+         parentTitle="Season 1999">
+    <Media id="4346" duration="3600000" channelCallSign="11.1 | FOX: WLUK Green Bay"
+           channelIdentifier="11.1" channelTitle="11.1 11.1 | FOX: WLUK Green Bay"
+           channelVcn="11.1" protocol="livetv"
+           beginsAt="1779141600" endsAt="1779145200" channelID="9" />
+    <Media id="4375" duration="3600000" channelCallSign="11.1 | FOX: WLUK Green Bay"
+           channelIdentifier="11.1" channelTitle="11.1 11.1 | FOX: WLUK Green Bay"
+           channelVcn="11.1" protocol="livetv"
+           beginsAt="1779228000" endsAt="1779231600" channelID="9" />
+    <Media id="4404" duration="3600000" channelCallSign="11.1 | FOX: WLUK Green Bay"
+           channelIdentifier="11.1" channelTitle="11.1 11.1 | FOX: WLUK Green Bay"
+           channelVcn="11.1" protocol="livetv"
+           beginsAt="1779314400" endsAt="1779318000" channelID="9" />
+    <Media id="4433" duration="3600000" channelCallSign="11.1 | FOX: WLUK Green Bay"
+           channelIdentifier="11.1" channelTitle="11.1 11.1 | FOX: WLUK Green Bay"
+           channelVcn="11.1" protocol="livetv"
+           beginsAt="1779400800" endsAt="1779404400" channelID="9" />
+  </Video>
+</MediaContainer>

--- a/backend/tests/fixtures/plex/epg_section_one_current_airing.xml
+++ b/backend/tests/fixtures/plex/epg_section_one_current_airing.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- bd-ma6r3 EPG fixture: one DVR section with three episodes; the
+     middle episode is currently airing (1779148800 = 2026-05-19T00:00:00Z),
+     the first ended an hour ago, the third starts in three hours.
+
+     Time-window filter (epg_entry_is_current with now=1779150000):
+       beginsAt=1779148800 endsAt=1779159600  → currently airing
+       beginsAt=1779141600 endsAt=1779145200  → ended ~80m ago
+       beginsAt=1779159600 endsAt=1779163200  → starts in ~25m
+
+     The currently-airing entry's channelCallSign="8.1 | NBC: KGW Portland"
+     is the PO's actual symptom — without bd-ma6r3 the resolver only
+     gets "MLB Baseball" (the program) from /status/sessions and never
+     knows the channel. -->
+<MediaContainer size="3" identifier="tv.plex.providers.epg.xmltv" title1="Sports" title2="All Shows" viewGroup="show">
+  <Video ratingKey="airing-past" type="episode"
+         title="Conference Semifinals: Past Game"
+         grandparentTitle="NBA Basketball"
+         parentTitle="Season 2026">
+    <Media id="999" duration="3600000" channelCallSign="5.1 | CBS: KIRO Seattle"
+           channelIdentifier="5.1" channelTitle="5.1 5.1 | CBS: KIRO Seattle"
+           channelVcn="5.1" protocol="livetv"
+           beginsAt="1779141600" endsAt="1779145200" channelID="7" />
+  </Video>
+  <Video ratingKey="airing-current" type="episode"
+         title="Milwaukee Brewers at Chicago Cubs"
+         grandparentTitle="MLB Baseball"
+         parentTitle="Season 2026">
+    <Media id="3230" duration="10800000" channelCallSign="8.1 | NBC: KGW Portland"
+           channelIdentifier="8.1" channelTitle="8.1 8.1 | NBC: KGW Portland"
+           channelVcn="8.1" protocol="livetv"
+           beginsAt="1779148800" endsAt="1779159600" channelID="8" />
+  </Video>
+  <Video ratingKey="airing-future" type="episode"
+         title="Episode 138"
+         grandparentTitle="The Kelly Clarkson Show"
+         parentTitle="Season 7">
+    <Media id="756" duration="3600000" channelCallSign="6.1 | CBS: KOIN Portland"
+           channelIdentifier="6.1" channelTitle="6.1 6.1 | CBS: KOIN Portland"
+           channelVcn="6.1" protocol="livetv"
+           beginsAt="1779159600" endsAt="1779163200" channelID="6" />
+  </Video>
+</MediaContainer>

--- a/backend/tests/fixtures/plex/livetv_dvrs.xml
+++ b/backend/tests/fixtures/plex/livetv_dvrs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- bd-ma6r3 fixture for GET /livetv/dvrs. Mirrors the shape PO's
+     running Plex returns: a single DVR with key="7" (the Dispatcharr-
+     HDHomeRun fronted setup the bead targets). Tests that exercise
+     multi-DVR setups assemble a synthetic XML inline rather than
+     loading a fixture — the multi-DVR path is rare and the fixture
+     would not represent any real operator's setup. -->
+<MediaContainer size="1">
+  <Dvr key="7" uuid="c3b23c5e-45c0-4a73-bb4b-8be36abb0b22"
+       language="eng" lineupTitle="My Guide"
+       country="usa" refreshedAt="1779144558"
+       epgIdentifier="tv.plex.providers.epg.xmltv:7">
+    <Device parentID="7" key="2" protocol="livetv"
+            status="alive" state="enabled" />
+  </Dvr>
+</MediaContainer>

--- a/backend/tests/services/test_plex_epg_cache.py
+++ b/backend/tests/services/test_plex_epg_cache.py
@@ -1,0 +1,291 @@
+"""Unit tests for :mod:`services.plex_epg_cache` (bd-ma6r3).
+
+The EPG cache is a sibling of :mod:`services.plex_cache` and shares its
+six behavioral guarantees verbatim, with one structural difference:
+the upstream call is :meth:`PlexClient.get_current_live_epg_channels`
+(a DVR/section sweep) rather than ``get_sessions``. TTL is 30 s vs
+the session cache's 5 s — the bead's rationale for the longer TTL is
+that broadcast airings change on 30+ minute boundaries so refreshing
+faster is wasted upstream load.
+
+The tests below mirror ``test_plex_cache.py`` test-for-test (cache hit,
+cache miss, stale fallback, cold-start failure, settings gate,
+thundering-herd) so deviation between the two caches surfaces as a
+test gap rather than silent drift.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import observability
+from plex_client import PlexClientError, PlexEpgEntry
+from services import plex_epg_cache
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(
+    *,
+    grandparent_title: str = "MLB Baseball",
+    channel_call_sign: str = "8.1 | NBC: KGW Portland",
+) -> PlexEpgEntry:
+    """Build a representative :class:`PlexEpgEntry` for cache assertions."""
+    return PlexEpgEntry(
+        grandparent_title=grandparent_title,
+        channel_call_sign=channel_call_sign,
+        channel_identifier="8.1",
+        channel_title="8.1 NBC",
+        channel_vcn="8.1",
+        begins_at=datetime(2026, 5, 18, 22, 0, 0, tzinfo=timezone.utc),
+        ends_at=datetime(2026, 5, 19, 1, 0, 0, tzinfo=timezone.utc),
+        protocol="livetv",
+    )
+
+
+def _enabled_settings(base_url: str = "http://plex.example:32400") -> MagicMock:
+    """Settings stub representing a fully-configured, enabled Plex."""
+    settings = MagicMock()
+    settings.plex_enabled = True
+    settings.plex_base_url = base_url
+    settings.plex_token = "token-123"
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def reset_epg_cache_state():
+    """Ensure each test starts with a clean module-level cache."""
+    plex_epg_cache._reset_for_tests()
+    observability.reset_for_tests()
+    observability.install_metrics()
+    yield
+    plex_epg_cache._reset_for_tests()
+    observability.reset_for_tests()
+
+
+def _get_counter_value(metric_key: str, source: str) -> float:
+    """Return the current value of a labeled counter from the live registry."""
+    metric = observability.get_metric(metric_key)
+    prom_name = f"ecm_{metric_key}"
+    for mf in metric.collect():
+        for sample in mf.samples:
+            if sample.name == prom_name and sample.labels.get("source") == source:
+                return sample.value
+    return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Settings gate
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsGate:
+    """When Plex is disabled or unconfigured, the cache short-circuits."""
+
+    async def test_plex_disabled_returns_empty_without_client_construction(self):
+        """``plex_enabled=False`` short-circuits before constructing PlexClient."""
+        settings = MagicMock()
+        settings.plex_enabled = False
+        settings.plex_base_url = "http://plex.example:32400"
+        settings.plex_token = "token"
+        with patch.object(plex_epg_cache, "get_settings", return_value=settings), \
+             patch.object(plex_epg_cache, "PlexClient") as client_cls:
+            result = await plex_epg_cache.maybe_get_cached_plex_epg()
+        assert result == []
+        client_cls.assert_not_called()
+
+    async def test_empty_base_url_returns_empty(self):
+        """Empty ``plex_base_url`` also short-circuits — there's no upstream
+        to call even if ``plex_enabled`` somehow ended up True."""
+        settings = MagicMock()
+        settings.plex_enabled = True
+        settings.plex_base_url = ""
+        settings.plex_token = "token"
+        with patch.object(plex_epg_cache, "get_settings", return_value=settings), \
+             patch.object(plex_epg_cache, "PlexClient") as client_cls:
+            result = await plex_epg_cache.maybe_get_cached_plex_epg()
+        assert result == []
+        client_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Cache miss → upstream call → cache populated
+# ---------------------------------------------------------------------------
+
+
+class TestCacheMiss:
+    """First call when the cache is empty fires the upstream sweep."""
+
+    async def test_cold_call_fires_upstream(self):
+        entries = [_make_entry()]
+        plex_client_mock = MagicMock()
+        plex_client_mock.get_current_live_epg_channels = AsyncMock(
+            return_value=entries,
+        )
+        plex_client_mock.close = AsyncMock()
+        with patch.object(plex_epg_cache, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_epg_cache, "PlexClient",
+                          return_value=plex_client_mock):
+            result = await plex_epg_cache.maybe_get_cached_plex_epg()
+        assert result == entries
+        plex_client_mock.get_current_live_epg_channels.assert_awaited_once()
+        plex_client_mock.close.assert_awaited_once()
+
+    async def test_cold_call_returns_empty_list_when_plex_has_no_airings(self):
+        """Empty upstream snapshot is a normal state — cache populates with
+        ``[]`` and subsequent calls hit cache."""
+        plex_client_mock = MagicMock()
+        plex_client_mock.get_current_live_epg_channels = AsyncMock(return_value=[])
+        plex_client_mock.close = AsyncMock()
+        with patch.object(plex_epg_cache, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_epg_cache, "PlexClient",
+                          return_value=plex_client_mock):
+            result = await plex_epg_cache.maybe_get_cached_plex_epg()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Cache hit — second call within TTL skips upstream
+# ---------------------------------------------------------------------------
+
+
+class TestCacheHit:
+    """Once populated, the cache serves subsequent reads from memory."""
+
+    async def test_second_call_within_ttl_does_not_call_upstream(self):
+        entries = [_make_entry()]
+        plex_client_mock = MagicMock()
+        plex_client_mock.get_current_live_epg_channels = AsyncMock(
+            return_value=entries,
+        )
+        plex_client_mock.close = AsyncMock()
+        with patch.object(plex_epg_cache, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_epg_cache, "PlexClient",
+                          return_value=plex_client_mock):
+            first = await plex_epg_cache.maybe_get_cached_plex_epg()
+            second = await plex_epg_cache.maybe_get_cached_plex_epg()
+        assert first == entries
+        assert second == entries
+        # Upstream fired exactly once across the two calls.
+        plex_client_mock.get_current_live_epg_channels.assert_awaited_once()
+        # Cache-hit counter incremented exactly once (the second call).
+        assert _get_counter_value(
+            "media_session_cache_hits_total", "plex_epg",
+        ) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Stale fallback — fetch failure with prior cache returns stale
+# ---------------------------------------------------------------------------
+
+
+class TestStaleFallback:
+    """When the upstream fails AFTER a successful prior fetch, the cache
+    returns the stale entries rather than ``[]``."""
+
+    async def test_stale_returned_after_upstream_failure(self):
+        first_entries = [_make_entry()]
+        plex_client_mock = MagicMock()
+        plex_client_mock.get_current_live_epg_channels = AsyncMock(
+            side_effect=[first_entries, PlexClientError("network down")],
+        )
+        plex_client_mock.close = AsyncMock()
+        with patch.object(plex_epg_cache, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_epg_cache, "PlexClient",
+                          return_value=plex_client_mock):
+            first = await plex_epg_cache.maybe_get_cached_plex_epg()
+            # Force TTL expiry by reaching into the module state.
+            plex_epg_cache._cached_entry.cached_at -= plex_epg_cache.CACHE_TTL_SECONDS + 1
+            second = await plex_epg_cache.maybe_get_cached_plex_epg()
+        assert first == first_entries
+        # Stale fallback returns the SAME entries the first call cached.
+        assert second == first_entries
+        assert _get_counter_value(
+            "media_session_stale_fallback_total", "plex_epg",
+        ) == 1.0
+        assert _get_counter_value(
+            "media_session_fetch_errors_total", "plex_epg",
+        ) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Cold-start failure — no prior cache, fetch fails, returns []
+# ---------------------------------------------------------------------------
+
+
+class TestColdStartFailure:
+    """Cold-start fetch failure must return ``[]`` (never raise) and
+    increment the fetch_errors counter without firing stale_fallback."""
+
+    async def test_cold_failure_returns_empty(self):
+        plex_client_mock = MagicMock()
+        plex_client_mock.get_current_live_epg_channels = AsyncMock(
+            side_effect=PlexClientError("auth"),
+        )
+        plex_client_mock.close = AsyncMock()
+        with patch.object(plex_epg_cache, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_epg_cache, "PlexClient",
+                          return_value=plex_client_mock):
+            result = await plex_epg_cache.maybe_get_cached_plex_epg()
+        assert result == []
+        assert _get_counter_value(
+            "media_session_fetch_errors_total", "plex_epg",
+        ) == 1.0
+        # Stale fallback did NOT fire — no prior cache to fall back to.
+        assert _get_counter_value(
+            "media_session_stale_fallback_total", "plex_epg",
+        ) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Thundering-herd guard — concurrent misses collapse to one upstream call
+# ---------------------------------------------------------------------------
+
+
+class TestThunderingHerd:
+    """Concurrent cache-miss waiters must produce exactly one upstream
+    call thanks to the ``asyncio.Lock`` + double-check pattern."""
+
+    async def test_concurrent_callers_share_one_fetch(self):
+        entries = [_make_entry()]
+
+        first_call_seen = asyncio.Event()
+        release_first_call = asyncio.Event()
+
+        async def slow_fetch():
+            """Block on a barrier so concurrent waiters queue on the lock."""
+            first_call_seen.set()
+            await release_first_call.wait()
+            return entries
+
+        plex_client_mock = MagicMock()
+        plex_client_mock.get_current_live_epg_channels = AsyncMock(
+            side_effect=slow_fetch,
+        )
+        plex_client_mock.close = AsyncMock()
+        with patch.object(plex_epg_cache, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_epg_cache, "PlexClient",
+                          return_value=plex_client_mock):
+            # Launch 5 concurrent callers; only one should fetch.
+            tasks = [
+                asyncio.create_task(plex_epg_cache.maybe_get_cached_plex_epg())
+                for _ in range(5)
+            ]
+            await first_call_seen.wait()
+            release_first_call.set()
+            results = await asyncio.gather(*tasks)
+        for r in results:
+            assert r == entries
+        plex_client_mock.get_current_live_epg_channels.assert_awaited_once()

--- a/backend/tests/services/test_plex_resolver.py
+++ b/backend/tests/services/test_plex_resolver.py
@@ -1404,3 +1404,437 @@ class TestECMPipePrefixTolerance:
                 ecm_channel_name="109 | cnn",
             )
         assert result == "case_user"
+
+
+# ---------------------------------------------------------------------------
+# bd-ma6r3: EPG cross-reference tier
+# ---------------------------------------------------------------------------
+
+
+from plex_client import PlexEpgEntry  # noqa: E402 — group bd-ma6r3 additions
+
+
+def _epg_entry(
+    *,
+    grandparent_title: str,
+    channel_call_sign: str,
+) -> PlexEpgEntry:
+    """Build a representative EPG entry covering "now" with livetv protocol.
+
+    The time window is intentionally wide so window-filter mechanics
+    don't interfere with the matcher tests — those are exercised in
+    :mod:`tests.unit.test_plex_client`.
+    """
+    return PlexEpgEntry(
+        grandparent_title=grandparent_title,
+        channel_call_sign=channel_call_sign,
+        channel_identifier="x",
+        channel_title="x",
+        channel_vcn="x",
+        begins_at=datetime(2026, 5, 18, 0, 0, 0, tzinfo=timezone.utc),
+        ends_at=datetime(2026, 5, 20, 0, 0, 0, tzinfo=timezone.utc),
+        protocol="livetv",
+    )
+
+
+def _make_live_session(
+    *,
+    session_id: str | None = None,
+    user_name: str = "MotWakorb",
+    grandparent_title: str | None = None,
+    item_name: str | None = None,
+) -> PlexSession:
+    """Build a Plex Live TV session — ``is_live=True`` is the EPG-tier gate."""
+    if last_activity := datetime(2026, 5, 18, 19, 0, 0, tzinfo=timezone.utc):
+        pass
+    return PlexSession(
+        session_id=session_id or f"sess-{user_name}",
+        user_id="uid-x",
+        user_name=user_name,
+        remote_endpoint="10.0.0.99",
+        now_playing_item_name=item_name,
+        now_playing_channel_name=grandparent_title,
+        now_playing_parent_title=None,
+        last_activity_date=last_activity,
+        is_live=True,
+    )
+
+
+class TestEpgTierLiveTvChannelMatch:
+    """bd-ma6r3: when Plex Live TV's ``/status/sessions`` surfaces the
+    program in ``grandparentTitle`` but the channel is NOT carried on
+    any session field, the EPG tier cross-references the EPG snapshot
+    to recover the channel ``channelCallSign``.
+
+    PO's actual symptom from v0.17.1-0056: ECM channel
+    ``'8.1 | NBC: KGW Portland'``, Plex Live TV session with
+    ``grandparentTitle='MLB Baseball'``, EPG entry mapping
+    ``MLB Baseball`` → ``channelCallSign='8.1 | NBC: KGW Portland'`` →
+    must resolve to ``MotWakorb``.
+    """
+
+    async def test_po_symptom_resolves_via_epg(self):
+        """The exact PO symptom: program-only session + EPG carries the
+        channel callsign → resolver picks up MotWakorb."""
+        session = _make_live_session(
+            user_name="MotWakorb",
+            item_name="Brewers at Cubs",
+            grandparent_title="MLB Baseball",
+        )
+        epg = [
+            _epg_entry(
+                grandparent_title="MLB Baseball",
+                channel_call_sign="8.1 | NBC: KGW Portland",
+            ),
+        ]
+        with patch.object(plex_resolver, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver, "maybe_get_cached_plex_epg",
+                          AsyncMock(return_value=epg)):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="US: 8.1 NBC",
+                ecm_channel_name="8.1 | NBC: KGW Portland",
+            )
+        assert result == "MotWakorb"
+        # Per-viewer metric incremented exactly once.
+        assert _get_counter_value(
+            "user_attribution_resolved_total", "plex",
+        ) == 1.0
+
+    async def test_epg_tier_matches_pipe_suffix_against_clean_ecm(self):
+        """EPG channelCallSign has pipe-prefix, ECM channel_name is the
+        clean right-hand part — same pipe-suffix tolerance as Tier 1."""
+        session = _make_live_session(
+            user_name="alice",
+            item_name="Brewers at Cubs",
+            grandparent_title="MLB Baseball",
+        )
+        epg = [
+            _epg_entry(
+                grandparent_title="MLB Baseball",
+                channel_call_sign="8.1 | NBC: KGW Portland",
+            ),
+        ]
+        with patch.object(plex_resolver, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver, "maybe_get_cached_plex_epg",
+                          AsyncMock(return_value=epg)):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ignored",
+                ecm_channel_name="NBC: KGW Portland",
+            )
+        assert result == "alice"
+
+    async def test_epg_tier_returns_none_when_no_epg_grandparent_match(self):
+        """EPG snapshot contains airings but none match the session's
+        ``grandparent_title`` — resolver returns None."""
+        session = _make_live_session(
+            user_name="bob",
+            item_name="Some Episode",
+            grandparent_title="Unknown Show",
+        )
+        epg = [
+            _epg_entry(
+                grandparent_title="MLB Baseball",
+                channel_call_sign="8.1 | NBC: KGW Portland",
+            ),
+        ]
+        with patch.object(plex_resolver, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver, "maybe_get_cached_plex_epg",
+                          AsyncMock(return_value=epg)):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="totally unrelated",
+                ecm_channel_name="8.1 | NBC: KGW Portland",
+            )
+        assert result is None
+
+    async def test_epg_tier_returns_none_when_callsign_does_not_match(self):
+        """EPG entry's grandparent matches the session, but its
+        ``channelCallSign`` is for a different ECM channel — returns
+        None. Defends against false positives when the same program
+        airs on multiple channels in the EPG."""
+        session = _make_live_session(
+            user_name="carol",
+            item_name="Brewers at Cubs",
+            grandparent_title="MLB Baseball",
+        )
+        epg = [
+            _epg_entry(
+                grandparent_title="MLB Baseball",
+                channel_call_sign="3.2 | TVW",  # different channel
+            ),
+        ]
+        with patch.object(plex_resolver, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver, "maybe_get_cached_plex_epg",
+                          AsyncMock(return_value=epg)):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ignored",
+                ecm_channel_name="8.1 | NBC: KGW Portland",
+            )
+        assert result is None
+
+    async def test_epg_tier_does_not_run_when_no_live_sessions(self):
+        """Bead acceptance criterion: resolver MUST NOT fetch EPG when
+        there are zero live sessions to disambiguate. Idle Plex
+        deployments must not incur an EPG fetch storm."""
+        session = _make_session(  # not live — VOD
+            user_name="alice",
+            item_name="Dune",
+        )
+        epg_mock = AsyncMock(return_value=[])
+        with patch.object(plex_resolver, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver, "maybe_get_cached_plex_epg",
+                          epg_mock):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ignored",
+                ecm_channel_name="8.1 | NBC: KGW Portland",
+            )
+        assert result is None
+        # The EPG cache was NEVER consulted because no live session
+        # needed disambiguation.
+        epg_mock.assert_not_awaited()
+
+    async def test_epg_tier_does_not_run_when_no_ecm_channel_name(self):
+        """When the resolver is invoked without ``ecm_channel_name``,
+        the EPG tier has no candidate to test against — must not fetch
+        EPG."""
+        session = _make_live_session(
+            user_name="bob",
+            item_name="Brewers at Cubs",
+            grandparent_title="MLB Baseball",
+        )
+        epg_mock = AsyncMock(return_value=[])
+        with patch.object(plex_resolver, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver, "maybe_get_cached_plex_epg",
+                          epg_mock):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="unrelated",
+                # No ecm_channel_name supplied.
+            )
+        assert result is None
+        epg_mock.assert_not_awaited()
+
+    async def test_epg_tier_does_not_run_when_tier1_already_matched(self):
+        """If Tier 1 already matched (e.g. session.now_playing_channel_name
+        is itself the channel), the EPG tier has no unmatched session
+        to look up and must not fetch EPG — avoids redundant upstream
+        load on the steady-state happy path."""
+        session = _make_live_session(
+            user_name="MotWakorb",
+            item_name="Some Program",
+            # grandparent_title IS the channel here (typical NBC, ESPN
+            # straight-up channel name) — Tier 1 will match.
+            grandparent_title="NBC",
+        )
+        epg_mock = AsyncMock(return_value=[])
+        with patch.object(plex_resolver, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver, "maybe_get_cached_plex_epg",
+                          epg_mock):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ignored",
+                ecm_channel_name="NBC",
+            )
+        assert result == "MotWakorb"
+        epg_mock.assert_not_awaited()
+
+    async def test_epg_tier_skipped_for_non_live_sessions(self):
+        """A VOD session whose grandparent happens to match an EPG entry
+        must not trigger the EPG tier — only ``is_live=True`` sessions
+        opt in. Defends against accidental cross-attribution where a
+        Plex user is watching a recording of an episode whose show
+        title coincidentally airs on a channel."""
+        # VOD session (is_live=False) playing an episode named
+        # "MLB Baseball" — the EPG carries a real Live TV "MLB Baseball"
+        # entry on 8.1, but the VOD session must NOT be matched against
+        # ECM's 8.1 channel.
+        session = _make_session(
+            user_name="dave",
+            item_name="Brewers Documentary",
+            channel_name="MLB Baseball",  # grandparentTitle present
+        )
+        # Force is_live=False — _make_session defaults to that.
+        assert session.is_live is False
+        epg = [
+            _epg_entry(
+                grandparent_title="MLB Baseball",
+                channel_call_sign="8.1 | NBC: KGW Portland",
+            ),
+        ]
+        epg_mock = AsyncMock(return_value=epg)
+        with patch.object(plex_resolver, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver, "maybe_get_cached_plex_epg",
+                          epg_mock):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ignored",
+                ecm_channel_name="8.1 | NBC: KGW Portland",
+            )
+        # VOD session must NOT match via the EPG tier; the EPG cache
+        # is never consulted because the only session in the list is
+        # not live.
+        assert result is None
+        epg_mock.assert_not_awaited()
+
+    async def test_epg_tier_handles_empty_snapshot(self):
+        """When the EPG cache returns ``[]`` (Plex idle / cold-start
+        fetch failure), the tier matches nothing — no exception, no
+        attribution change."""
+        session = _make_live_session(
+            user_name="alice",
+            item_name="Some Episode",
+            grandparent_title="MLB Baseball",
+        )
+        with patch.object(plex_resolver, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver, "maybe_get_cached_plex_epg",
+                          AsyncMock(return_value=[])):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ignored",
+                ecm_channel_name="8.1 | NBC: KGW Portland",
+            )
+        assert result is None
+
+    async def test_epg_tier_picks_correct_callsign_when_multiple_share_grandparent(self):
+        """The same program (e.g., "MLB Baseball") can air on multiple
+        channels in the EPG snapshot. The tier must pick the entry whose
+        ``channelCallSign`` matches the operator's ECM channel_name and
+        ignore the others."""
+        session = _make_live_session(
+            user_name="ed",
+            item_name="Brewers at Cubs",
+            grandparent_title="MLB Baseball",
+        )
+        epg = [
+            _epg_entry(
+                grandparent_title="MLB Baseball",
+                channel_call_sign="3.2 | TVW",
+            ),
+            _epg_entry(
+                grandparent_title="MLB Baseball",
+                channel_call_sign="8.1 | NBC: KGW Portland",
+            ),
+            _epg_entry(
+                grandparent_title="MLB Baseball",
+                channel_call_sign="679 | Milwaukee Brewers",
+            ),
+        ]
+        with patch.object(plex_resolver, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver, "maybe_get_cached_plex_epg",
+                          AsyncMock(return_value=epg)):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ignored",
+                ecm_channel_name="679 | Milwaukee Brewers",
+            )
+        assert result == "ed"
+
+    async def test_epg_tier_diagnostic_logged_when_no_match(
+        self, caplog,
+    ):
+        """The no-match WARN diagnostic must include the EPG attempt
+        payload so a PO can see why the tier didn't help. The line
+        carries ``epg=`` with snapshot_count + candidates_by_session."""
+        import logging
+        session = _make_live_session(
+            user_name="frank",
+            item_name="Brewers at Cubs",
+            grandparent_title="MLB Baseball",
+        )
+        epg = [
+            _epg_entry(
+                grandparent_title="MLB Baseball",
+                channel_call_sign="3.2 | TVW",  # wrong channel
+            ),
+        ]
+        with caplog.at_level(logging.WARNING), \
+             patch.object(plex_resolver, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver, "maybe_get_cached_plex_epg",
+                          AsyncMock(return_value=epg)):
+            await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ignored",
+                ecm_channel_name="8.1 | NBC: KGW Portland",
+            )
+        warn_lines = [
+            r.getMessage() for r in caplog.records
+            if "[PLEX-RESOLVER] no-match" in r.getMessage()
+        ]
+        assert len(warn_lines) == 1
+        # The diagnostic must surface the EPG attempt so a PO can see
+        # which channelCallSigns the tier considered.
+        assert "epg=" in warn_lines[0]
+        assert "snapshot_count" in warn_lines[0]
+        assert "3.2 | TVW" in warn_lines[0]
+
+    async def test_epg_tier_handles_session_with_grandparent_falls_back_to_title(self):
+        """When ``now_playing_channel_name`` is None but
+        ``now_playing_item_name`` carries the program (some Plex Live
+        TV surfaces leave grandparent blank), the EPG tier falls back
+        to looking up by title."""
+        session = PlexSession(
+            session_id="sess-grace",
+            user_id="uid-grace",
+            user_name="grace",
+            remote_endpoint="10.0.0.99",
+            now_playing_item_name="MLB Baseball",
+            now_playing_channel_name=None,  # grandparent absent
+            now_playing_parent_title=None,
+            last_activity_date=datetime(2026, 5, 18, 19, 0, 0, tzinfo=timezone.utc),
+            is_live=True,
+        )
+        epg = [
+            _epg_entry(
+                grandparent_title="MLB Baseball",
+                channel_call_sign="8.1 | NBC: KGW Portland",
+            ),
+        ]
+        with patch.object(plex_resolver, "get_settings",
+                          return_value=_enabled_settings()), \
+             patch.object(plex_resolver, "get_cached_plex_sessions",
+                          AsyncMock(return_value=[session])), \
+             patch.object(plex_resolver, "maybe_get_cached_plex_epg",
+                          AsyncMock(return_value=epg)):
+            result = await plex_resolver.resolve_plex_user(
+                ecm_session_ip="192.168.1.20",
+                ecm_stream_name="ignored",
+                ecm_channel_name="8.1 | NBC: KGW Portland",
+            )
+        assert result == "grace"

--- a/backend/tests/unit/test_plex_client.py
+++ b/backend/tests/unit/test_plex_client.py
@@ -416,3 +416,369 @@ async def test_close_releases_pool():
     with patch.object(client._client, "aclose", new_callable=AsyncMock) as aclose_mock:
         await client.close()
     aclose_mock.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# bd-ma6r3 EPG-tier tests — DVR/section discovery + EPG entry parsing
+# ---------------------------------------------------------------------------
+
+
+from plex_client import (  # noqa: E402 — group bd-ma6r3 additions below
+    PlexEpgEntry,
+    _epg_entry_is_current,
+    _parse_epg_xml,
+)
+
+
+# ----- PlexEpgEntry parsing
+
+
+def test_parse_epg_xml_emits_one_entry_per_media_element():
+    """The parser must flatten each ``<Media>`` under each ``<Video>``
+    into a separate :class:`PlexEpgEntry`. A single Video carrying four
+    upcoming airings must produce four entries — the resolver's
+    time-window filter then keeps only the one currently airing.
+    """
+    xml = _load_fixture("epg_section_multi_media_per_video.xml")
+    entries = _parse_epg_xml(xml)
+    assert len(entries) == 4
+    # All four entries share the same grandparent_title and call_sign
+    # (operator's "Fox 11 News at Five" airs at four times on 11.1).
+    for entry in entries:
+        assert entry.grandparent_title == "Fox 11 News at Five"
+        assert entry.channel_call_sign == "11.1 | FOX: WLUK Green Bay"
+        assert entry.channel_identifier == "11.1"
+        assert entry.channel_vcn == "11.1"
+        assert entry.protocol == "livetv"
+        assert entry.begins_at is not None
+        assert entry.ends_at is not None
+
+
+def test_parse_epg_xml_handles_empty_container():
+    """An empty ``<MediaContainer/>`` (section has no airings) must
+    produce ``[]`` without raising — this is the normal state of the
+    Movies section in the PO's all-Dispatcharr setup."""
+    xml = '<?xml version="1.0"?><MediaContainer size="0"/>'
+    assert _parse_epg_xml(xml) == []
+
+
+def test_parse_epg_xml_skips_videos_without_grandparent_title():
+    """A ``<Video>`` element missing ``@grandparentTitle`` cannot be
+    cross-referenced (the resolver's lookup key is grandparent_title),
+    so the parser must skip it entirely rather than emit entries with
+    an empty grandparent."""
+    xml = (
+        '<?xml version="1.0"?>'
+        '<MediaContainer size="1">'
+        '<Video ratingKey="orphan" type="episode" title="Orphan">'
+        '<Media id="0" channelCallSign="X" protocol="livetv"'
+        ' beginsAt="1779148800" endsAt="1779159600" />'
+        '</Video>'
+        '</MediaContainer>'
+    )
+    assert _parse_epg_xml(xml) == []
+
+
+def test_parse_epg_xml_preserves_individual_media_time_windows():
+    """When a Video has multiple Media elements with DIFFERENT begins/ends,
+    the parser must preserve each pair on its own entry. The resolver
+    then independently filters each entry's time window."""
+    xml = _load_fixture("epg_section_multi_media_per_video.xml")
+    entries = _parse_epg_xml(xml)
+    begins = sorted(e.begins_at for e in entries)
+    # All four begin times distinct (24h spacing in the fixture).
+    assert len({b for b in begins}) == 4
+
+
+def test_parse_epg_xml_raises_on_malformed_xml():
+    """Malformed XML must raise :class:`PlexClientError` for the cache
+    layer to absorb via stale-fallback — not return ``[]`` silently."""
+    with pytest.raises(PlexClientError):
+        _parse_epg_xml("<not really xml")
+
+
+# ----- Time-window filter
+
+
+def test_epg_entry_is_current_accepts_window_match():
+    """An entry whose time window covers ``now`` and protocol is
+    ``"livetv"`` is current."""
+    now = datetime(2026, 5, 19, 0, 0, 0, tzinfo=timezone.utc)
+    entry = PlexEpgEntry(
+        grandparent_title="MLB Baseball",
+        channel_call_sign="8.1 | NBC: KGW Portland",
+        channel_identifier="8.1",
+        channel_title="8.1 NBC",
+        channel_vcn="8.1",
+        begins_at=datetime(2026, 5, 18, 22, 0, 0, tzinfo=timezone.utc),
+        ends_at=datetime(2026, 5, 19, 1, 0, 0, tzinfo=timezone.utc),
+        protocol="livetv",
+    )
+    assert _epg_entry_is_current(entry, now=now) is True
+
+
+def test_epg_entry_is_current_rejects_protocol_mismatch():
+    """An entry whose protocol is not ``"livetv"`` is never current —
+    defensive against mixed-provider Plex setups that surface non-live
+    EPG entries."""
+    now = datetime(2026, 5, 19, 0, 0, 0, tzinfo=timezone.utc)
+    entry = PlexEpgEntry(
+        grandparent_title="Some Show",
+        channel_call_sign="X",
+        channel_identifier="X",
+        channel_title="X",
+        channel_vcn="X",
+        begins_at=datetime(2026, 5, 18, 22, 0, 0, tzinfo=timezone.utc),
+        ends_at=datetime(2026, 5, 19, 1, 0, 0, tzinfo=timezone.utc),
+        protocol="vod",
+    )
+    assert _epg_entry_is_current(entry, now=now) is False
+
+
+def test_epg_entry_is_current_rejects_outside_window():
+    """An entry whose window is entirely in the past (or future) is not
+    current."""
+    now = datetime(2026, 5, 19, 0, 0, 0, tzinfo=timezone.utc)
+    past = PlexEpgEntry(
+        grandparent_title="Past Show",
+        channel_call_sign="X",
+        channel_identifier="X",
+        channel_title="X",
+        channel_vcn="X",
+        begins_at=datetime(2026, 5, 18, 18, 0, 0, tzinfo=timezone.utc),
+        ends_at=datetime(2026, 5, 18, 19, 0, 0, tzinfo=timezone.utc),
+        protocol="livetv",
+    )
+    future = PlexEpgEntry(
+        grandparent_title="Future Show",
+        channel_call_sign="X",
+        channel_identifier="X",
+        channel_title="X",
+        channel_vcn="X",
+        begins_at=datetime(2026, 5, 19, 3, 0, 0, tzinfo=timezone.utc),
+        ends_at=datetime(2026, 5, 19, 4, 0, 0, tzinfo=timezone.utc),
+        protocol="livetv",
+    )
+    assert _epg_entry_is_current(past, now=now) is False
+    assert _epg_entry_is_current(future, now=now) is False
+
+
+def test_epg_entry_is_current_rejects_missing_times():
+    """Missing begins_at OR ends_at can't be window-checked — defensively
+    treat the entry as not-current."""
+    now = datetime(2026, 5, 19, 0, 0, 0, tzinfo=timezone.utc)
+    entry = PlexEpgEntry(
+        grandparent_title="X",
+        channel_call_sign="X",
+        channel_identifier="X",
+        channel_title="X",
+        channel_vcn="X",
+        begins_at=None,
+        ends_at=None,
+        protocol="livetv",
+    )
+    assert _epg_entry_is_current(entry, now=now) is False
+
+
+# ----- DVR/section discovery
+
+
+@pytest.mark.asyncio
+async def test_get_dvr_keys_returns_keys_from_livetv_dvrs():
+    """``get_dvr_keys`` extracts the ``key`` attribute from each
+    ``<Dvr>`` element under ``<MediaContainer>``."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        xml = _load_fixture("livetv_dvrs.xml")
+        fake_resp = _xml_response(200, xml)
+        with patch.object(client._client, "request",
+                          AsyncMock(return_value=fake_resp)):
+            keys = await client.get_dvr_keys()
+        assert keys == ["7"]
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_dvr_keys_returns_empty_for_empty_container():
+    """When ``/livetv/dvrs`` returns an empty container (no DVRs
+    configured), the method returns ``[]`` without raising — this is
+    a normal state on non-LiveTV Plex installs."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        fake_resp = _xml_response(200, '<MediaContainer size="0"/>')
+        with patch.object(client._client, "request",
+                          AsyncMock(return_value=fake_resp)):
+            keys = await client.get_dvr_keys()
+        assert keys == []
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_dvr_section_keys_returns_keys_for_dvr():
+    """``get_dvr_section_keys(dvr_key)`` returns the section
+    ``<Directory key="...">`` attributes for the provided DVR."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        xml = _load_fixture("dvr_sections.xml")
+        fake_resp = _xml_response(200, xml)
+        with patch.object(client._client, "request",
+                          AsyncMock(return_value=fake_resp)) as request_mock:
+            keys = await client.get_dvr_section_keys("7")
+        # Per the fixture: Movies=1, News=4, Shows=2, Sports=3.
+        assert sorted(keys) == ["1", "2", "3", "4"]
+        # The URL must include the DVR-keyed EPG provider path so a
+        # typo in path construction would be caught here.
+        request_mock.assert_awaited_once()
+        called_url = request_mock.await_args.args[1]
+        assert "tv.plex.providers.epg.xmltv:7/sections" in called_url
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_section_epg_entries_parses_fixture():
+    """``get_section_epg_entries`` returns one entry per ``<Media>``
+    element across all ``<Video>`` elements in the section, with no
+    time-window filtering — that's the caller's responsibility."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        xml = _load_fixture("epg_section_one_current_airing.xml")
+        fake_resp = _xml_response(200, xml)
+        with patch.object(client._client, "request",
+                          AsyncMock(return_value=fake_resp)) as request_mock:
+            entries = await client.get_section_epg_entries(
+                dvr_key="7", section_key="3",
+            )
+        # Three entries (one per Video, each Video has one Media).
+        assert len(entries) == 3
+        # Ensure the ?type=4 query was sent.
+        called_kwargs = request_mock.await_args.kwargs
+        assert called_kwargs.get("params") == {"type": "4"}
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_section_epg_entries_raises_on_non_2xx():
+    """Non-2xx propagates as :class:`PlexClientError` so the cache
+    layer can wrap with stale-fallback."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        fake_resp = _xml_response(503, "")
+        with patch.object(client._client, "request",
+                          AsyncMock(return_value=fake_resp)):
+            with pytest.raises(PlexClientError):
+                await client.get_section_epg_entries(
+                    dvr_key="7", section_key="3",
+                )
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_current_live_epg_channels_filters_to_current_airings():
+    """``get_current_live_epg_channels`` orchestrates DVR + section
+    discovery and applies the time-window filter. Across the fixture's
+    three airings only the middle one (NBC, beginsAt=1779148800,
+    endsAt=1779159600) covers ``now=1779150000``."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        # Stage three responses in order: DVRs, sections, airings.
+        dvrs_xml = _load_fixture("livetv_dvrs.xml")
+        sections_xml = (
+            '<?xml version="1.0"?><MediaContainer size="1">'
+            '<Directory key="3" type="show" title="Sports" />'
+            '</MediaContainer>'
+        )
+        airings_xml = _load_fixture("epg_section_one_current_airing.xml")
+        responses = [
+            _xml_response(200, dvrs_xml),
+            _xml_response(200, sections_xml),
+            _xml_response(200, airings_xml),
+        ]
+        with patch.object(client._client, "request",
+                          AsyncMock(side_effect=responses)):
+            now = datetime(2026, 5, 19, 0, 20, 0, tzinfo=timezone.utc)
+            entries = await client.get_current_live_epg_channels(now=now)
+        assert len(entries) == 1
+        assert entries[0].grandparent_title == "MLB Baseball"
+        assert entries[0].channel_call_sign == "8.1 | NBC: KGW Portland"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_current_live_epg_channels_returns_empty_when_no_dvrs():
+    """No DVRs configured → empty list (no error). The resolver's
+    EPG-tier gate then quietly does nothing."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        fake_resp = _xml_response(200, '<MediaContainer size="0"/>')
+        with patch.object(client._client, "request",
+                          AsyncMock(return_value=fake_resp)):
+            entries = await client.get_current_live_epg_channels()
+        assert entries == []
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_current_live_epg_channels_continues_on_per_dvr_section_failure():
+    """When one DVR's section listing fails, the sweep must log + continue
+    so a broken DVR doesn't disable EPG attribution for the others —
+    multi-DVR friendliness for the operator. Here we simulate the
+    single-DVR case with the sections call failing; the result should
+    be an empty list (no airings discovered) but NO exception."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        dvrs_xml = _load_fixture("livetv_dvrs.xml")
+        responses = [
+            _xml_response(200, dvrs_xml),
+            _xml_response(500, ""),  # sections call fails
+        ]
+        with patch.object(client._client, "request",
+                          AsyncMock(side_effect=responses)):
+            entries = await client.get_current_live_epg_channels()
+        assert entries == []
+    finally:
+        await client.close()
+
+
+# ----- is_live extraction
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_extracts_is_live_flag_from_video_live_attribute():
+    """bd-ma6r3: ``@live="1"`` on the ``<Video>`` element marks Plex Live
+    TV sessions. The resolver's EPG-tier gate runs only for sessions
+    with ``is_live=True``."""
+    client = PlexClient(base_url="http://plex.local:32400", api_key="token")
+    try:
+        xml = (
+            '<?xml version="1.0"?>'
+            '<MediaContainer size="2">'
+            '<Video ratingKey="live-1" type="episode"'
+            ' title="MLB Baseball" grandparentTitle="MLB Baseball"'
+            ' live="1" lastViewedAt="1779150000">'
+            '<User id="2" title="MotWakorb" />'
+            '<Player address="172.16.0.2" />'
+            '</Video>'
+            '<Video ratingKey="vod-1" type="movie"'
+            ' title="Dune" lastViewedAt="1779150000">'
+            '<User id="1" title="alice" />'
+            '<Player address="172.16.0.3" />'
+            '</Video>'
+            '</MediaContainer>'
+        )
+        fake_resp = _xml_response(200, xml)
+        with patch.object(client._client, "request",
+                          AsyncMock(return_value=fake_resp)):
+            sessions = await client.get_sessions()
+        live = next(s for s in sessions if s.session_id == "live-1")
+        vod = next(s for s in sessions if s.session_id == "vod-1")
+        assert live.is_live is True
+        assert vod.is_live is False
+    finally:
+        await client.close()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0057",
+  "version": "0.17.1-0058",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Closes the Plex Live TV attribution gap that PR #352 / bd-2zcvf flagged but
couldn't fix from the `/status/sessions` surface alone. PO's Plex Live TV
sessions still showed "User #N" in Stats because Plex's `/status/sessions`
XML carries the PROGRAM in `@grandparentTitle` (e.g. "MLB Baseball") — NOT
the channel callsign — for DVR-fronted Live TV. The channel
`channelCallSign` lives only on the EPG endpoint's `<Media>` element. This
PR adds an EPG cross-reference resolver tier.

- New `PlexEpgEntry` dataclass + composed `get_current_live_epg_channels()`
  on `PlexClient` (walks `/livetv/dvrs` → DVR sections → `/all?type=4`,
  emits one entry per `<Media>` time slot, time-window filters to current
  airings).
- New sibling cache `services/plex_epg_cache.py` (30 s TTL, thundering-
  herd lock, stale-fallback parity with the session cache).
- New EPG-cross-reference tier in `services/plex_resolver.py`, slotted
  AFTER tier 1/2/3 and BEFORE the no-match diagnostic. Gates on (a) at
  least one `is_live=True` session AND (b) `ecm_channel_name` set so
  idle Plex deployments incur zero EPG fetch storm (bd-ma6r3 acceptance
  criterion).
- No-match diagnostic WARN now surfaces the EPG attempt payload
  (`snapshot_count`, per-session `channelCallSign` candidates considered)
  so future Live TV attribution gaps don't require re-running the EPG
  probe by hand.

## Probe results vs bd-ma6r3 shape

Re-ran the API probes against PO's running Plex at 172.16.0.19:32400
(2026-05-18):

- DVR key: `7` (single DVR, Dispatcharr-HDHomeRun fronted)
- EPG sections: Movies (`1`), News (`4`), Shows (`2`), Sports (`3`)
- Sweep latency: ~0.43 s sequential for the full DVR. Shows section is
  the long pole at 3.27 MB / 0.33 s. Acceptable for the 30 s TTL.
- The `?onAir=1` query parameter is IGNORED by Plex — time-window
  filtering must happen client-side.
- Each `<Video>` may carry MULTIPLE `<Media>` elements covering
  different upcoming airings of the same episode. The parser emits one
  `PlexEpgEntry` per `<Media>` so the time-window filter handles each
  airing slot independently.

These confirm the bead's described shape; no design pivot required.

## Design choices (called out in code)

- **Composed client API.** `get_current_live_epg_channels()` is the
  resolver-facing entry point; it hides DVR + section iteration and the
  time-window filter. The granular helpers (`get_dvr_keys`,
  `get_dvr_section_keys`, `get_section_epg_entries`) stay public for
  tests / future MCP surfaces but are not load-bearing. Comment in
  `plex_client.py` explains the rationale.
- **Sibling cache, not extension of `plex_cache`.** Different TTL (30 s
  vs 5 s), different upstream shape (DVR sweep vs single `/status/
  sessions`), different idle-state behavior (gate-on-demand vs always-
  consulted). Comment in `plex_epg_cache.py` explains.
- **EPG tier sits after Tier 1/2/3.** Sessions still match through
  existing tiers first; the EPG tier only runs for unmatched live
  sessions. Matches the bead's "stick with tier-1 first" direction.
- **Reuses `_match_against_candidates`.** EPG-derived `channelCallSign`
  values feed into the same Tier-1 comparator so pipe-suffix tolerance
  (bd-r5f0c.11) applies uniformly.

## Observability

- `media_session_*` metric family extended with `source="plex_epg"`
  label value (cache hits, fetch duration histogram, errors, stale
  fallback). Descriptive enum text updated in `observability.py`.
- Resolver-tier counters (`user_attribution_resolved_total{source=plex}`)
  unchanged — a session matched via the EPG tier increments the
  existing `plex` resolver counter just like Tier 1/2/3 hits do.

## Test plan

- [x] Backend Tests: 4408 passed (+38 new) — `cd backend && python3
  -m pytest tests/ --tb=short --no-header -p no:warnings`
- [x] Plex test suite focused: 128 passed (90 prior + 38 new)
- [x] Frontend Tests: 1488 passed (no frontend changes — sanity check)
- [x] Frontend lint: clean
- [x] Frontend typecheck: clean
- [x] Version touchpoints consistent at v0.17.1-0058 — `python
  scripts/check_version_consistency.py`
- [ ] PO smoke test in `ecm-ecm-1`: Plex Live TV session on channel
  `'8.1 | NBC: KGW Portland'` resolves to MotWakorb (currently
  "User #N"). VOD attribution unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)