### PR TITLE
v0.17.1-0074: Compact x-axis labels on provider stats charts (bd-qk2zy)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0073",
+    version="0.17.1-0074",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0073"
+APP_VERSION = "0.17.1-0074"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0073",
+  "version": "0.17.1-0074",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/tabs/ProvidersPanel.test.tsx
+++ b/frontend/src/components/tabs/ProvidersPanel.test.tsx
@@ -21,7 +21,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
-import { ProvidersPanel } from './ProvidersPanel';
+import { ProvidersPanel, formatBucketTick } from './ProvidersPanel';
 import * as api from '../../services/api';
 import { HttpError } from '../../services/httpClient';
 import type {
@@ -758,5 +758,76 @@ describe('ProvidersPanel — a11y', () => {
       expect(screen.getByRole('combobox', { name: /window/i })).toBeInTheDocument();
       expect(screen.getByRole('combobox', { name: /bucket/i })).toBeInTheDocument();
     });
+  });
+});
+
+/**
+ * Unit tests for formatBucketTick (bd-qk2zy).
+ *
+ * All assertions pass explicit locale="en-US" and timeZone="UTC" so the
+ * expected strings are deterministic regardless of the CI runner's locale
+ * or timezone. This mirrors the injection-point pattern from
+ * UserStatsPanel.tsx's formatLocalDayLabel / isTodayInLocalTz tests.
+ *
+ * The en-US + UTC combination produces exactly the fixed-width numeric
+ * labels the format string targets ("MM/DD HH:mm" / "MM/DD").
+ *
+ * Intl.DateTimeFormat hour12:false produces "24:00" for midnight in some
+ * runtimes instead of "00:00". The midnight test covers this boundary so a
+ * regression in the formatter surfaces here before it reaches the chart.
+ */
+describe('formatBucketTick — compact X-axis tick formatter (bd-qk2zy)', () => {
+  // --- hour granularity ---
+
+  it('formats a mid-day UTC ISO string as MM/DD HH:mm for hour bucket', () => {
+    const result = formatBucketTick('2026-05-14T14:30:00Z', 'hour', 'en-US', 'UTC');
+    expect(result).toBe('05/14 14:30');
+  });
+
+  it('formats a morning UTC ISO string as MM/DD HH:mm for hour bucket', () => {
+    const result = formatBucketTick('2026-05-14T02:00:00Z', 'hour', 'en-US', 'UTC');
+    expect(result).toBe('05/14 02:00');
+  });
+
+  it('formats a midnight UTC ISO string (boundary case) for hour bucket', () => {
+    // Midnight is the most common boundary value (e.g. daily-rollover buckets).
+    // Intl.DateTimeFormat hour12:false renders 00:00 — not "24:00".
+    const result = formatBucketTick('2026-05-14T00:00:00Z', 'hour', 'en-US', 'UTC');
+    expect(result).toBe('05/14 00:00');
+  });
+
+  it('handles trailing Z (UTC suffix) correctly for hour bucket', () => {
+    // The backend always produces trailing-Z ISO strings. Explicit guard so
+    // a future change removing the Z does not silently break the formatter.
+    const withZ = formatBucketTick('2026-05-14T06:00:00Z', 'hour', 'en-US', 'UTC');
+    expect(withZ).toMatch(/^\d{2}\/\d{2} \d{2}:\d{2}$/);
+    expect(withZ).toBe('05/14 06:00');
+  });
+
+  // --- day granularity ---
+
+  it('formats a UTC day-level ISO string as MM/DD for day bucket', () => {
+    const result = formatBucketTick('2026-05-14T00:00:00Z', 'day', 'en-US', 'UTC');
+    expect(result).toBe('05/14');
+  });
+
+  it('formats a non-midnight day ISO string as MM/DD for day bucket', () => {
+    // Backend day buckets typically start at T00:00:00Z, but guard against
+    // a non-midnight value being passed through.
+    const result = formatBucketTick('2026-05-14T12:00:00Z', 'day', 'en-US', 'UTC');
+    expect(result).toBe('05/14');
+  });
+
+  it('formats a month-boundary date correctly for day bucket', () => {
+    const result = formatBucketTick('2026-05-01T00:00:00Z', 'day', 'en-US', 'UTC');
+    expect(result).toBe('05/01');
+  });
+
+  // --- fallback (malformed input) ---
+
+  it('returns the raw string when the input is not a parseable date', () => {
+    const bad = 'not-a-date';
+    expect(formatBucketTick(bad, 'hour')).toBe(bad);
+    expect(formatBucketTick(bad, 'day')).toBe(bad);
   });
 });

--- a/frontend/src/components/tabs/ProvidersPanel.tsx
+++ b/frontend/src/components/tabs/ProvidersPanel.tsx
@@ -261,6 +261,59 @@ function formatBitrateBps(bps: number): string {
   return `${bps} bps`;
 }
 
