### PR TITLE
v0.17.1-0073: Rule-level scope group selector for merge lookups (GH#298)

### DIFF
--- a/backend/alembic/versions/20260520_2100_0019_auto_creation_match_scope_group_id.py
+++ b/backend/alembic/versions/20260520_2100_0019_auto_creation_match_scope_group_id.py
@@ -1,0 +1,112 @@
+"""auto_creation: add explicit match_scope_group_id to rules
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-05-20 21:00:00.000000
+
+GH #298 (bd-kncun): "When merge lookup scope is ticked, I can't set the target
+group in the GUI so it just matches against any group."
+
+Migration 0002 added ``match_scope_target_group`` (the rule-level checkbox that
+scopes existing-channel name lookups to "this rule's target group"). But the
+only Target Group control lives on the Create Channel action — a Merge-Streams-
+only rule had no group to scope to, so the lookup silently fell back to ALL
+groups, exactly as the reporter described.
+
+This migration adds a nullable ``match_scope_group_id`` column to
+``auto_creation_rules`` so the operator can pin the scope group explicitly in
+the rule builder, independent of any action's Target Group. The executor
+enforces it across BOTH create_channel and merge_streams name lookups when
+``match_scope_target_group`` is on.
+
+Backwards-compatible: the column defaults to NULL for every existing row, which
+preserves the prior behavior exactly — create_channel derives the scope from
+the action's effective group_id, and merge_streams stays group-agnostic. No
+backfill is needed (NULL is the correct value for all existing rules).
+
+SQLite specifics:
+
+* A single ``ALTER TABLE ADD COLUMN`` for a NULLABLE column with no default.
+  SQLite supports this directly without a batch-rebuild — a nullable add does
+  not require a default value, and every existing row gets NULL inline.
+
+bd-5w6jz idempotency: long-running installs may already have the column via
+``create_all()`` from the post-0019 ORM model in ``models.py``. The column-add
+is guarded — if the column is already present the migration returns
+immediately without raising ``OperationalError: duplicate column name``.
+
+Pre-merge gate: ``backend/tests/integration/test_alembic_smoke.py::TestMigration0019``
+covers fresh up, fresh down, and idempotency (column already present).
+
+Bead: ``enhancedchannelmanager-kncun``.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0019"
+down_revision: Union[str, Sequence[str], None] = "0018"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+_NEW_COLUMN = "match_scope_group_id"
+
+
+def _auto_creation_rules_columns(connection) -> set[str]:
+    """Return the set of column names currently on ``auto_creation_rules``.
+
+    Returns the empty set if the table is missing — the bd-5w6jz guard treats
+    a missing table as "no column to add" so this migration becomes a no-op
+    rather than raising; the next ``create_all()`` + schema-parity pass
+    surfaces the missing table.
+    """
+    insp = inspect(connection)
+    if not insp.has_table("auto_creation_rules"):
+        return set()
+    return {c["name"] for c in insp.get_columns("auto_creation_rules")}
+
+
+def upgrade() -> None:
+    """Add the nullable ``match_scope_group_id`` column to ``auto_creation_rules``.
+
+    Idempotent (bd-5w6jz): if the column is already present (e.g. materialised
+    by ``create_all()`` against a newer ORM snapshot on a long-running install),
+    return without raising ``OperationalError: duplicate column name``.
+    """
+    conn = op.get_bind()
+    if _NEW_COLUMN in _auto_creation_rules_columns(conn):
+        return
+
+    # Nullable column, no server_default — NULL is the correct value for every
+    # existing rule (preserves pre-GH-298 behavior). The ORM declaration in
+    # models.py matches (``Column(Integer, nullable=True)``); the drift test in
+    # ``test_alembic_baseline.py`` locks this on the next boot.
+    op.add_column(
+        "auto_creation_rules",
+        sa.Column(_NEW_COLUMN, sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``match_scope_group_id`` column.
+
+    Defensive (bd-5w6jz): inspect first; skip if the column is already absent
+    so a partial-rerun cleans up rather than raising. SQLite 3.35+ supports
+    native ``ALTER TABLE DROP COLUMN`` via ``op.drop_column`` without a full
+    table rebuild.
+
+    Operators who downgrade past this point lose any explicitly-pinned scope
+    group; rules fall back to the pre-GH-298 behavior (create_channel derives
+    the scope from the action group; merge_streams is group-agnostic).
+    """
+    conn = op.get_bind()
+    if _NEW_COLUMN not in _auto_creation_rules_columns(conn):
+        return
+
+    op.drop_column("auto_creation_rules", _NEW_COLUMN)

--- a/backend/auto_creation_engine.py
+++ b/backend/auto_creation_engine.py
@@ -1291,7 +1291,8 @@ class AutoCreationEngine:
                 action_result = await executor.execute(
                     action, stream, exec_ctx, winning_rule.target_group_id,
                     normalization_group_ids=winning_rule.get_normalization_group_ids(),
-                    match_scope_target_group=bool(getattr(winning_rule, 'match_scope_target_group', False))
+                    match_scope_target_group=bool(getattr(winning_rule, 'match_scope_target_group', False)),
+                    rule_scope_group_id=getattr(winning_rule, 'match_scope_group_id', None)
                 )
 
                 action_entry = {

--- a/backend/auto_creation_executor.py
+++ b/backend/auto_creation_executor.py
@@ -272,7 +272,8 @@ class ActionExecutor:
     async def execute(self, action: Action | dict, stream_ctx: StreamContext,
                       exec_ctx: ExecutionContext, rule_target_group_id: int = None,
                       normalization_group_ids: list[int] = None,
-                      match_scope_target_group: bool = False) -> ActionResult:
+                      match_scope_target_group: bool = False,
+                      rule_scope_group_id: int = None) -> ActionResult:
         """
         Execute a single action.
 
@@ -288,6 +289,14 @@ class ActionExecutor:
                 to create separate channels with the same name instead of
                 merging into the first group's channel (GH-92, bd-r9mtd).
                 Default False preserves pre-GH-92 global-lookup behavior.
+            rule_scope_group_id: Explicit rule-level scope group (GH #298,
+                bd-kncun). When set AND match_scope_target_group is True, it
+                pins the group that name lookups are restricted to — in
+                create_channel it takes precedence over the action's derived
+                group_id, and in merge_streams it is the ONLY way to scope the
+                match (merge_streams has no action group_id). None (default)
+                preserves prior behavior: create_channel falls back to the
+                derived group, merge_streams stays group-agnostic.
 
         Returns:
             ActionResult with execution details
@@ -321,13 +330,16 @@ class ActionExecutor:
             result = await self._execute_create_channel(
                 action, stream_ctx, exec_ctx, template_ctx, rule_target_group_id,
                 normalization_group_ids=normalization_group_ids,
-                match_scope_target_group=match_scope_target_group
+                match_scope_target_group=match_scope_target_group,
+                rule_scope_group_id=rule_scope_group_id
             )
         elif action_type == ActionType.CREATE_GROUP:
             result = await self._execute_create_group(action, stream_ctx, exec_ctx, template_ctx)
         elif action_type == ActionType.MERGE_STREAMS:
             result = await self._execute_merge_streams(action, stream_ctx, exec_ctx, template_ctx,
-                                                         normalization_group_ids=normalization_group_ids)
+                                                         normalization_group_ids=normalization_group_ids,
+                                                         match_scope_target_group=match_scope_target_group,
+                                                         rule_scope_group_id=rule_scope_group_id)
         elif action_type == ActionType.ASSIGN_LOGO:
             result = await self._execute_assign_logo(action, stream_ctx, exec_ctx, template_ctx)
         elif action_type == ActionType.ASSIGN_TVG_ID:
@@ -507,7 +519,8 @@ class ActionExecutor:
                                        exec_ctx: ExecutionContext, template_ctx: dict,
                                        rule_target_group_id: int = None,
                                        normalization_group_ids: list[int] = None,
-                                       match_scope_target_group: bool = False) -> ActionResult:
+                                       match_scope_target_group: bool = False,
+                                       rule_scope_group_id: int = None) -> ActionResult:
         """Execute create_channel action."""
         params = action.params
         name_template = params.get("name_template", "{stream_name}")
@@ -558,7 +571,11 @@ class ActionExecutor:
         # When match_scope_target_group is True, restrict the lookup to channels in the
         # effective target group (GH-92, bd-r9mtd) so that two rules targeting different
         # groups can create separate channels with the same name.
-        scope_group_id = group_id if match_scope_target_group else None
+        #
+        # GH #298 (bd-kncun): prefer the explicit rule-level scope group when set,
+        # falling back to the action's derived group_id. NULL rule_scope_group_id
+        # preserves the prior behavior (scope = derived group_id).
+        scope_group_id = (rule_scope_group_id or group_id) if match_scope_target_group else None
         existing = self._find_channel_by_name(channel_name, scope_group_id=scope_group_id)
         logger.debug(
             "[AUTO-CREATE-EXEC] Lookup '%s' (scope_group_id=%s): %s",
@@ -1073,19 +1090,36 @@ class ActionExecutor:
 
     async def _execute_merge_streams(self, action: Action, stream_ctx: StreamContext,
                                       exec_ctx: ExecutionContext, template_ctx: dict,
-                                      normalization_group_ids: list[int] = None) -> ActionResult:
-        """Execute merge_streams action."""
+                                      normalization_group_ids: list[int] = None,
+                                      match_scope_target_group: bool = False,
+                                      rule_scope_group_id: int = None) -> ActionResult:
+        """Execute merge_streams action.
+
+        GH #298 (bd-kncun): when ``match_scope_target_group`` is on and the rule
+        carries an explicit ``rule_scope_group_id``, the channel match is scoped
+        to that group across EVERY resolution path (name_exact, regex, tvg_id,
+        normalized auto, core-name map, deparen, word-prefix, call-sign). merge_
+        streams has no action group_id, so ``rule_scope_group_id`` is the only
+        source of an effective scope group — if scope is on but the rule has no
+        explicit scope group (NULL), behavior is unchanged (search all groups),
+        and the rule builder warns the operator about that case.
+        """
         params = action.params
         target = params.get("target", "auto")
         find_channel_by = params.get("find_channel_by")
         max_streams = params.get("max_streams_per_channel", 0)  # 0 = unlimited
         find_channel_value = params.get("find_channel_value")
         remove_non_matching = params.get("remove_non_matching", False) is True
+        # Effective scope group for merge lookups (GH #298). merge_streams has no
+        # action group_id, so the explicit rule scope group is the only source.
+        # None when scope is off or no explicit group is pinned — preserves the
+        # prior group-agnostic match.
+        effective_scope_group_id = rule_scope_group_id if match_scope_target_group else None
         logger.debug(
             "[AUTO-CREATE-EXEC] target=%s find_by=%s "
-            "find_value=%s stream=%r",
+            "find_value=%s stream=%r scope_group_id=%s",
             target, find_channel_by,
-            find_channel_value, stream_ctx.stream_name
+            find_channel_value, stream_ctx.stream_name, effective_scope_group_id
         )
 
         # For existing_channel target, find the channel
@@ -1094,7 +1128,7 @@ class ActionExecutor:
 
             if find_channel_by == "name_exact":
                 expanded_name = TemplateVariables.expand_template(find_channel_value or "", template_ctx, exec_ctx.custom_variables)
-                channel = self._find_channel_by_name(expanded_name)
+                channel = self._find_channel_by_name(expanded_name, scope_group_id=effective_scope_group_id)
             elif find_channel_by == "name_regex":
                 channel = self._find_channel_by_regex(find_channel_value)
             elif find_channel_by == "tvg_id":
@@ -1113,7 +1147,7 @@ class ActionExecutor:
                     except Exception as e:
                         logger.warning("[AUTO-CREATE-EXEC] Normalization failed for stream '%s': %s", stream_ctx.stream_name, e)
                 logger.debug("[AUTO-CREATE-EXEC] Auto-lookup by normalized name: '%s'", lookup_name)
-                channel = self._find_channel_by_name(lookup_name)
+                channel = self._find_channel_by_name(lookup_name, scope_group_id=effective_scope_group_id)
 
             # Core-name fallback: strip country prefix + quality suffix using
             # tag groups directly (works even when normalization rules are disabled)
@@ -1171,6 +1205,26 @@ class ActionExecutor:
                             logger.debug("[AUTO-CREATE-EXEC] Call sign matched '%s' (id=%s)", channel.get('name'), channel.get('id'))
                 except Exception as e:
                     logger.debug("[AUTO-CREATE-EXEC] Call sign fallback failed: %s", e)
+
+            # GH #298 (bd-kncun): post-resolution scope enforcement. The name-
+            # keyed paths above — name_regex, tvg_id, and especially the global
+            # fallback maps (_core_name_to_channel, _callsign_to_channel) and the
+            # deparen / word-prefix lookups — do NOT honor the group scope on
+            # their own. Whatever path produced the candidate, if a scope group
+            # is in effect and the resolved channel lives in a different group,
+            # treat it as "not found" so the rule does not merge across groups.
+            # name_exact and the normalized auto-fallback already filtered via
+            # _find_channel_by_name(scope_group_id=...); re-checking them here is
+            # a cheap, harmless no-op (same group passes again).
+            if channel and effective_scope_group_id is not None \
+                    and channel.get("channel_group_id") != effective_scope_group_id:
+                logger.debug(
+                    "[AUTO-CREATE-EXEC] Scope reject: candidate '%s' (id=%s) in "
+                    "group %s != scope group %s — treating as not found",
+                    channel.get('name'), channel.get('id'),
+                    channel.get('channel_group_id'), effective_scope_group_id
+                )
+                channel = None
 
             if channel:
                 # Track merged stream IDs per channel for optional prune step.

--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0072",
+    version="0.17.1-0073",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/models.py
+++ b/backend/models.py
@@ -1925,6 +1925,17 @@ class AutoCreationRule(Base):
     # default does NOT migrate them; no Alembic revision is needed.
     match_scope_target_group = Column(Boolean, default=True, nullable=False)
 
+    # Explicit rule-level scope group for merge lookups (GH #298, bd-kncun).
+    # When match_scope_target_group is on, this column lets the operator pin
+    # the group that name lookups are restricted to — independent of any
+    # Create Channel action's Target Group. NULL (the default) preserves the
+    # prior behavior: create_channel derives the scope from the action's
+    # effective group_id, and merge_streams stays group-agnostic. A non-NULL
+    # value is enforced across BOTH create_channel and merge_streams name
+    # lookups so a Merge-Streams-only rule can finally scope its match to one
+    # group instead of matching same-name channels in any group.
+    match_scope_group_id = Column(Integer, nullable=True)
+
     # Timestamps
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
@@ -2028,6 +2039,7 @@ class AutoCreationRule(Base):
             "skip_struck_streams": self.skip_struck_streams or False,
             "orphan_action": self.orphan_action or "delete",
             "match_scope_target_group": self.match_scope_target_group or False,
+            "match_scope_group_id": self.match_scope_group_id,
             "last_run_at": self.last_run_at.isoformat() + "Z" if self.last_run_at else None,
             "last_run_stats": self.get_last_run_stats(),
             "match_count": self.match_count or 0,

--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -70,6 +70,10 @@ class CreateAutoCreationRuleRequest(BaseModel):
     orphan_action: str = "delete"
     # Default True for new rules (bd-p6ko9, GH #226) — see models.AutoCreationRule.
     match_scope_target_group: bool = True
+    # Explicit rule-level scope group for merge lookups (GH #298, bd-kncun).
+    # None = "Auto" (create_channel falls back to the action's target group;
+    # merge_streams stays group-agnostic) — see models.AutoCreationRule.
+    match_scope_group_id: Optional[int] = None
 
 
 class UpdateAutoCreationRuleRequest(BaseModel):
@@ -96,6 +100,11 @@ class UpdateAutoCreationRuleRequest(BaseModel):
     skip_struck_streams: Optional[bool] = None
     orphan_action: Optional[str] = None
     match_scope_target_group: Optional[bool] = None
+    # GH #298 (bd-kncun): None is a MEANINGFUL value here (the "Auto" choice),
+    # so the update handler distinguishes "field present in request" from "field
+    # absent" via ``model_fields_set`` rather than the ``is not None`` convention
+    # used by the other optionals — otherwise a rule could never be reset to Auto.
+    match_scope_group_id: Optional[int] = None
 
 
 class BulkUpdateAutoCreationRulesRequest(UpdateAutoCreationRuleRequest):
@@ -215,6 +224,11 @@ def _apply_rule_scalar_updates(
         _set("orphan_action", request.orphan_action)
     if getattr(request, "match_scope_target_group", None) is not None:
         _set("match_scope_target_group", request.match_scope_target_group)
+    # GH #298 (bd-kncun): only touch the scope group when the field was actually
+    # supplied. ``model_fields_set`` lets an explicit ``None`` (reset to "Auto")
+    # through, which the ``is not None`` convention above could not express.
+    if "match_scope_group_id" in request.model_fields_set:
+        _set("match_scope_group_id", request.match_scope_group_id)
 
     return diff
 
@@ -590,7 +604,8 @@ async def create_auto_creation_rule(request: CreateAutoCreationRuleRequest):
                 normalization_group_ids=json.dumps(request.normalization_group_ids) if request.normalization_group_ids else None,
                 skip_struck_streams=request.skip_struck_streams,
                 orphan_action=request.orphan_action,
-                match_scope_target_group=request.match_scope_target_group
+                match_scope_target_group=request.match_scope_target_group,
+                match_scope_group_id=request.match_scope_group_id
             )
             session.add(rule)
             session.commit()
@@ -975,7 +990,8 @@ async def duplicate_auto_creation_rule(rule_id: int):
                 probe_on_sort=rule.probe_on_sort,
                 sort_regex=rule.sort_regex,
                 orphan_action=rule.orphan_action,
-                match_scope_target_group=rule.match_scope_target_group
+                match_scope_target_group=rule.match_scope_target_group,
+                match_scope_group_id=rule.match_scope_group_id
             )
             session.add(new_rule)
             session.commit()
@@ -1401,7 +1417,8 @@ async def export_auto_creation_rules_yaml():
                     "skip_struck_streams": rule.skip_struck_streams or False,
                     "probe_on_sort": rule.probe_on_sort or False,
                     "orphan_action": rule.orphan_action or "delete",
-                    "match_scope_target_group": rule.match_scope_target_group or False
+                    "match_scope_target_group": rule.match_scope_target_group or False,
+                    "match_scope_group_id": rule.match_scope_group_id
                 }
 
                 # Add group_name to actions that have group_id
@@ -1572,6 +1589,7 @@ async def import_auto_creation_rules_yaml(request: ImportYAMLRequest):
                         existing.probe_on_sort = rule_data.get("probe_on_sort", False)
                         existing.orphan_action = rule_data.get("orphan_action", "delete")
                         existing.match_scope_target_group = rule_data.get("match_scope_target_group", True)
+                        existing.match_scope_group_id = rule_data.get("match_scope_group_id")
                         logger.debug("[AUTO-CREATE-YAML] Rule '%s': updated existing (id=%s), stored actions=%s", rule_name, existing.id, existing.actions)
                         imported.append({"name": existing.name, "action": "updated"})
                     else:
@@ -1605,7 +1623,8 @@ async def import_auto_creation_rules_yaml(request: ImportYAMLRequest):
                         skip_struck_streams=rule_data.get("skip_struck_streams", False),
                         probe_on_sort=rule_data.get("probe_on_sort", False),
                         orphan_action=rule_data.get("orphan_action", "delete"),
-                        match_scope_target_group=rule_data.get("match_scope_target_group", True)
+                        match_scope_target_group=rule_data.get("match_scope_target_group", True),
+                        match_scope_group_id=rule_data.get("match_scope_group_id")
                     )
                     session.add(rule)
                     logger.debug("[AUTO-CREATE-YAML] Rule '%s': created new, stored actions=%s", rule_name, rule.actions)

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0072"
+APP_VERSION = "0.17.1-0073"
 
 REDACTED = "***REDACTED***"
 
@@ -1182,6 +1182,9 @@ def _restore_auto_creation_rules(items: list) -> dict:
                 # backups always include this field (via to_dict). An ancient
                 # backup that omits it inherits the new-rule default (True).
                 match_scope_target_group=item.get("match_scope_target_group", True),
+                # GH #298 (bd-kncun): None = "Auto" (preserves prior behavior).
+                # Backups predating this column omit it and inherit None.
+                match_scope_group_id=item.get("match_scope_group_id"),
             )
             session.add(rule)
         session.commit()

--- a/backend/tests/integration/test_alembic_smoke.py
+++ b/backend/tests/integration/test_alembic_smoke.py
@@ -1690,6 +1690,20 @@ class TestSmartBootstrapFastPath:
             Base = database.Base
             Base.metadata.create_all(bind=engine)
 
+            # create_all() materialises missing TABLES and their columns, but it
+            # cannot add a column to a table that already exists at 0005. Post-
+            # 0005 migrations that ADD COLUMN to a pre-0005 table (e.g. 0019's
+            # auto_creation_rules.match_scope_group_id, GH #298) therefore stay
+            # absent after create_all(). To simulate the true "ORM fully ahead
+            # of the migration timeline" state this test asserts on, add those
+            # columns by hand so the live schema genuinely matches head — exactly
+            # what _schema_matches_head must see for the fast-path to engage.
+            with engine.begin() as conn:
+                conn.execute(text(
+                    "ALTER TABLE auto_creation_rules "
+                    "ADD COLUMN match_scope_group_id INTEGER"
+                ))
+
             # Sanity: alembic_version is still at 0005 (create_all does not
             # touch the version row), but every model table is now present.
             with engine.connect() as conn:
@@ -3724,5 +3738,196 @@ class TestMigration0018Idempotent:
                 assert col_type == "TEXT", (
                     f"{name} must be TEXT after round-trip"
                 )
+        finally:
+            engine.dispose()
+
+
+@pytest.mark.integration
+class TestMigration0019:
+    """Migration 0019 — explicit ``match_scope_group_id`` on ``auto_creation_rules``.
+
+    GH #298 (bd-kncun): adds a single NULLABLE INTEGER column so a rule can
+    pin the group its merge lookups are scoped to, independent of any action's
+    target group. NULL (the default for every existing row) preserves prior
+    behavior exactly — no backfill, no NOT NULL, no server default.
+
+    Coverage:
+      - Fresh upgrade through 0019 — column exists as INTEGER NULL; every prior
+        auto_creation_rules column (the 0002 ``match_scope_target_group`` flag,
+        ``orphan_action``, the 0005 quality columns) is untouched.
+      - Fresh downgrade — the column is gone; everything prior survives.
+      - Idempotency (bd-5w6jz) — column already present via create_all() drift
+        does not raise ``OperationalError: duplicate column name``.
+      - Round-trip up/down/up — re-appliable after a downgrade.
+    """
+
+    NEW_COLUMN = "match_scope_group_id"
+
+    def test_fresh_sqlite_upgrade_through_0019(self, tmp_path):
+        """Fresh DB: ``alembic upgrade 0019`` adds the nullable column."""
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'mig0019_fresh.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "0019")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            cols = _column_names(engine, "auto_creation_rules")
+            assert self.NEW_COLUMN in cols, (
+                f"{self.NEW_COLUMN} missing after upgrade 0019 — migration "
+                f"0019 did not run correctly."
+            )
+            # Prior auto_creation_rules columns are preserved — additive only.
+            for prior in (
+                "match_scope_target_group",
+                "orphan_action",
+                "quality_tie_break_order",
+                "quality_m3u_tie_break_enabled",
+            ):
+                assert prior in cols, (
+                    f"{prior} must be preserved by 0019 — the scope-group "
+                    f"column is additive."
+                )
+            # Verify NULLABLE INTEGER with no DEFAULT via PRAGMA.
+            with engine.connect() as conn:
+                rows = conn.execute(text(
+                    "PRAGMA table_info(auto_creation_rules)"
+                )).fetchall()
+            col_info = {r[1]: r for r in rows}
+            _, name, col_type, notnull, dflt, _pk = col_info[self.NEW_COLUMN]
+            assert notnull == 0, (
+                f"{name} must be NULLABLE (notnull=0); got notnull={notnull}"
+            )
+            assert col_type == "INTEGER", (
+                f"{name} must be INTEGER; got type={col_type!r}"
+            )
+            assert dflt is None, (
+                f"{name} must have no DEFAULT; got dflt={dflt!r}"
+            )
+        finally:
+            engine.dispose()
+
+    def test_fresh_sqlite_downgrade_from_0019(self, tmp_path):
+        """Downgrade 0019 -> 0018: the new column is dropped."""
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'mig0019_downgrade.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "0019")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            assert self.NEW_COLUMN in _column_names(engine, "auto_creation_rules"), (
+                "test setup is wrong — column missing post-upgrade"
+            )
+        finally:
+            engine.dispose()
+
+        command.downgrade(cfg, "0018")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            cols = _column_names(engine, "auto_creation_rules")
+            assert self.NEW_COLUMN not in cols, (
+                f"{self.NEW_COLUMN} still present after downgrade — 0019's "
+                f"downgrade() did not drop the column."
+            )
+            # The 0002 flag must survive — it is unrelated to this migration.
+            assert "match_scope_target_group" in cols, (
+                "match_scope_target_group must survive downgrade — it was "
+                "never added or dropped by 0019."
+            )
+        finally:
+            engine.dispose()
+
+    def test_drifted_column_already_added(self, tmp_path):
+        """create_all()-style drift: column already present pre-0019.
+
+        Long-running install where ``create_all()`` materialised the post-0019
+        ORM column ahead of Alembic. The guarded upgrade must early-return
+        rather than raising ``OperationalError: duplicate column name``.
+        """
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'mig0019_drift.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "0018")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            assert self.NEW_COLUMN not in _column_names(engine, "auto_creation_rules"), (
+                "test setup is wrong — column already at 0018"
+            )
+            with engine.begin() as conn:
+                conn.execute(text(
+                    f"ALTER TABLE auto_creation_rules ADD COLUMN "
+                    f"{self.NEW_COLUMN} INTEGER"
+                ))
+            with engine.connect() as conn:
+                row = conn.execute(
+                    text("SELECT version_num FROM alembic_version")
+                ).fetchone()
+            assert row is not None and row[0] == "0018"
+        finally:
+            engine.dispose()
+
+        # Pre-fix this would raise:
+        #   OperationalError: duplicate column name: match_scope_group_id
+        command.upgrade(cfg, "head")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            assert self.NEW_COLUMN in _column_names(engine, "auto_creation_rules")
+            with engine.connect() as conn:
+                row = conn.execute(
+                    text("SELECT version_num FROM alembic_version")
+                ).fetchone()
+            assert row is not None and row[0] == database.get_alembic_head_revision()
+        finally:
+            engine.dispose()
+
+    def test_round_trip_up_down_up(self, tmp_path):
+        """Round-trip: upgrade 0019, downgrade to 0018, re-upgrade to 0019.
+
+        A migration that breaks on re-apply after a downgrade is the hardest
+        mistake to catch in a fresh-DB test. The column must reappear with its
+        NULLABLE INTEGER shape intact.
+        """
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'mig0019_round_trip.db'}"
+        cfg = _make_alembic_config(db_url)
+
+        command.upgrade(cfg, "0019")
+        engine = create_engine(db_url, future=True)
+        try:
+            assert self.NEW_COLUMN in _column_names(engine, "auto_creation_rules")
+        finally:
+            engine.dispose()
+
+        command.downgrade(cfg, "0018")
+        engine = create_engine(db_url, future=True)
+        try:
+            assert self.NEW_COLUMN not in _column_names(engine, "auto_creation_rules")
+        finally:
+            engine.dispose()
+
+        command.upgrade(cfg, "0019")
+        engine = create_engine(db_url, future=True)
+        try:
+            cols = _column_names(engine, "auto_creation_rules")
+            assert self.NEW_COLUMN in cols, (
+                f"{self.NEW_COLUMN} missing after re-upgrade — the migration "
+                f"must be re-appliable after a downgrade."
+            )
+            with engine.connect() as conn:
+                rows = conn.execute(text(
+                    "PRAGMA table_info(auto_creation_rules)"
+                )).fetchall()
+            col_info = {r[1]: r for r in rows}
+            _, name, col_type, notnull, _dflt, _pk = col_info[self.NEW_COLUMN]
+            assert notnull == 0, f"{name} must be NULLABLE after round-trip"
+            assert col_type == "INTEGER", f"{name} must be INTEGER after round-trip"
         finally:
             engine.dispose()

--- a/backend/tests/integration/test_api_auto_creation.py
+++ b/backend/tests/integration/test_api_auto_creation.py
@@ -335,6 +335,7 @@ class TestAutoCreationYAMLAPI:
         mock_rule.probe_on_sort = False
         mock_rule.orphan_action = "delete"
         mock_rule.match_scope_target_group = False
+        mock_rule.match_scope_group_id = None
         mock_db_session.query.return_value.order_by.return_value.all.return_value = [mock_rule]
 
         response = test_client.get("/api/auto-creation/export/yaml")

--- a/backend/tests/routers/test_auto_creation.py
+++ b/backend/tests/routers/test_auto_creation.py
@@ -392,6 +392,120 @@ class TestUpdateAutoCreationRule:
         assert response.json()["name"] == "Renamed"
 
 
+class TestMatchScopeGroupIdPersistence:
+    """GH #298 / bd-kncun: persistence + round-trip of ``match_scope_group_id``.
+
+    The new explicit scope-group column must survive create, be readable via
+    GET, be settable AND clearable-to-NULL via PUT (the "Auto" choice), and be
+    included in the YAML export so import/restore round-trips it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_persists_scope_group_and_get_round_trips(
+        self, async_client
+    ):
+        """POST with match_scope_group_id stores it; GET returns it."""
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            create = await async_client.post("/api/auto-creation/rules", json={
+                "name": "Scoped Rule",
+                "conditions": [{"type": "stream_name_contains", "value": "ESPN"}],
+                "actions": [{"type": "merge_streams", "target": "auto"}],
+                "match_scope_target_group": True,
+                "match_scope_group_id": 7,
+            })
+
+        assert create.status_code == 200, create.text
+        rule_id = create.json()["id"]
+        assert create.json()["match_scope_group_id"] == 7
+
+        get = await async_client.get(f"/api/auto-creation/rules/{rule_id}")
+        assert get.status_code == 200
+        assert get.json()["match_scope_group_id"] == 7
+
+    @pytest.mark.asyncio
+    async def test_create_defaults_scope_group_to_null(self, async_client):
+        """POST without the field stores NULL (the Auto default)."""
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            create = await async_client.post("/api/auto-creation/rules", json={
+                "name": "Unscoped Rule",
+                "conditions": [{"type": "stream_name_contains", "value": "CNN"}],
+                "actions": [{"type": "create_channel", "name_template": "{stream_name}"}],
+            })
+
+        assert create.status_code == 200, create.text
+        assert create.json()["match_scope_group_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_update_sets_scope_group(self, async_client, test_session):
+        """PUT match_scope_group_id stores the value."""
+        rule = _create_rule(test_session, name="ToScope")
+
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.put(
+                f"/api/auto-creation/rules/{rule.id}",
+                json={"match_scope_group_id": 3},
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["match_scope_group_id"] == 3
+
+    @pytest.mark.asyncio
+    async def test_update_clears_scope_group_to_null(self, async_client, test_session):
+        """PUT with explicit null resets to Auto (model_fields_set path).
+
+        The other Optional fields use the ``is not None`` convention which can
+        never express "reset to None"; match_scope_group_id uses
+        ``model_fields_set`` so an explicit null clears the stored group.
+        """
+        rule = _create_rule(test_session, name="ScopedThenAuto", match_scope_group_id=5)
+        assert rule.match_scope_group_id == 5
+
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.put(
+                f"/api/auto-creation/rules/{rule.id}",
+                json={"match_scope_group_id": None},
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["match_scope_group_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_update_omitting_field_leaves_scope_group_unchanged(
+        self, async_client, test_session
+    ):
+        """PUT without the field must not touch the stored scope group."""
+        rule = _create_rule(test_session, name="KeepScope", match_scope_group_id=9)
+
+        with patch("auto_creation_schema.validate_rule", return_value={"valid": True, "errors": []}), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.put(
+                f"/api/auto-creation/rules/{rule.id}",
+                json={"name": "Renamed Keep"},
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["match_scope_group_id"] == 9
+
+    @pytest.mark.asyncio
+    async def test_export_includes_scope_group(self, async_client, test_session):
+        """The YAML export carries match_scope_group_id for round-trip restore."""
+        _create_rule(test_session, name="ExportScoped", match_scope_group_id=4)
+
+        mock_client = AsyncMock()
+        mock_client.get_channel_groups.return_value = []
+        mock_client.get_m3u_accounts.return_value = []
+
+        with patch("routers.auto_creation.get_client", return_value=mock_client):
+            response = await async_client.get("/api/auto-creation/export/yaml")
+
+        assert response.status_code == 200
+        assert "match_scope_group_id" in response.text
+
+
 class TestBulkUpdateAutoCreationRules:
     """Tests for POST /api/auto-creation/rules/bulk-update."""
 

--- a/backend/tests/unit/test_auto_creation_engine.py
+++ b/backend/tests/unit/test_auto_creation_engine.py
@@ -738,7 +738,8 @@ class TestPass3RenumberGating:
         async def _fake_execute(action, stream_ctx, exec_ctx,
                                 rule_target_group_id=None,
                                 normalization_group_ids=None,
-                                match_scope_target_group=False):
+                                match_scope_target_group=False,
+                                rule_scope_group_id=None):
             exec_ctx.current_channel_id = channel_id
             if created:
                 exec_ctx.created_channel_ids.add(channel_id)
@@ -842,7 +843,8 @@ class TestPass3RenumberGating:
         async def _fake_execute(action, stream_ctx, exec_ctx,
                                 rule_target_group_id=None,
                                 normalization_group_ids=None,
-                                match_scope_target_group=False):
+                                match_scope_target_group=False,
+                                rule_scope_group_id=None):
             exec_ctx.current_channel_id = 501
             return self.ActionResult(
                 success=True,

--- a/backend/tests/unit/test_auto_creation_executor.py
+++ b/backend/tests/unit/test_auto_creation_executor.py
@@ -1957,6 +1957,194 @@ class TestMatchScopeTargetGroup:
         self.client.create_channel.assert_not_called()
 
 
+class TestMatchScopeGroupId:
+    """GH #298 / bd-kncun: explicit rule-level ``match_scope_group_id``.
+
+    Migration 0002 scoped create_channel name lookups to the *action's*
+    target group, but a Merge-Streams-only rule had no group to scope to and
+    silently fell back to ALL groups (the reporter's symptom). The explicit
+    ``rule_scope_group_id`` threads a group through BOTH create_channel and
+    merge_streams name lookups, independent of any action's target group.
+    NULL preserves prior behavior exactly.
+    """
+
+    def setup_method(self):
+        """Two groups; an existing 'ESPN' channel in group 1 (SPORTS)."""
+        self.client = MagicMock()
+        self._next_id = 600
+
+        async def _create_channel(data):
+            self._next_id += 1
+            return {
+                "id": self._next_id,
+                "name": data["name"],
+                "channel_number": data.get("channel_number"),
+                "channel_group_id": data.get("channel_group_id"),
+                "streams": data.get("streams", []),
+            }
+
+        self.client.create_channel = AsyncMock(side_effect=_create_channel)
+        self.client.update_channel = AsyncMock()
+
+        # Existing ESPN lives in group 1 (SPORTS). Group 2 (ESPN-GROUP) is empty.
+        self.channels = [
+            {"id": 1, "name": "ESPN", "tvg_id": "ESPN.US", "channel_number": 100,
+             "channel_group_id": 1, "streams": [101]},
+        ]
+        self.groups = [
+            {"id": 1, "name": "SPORTS"},
+            {"id": 2, "name": "ESPN-GROUP"},
+        ]
+        self.executor = ActionExecutor(
+            self.client,
+            existing_channels=self.channels,
+            existing_groups=self.groups,
+        )
+        self.stream_ctx = StreamContext(
+            stream_id=202,
+            stream_name="ESPN",
+            m3u_account_id=1,
+            m3u_account_name="Provider A",
+            group_name="ESPN-GROUP",
+            tvg_id="ESPN.US",
+        )
+
+    def _run(self, action, exec_ctx=None, **kwargs):
+        exec_ctx = exec_ctx or ExecutionContext()
+        return asyncio.get_event_loop().run_until_complete(
+            self.executor.execute(action, self.stream_ctx, exec_ctx, **kwargs)
+        )
+
+    # --- create_channel ---------------------------------------------------
+
+    def test_create_channel_explicit_scope_group_overrides_action_group(self):
+        """Explicit rule scope group wins over the action's derived group_id.
+
+        Existing ESPN is in group 1; the action targets group 1, but the rule
+        pins the scope to group 2. The group-1 ESPN must NOT be found, so a new
+        ESPN is created in the action's group rather than merging.
+        """
+        action = {
+            "type": "create_channel",
+            "name_template": "{stream_name}",
+            "group_id": 1,
+            "if_exists": "merge",
+        }
+        result = self._run(
+            action,
+            match_scope_target_group=True,
+            rule_scope_group_id=2,
+        )
+        assert result.success is True
+        # Scope pinned to group 2 → group-1 ESPN invisible → new channel created.
+        self.client.create_channel.assert_called_once()
+        self.client.update_channel.assert_not_called()
+
+    def test_create_channel_falls_back_to_action_group_when_scope_null(self):
+        """NULL rule scope group → scope derives from the action group (prior behavior).
+
+        Action targets group 1 where ESPN already exists → merge into it, no
+        new channel. This is the exact pre-GH-298 create_channel path.
+        """
+        action = {
+            "type": "create_channel",
+            "name_template": "{stream_name}",
+            "group_id": 1,
+            "if_exists": "merge",
+        }
+        result = self._run(
+            action,
+            match_scope_target_group=True,
+            rule_scope_group_id=None,
+        )
+        assert result.success is True
+        self.client.create_channel.assert_not_called()
+        self.client.update_channel.assert_called()
+
+    # --- merge_streams ----------------------------------------------------
+
+    def test_merge_streams_rejects_candidate_in_wrong_group(self):
+        """Scope on + explicit group → a candidate in another group is rejected.
+
+        This is the reporter's core scenario: a Merge-Streams rule scoped to
+        group 2 must NOT merge into the group-1 ESPN. With no channel in scope,
+        merge_streams skips (it only adds to existing channels).
+        """
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "ESPN",
+        }
+        result = self._run(
+            action,
+            match_scope_target_group=True,
+            rule_scope_group_id=2,
+        )
+        assert result.success is True
+        assert result.skipped is True
+        # No cross-group merge happened.
+        self.client.update_channel.assert_not_called()
+
+    def test_merge_streams_matches_candidate_in_scope_group(self):
+        """Scope on + explicit group matching the candidate → merge proceeds."""
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "ESPN",
+        }
+        result = self._run(
+            action,
+            match_scope_target_group=True,
+            rule_scope_group_id=1,  # ESPN's actual group
+        )
+        assert result.success is True
+        assert result.skipped is not True
+        self.client.update_channel.assert_called()
+
+    def test_merge_streams_unchanged_when_scope_group_null(self):
+        """Scope on but NULL group → group-agnostic match (prior behavior).
+
+        merge_streams has no action group_id, so a NULL rule scope group means
+        the lookup still finds the group-1 ESPN and merges — exactly as before
+        GH-298 (the rule builder warns the operator about this case).
+        """
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "ESPN",
+        }
+        result = self._run(
+            action,
+            match_scope_target_group=True,
+            rule_scope_group_id=None,
+        )
+        assert result.success is True
+        self.client.update_channel.assert_called()
+
+    def test_merge_streams_scope_off_searches_all_groups(self):
+        """Scope OFF → explicit group ignored, lookup spans all groups.
+
+        Even with a rule_scope_group_id set, match_scope_target_group=False
+        disables scoping entirely, so the group-1 ESPN is matched and merged.
+        """
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "ESPN",
+        }
+        result = self._run(
+            action,
+            match_scope_target_group=False,
+            rule_scope_group_id=2,  # ignored because scope is off
+        )
+        assert result.success is True
+        self.client.update_channel.assert_called()
+
+
 
 class TestCreateChannelSuperscriptStripping:
     """

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0072",
+  "version": "0.17.1-0073",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/autoCreation/RuleBuilder.test.tsx
+++ b/frontend/src/components/autoCreation/RuleBuilder.test.tsx
@@ -9,6 +9,8 @@ import userEvent from '@testing-library/user-event';
 import {
   server,
   resetMockDataStore,
+  mockDataStore,
+  createMockChannelGroup,
 } from '../../test/mocks/server';
 import { RuleBuilder } from './RuleBuilder';
 import type { AutoCreationRule } from '../../types/autoCreation';
@@ -526,6 +528,131 @@ describe('RuleBuilder', () => {
       await waitFor(() => {
         expect(onSave).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('merge scope group (GH #298)', () => {
+    it('shows the Scope group selector when merge scope is on', async () => {
+      mockDataStore.channelGroups.push(
+        createMockChannelGroup({ id: 11, name: 'Sports' }),
+      );
+      // Default rule has match_scope_target_group ON, so the selector shows.
+      render(<RuleBuilder onSave={vi.fn()} onCancel={vi.fn()} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Scope group')).toBeInTheDocument();
+      });
+    });
+
+    it('hides the Scope group selector when merge scope is off', async () => {
+      const user = userEvent.setup();
+      mockDataStore.channelGroups.push(
+        createMockChannelGroup({ id: 11, name: 'Sports' }),
+      );
+      render(<RuleBuilder onSave={vi.fn()} onCancel={vi.fn()} />);
+
+      // Toggle the merge-scope checkbox OFF.
+      await user.click(
+        screen.getByRole('checkbox', { name: /scope merge lookups to a target group/i }),
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText('Scope group')).not.toBeInTheDocument();
+      });
+    });
+
+    it('includes match_scope_group_id in the save payload', async () => {
+      const user = userEvent.setup();
+      const onSave = vi.fn();
+      mockDataStore.channelGroups.push(
+        createMockChannelGroup({ id: 42, name: 'Sports' }),
+      );
+
+      const rule: Partial<AutoCreationRule> = {
+        name: 'Scoped',
+        conditions: [{ type: 'always' }],
+        actions: [{ type: 'merge_streams' }],
+        match_scope_target_group: true,
+        match_scope_group_id: 42,
+      };
+      render(<RuleBuilder rule={rule as AutoCreationRule} onSave={onSave} onCancel={vi.fn()} />);
+
+      await user.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(
+          expect.objectContaining({ match_scope_group_id: 42 }),
+        );
+      });
+    });
+
+    it('sends null match_scope_group_id when scope is off', async () => {
+      const user = userEvent.setup();
+      const onSave = vi.fn();
+      mockDataStore.channelGroups.push(
+        createMockChannelGroup({ id: 42, name: 'Sports' }),
+      );
+
+      const rule: Partial<AutoCreationRule> = {
+        name: 'Scoped',
+        conditions: [{ type: 'always' }],
+        actions: [{ type: 'merge_streams' }],
+        match_scope_target_group: true,
+        match_scope_group_id: 42,
+      };
+      render(<RuleBuilder rule={rule as AutoCreationRule} onSave={onSave} onCancel={vi.fn()} />);
+
+      // Turn scope OFF — the saved scope group must be cleared to null.
+      await user.click(
+        screen.getByRole('checkbox', { name: /scope merge lookups to a target group/i }),
+      );
+      await user.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(
+          expect.objectContaining({ match_scope_group_id: null }),
+        );
+      });
+    });
+
+    it('warns about the all-groups fallback for a merge-only rule with no scope group', async () => {
+      mockDataStore.channelGroups.push(
+        createMockChannelGroup({ id: 11, name: 'Sports' }),
+      );
+      // Merge-Streams-only rule (no create_channel/create_group action),
+      // scope ON, no explicit scope group → the all-groups fallback warning.
+      const rule: Partial<AutoCreationRule> = {
+        name: 'MergeOnly',
+        conditions: [{ type: 'always' }],
+        actions: [{ type: 'merge_streams' }],
+        match_scope_target_group: true,
+        match_scope_group_id: null,
+      };
+      render(<RuleBuilder rule={rule as AutoCreationRule} onSave={vi.fn()} onCancel={vi.fn()} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/fall back to ALL channel groups/i)).toBeInTheDocument();
+      });
+    });
+
+    it('does not warn when a create_channel action provides a target group', async () => {
+      mockDataStore.channelGroups.push(
+        createMockChannelGroup({ id: 11, name: 'Sports' }),
+      );
+      const rule: Partial<AutoCreationRule> = {
+        name: 'HasCreateChannel',
+        conditions: [{ type: 'always' }],
+        actions: [{ type: 'create_channel', name_template: '{stream_name}', group_id: 11 }],
+        match_scope_target_group: true,
+        match_scope_group_id: null,
+      };
+      render(<RuleBuilder rule={rule as AutoCreationRule} onSave={vi.fn()} onCancel={vi.fn()} />);
+
+      // Selector is visible, but the all-groups warning must NOT appear.
+      await waitFor(() => {
+        expect(screen.getByText('Scope group')).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/fall back to ALL channel groups/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/autoCreation/RuleBuilder.tsx
+++ b/frontend/src/components/autoCreation/RuleBuilder.tsx
@@ -6,7 +6,7 @@ import type { AutoCreationRule, CreateRuleData, Condition, Action, ConditionType
 import { ConditionEditor } from './ConditionEditor';
 import { ActionEditor } from './ActionEditor';
 import { CustomSelect } from '../CustomSelect';
-import { getNormalizationRules } from '../../services/api';
+import { getNormalizationRules, getChannelGroups } from '../../services/api';
 import './RuleBuilder.css';
 
 export interface RuleBuilderProps {
@@ -51,10 +51,12 @@ export function RuleBuilder({
   const [skipStruckStreams, setSkipStruckStreams] = useState(rule?.skip_struck_streams ?? false);
   const [orphanAction, setOrphanAction] = useState(rule?.orphan_action || 'delete');
   const [matchScopeTargetGroup, setMatchScopeTargetGroup] = useState(rule?.match_scope_target_group ?? true);
+  const [matchScopeGroupId, setMatchScopeGroupId] = useState<number | null>(rule?.match_scope_group_id ?? null);
   const [conditions, setConditions] = useState<Condition[]>(rule?.conditions || []);
   const [actions, setActions] = useState<Action[]>(rule?.actions || []);
 
   const [availableNormGroups, setAvailableNormGroups] = useState<{id: number; name: string; enabled: boolean}[]>([]);
+  const [availableChannelGroups, setAvailableChannelGroups] = useState<{id: number; name: string}[]>([]);
   const [errors, setErrors] = useState<ValidationErrors>({});
   const [saving, setSaving] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
@@ -64,6 +66,13 @@ export function RuleBuilder({
   useEffect(() => {
     getNormalizationRules().then(({ groups }) => {
       setAvailableNormGroups(groups.map(g => ({ id: g.id, name: g.name, enabled: g.enabled })));
+    }).catch(() => {});
+  }, []);
+
+  // Load available channel groups for the merge-scope group selector (GH #298)
+  useEffect(() => {
+    getChannelGroups().then(groups => {
+      setAvailableChannelGroups(groups.map(g => ({ id: g.id, name: g.name })));
     }).catch(() => {});
   }, []);
 
@@ -182,6 +191,7 @@ export function RuleBuilder({
         skip_struck_streams: skipStruckStreams,
         orphan_action: orphanAction,
         match_scope_target_group: matchScopeTargetGroup,
+        match_scope_group_id: matchScopeTargetGroup ? matchScopeGroupId : null,
       });
     } finally {
       setSaving(false);
@@ -239,6 +249,15 @@ export function RuleBuilder({
       handleSave();
     }
   };
+
+  // GH #298: an effective scope group resolves for create_channel when a
+  // Create Channel action carries a target group, OR a Create Group action
+  // exists (which sets the group used by a later Create Channel). When neither
+  // holds (e.g. a Merge-Streams-only rule) and no explicit Scope group is set,
+  // the merge lookup falls back to ALL groups — warn the operator about that.
+  const ruleResolvesAScopeGroup =
+    actions.some(a => a.type === 'create_channel' && a.group_id != null) ||
+    actions.some(a => a.type === 'create_group');
 
   return (
     <div className="rule-builder" data-testid="rule-builder" onKeyDown={handleKeyDown}>
@@ -336,9 +355,10 @@ export function RuleBuilder({
           <div className="form-field">
             <label>Merge lookup scope</label>
             <span className="field-hint">
-              On (default): when a Create Channel action merges into an existing channel, only look within this rule&apos;s
-              target group — so the rule creates a new channel in the target group instead of merging into a same-name
-              channel in another group. Off: search all channel groups for a matching name (the original behavior).
+              On (default): when this rule merges into an existing channel, only look within a single target group —
+              so the rule creates a new channel in that group instead of merging into a same-name channel in another
+              group. Pick the group below, or leave it on Auto to use the Create Channel action&apos;s target group.
+              Off: search all channel groups for a matching name (the original behavior).
             </span>
             <div className="checkbox-group">
               <label className="checkbox-item">
@@ -347,11 +367,37 @@ export function RuleBuilder({
                   checked={matchScopeTargetGroup}
                   onChange={e => setMatchScopeTargetGroup(e.target.checked)}
                   disabled={isLoading}
-                  aria-label="Scope merge lookups to this rule's target group"
+                  aria-label="Scope merge lookups to a target group"
                 />
-                <span>Scope merge lookups to this rule&apos;s target group</span>
+                <span>Scope merge lookups to a target group</span>
               </label>
             </div>
+            {matchScopeTargetGroup && (
+              <div className="form-field" style={{ marginTop: '8px' }}>
+                <label>Scope group</label>
+                <CustomSelect
+                  value={matchScopeGroupId != null ? matchScopeGroupId.toString() : ''}
+                  onChange={val => setMatchScopeGroupId(val ? parseInt(val, 10) : null)}
+                  options={[
+                    { value: '', label: 'Auto — use the Create Channel action\'s target group' },
+                    ...availableChannelGroups.map(group => ({
+                      value: group.id.toString(),
+                      label: group.name,
+                    })),
+                  ]}
+                  disabled={isLoading}
+                  searchable
+                  searchPlaceholder="Search groups..."
+                />
+                {matchScopeGroupId == null && !ruleResolvesAScopeGroup && (
+                  <span className="norm-hint">
+                    <span className="material-icons norm-hint-icon">warning</span>
+                    No scope group will resolve — this rule has no Create Channel target group, so merge lookups will
+                    fall back to ALL channel groups. Pick a Scope group above to restrict matching to one group.
+                  </span>
+                )}
+              </div>
+            )}
           </div>
 
           <div className="form-field">

--- a/frontend/src/types/autoCreation.ts
+++ b/frontend/src/types/autoCreation.ts
@@ -219,6 +219,12 @@ export interface AutoCreationRule {
   // targeting different groups can create separate channels with the
   // same name instead of merging into a foreign group (GH-92).
   match_scope_target_group?: boolean;
+  // Explicit rule-level scope group for merge lookups (GH #298). When
+  // match_scope_target_group is on, this pins the group that name lookups
+  // are restricted to across both create_channel and merge_streams. null/
+  // undefined = "Auto" (create_channel falls back to the action's target
+  // group; merge_streams stays group-agnostic).
+  match_scope_group_id?: number | null;
   last_run_at?: string;
   match_count: number;
   created_at: string;
@@ -251,6 +257,8 @@ export interface CreateRuleData {
   skip_struck_streams?: boolean;
   orphan_action?: string;
   match_scope_target_group?: boolean;
+  // Explicit rule-level scope group for merge lookups (GH #298). null = "Auto".
+  match_scope_group_id?: number | null;
 }
 
 /**


### PR DESCRIPTION
Fixes **GH#298** — *"Can't set target group from the rule builder."* Bead: `enhancedchannelmanager-kncun`.

## Problem
When **Merge lookup scope** was ticked, there was no way to set the target group in the rule builder, so merge lookups matched against **any** group. The rule-level checkbox referenced "this rule's target group", but no rule-level control existed — Target Group only lived on the Create Channel action, and the **Merge Streams** action had no group control at all (so its lookups always searched every group).

## Fix
Adds an explicit nullable `match_scope_group_id` on the rule, surfaced as a **"Scope group"** selector under the checkbox (Auto + group list), threaded through **both** the `create_channel` and `merge_streams` name lookups. `NULL = "Auto"` preserves existing behavior, so this is **fully backward-compatible**.

- `models.py`: nullable `match_scope_group_id` + `to_dict()`
- Alembic migration **0019** (nullable add, reversible, no backfill)
- `auto_creation_executor.py`: prefer explicit scope group; `merge_streams` now rejects a candidate resolved by any path (including the global core-name / call-sign fallback maps) when it falls outside the effective scope group
- `routers/auto_creation.py` + `routers/backup.py`: persist / round-trip / export / import
- `RuleBuilder.tsx`: scope-group `CustomSelect` (shown when scope on), all-groups fallback warning for merge-only rules, corrected hint
- Tests: executor (6), router persistence (6), migration 0019 up/down/idempotent, RuleBuilder (6)
- Version bump `0.17.1-0072 → 0.17.1-0073` (3 touchpoints)

## Verification
- Backend `4626 passed, 1 skipped`; frontend vitest `1506 passed`, eslint/tsc/vite build clean; version-consistency check passes.
- Deployed to the dev container and verified live via Playwright: selector shows when scope on, hides when off, defaults to Auto; migration applied (`alembic current = 0019`, schema healthy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)