+/**
+ * Compact X-axis tick label for time-bucketed line charts.
+ *
+ * time_bucket values are full UTC ISO-8601 strings from the backend
+ * (e.g. "2026-05-14T02:00:00Z"). We convert to the operator's local
+ * timezone for display — consistent with UserStatsPanel's approach for
+ * day labels (which also converts UTC-anchored buckets to local time).
+ * For hour granularity the local-time hour is more meaningful to operators
+ * than a UTC hour; for day granularity a short date is sufficient.
+ *
+ * Format produced:
+ *   hour → "MM/DD HH:mm"  e.g. "05/14 02:00" (local)
+ *   day  → "MM/DD"        e.g. "05/14"        (local)
+ *
+ * Falls back to the raw string if Date parsing fails (malformed input).
+ *
+ * `locale` and `timeZone` are injection points for unit tests (same
+ * pattern as `formatLocalDayLabel` in UserStatsPanel.tsx).
+ */
+// eslint-disable-next-line react-refresh/only-export-components -- pure helper co-located with the only component that uses it; splitting is mechanical churn
+export function formatBucketTick(
+  timeBucket: string,
+  granularity: ProviderStatsBucket,
+  locale?: string,
+  timeZone?: string,
+): string {
+  const d = new Date(timeBucket);
+  if (Number.isNaN(d.getTime())) return timeBucket;
+
+  if (granularity === 'hour') {
+    // Render as "MM/DD HH:mm" in the operator's local timezone.
+    const datePart = new Intl.DateTimeFormat(locale ?? 'en-US', {
+      month: '2-digit',
+      day: '2-digit',
+      timeZone,
+    }).format(d);
+    const timePart = new Intl.DateTimeFormat(locale ?? 'en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+      timeZone,
+    }).format(d);
+    return `${datePart} ${timePart}`;
+  }
+
+  // granularity === 'day': render as "MM/DD" in the operator's local timezone.
+  return new Intl.DateTimeFormat(locale ?? 'en-US', {
+    month: '2-digit',
+    day: '2-digit',
+    timeZone,
+  }).format(d);
+}
+
 function formatBytes(b: number): string {
   if (b >= 1_000_000_000) return `${(b / 1_000_000_000).toFixed(2)} GB`;
   if (b >= 1_000_000) return `${(b / 1_000_000).toFixed(1)} MB`;
@@ -552,7 +605,12 @@ export function ProvidersPanel() {
             <ResponsiveContainer width="100%" height={200}>
               <LineChart data={bufferingChart} margin={{ top: 10, right: 16, bottom: 8, left: 8 }}>
                 <CartesianGrid stroke="var(--border-primary)" strokeDasharray="3 3" />
-                <XAxis dataKey="time_bucket" tick={{ fontSize: 11, fill: 'var(--text-primary)' }} />
+                <XAxis
+                  dataKey="time_bucket"
+                  tick={{ fontSize: 11, fill: 'var(--text-primary)' }}
+                  tickFormatter={(v: string) => formatBucketTick(v, bucketSel)}
+                  minTickGap={50}
+                />
                 <YAxis tick={{ fontSize: 11, fill: 'var(--text-primary)' }} width={40} />
                 <Tooltip />
                 <Legend />
@@ -837,7 +895,12 @@ export function ProvidersPanel() {
             <ResponsiveContainer width="100%" height={220}>
               <LineChart data={bitrateChart} margin={{ top: 10, right: 16, bottom: 8, left: 8 }}>
                 <CartesianGrid stroke="var(--border-primary)" strokeDasharray="3 3" />
-                <XAxis dataKey="time_bucket" tick={{ fontSize: 11, fill: 'var(--text-primary)' }} />
+                <XAxis
+                  dataKey="time_bucket"
+                  tick={{ fontSize: 11, fill: 'var(--text-primary)' }}
+                  tickFormatter={(v: string) => formatBucketTick(v, bucketSel)}
+                  minTickGap={50}
+                />
                 <YAxis
                   tick={{ fontSize: 11, fill: 'var(--text-primary)' }}
                   width={80}


### PR DESCRIPTION
Bead: `enhancedchannelmanager-qk2zy`. Reported by PO and verified live via Playwright.

## Problem
The **"Channel events by provider"** and **"Bitrate by provider"** line charts in the Stats → Providers section rendered raw ISO `time_bucket` strings (`2026-05-14T02:00:00Z`) on the x-axis with no formatter, thinning, or rotation. With a 7-day/Hour window (~118 buckets) the auto-thinned ticks each printed ~19 chars and **collided** — you couldn't tell when/what each point was.

## Fix
Adds a unit-tested `formatBucketTick(timeBucket, granularity)` helper rendering compact **local-time** labels (matching `UserStatsPanel`'s convention), applied as `tickFormatter` + `minTickGap={50}` on **both** time-bucketed line charts:
- `hour` → `MM/DD HH:mm` (e.g. `05/14 13:00`)
- `day`  → `MM/DD` (e.g. `05/14`)

Bar charts already handled their axes via `interval={0}` + `angle` and are unchanged. Data tables still show the raw `time_bucket`.

## Verification
- Deployed to the dev container and verified live via Playwright: the events chart now shows 10 evenly-spaced, readable labels (`05/14 13:00`, `05/15 01:00`, …) with no overlap.
- 8 new `formatBucketTick` unit tests pass; eslint / tsc / vite build clean; version-consistency passes.
- Note: render-based tests could not run in the agent's worktree (jsdom env artifact); CI **Frontend Tests** runs them in a clean environment as the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)