### PR TITLE
docs: ADR-009 + STRIDE threat model for MCP OAuth 2.1 (bd-buiqr.1)

### DIFF
--- a/docs/adr/ADR-009-mcp-oauth-authorization-server-split.md
+++ b/docs/adr/ADR-009-mcp-oauth-authorization-server-split.md
@@ -1,0 +1,255 @@
+# ADR-009: MCP OAuth 2.1 — ECM as Authorization Server, MCP as Resource Server
+
+- **Status**: Proposed
+- **Date**: 2026-05-20 (proposed)
+- **Author**: Security Engineer persona (PRIMARY) with IT Architect + Technical Writer personas, encoding the 2026-05-19 team-plan grooming + PO-locked decisions on epic `enhancedchannelmanager-buiqr`
+- **Bead**: `enhancedchannelmanager-buiqr.1` (first child of the OAuth 2.1 epic — design lands here before any code child opens)
+- **Related**:
+  - `enhancedchannelmanager-buiqr` — Epic: Add OAuth 2.1 support to ECM MCP server for Claude Desktop Custom Connector compatibility. **The epic body is the source of truth for the PO-locked decisions; this ADR formalizes them.**
+  - `enhancedchannelmanager-buiqr.1` — this ADR's tracker (ADR + STRIDE threat model)
+  - `enhancedchannelmanager-ak7xa` — PRECONDITION (closed): gate `mcp-server/tests/` in CI before any OAuth child opens. The OAuth abuse-case tests this ADR motivates would rot silently without this gate
+  - `enhancedchannelmanager-buiqr.2` — OAuth state store: SQLite on `/config/mcp_oauth.db` (consumes §6)
+  - `enhancedchannelmanager-buiqr.3` — Backend OAuth authorization server: PKCE `/authorize` + `/token` endpoints in ECM (consumes §1, §3)
+  - `enhancedchannelmanager-buiqr.4` — OAuth security hardening: rate limiting + open-redirect guards + token hashing (consumes §6, §7)
+  - `enhancedchannelmanager-buiqr.5` — OAuth discovery endpoints + `oauth_allow_insecure` flag (consumes §1, §5)
+  - `enhancedchannelmanager-buiqr.6` — Hardcoded OAuth client registry for Claude Desktop + Claude Code (consumes §4)
+  - `enhancedchannelmanager-buiqr.7` — ECM consent screen: `/oauth/authorize` route + copy + returning-user state + active grants (consumes §3)
+  - `enhancedchannelmanager-buiqr.8` — MCP resource server: Bearer-token validator with dual-path-by-shape routing (consumes §2, §3)
+  - `enhancedchannelmanager-buiqr.9` — OAuth test infrastructure: abuse cases + dual-path matrix + `.mcp.json` compat + captured-traffic replay (consumes §3, §7)
+  - `docs/security/threat_model_mcp_oauth.md` — **the STRIDE threat model that is the security companion to this ADR (same bead `buiqr.1`).** Every decision below maps to one or more threat rows there
+  - `docs/architecture.md` — MCP Server section (current static-key auth model this ADR extends; the `settings.json` credential schema in §4 of that doc is the contract the §1 split inherits)
+  - `backend/auth/tokens.py` — JWT (HS256) + JTI revocation + `hash_token()` SHA-256 pattern that §3 and §6 mirror
+  - `docs/adr/ADR-005-code-security-gating-strategy.md` — the new OAuth routers land subject to CodeQL delta-zero at PR time
+  - `docs/adr/ADR-008-interactive-stream-dedup.md` — ADR template/format mirrored here
+
+## Context
+
+ECM's MCP server (`mcp-server/`, default port 6101) today authenticates AI agents with a single static API key (`mcp_api_key` in `/config/settings.json`), accepted either as `?api_key=<key>` or `Authorization: Bearer <key>` (see `docs/architecture.md` → MCP Server → Auth model). This works for Claude Code (`.mcp.json` with a `?api_key=` URL) and for any script. It does **not** work for Claude Desktop's **Custom Connector** UI (Settings → Connectors → Add custom connector), which speaks OAuth 2.1 + PKCE and has no field for a pre-shared key. Today the only Claude Desktop path is the `mcp-remote` bridge, which requires the operator to install Node.js — a non-starter on corporate-managed laptops and a friction wall for less-technical home-server operators.
+
+The epic `buiqr` adds OAuth 2.1 + PKCE so the Custom Connector UI can authenticate **without** the Node.js bridge. This is a security-sensitive change: it introduces a browser-driven authorization flow, a token-issuance surface, a consent screen, and a second authentication path that must coexist with the permanent static-key path. Two authentication paths sharing one resource server is exactly the shape that produces auth-bypass bugs, so the architecture must be locked **before** any code child opens. That is what this ADR does.
+
+### Critical finding that shapes the HTTPS posture
+
+MCP SDK 1.27.0 (already pinned in `mcp-server/`) **rejects `http://` issuer URLs for non-loopback hostnames** in its OAuth discovery handling. The typical ECM deploy shape is `http://<LAN-IP>:6101` — a non-loopback host over plain HTTP — which the SDK refuses. Operators on that shape must front MCP with HTTPS (a reverse proxy: Caddy / nginx / Traefik, or ECM's existing `:6143`). This epic therefore trades "install Node.js" for "set up HTTPS" — better for some operators, worse for others. The PO accepted this trade and locked an opt-in escape hatch (`oauth_allow_insecure`, §5) for operators who knowingly run HTTP-only.
+
+### Why this ADR must land before the code children start
+
+The epic decomposes into ~13 children (`buiqr.2` through `buiqr.13`) spanning the AS endpoints, the RS validator, the SQLite token store, the consent UI, the discovery endpoints, the client registry, the hardening, the test infrastructure, and the docs bundle. The two highest-leverage contract-locks are (a) the **AS/RS split and the offline-verification boundary** (§1, §2) — get this wrong and you couple the two containers at runtime, destroying the failure-isolation envelope — and (b) the **dual-path-by-shape routing rule** (§3) — get this wrong and you ship an auth-bypass. Both must be named once, here, and referenced from the children. This ADR encodes the PO-locked decisions verbatim; it is **not** the place to re-litigate them.
+
+### Architecture overview
+
+```mermaid
+graph LR
+    Desktop["Claude Desktop<br/>(Custom Connector, OAuth 2.1 + PKCE)"]
+    Code["Claude Code / scripts<br/>(static ?api_key= / Bearer static-key)"]
+
+    subgraph ECMContainer["ECM Container (:6100, AS)"]
+        AuthZ["/authorize + consent UI"]
+        Token["/token (PKCE S256)"]
+        DiscAS["/.well-known/<br/>oauth-authorization-server"]
+        Session["Admin user session<br/>(existing JWT auth)"]
+        HS256["Shared HS256 secret<br/>(/config/settings.json)"]
+    end
+
+    subgraph MCPContainer["MCP Container (:6101, RS)"]
+        Route["Auth router<br/>(dual-path by SHAPE)"]
+        DiscRS["/.well-known/<br/>oauth-protected-resource"]
+        Verify["Offline JWT verify<br/>(HS256, no callback to ECM)"]
+        Tools["~110 MCP tools"]
+    end
+
+    Store["/config/mcp_oauth.db<br/>(SQLite WAL, MCP-managed,<br/>tokens hashed-at-rest)"]
+    Settings["/config/settings.json<br/>(shared volume)"]
+
+    Desktop -->|"1. discover"| DiscRS
+    Desktop -->|"2. /authorize"| AuthZ
+    AuthZ --> Session
+    Desktop -->|"3. /token + PKCE verifier"| Token
+    Token --> HS256
+    Token -.writes hash.-> Store
+    Desktop -->|"4. /mcp + Bearer JWT"| Route
+    Code -->|"/mcp + static key"| Route
+    Route --> Verify
+    Verify --> HS256
+    Verify -.reads hash.-> Store
+    Route --> Tools
+    HS256 -.same secret.-> Settings
+```
+
+## Decision
+
+### §1 — ECM = Authorization Server; MCP = Resource Server (offline verification, no runtime callback)
+
+The OAuth roles are split across the two existing containers along the line that already owns the relevant state:
+
+- **ECM container is the OAuth Authorization Server (AS).** It already owns the admin user session (its existing JWT auth subsystem, `backend/auth/`). The AS hosts:
+  - `GET /authorize` — the authorization endpoint, which renders the consent UI (§3).
+  - `POST /token` — the token endpoint, which exchanges an authorization code + PKCE verifier for a Bearer JWT.
+  - `GET /.well-known/oauth-authorization-server` — RFC 8414 AS metadata.
+- **MCP container is the OAuth Resource Server (RS).** It owns the protected resource (the `/mcp` tools surface). The RS hosts:
+  - `GET /.well-known/oauth-protected-resource` — RFC 9728 protected-resource metadata, pointing at the ECM AS.
+  - The `/mcp` endpoint, which validates the Bearer JWT **offline** on every request.
+
+**Rationale — why ECM is the AS.** OAuth's `/authorize` step requires an authenticated user session to obtain consent. ECM already has that session; MCP does not. Putting the AS in MCP would mean MCP re-implementing or proxying ECM's login, which is both duplicative and a wider attack surface. The user-facing consent screen belongs where the user identity lives.
+
+**Rationale — why offline verification with a shared HS256 secret, NOT a runtime callback.** The RS validates each Bearer JWT by verifying its HS256 signature against a secret read from the shared `/config/settings.json` volume — the same volume the two containers already share for `mcp_api_key` (per `docs/architecture.md`). It does **not** call back to ECM on a per-request basis. This is a deliberate, load-bearing choice:
+
+  - **Performance.** A per-request HTTP callback from MCP to ECM would add a network round-trip to every tool call. AC#11 caps the p50 latency increase at ≤ 5 ms vs the static-key baseline; an in-process HMAC verification meets that, a callback does not.
+  - **Failure isolation.** The current MCP server can serve cached/tool operations even under ECM backend stress; coupling token validation to a live ECM call would mean an ECM hiccup takes down all authenticated MCP traffic. Offline verification preserves the existing failure-isolation envelope.
+  - **The trade-off is acknowledged:** offline verification means revocation is not instantaneous — a revoked token is rejected only once the RS sees the revocation state (via the shared token store, §6) or the token's short TTL expires. This is the standard JWT trade and is mitigated by short access-token TTLs (§3) and the shared hashed-token store the RS reads (§6). See the threat model's *token-replay* and *secret-rotation* rows.
+
+HS256 (symmetric) is chosen over RS256 (asymmetric) because the two containers already co-locate on one host and share a config volume; a symmetric secret is the simplest primitive that fits the deployment, and it mirrors ECM's existing JWT subsystem (`backend/auth/tokens.py`, `ALGORITHM = "HS256"`). The exit path to RS256 (publish a JWKS from ECM, have MCP fetch + cache it) exists if a future multi-host split needs it, but is out of scope here.
+
+### §2 — Dual-path-by-shape auth routing (route by credential SHAPE, never by fail-cascade)
+
+This is the security-critical routing rule (epic AC#2 / AC#7). The RS's auth router classifies each inbound request by the **shape** of the presented credential and dispatches to exactly one validation path. It **never** tries one path, fails, and falls through to the other.
+
+**The rule:**
+
+| Presented credential | Routed to | Fallback on failure? |
+|---|---|---|
+| `Authorization: Bearer <JWT-shaped value>` (three base64url segments separated by dots, decodable header with `alg`/`typ`) | **OAuth path only** — offline HS256 verify (§1) | **NO.** A malformed/expired/bad-signature JWT returns 401. It does **NOT** fall through to the static-key check. |
+| `?api_key=<value>` query param | **Static-key path only** — compare against `mcp_api_key` | NO. A wrong static key returns 401. |
+| `Authorization: Bearer <static-key-prefixed value>` (matches the recognizable static-key shape/prefix, not JWT-shaped) | **Static-key path only** | NO. |
+| Neither shape present | 401 with `WWW-Authenticate` pointing at the RS discovery doc | n/a |
+
+**Why route by shape and not by fail-cascade.** A fail-cascade design ("try OAuth; if it fails, try the static key") is an **auth-bypass smell** and the headline threat this whole ADR is built to prevent (threat model §3.6, confused-deputy / privilege-elevation). Two concrete dangers:
+
+  - **Downgrade / confused-deputy.** An attacker who can influence the request could present a deliberately-broken JWT to skip OAuth and have the server "fall back" to evaluating the value as a static key — collapsing the OAuth path's stronger guarantees onto the weaker static-key path. The server must never let a *failed* strong-auth attempt become a *retry* on weaker auth.
+  - **Silent guarantee loss.** Even without a malicious actor, fail-cascade means an OAuth misconfiguration (wrong secret, clock skew) silently routes traffic onto the static-key path, masking the OAuth failure and erasing the audit distinction between an OAuth-authenticated session and a static-key session.
+
+**The invariant, stated for the implementer (`buiqr.8`):** *OAuth-validation FAILURE must NEVER fall through to the static-key check.* Once a request is classified as JWT-shaped, its only outcomes are "valid OAuth session" or "401". The classification is on the **shape** of the credential, decided before any validation runs; validation outcome never re-routes. A dedicated regression test (`buiqr.9`) asserts that a JWT-shaped-but-invalid Bearer value is rejected and is **not** evaluated as a static key.
+
+### §3 — Single ECM-admin identity; PKCE S256 only; short-TTL access tokens
+
+- **Single ECM-admin identity model.** Per the PO-locked decision, OAuth grants are made by the **single ECM admin on behalf of the deployment**. The issued token's `sub` claim binds to the admin user. There is no multi-tenant / per-end-user identity in v1 (out of scope, §8). The consent screen (§ below) is the admin saying "this deployment authorizes Claude Desktop."
+- **PKCE S256 only.** The `code_challenge_method` accepted at `/authorize` and enforced at `/token` is **`S256` only**. The `plain` method is **rejected with HTTP 400 `invalid_request`** (AC#5). PKCE is mandatory (no non-PKCE authorization-code flow); a missing or `plain` challenge is a 400.
+- **Hardcoded client registry; no Dynamic Client Registration.** The set of OAuth clients is a fixed, in-code registry (`buiqr.6`) containing the Claude Desktop and Claude Code client identifiers and their exact redirect URIs. **RFC 7591 Dynamic Client Registration is not implemented** (out of scope, §8). An unknown `client_id` is rejected; a `redirect_uri` that is not an exact match for the registered client's allowlisted URI(s) is rejected (threat model: redirect-URI validation, open-redirect).
+- **Token shape and TTL.** Access tokens are HS256 JWTs carrying at minimum `sub` (admin user binding), `jti` (unique id for revocation, mirroring `backend/auth/tokens.py`), `iss` (the ECM AS), `aud` (the MCP RS), `scope` (`mcp`, §8), `iat`, and `exp`. Access-token TTL is **short** (mirroring ECM's existing `ACCESS_TOKEN_EXPIRE_MINUTES = 30` posture; the exact value is `buiqr.3`'s call within that envelope) to bound the offline-verification revocation gap (§1). Refresh handling, if issued, follows the existing one-time-use rotation pattern in `backend/auth/tokens.py`.
+- **Consent UI.** Rendered by the AS at the `/authorize` step (`buiqr.7`), shown to the authenticated admin. Copy is the PO-locked single-`mcp`-scope wording: *"Claude Desktop will be able to read and manage your ECM channels, streams, M3U accounts, and EPG sources."* The consent screen pins the requesting client's name (from the hardcoded registry, not from attacker-supplied input) and enforces same-origin / allowlist on any `return_to`-style parameter (threat model: consent-phishing, open-redirect).
+
+### §4 — `oauth_allow_insecure` flag policy
+
+A single boolean in `/config/settings.json`, **default `false`**, governs whether the OAuth surface is offered on plain-HTTP deployments:
+
+- **When `false` (default):** the discovery endpoints (`/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`) **return 404 on plain HTTP** (non-HTTPS request, non-loopback host). The OAuth flow is effectively off for HTTP-only deploys — the operator sees no discovery metadata, so Claude Desktop's Custom Connector cannot proceed, and they fall back to the (permanent) static-key path or set up HTTPS.
+- **When `true`:** the operator has **explicitly opted in** (AC#6) to running OAuth over plain HTTP, accepting the token-interception and replay risk (threat model: token-replay-over-plain-HTTP, HTTP-only deploy). Discovery returns its normal metadata.
+
+**Rationale.** This flag exists because of the MCP SDK 1.27.0 http-issuer rejection finding (see Context). Rather than silently failing on the typical `http://<LAN-IP>:6101` shape, ECM defaults to refusing the insecure posture (404, fail-closed) and makes the operator make an explicit, documented choice to weaken it. The default is the safe value; weakening it is a deliberate act recorded in `settings.json`. The flag never weakens the static-key path — that path is unchanged and HTTP-or-HTTPS as today.
+
+### §5 — Token store: SQLite at `/config/mcp_oauth.db`, MCP-container-managed, hashed-at-rest
+
+- **Location & engine.** A dedicated SQLite database at **`/config/mcp_oauth.db`**, in **WAL mode** (consistent with ECM's other SQLite stores). It is **MCP-container-managed** — the RS owns its lifecycle (`buiqr.2`). This deliberately avoids any runtime HTTP coupling to ECM for token state, preserving the §1 failure-isolation property: the AS issues tokens and writes their hashed records; the RS reads/validates against the same store; neither calls the other at request time.
+- **Hashed-at-rest.** Tokens are **never stored in plaintext.** The store holds **SHA-256 hashes** of the token (or of the `jti`, per `buiqr.2`/`buiqr.4` implementation), mirroring the established `hash_token()` pattern in `backend/auth/tokens.py` (`hashlib.sha256(token.encode()).hexdigest()`) and that module's `jti`-based revocation set. A read of `mcp_oauth.db` yields hashes, not bearer credentials — so a compromised store leaks revocation/audit metadata, not usable tokens (threat model: token-store at-rest compromise).
+- **Revocation.** Revocation marks the `jti`/hash record revoked; the RS's offline verifier consults the store to reject revoked tokens (the §1 revocation-gap mitigation), exactly mirroring `revoke_token(jti)` in the existing JWT subsystem.
+
+### §6 — Rate limiting; `dispatcharr_api_key` isolation
+
+- **Rate limiting on `/authorize` and `/token`** (AC#9), applied **per-IP and per-user**, to blunt brute-force on the token endpoint, authorization-code-guessing, and consent-spam. Implemented in `buiqr.4`.
+- **`dispatcharr_api_key` is never referenced in OAuth code paths.** The Dispatcharr REST API token (`dispatcharr_api_key`, the canonical field per `docs/architecture.md`) is a distinct credential class from the OAuth machinery. No OAuth router, validator, token-store, or discovery handler reads, logs, or forwards `dispatcharr_api_key`. This is enforced by a **CI grep guard** (AC#10) — the OAuth code paths grepped for `dispatcharr_api_key` must return zero hits. This keeps the OAuth trust boundary from leaking into the Dispatcharr trust boundary (threat model: Dispatcharr trust boundary). The historical field-name-collision incident (GH #273, `bd-jmi1c`) is exactly the class of error this guard prevents.
+
+### §7 — Discovery-endpoint hygiene
+
+The two `/.well-known/*` documents (RFC 8414 AS metadata, RFC 9728 protected-resource metadata) are **public, unauthenticated** by spec, and their shape is pinned by snapshot tests (AC#4). They MUST expose only the protocol-required fields (issuer, endpoint URLs, supported `code_challenge_methods` = `["S256"]`, supported scopes = `["mcp"]`, token-endpoint-auth methods) and MUST NOT leak the shared HS256 secret, internal Docker-network hostnames (`ecm:6100`), filesystem paths, version-internal details, or the static `mcp_api_key`. On plain HTTP with `oauth_allow_insecure=false` they return 404 (§4). See the threat model's discovery-endpoint-information-leakage row.
+
+### §8 — Out of Scope (condensed from the epic)
+
+Explicitly **not** built in v1. Each is a future-epic candidate, not a silent omission:
+
+- **Multi-tenant OAuth** — per-end-user grants beyond the single ECM admin. v1 is single-admin-on-behalf-of-deployment (§3).
+- **Dynamic Client Registration (RFC 7591)** — the client registry is hardcoded (§3).
+- **OIDC / `id_token` issuance** — this is OAuth authorization only, no identity-layer tokens.
+- **Per-tool / fine-grained scopes** — single `mcp` scope in v1 (§3). Per-tool scopes are a future epic if asked for.
+- **ECM-managed TLS** — HTTPS is operator-supplied (reverse proxy); ECM does not terminate TLS for the OAuth surface (§4 / Context).
+- **External OAuth providers** (Google / GitHub / Microsoft login) — ECM is the AS; no federated upstream IdP.
+- **WebAuthn / hardware-token binding** on the consent step.
+- **Encryption-at-rest for `/config/settings.json` broadly** — only token-specific hashing (§5); the shared HS256 secret and `mcp_api_key` live in `settings.json` as today.
+- **Replacement / deprecation of the `?api_key=` static path** — that path is **permanent** (PO-locked); the dual-path matrix (§2) is a permanent CI fixture.
+- **Migrating `mcp_api_key` off `settings.json`.**
+
+## Alternatives Considered
+
+| # | Option | Pros | Cons | Portability | Decision |
+|---|--------|------|------|-------------|----------|
+| 1 | **Chosen — ECM=AS, MCP=RS, offline HS256 verify, dual-path-by-shape** | Consent lives where the user session lives; no per-request callback (meets ≤5 ms AC#11); failure-isolation preserved; shape-routing closes the auth-bypass class | Revocation is not instantaneous (TTL/shared-store mitigated); one shared secret to rotate | High — symmetric secret on a co-located shared volume, no new infra | **Adopted** (PO-locked) |
+| 2 | MCP=AS (MCP hosts `/authorize` + consent) | Single container owns the whole OAuth surface | MCP has no user session — would have to proxy/re-implement ECM login; wider attack surface; consent UI divorced from identity | Med | Rejected — consent must live with identity |
+| 3 | Per-request runtime callback MCP→ECM to validate every token | Instant revocation; single source of truth at request time | Adds a network round-trip per tool call (blows AC#11); couples MCP availability to ECM; destroys failure isolation | Med | Rejected — perf + isolation |
+| 4 | RS256 (asymmetric) instead of HS256 | No shared secret; RS only needs the public key; cleaner multi-host story | More moving parts (JWKS publish/fetch/cache) for two co-located containers that already share a volume; doesn't mirror ECM's existing HS256 JWT subsystem | High | Rejected for v1; documented exit path if multi-host split appears |
+| 5 | Fail-cascade dual auth (try OAuth, fall back to static key) | Trivially "just works" for any credential | **Auth-bypass smell** — a failed strong-auth attempt becomes a weak-auth retry; confused-deputy / downgrade; erases audit distinction | n/a | **Rejected — this is the headline threat the ADR exists to prevent (§2)** |
+| 6 | OAuth-only (drop the static `?api_key=` path) | One auth path, no dual-path complexity | Breaks every existing Claude Code `.mcp.json` and `?api_key=` script (AC#2, AC#3); PO-locked the static path as permanent | n/a | Rejected — static path is permanent |
+| 7 | Plain PKCE allowed (accept `code_challenge_method=plain`) | Marginally simpler clients | `plain` PKCE offers no protection against code interception; S256 is the security baseline | n/a | Rejected — `plain` → 400 (§3) |
+| 8 | Discovery always-on regardless of transport | One less flag | Serves an OAuth flow that the SDK will reject over HTTP and that exposes tokens to interception; fails open | n/a | Rejected — fail-closed via `oauth_allow_insecure` (§4) |
+
+## Consequences
+
+### Positive
+
+- **Contract-lock for the OAuth children (`buiqr.2`–`buiqr.9`).** The AS/RS split, the offline-verification boundary, the dual-path-by-shape rule, the token-store location and hashing, the flag policy, and the scope/client model are each named once here and consumed by the children. Divergent implementations have nowhere to hide.
+- **The auth-bypass class is closed by construction.** Routing by credential shape, with no fail-cascade, means a failed OAuth validation can never become a static-key retry. The single most dangerous failure mode of dual auth is designed out, not patched after.
+- **Performance and failure-isolation envelopes are preserved.** Offline verification keeps the MCP request path in-process; an ECM hiccup does not take down authenticated MCP traffic, and the ≤5 ms latency budget (AC#11) is achievable.
+- **The existing static-key path is untouched.** Claude Code `.mcp.json` and `?api_key=` scripts keep working (AC#2, AC#3); the dual-path matrix is a permanent regression fixture.
+- **Mirrors existing ECM primitives.** HS256, `jti` revocation, and SHA-256 token hashing all reuse the patterns in `backend/auth/tokens.py` — less novel security code, fewer ways to get it wrong.
+- **Fail-closed on insecure transport.** The default `oauth_allow_insecure=false` means an HTTP-only deploy gets 404 discovery, not a silently-insecure OAuth flow.
+
+### Negative
+
+- **One shared HS256 secret to protect and rotate.** Both containers read it from `/config/settings.json`. Compromise of the secret allows token forgery; rotation invalidates all live tokens (acceptable given short TTLs). The threat model's secret-rotation / alg-confusion rows track this; protecting `settings.json` file permissions is the compensating control.
+- **Revocation is not instantaneous.** The offline-verification trade means a revoked token is honored until the RS sees the revocation (shared store, §6) or the TTL expires. Mitigated by short TTLs and the shared hashed-token store, but it is a real gap vs a callback design.
+- **A second auth path is permanent operational surface.** The dual-path matrix must be maintained forever (PO-locked). Every future change to either path must re-verify the shape-routing invariant.
+- **The HTTPS prerequisite shifts operator burden.** Operators on the typical `http://<LAN-IP>:6101` shape must set up a reverse proxy or accept the `oauth_allow_insecure` risk. This is documented (`buiqr.11`) but it is a real friction wall the epic explicitly accepted.
+
+### Neutral / Out of Scope
+
+- **TLS termination** is operator-supplied (reverse proxy); ECM does not manage it for the OAuth surface (§4, §8).
+- **CodeQL exposure** of the new OAuth routers is governed by ADR-005's delta-zero gate at PR time — no special carve-out.
+- **The static-key path's own threat surface** is unchanged from today and is not re-modeled here beyond the dual-path interaction (§2).
+
+## Exit Path
+
+If a decision here proves wrong:
+
+1. **Soft exit — flip `oauth_allow_insecure` semantics or default.** Single flag; a policy change is a one-line default change plus an ADR addendum and a doc update. Tightening (e.g., remove the HTTP escape hatch entirely) is safe; loosening requires Security re-confirmation.
+2. **Soft exit — shorten/lengthen token TTL.** TTL is a config value within the §3 envelope; shortening narrows the revocation gap, lengthening widens it. ADR addendum noting the new value and the revocation-gap analysis.
+3. **Additive exit — RS256 / JWKS for multi-host.** If a future deployment splits the two containers across hosts (no shared volume), publish a JWKS from the ECM AS and have the RS fetch+cache it. The token claims (`iss`/`aud`/`jti`/`sub`/`scope`) are algorithm-agnostic; only the signature primitive changes. Own ADR.
+4. **Additive exit — per-tool scopes.** The single `mcp` scope is carried as a `scope` claim; adding granular scopes is additive (new scope values, RS-side enforcement per tool). Out of scope for v1 (§8); future epic.
+5. **Hard exit — abandon offline verification for a callback.** Only if instant revocation becomes a hard requirement that short TTLs cannot satisfy. Reconsider against the AC#11 latency budget and the failure-isolation envelope. Own ADR; the §1 rationale is the evaluation baseline.
+
+No external vendor relationship is introduced; no new infrastructure beyond the SQLite token store the MCP container already has the volume for.
+
+## Open Questions
+
+### Resolved by the PO-locked epic (no PO action needed here)
+
+- **AS vs RS placement?** → ECM=AS, MCP=RS (§1).
+- **Offline verify vs runtime callback?** → Offline, shared HS256 secret, no per-request callback (§1).
+- **Dual-auth coexistence policy?** → Route by credential **shape**; never fail-cascade; OAuth failure never falls through to static key (§2).
+- **Identity model?** → Single ECM admin; token `sub` binds to admin (§3).
+- **PKCE method?** → S256 only; `plain` → 400 `invalid_request` (§3).
+- **Dynamic Client Registration?** → No; hardcoded client registry (§3).
+- **HTTP posture?** → `oauth_allow_insecure` default false; discovery 404 on plain HTTP unless set (§4).
+- **Token store?** → SQLite `/config/mcp_oauth.db`, WAL, MCP-managed, SHA-256 hashed-at-rest (§5).
+- **Scope model?** → Single `mcp` scope in v1 (§3, §8).
+- **Static `?api_key=` path?** → Permanent, no deprecation (§8); dual-path matrix is a permanent CI fixture.
+
+### Pending — AC#5
+
+- **PO sign-off on this ADR.** AC#5 of `buiqr.1` requires PO sign-off on the ADR **before any implementation child opens.** Status is therefore **Proposed**, not Accepted. PO sign-off flips this to Accepted and unblocks `buiqr.2`–`buiqr.9`.
+
+## References
+
+- Bead `enhancedchannelmanager-buiqr.1` — this ADR's tracker (ADR + STRIDE threat model)
+- Bead `enhancedchannelmanager-buiqr` — OAuth 2.1 epic; PO-locked decision record this ADR encodes
+- Bead `enhancedchannelmanager-ak7xa` (closed) — CI gate precondition for `mcp-server/tests/`
+- Beads `enhancedchannelmanager-buiqr.2` … `enhancedchannelmanager-buiqr.9` — implementation children consuming this ADR
+- `docs/security/threat_model_mcp_oauth.md` — STRIDE threat model companion (same bead)
+- `docs/architecture.md` → MCP Server — current static-key auth model + `settings.json` credential schema this ADR extends
+- `backend/auth/tokens.py` — HS256 + `jti` revocation + `hash_token()` SHA-256 pattern (§3, §5 mirror this)
+- `docs/adr/ADR-005-code-security-gating-strategy.md` — CodeQL delta-zero gate covering the new routers
+- `docs/adr/ADR-008-interactive-stream-dedup.md` — ADR template/format mirrored here
+- RFC 8414 (OAuth 2.0 Authorization Server Metadata), RFC 9728 (OAuth 2.0 Protected Resource Metadata), RFC 7636 (PKCE), RFC 7591 (Dynamic Client Registration — explicitly **not** implemented, §8)
+
+## Revision History
+
+| Date | Bead | Change | Rationale |
+|---|---|---|---|
+| 2026-05-20 | `enhancedchannelmanager-buiqr.1` | Proposed | Formalizes the PO-locked OAuth split from epic `buiqr` (2026-05-19 grooming). Contract-lock for `buiqr.2`–`buiqr.9`. Status Proposed pending AC#5 PO sign-off before any implementation child opens. |

--- a/docs/security/threat_model_mcp_oauth.md
+++ b/docs/security/threat_model_mcp_oauth.md
@@ -1,0 +1,281 @@
+# STRIDE Threat Model: MCP OAuth 2.1 (ECM as Authorization Server, MCP as Resource Server)
+
+**Bead:** `enhancedchannelmanager-buiqr.1` (ADR + STRIDE threat model — the security companion to `docs/adr/ADR-009-mcp-oauth-authorization-server-split.md`); informs implementation children `buiqr.2`–`buiqr.9`
+**Author:** Security Engineer persona (Claude)
+**Date:** 2026-05-20
+**Status:** Draft — pending PO review (AC#5 sign-off on ADR-009 + Assumptions §6 + Residual Risks §8)
+**Related:** epic `enhancedchannelmanager-buiqr` (PO-locked decisions), ADR-009 (the architecture this model secures — every mitigation below ties to an ADR-009 §section), `enhancedchannelmanager-ak7xa` (closed — CI gate precondition), `docs/architecture.md` (MCP Server static-key baseline + `settings.json` credential schema), `backend/auth/tokens.py` (HS256 + `jti` revocation + `hash_token()` patterns reused), `docs/adr/ADR-008-interactive-stream-dedup.md`, `docs/security/threat_model_dbas_import.md` (template mirrored)
+
+---
+
+## 1. Scope & System Overview
+
+Epic `buiqr` adds OAuth 2.1 + PKCE so Claude Desktop's **Custom Connector** UI can authenticate to ECM's MCP server **without** the Node.js `mcp-remote` bridge. The architecture (ADR-009) splits the OAuth roles across the two existing containers:
+
+- **ECM container = Authorization Server (AS):** hosts `GET /authorize` + consent UI, `POST /token` (PKCE S256), and `GET /.well-known/oauth-authorization-server`. It owns the admin user session.
+- **MCP container = Resource Server (RS):** hosts `GET /.well-known/oauth-protected-resource`, validates Bearer JWTs **offline** (HS256, shared secret from `/config/settings.json`, **no per-request callback to ECM**), and serves the `/mcp` tools surface.
+
+A **second** authentication path now coexists with the **permanent** static `?api_key=` path. The RS routes by credential **shape** (JWT-shaped → OAuth-only; static-key-shaped → static-key-only) and **never** fail-cascades from a failed OAuth validation to the static-key check (ADR-009 §2). Tokens are stored hashed-at-rest (SHA-256) in a MCP-managed SQLite DB at `/config/mcp_oauth.db` (WAL).
+
+This threat model covers the **OAuth subsystem ECM + MCP will build.** The current static-key MCP auth (`APIKeyAuthMiddleware`, `mcp_api_key`, per `docs/architecture.md`) is the **inherited baseline**; its protections are table stakes and the dual-path interaction is modeled here (§3.6) because two paths sharing one RS is precisely where auth-bypass bugs live.
+
+Attack surfaces modeled:
+
+1. **Discovery** — `/.well-known/oauth-authorization-server` (AS), `/.well-known/oauth-protected-resource` (RS): unauthenticated metadata, information leakage, HTTP-downgrade.
+2. **Authorization (`/authorize` + consent)** — browser-driven flow: redirect-URI validation, open-redirect, consent-phishing/clickjacking, PKCE downgrade.
+3. **Token (`/token`)** — code-for-token exchange: PKCE enforcement, code interception/replay, rate-limit bypass.
+4. **Resource access (`/mcp` Bearer validation)** — the dual-path-by-shape router: confused-deputy / fail-cascade bypass, token replay, JWT alg-confusion.
+5. **Token store** — `/config/mcp_oauth.db`: at-rest compromise, revocation correctness.
+6. **Shared secret** — the HS256 key in `settings.json`: forgery on compromise, rotation.
+7. **Cross-boundary** — MCP → Dispatcharr trust boundary; `dispatcharr_api_key` isolation.
+
+---
+
+## 2. Data Flow (Trust Boundaries)
+
+```
+[Admin browser / Claude Desktop] --TLS (operator-supplied proxy)-->
+   |
+   |--(discover)--> [MCP RS /.well-known/oauth-protected-resource] --points at--> [ECM AS]
+   |--(discover)--> [ECM AS /.well-known/oauth-authorization-server]
+   |
+   |--(/authorize + PKCE S256 challenge)--> [ECM AS] --> admin session (existing JWT auth)
+   |                                                  --> consent UI (client name pinned)
+   |<--(redirect to allowlisted redirect_uri + code)--
+   |
+   |--(/token: code + PKCE verifier)--> [ECM AS] --HS256 sign--> JWT (sub=admin, jti, aud=RS)
+   |                                            --writes hash--> [/config/mcp_oauth.db]
+   |
+   |--(/mcp + Authorization: Bearer <JWT>)--> [MCP RS dual-path-by-shape router]
+   |                                            --offline HS256 verify (shared secret)
+   |                                            --reads revocation--> [/config/mcp_oauth.db]
+   |                                            --> ~110 MCP tools --> [ECM backend :6100]
+   |                                                                 --> [Dispatcharr (separate boundary)]
+[Claude Code / scripts] --(/mcp + ?api_key= OR Bearer static-key)--> [static-key path only]
+```
+
+Trust boundaries crossed:
+
+- **Client → operator-supplied TLS proxy → ECM AS / MCP RS** (the network boundary; **TLS is operator-supplied**, not ECM-managed — ADR-009 §4/§8).
+- **AS ⇄ shared `/config/settings.json`** (HS256 secret, `oauth_allow_insecure`, `mcp_api_key`).
+- **AS ⇄ `/config/mcp_oauth.db` ⇄ RS** (hashed tokens; the **only** shared OAuth state — no runtime HTTP coupling between AS and RS, ADR-009 §1/§5).
+- **MCP RS → ECM backend → Dispatcharr** (the existing service boundary; Dispatcharr is admin-configured & trusted per the existing model; the OAuth token must **not** widen authority beyond the admin's existing reach — §3.6 / threat O1).
+
+---
+
+## 3. STRIDE Analysis
+
+**Legend:** `status` ∈ {**baseline** (already enforced by the existing static-key MCP auth or ECM JWT subsystem), **to-build** (an OAuth child `buiqr.2`–`buiqr.9` must implement), **accepted-risk** (PO-signed deviation)}.
+Each row's mitigation cites the ADR-009 §section it derives from. Severity is relative to the **MCP OAuth subsystem**, not the whole product.
+
+### 3.1 Spoofing
+
+| # | Surface | Threat | Attack scenario | Mitigation (ADR-009 ref) | Status | Sev |
+|---|---------|--------|-----------------|--------------------------|--------|-----|
+| SP1 | Token validation | Attacker forges a Bearer JWT to impersonate the admin | Attacker crafts a JWT with `sub`=admin and presents it to `/mcp` | Offline HS256 verify against the shared secret rejects any signature not produced by the AS (§1); secret never leaves `/config/settings.json` (§6/SR1) | to-build (`buiqr.8`) | High |
+| SP2 | Token validation | **JWT `alg` confusion / `alg:none`** — attacker submits a token with `alg:none` or swaps HS256→RS256 to bypass signature check | Token header set to `{"alg":"none"}` or `{"alg":"RS256"}` so the verifier "validates" with no/attacker key | Verifier pins **exactly `HS256`** and rejects any other `alg` (incl. `none`) with 401; mirrors `backend/auth/tokens.py` `ALGORITHM = "HS256"`. Explicit allowlist, not "whatever the header says" (§1, §3) | to-build (`buiqr.8`) | **High** |
+| SP3 | `/authorize` | Unauthenticated actor reaches `/authorize` and obtains a code | Attacker hits `/authorize` without an admin session | `/authorize` requires the existing ECM admin session before rendering consent (§3); no session → ECM login | to-build (`buiqr.3`/`buiqr.7`) | High |
+| SP4 | Client identity | Attacker registers/spoofs a client to obtain tokens | Attacker presents an unknown or look-alike `client_id` | Hardcoded client registry; unknown `client_id` rejected; **no Dynamic Client Registration** (§3) | to-build (`buiqr.6`) | High |
+| SP5 | Discovery | Rogue server impersonates the AS to a client | Attacker MITMs discovery and points the client at an attacker AS | Operator-supplied TLS authenticates the AS host; RS protected-resource doc names the canonical AS issuer; discovery 404 on plain HTTP unless opted in (§4/§7) | baseline + to-build | Med |
+| SP6 | Static-key path | Static key presented as a forged OAuth session | Attacker submits the static key shaped as a JWT to confuse routing | Routing is by **shape** decided pre-validation; a static-key value is not JWT-shaped so it never enters the OAuth path, and vice-versa (§2) | to-build (`buiqr.8`) | Med |
+
+### 3.2 Tampering
+
+| # | Surface | Threat | Attack scenario | Mitigation (ADR-009 ref) | Status | Sev |
+|---|---------|--------|-----------------|--------------------------|--------|-----|
+| T1 | Token in transit | MITM modifies the Bearer token / authorization code in flight | Plain-HTTP deploy; attacker on the LAN rewrites the token | TLS (operator-supplied) is the in-transit integrity control; on plain HTTP, OAuth is **off by default** (discovery 404, §4) — the operator must explicitly opt in (HT1) | baseline + to-build | High |
+| T2 | Token contents | Attacker mutates JWT claims (e.g., extends `exp`, changes `scope`) | Edit the payload segment of a captured token | HS256 signature covers header+payload; any claim mutation invalidates the signature → 401 (§1) | to-build (`buiqr.8`) | High |
+| T3 | PKCE | **PKCE downgrade** — attacker forces `plain` to defeat code-interception protection | Client/attacker sends `code_challenge_method=plain` | **S256 only**; `plain` (or missing challenge) rejected with **400 `invalid_request`** at `/authorize` and `/token` (§3, AC#5) | to-build (`buiqr.3`) | **High** |
+| T4 | Token store | Attacker tampers with `mcp_oauth.db` to un-revoke or forge a token record | Write access to `/config/mcp_oauth.db` | Store holds **hashes**, not tokens — cannot reconstruct a usable token from a record (§5); file lives on the protected `/config` volume (filesystem perms = compensating control, §6/TS1) | to-build (`buiqr.2`) | Med |
+| T5 | Settings flag | Attacker flips `oauth_allow_insecure=true` to enable HTTP OAuth | Write access to `settings.json` | Flag default false; flipping it requires write access to `settings.json` (same trust level as the HS256 secret itself — if an attacker has that, the secret is already lost). Change is operator-visible in `settings.json` (§4) | to-build (`buiqr.5`) | Med |
+| T6 | Consent params | Tampered `redirect_uri` / `return_to` to redirect the code/flow | Attacker alters the redirect target in the authorize request | **Exact-match allowlist** of `redirect_uri` against the hardcoded client registry; consent `return_to` enforced same-origin/allowlist (§3 — see RD1, OR1) | to-build (`buiqr.6`/`buiqr.7`) | High |
+
+### 3.3 Repudiation
+
+| # | Surface | Threat | Attack scenario | Mitigation (ADR-009 ref) | Status | Sev |
+|---|---------|--------|-----------------|--------------------------|--------|-----|
+| R1 | Consent grant | Admin denies having authorized Claude Desktop | Dispute over who granted access | AS writes an audit/journal entry at consent: user (admin `sub`), client name, scope, timestamp, request id; token carries `jti` for later correlation (§3, §5; mirrors `backend/auth/tokens.py` `jti`) | to-build (`buiqr.3`/`buiqr.7`) | Med |
+| R2 | Token issuance | No record of which token was issued / to which client | Untraceable token in the wild | `/token` records the issued token's `jti`+hash in `mcp_oauth.db` with client + issued-at (§5) | to-build (`buiqr.2`/`buiqr.3`) | Med |
+| R3 | Revocation | No record of a revocation action | Dispute over whether a token was revoked | Revocation marks the `jti`/hash record revoked with a timestamp; mirrors `revoke_token(jti)` (§5) | to-build (`buiqr.2`) | Low |
+| R4 | Resource access | Cannot distinguish an OAuth-authenticated call from a static-key call in logs | Audit blind spot if both paths log identically | Shape-routing means the path is known before tool dispatch; the RS records auth-mode (oauth vs static-key) per request — the dual-path distinction is preserved, not collapsed (§2 — a side benefit of refusing fail-cascade) | to-build (`buiqr.8`) | Med |
+
+### 3.4 Information Disclosure
+
+| # | Surface | Threat | Attack scenario | Mitigation (ADR-009 ref) | Status | Sev |
+|---|---------|--------|-----------------|--------------------------|--------|-----|
+| ID1 | Discovery | **`/.well-known/*` leaks secrets or host-internal details** | Anyone GETs the public discovery docs and reads the HS256 secret, the internal Docker host `ecm:6100`, filesystem paths, or `mcp_api_key` | Discovery docs expose **only** protocol-required fields (issuer, endpoint URLs, `code_challenge_methods=["S256"]`, `scopes=["mcp"]`); **never** the secret, internal hostnames, paths, or the static key; shape pinned by snapshot tests (§7, AC#4) | to-build (`buiqr.5`) | **High** |
+| ID2 | Token store | At-rest compromise of `mcp_oauth.db` yields usable tokens | Attacker reads the DB file from a backup or the volume | Tokens **hashed-at-rest (SHA-256)** — a stolen record is a hash, not a bearer credential (§5, mirrors `hash_token()`) | to-build (`buiqr.2`) | High |
+| ID3 | Token in transit | Token observed on plain HTTP and read | Plain-HTTP deploy; passive sniffer captures the Bearer token | OAuth off by default on HTTP (discovery 404, §4); if opted in, the operator accepted this (HT1) — short TTL bounds the window (§3) | to-build (`buiqr.5`) | High |
+| ID4 | Error responses | Error bodies leak stack traces / secret material / internal paths | Malformed `/token` request returns a verbose 500 | Errors return short OAuth-standard codes (`invalid_request`, `invalid_grant`, etc.); full detail server-side only (mirrors existing ECM error pattern) | to-build (`buiqr.3`) | Med |
+| ID5 | Backup/export | The HS256 secret or `mcp_oauth.db` is swept into an export artifact in plaintext | Operator exports config; the OAuth secret rides along | The HS256 secret is credential-class in `settings.json` and MUST be in the shared `_SETTINGS_CREDENTIAL_FIELDS` redaction tuple (`backup.py`), same as `mcp_api_key`/`dispatcharr_api_key` (§5/§6; ties to `docs/architecture.md` redaction rule) | to-build (`buiqr.4`) | Med |
+
+### 3.5 Denial of Service
+
+| # | Surface | Threat | Attack scenario | Mitigation (ADR-009 ref) | Status | Sev |
+|---|---------|--------|-----------------|--------------------------|--------|-----|
+| D1 | `/token` | **Brute-force / rate-limit bypass** on the token endpoint | Attacker floods `/token` guessing codes or grinding the secret | **Rate limiting per-IP + per-user** on `/token` (§6, AC#9); short-lived single-use authorization codes (§3) | to-build (`buiqr.4`) | High |
+| D2 | `/authorize` | Consent-spam / authorization-flood | Attacker hammers `/authorize` to exhaust the AS or spam the admin | **Rate limiting per-IP + per-user** on `/authorize` (§6, AC#9) | to-build (`buiqr.4`) | Med |
+| D3 | Token validation | Offline verify is cheap by design — DoS via expensive validation is low | Flood `/mcp` with tokens | In-process HMAC verify is O(token size); no per-request callback to amplify (§1); the static-key path's existing protections apply to its share | to-build (`buiqr.8`) | Low |
+| D4 | Token store | `mcp_oauth.db` lock contention / unbounded growth | High token-issuance rate bloats the DB or WAL | WAL mode (§5); single-admin issuance keeps volume bounded; a reaper for expired/revoked rows is an additive lever (Assumptions §6/A4) | to-build (`buiqr.2`) | Low |
+
+### 3.6 Elevation of Privilege
+
+| # | Surface | Threat | Attack scenario | Mitigation (ADR-009 ref) | Status | Sev |
+|---|---------|--------|-----------------|--------------------------|--------|-----|
+| **CD1** | Dual-auth router | **Confused-deputy via dual-auth fail-cascade (THE HEADLINE THREAT)** | Attacker presents a JWT-shaped-but-invalid Bearer value (bad signature / expired / `alg:none`); a fail-cascade design would "fall back" to evaluating it as a static key, collapsing OAuth's guarantees onto the weaker path — or an OAuth misconfig silently routes all traffic to static-key | **Route by credential SHAPE, decided before any validation.** JWT-shaped → OAuth-only; **OAuth-validation FAILURE returns 401 and NEVER falls through to the static-key check.** Static-key-shaped → static-key-only. No path retries the other on failure (§2, AC#2/AC#7). Dedicated regression test asserts a JWT-shaped-but-invalid token is **not** evaluated as a static key (`buiqr.9`) | to-build (`buiqr.8`/`buiqr.9`) | **Crit** |
+| **RD1** | `/authorize` | **Redirect-URI not validated → token/code delivered to attacker** | Attacker uses a legit `client_id` with an attacker-controlled `redirect_uri`; the code is sent to the attacker | **Exact-match allowlist** of `redirect_uri` against the hardcoded client registry (no prefix/substring/wildcard matching); mismatch rejected before code issuance (§3) | to-build (`buiqr.6`) | **High** |
+| **OR1** | Consent `return_to` | **Open-redirect via consent `return_to`** | Consent flow carries a `return_to`/post-consent param set to `https://evil.example`; ECM redirects the admin there, enabling phishing/credential capture | `return_to` enforced **same-origin / allowlist**; any off-allowlist target rejected or replaced with a safe default (§3) | to-build (`buiqr.7`) | High |
+| **CP1** | Consent UI | **Consent-phishing / clickjacking** | Attacker frames the consent page (clickjacking) or crafts a flow that tricks the admin into approving a malicious client; or vague copy hides what is being granted | Anti-framing headers (`X-Frame-Options: DENY` / `frame-ancestors 'none'` CSP); **client name pinned from the hardcoded registry** (not attacker input); **clear consent copy** — the PO-locked single-`mcp`-scope wording naming exactly what is granted (§3) | to-build (`buiqr.7`) | High |
+| **O1** | MCP → Dispatcharr | **Dispatcharr trust boundary — OAuth token grants beyond the admin's existing authority** | An OAuth-authenticated MCP call reaches Dispatcharr with more reach than the admin already has, or leaks `dispatcharr_api_key` through the OAuth path | The OAuth token authorizes the admin acting **as themselves**; MCP→Dispatcharr uses the existing `dispatcharr_api_key` exactly as today — the OAuth token does **not** widen Dispatcharr authority. `dispatcharr_api_key` is **never referenced in OAuth code paths** (CI grep guard, §6, AC#10) | to-build (`buiqr.4`/`buiqr.8`) | High |
+| EP1 | Token scope | Token used outside its intended audience/scope | A token minted for the MCP RS is replayed against another endpoint, or the single `mcp` scope is ignored | `aud` claim bound to the MCP RS and checked; `scope=mcp` carried and enforced; single-scope in v1 (§3) | to-build (`buiqr.8`) | Med |
+| EP2 | Static-key path | OAuth bug silently widens the static-key path's reach | A shared helper change affects both paths | The two paths are dispatched separately by shape; no shared validation fallthrough (§2); dual-path matrix is a permanent CI fixture (epic AC#3) | to-build (`buiqr.8`/`buiqr.9`) | Med |
+
+### 3.7 Transport / Deployment-posture threats (HTTP-only)
+
+| # | Surface | STRIDE | Threat | Attack scenario | Mitigation (ADR-009 ref) | Status | Sev |
+|---|---------|--------|--------|-----------------|--------------------------|--------|-----|
+| **HT1** | Whole flow | Info-Disclosure / Tampering | **Token-replay over plain HTTP / HTTP-only deploy downgrade** | Operator runs `http://<LAN-IP>:6101`; tokens, codes, and the PKCE exchange traverse cleartext; a LAN attacker captures and **replays** a Bearer token | **Fail-closed:** discovery returns **404 on plain HTTP** unless `oauth_allow_insecure=true` is explicitly set (§4, AC#6) — the default refuses the insecure flow. If opted in, the operator accepted the risk; **short access-token TTL** bounds the replay window (§3); docs steer operators to HTTPS via reverse proxy (`buiqr.11`) | to-build (`buiqr.5`) | **High** |
+| HT2 | Discovery | Info-Disclosure | SDK http-issuer rejection masks a misconfig as "OAuth broken" | Operator on HTTP can't connect, doesn't know why | The `oauth_allow_insecure` flag is the documented, deliberate switch; the 404 is intentional fail-closed behavior, documented in the HTTPS guide (`buiqr.11`) | to-build (`buiqr.5`) | Low |
+
+### 3.8 Secret-management threats (shared HS256 key)
+
+| # | Surface | STRIDE | Threat | Attack scenario | Mitigation (ADR-009 ref) | Status | Sev |
+|---|---------|--------|--------|-----------------|--------------------------|--------|-----|
+| **SR1** | Shared HS256 secret | Spoofing / EoP | **Shared-secret compromise → universal token forgery** | Attacker reads the HS256 secret from `settings.json` (volume access, backup leak, export) and mints valid admin tokens at will | Secret is credential-class: file perms on `/config/settings.json` (compensating control); MUST be redacted from every export path via `_SETTINGS_CREDENTIAL_FIELDS` (§6, ID5); compromise is recoverable by **rotation** (SR2) | to-build (`buiqr.4`) | **High** |
+| SR2 | Secret rotation | Availability / EoP | **Rotation of the shared secret invalidates all live tokens (or fails to)** | Operator rotates the HS256 key; either all Claude Desktop sessions break with no warning, or stale tokens keep validating because rotation wasn't propagated to the RS | Both containers read the secret from the **same** `settings.json` (single source); rotation invalidates all live tokens **by design** (acceptable — short TTL means re-consent is cheap); document the operator-facing effect (re-add the connector) in `buiqr.11`. No second copy of the secret to drift | to-build (`buiqr.4`/`buiqr.11`) | Med |
+
+### 3.9 Token-store threats (`/config/mcp_oauth.db`)
+
+| # | Surface | STRIDE | Threat | Attack scenario | Mitigation (ADR-009 ref) | Status | Sev |
+|---|---------|--------|--------|-----------------|--------------------------|--------|-----|
+| TS1 | `mcp_oauth.db` | Info-Disclosure / Tampering | At-rest compromise or tamper of the token store | See ID2 (disclosure) + T4 (tamper) | Hashes-not-tokens (§5); `/config` volume perms; WAL durability; (cross-ref ID2/T4) | to-build (`buiqr.2`) | Med |
+| TS2 | Revocation read | EoP | **Revocation gap** — a revoked token keeps working because the RS verifies offline and hasn't seen the revocation | Admin revokes a token; offline RS honors it until TTL or until it reads the revocation record | RS consults the shared store's revocation state on validation (§5); **short TTL** is the backstop (§3); the gap is the documented offline-verification trade-off (ADR-009 §1) | to-build (`buiqr.8`) | Med |
+
+**Cell coverage note.** The six canonical STRIDE dimensions are all covered (§3.1–§3.6), plus three deployment/secret/store dimension tables (§3.7–§3.9) where a single surface warranted dedicated rows. Every grooming-named concern from AC#4 appears as an explicit row — see the AC#4 coverage map in §7.
+
+---
+
+## 4. Hardening Checklist (acceptance criteria for the OAuth children)
+
+The OAuth implementation must satisfy **all** of the following, each mapped to STRIDE rows above and to the epic's acceptance criteria:
+
+1. **Dual-path-by-shape routing, no fail-cascade** — the RS classifies by credential shape before validation; a JWT-shaped-but-invalid token returns 401 and is **never** evaluated as a static key. Regression test asserts this. *(CD1, SP6, EP2 — epic AC#2/AC#7)*
+2. **JWT `alg` pinned to HS256** — verifier rejects `alg:none`, `RS256`, or any non-HS256 algorithm. *(SP2, T2)*
+3. **PKCE S256 only** — `plain` or missing `code_challenge_method` → 400 `invalid_request` at `/authorize` and `/token`. *(T3 — epic AC#5)*
+4. **Exact-match redirect-URI allowlist** — `redirect_uri` matched exactly against the hardcoded client registry; no wildcard/prefix/substring matching. *(RD1, T6)*
+5. **Open-redirect guard on consent `return_to`** — same-origin/allowlist enforced; off-allowlist rejected or defaulted. *(OR1, T6)*
+6. **Consent anti-framing + pinned client name + clear copy** — `X-Frame-Options: DENY` / CSP `frame-ancestors 'none'`; client name from the registry; PO-locked single-`mcp`-scope copy. *(CP1)*
+7. **`oauth_allow_insecure` fail-closed** — discovery returns 404 on plain HTTP unless the flag is explicitly true; default false. *(HT1, HT2, ID3 — epic AC#6)*
+8. **Discovery hygiene** — `/.well-known/*` exposes only protocol-required fields; no secret, internal hostname, path, or static-key leakage; shape pinned by snapshot tests. *(ID1, SP5 — epic AC#4)*
+9. **Tokens hashed-at-rest** — `mcp_oauth.db` stores SHA-256 hashes (mirroring `hash_token()`), never plaintext tokens. *(ID2, TS1 — epic AC#8)*
+10. **Rate limiting on `/authorize` + `/token`** — per-IP + per-user. *(D1, D2 — epic AC#9)*
+11. **`dispatcharr_api_key` isolation** — never referenced in any OAuth code path; CI grep guard returns zero hits. *(O1 — epic AC#10)*
+12. **Secret + token-store redaction in exports** — the HS256 secret and `mcp_oauth.db` are credential-class; covered by `_SETTINGS_CREDENTIAL_FIELDS` / export redaction. *(ID5, SR1)*
+13. **Audience + scope enforcement** — `aud` bound to the MCP RS and checked; `scope=mcp` carried and enforced. *(EP1)*
+14. **Single-use, short-TTL authorization codes + short-TTL access tokens** — bounds code-replay and the offline revocation gap. *(D1, TS2, HT1)*
+15. **Revocation read on validation** — RS consults the shared store's revocation state; mirrors `revoke_token(jti)`. *(TS2, R3)*
+16. **Audit on consent / issuance / revocation** — AS journals consent (admin `sub`, client, scope, request id), token issuance (`jti`+hash), and revocation; RS records auth-mode per request. *(R1, R2, R3, R4)*
+17. **Error-response hygiene** — OAuth-standard short error codes; full detail server-side only. *(ID4)*
+
+---
+
+## 5. Test Cases (for `mcp-server/tests/` and `backend/tests/security/`)
+
+> The `mcp-server/tests/` suite is now CI-gated (precondition `enhancedchannelmanager-ak7xa`, closed), so these tests will not rot silently. Detailed test infrastructure lands in `buiqr.9`.
+
+- `test_dual_path_routing.py` *(CD1 — the headline)*
+  - `test_invalid_jwt_not_evaluated_as_static_key` — JWT-shaped Bearer with bad signature → 401, and the value is **never** compared to `mcp_api_key`.
+  - `test_expired_jwt_returns_401_no_fallback` — expired token → 401, no static-key retry.
+  - `test_alg_none_rejected` — `{"alg":"none"}` token → 401. *(SP2)*
+  - `test_static_key_path_unaffected` — `?api_key=` and `Bearer <static-key>` still authenticate (epic AC#2/AC#3).
+- `test_pkce.py` *(T3)*
+  - `test_plain_method_rejected_400` — `code_challenge_method=plain` → 400 `invalid_request`.
+  - `test_missing_challenge_rejected` — no challenge → 400.
+- `test_redirect_validation.py` *(RD1, OR1)*
+  - `test_unregistered_redirect_uri_rejected` — off-allowlist `redirect_uri` → rejected before code issuance.
+  - `test_redirect_uri_exact_match_only` — a prefix/substring of a registered URI → rejected.
+  - `test_consent_return_to_off_origin_rejected` — `return_to=https://evil` → rejected/defaulted.
+- `test_consent.py` *(CP1)*
+  - `test_consent_sets_anti_framing_headers`.
+  - `test_consent_pins_client_name_from_registry` — attacker-supplied client name not reflected.
+- `test_discovery.py` *(ID1, HT1, AC#4)*
+  - `test_well_known_shape_snapshot` — RFC 8414 / RFC 9728 shape pinned.
+  - `test_discovery_no_secret_or_internal_host` — grep response for the HS256 secret, `ecm:6100`, paths, `mcp_api_key` → absent.
+  - `test_discovery_404_on_plain_http_when_insecure_false`.
+  - `test_discovery_200_on_plain_http_when_insecure_true`.
+- `test_token_store.py` *(ID2, TS2)*
+  - `test_tokens_hashed_at_rest` — DB row contains a SHA-256 hash, not the token.
+  - `test_revoked_token_rejected` — revoke then validate → 401.
+- `test_rate_limit.py` *(D1, D2)*
+  - `test_token_endpoint_rate_limited` / `test_authorize_endpoint_rate_limited`.
+- `test_dispatcharr_isolation.py` *(O1)*
+  - `test_no_dispatcharr_api_key_in_oauth_paths` — CI grep guard / static assertion.
+
+---
+
+## 6. Assumptions & Trust Boundaries (PO decisions where flagged)
+
+This preamble states what the model assumes; deviations change the risk picture and need PO confirmation.
+
+- **TB1 — TLS is operator-supplied, not ECM-managed.** ECM does not terminate TLS for the OAuth surface; the operator fronts MCP with a reverse proxy (Caddy/nginx/Traefik) or ECM's `:6143`. In-transit confidentiality/integrity (T1, ID3, HT1) **depends on the operator doing this.** PO-locked (ADR-009 §4/§8). The `oauth_allow_insecure` flag is the explicit acknowledgment that an operator may run without it.
+- **TB2 — Both containers co-locate and share `/config`.** The AS/RS split assumes the two containers share the `/config` volume (HS256 secret, `oauth_allow_insecure`, `mcp_oauth.db`). HS256 (symmetric) is justified by this co-location (ADR-009 §1). A future multi-host split is the documented RS256/JWKS exit path, **out of scope** here.
+- **TB3 — `/config/settings.json` write access ≈ full trust.** Anyone who can write `settings.json` already controls the HS256 secret, so threats whose precondition is `settings.json` write access (T5, SR1) are bounded by the same trust level as secret compromise. The mitigation is filesystem perms on `/config`, which is an operational/deployment control, not OAuth code.
+- **TB4 — Dispatcharr is the existing admin-configured, trusted boundary.** The OAuth token does not change the MCP→Dispatcharr relationship; Dispatcharr is reached with `dispatcharr_api_key` as today (O1). Cross-instance / untrusted-Dispatcharr scenarios are out of scope (consistent with the existing model).
+- **TB5 — Single ECM admin identity.** v1 binds tokens to the single admin (`sub`). **Multi-tenant per-user grants are out of scope** (ADR-009 §8). If multi-admin/multi-user ECM auth lands later, this model must be revisited for per-user token scoping. **PO to confirm** single-admin is the v1 posture (it is, per epic — flagged for traceability).
+- **A1 — Offline-verification revocation gap is acceptable.** Tokens are verified offline; revocation propagates via the shared store + TTL, not instantly (TS2, ADR-009 §1). **PO to confirm** that a bounded revocation gap (≤ token TTL) is acceptable for v1 in exchange for the latency (AC#11) and failure-isolation properties. *(This is the central security/perf trade — the PO already accepted offline verification at grooming; restated here for the AC#5 sign-off.)*
+- **A2 — Access-token TTL value.** The model assumes a short TTL (in the spirit of ECM's existing `ACCESS_TOKEN_EXPIRE_MINUTES = 30`). The exact value is `buiqr.3`'s call within that envelope; a longer TTL widens HT1 (replay) and TS2 (revocation gap). **PO to ratify** the TTL ceiling.
+- **A3 — Rate-limit thresholds.** Per-IP + per-user limits on `/authorize` and `/token` are mandated (D1, D2); the concrete numbers are `buiqr.4`'s call. **PO to ratify** thresholds sized to single-admin usage.
+- **A4 — Token-store reaper deferred.** Expired/revoked rows in `mcp_oauth.db` are not auto-pruned in v1 (D4); single-admin volume keeps this small. An additive reaper is a backlog candidate if the table grows. **PO to confirm** deferral is acceptable.
+
+---
+
+## 7. AC#4 Coverage Map (every grooming concern → STRIDE row)
+
+AC#4 of `buiqr.1`: *every concern from grooming must appear as a row.* Coverage:
+
+| Grooming concern | STRIDE row(s) | Section |
+|---|---|---|
+| **Confused-deputy via dual-auth (fail-cascade bypass — headline)** | **CD1** | §3.6 |
+| **Redirect-URI validation** | **RD1** (+ T6) | §3.6 / §3.2 |
+| **Open-redirect via consent `return_to`** | **OR1** (+ T6) | §3.6 / §3.2 |
+| **Token-replay over plain HTTP** | **HT1** (+ ID3, T1) | §3.7 |
+| **Consent-phishing (clickjacking/framing, copy, client pinning)** | **CP1** | §3.6 |
+| **Dispatcharr trust boundary / `dispatcharr_api_key` isolation** | **O1** | §3.6 |
+| **HTTP-only deploy (discovery 404 unless opt-in, downgrade)** | **HT1, HT2** | §3.7 |
+| **Discovery-endpoint information leakage** | **ID1** (+ SP5) | §3.4 / §3.1 |
+| *Security-Engineer-added:* PKCE downgrade / `plain` | T3 | §3.2 |
+| *Security-Engineer-added:* JWT alg-confusion / `alg:none` | SP2 | §3.1 |
+| *Security-Engineer-added:* token-store at-rest compromise | ID2, TS1 | §3.4 / §3.9 |
+| *Security-Engineer-added:* revocation gap (offline verify) | TS2 | §3.9 |
+| *Security-Engineer-added:* rate-limit bypass / brute-force | D1, D2 | §3.5 |
+| *Security-Engineer-added:* shared HS256 secret compromise + rotation | SR1, SR2 | §3.8 |
+| *Security-Engineer-added:* audit/auth-mode distinction | R1–R4 | §3.3 |
+
+All eight grooming-named concerns from AC#4 are present, plus seven Security-Engineer-added rows the architecture's shape warranted.
+
+---
+
+## 8. Residual Risks Accepted for v1
+
+These remain after the §4 mitigations; each is bounded and noted for the PO's AC#5 sign-off.
+
+- **Residual: offline-verification revocation gap — Medium, accepted (A1/TS2).** A revoked token is honored until the RS reads the revocation or the TTL expires. Mitigated by short TTL + shared-store revocation read. Not closeable without a per-request callback, which the architecture deliberately rejects (latency AC#11 + failure isolation). The narrower the TTL, the smaller the gap.
+- **Residual: token-replay on opt-in HTTP — Medium, operator-accepted (HT1).** When `oauth_allow_insecure=true`, tokens traverse cleartext and can be replayed within their TTL. Bounded by the explicit opt-in (default fails closed) and short TTL. The operator chose this; the safe default is HTTPS.
+- **Residual: shared-secret compromise → token forgery — High impact / Low likelihood, accepted with compensating controls (SR1).** Whoever can read the HS256 secret can forge admin tokens. Likelihood is gated by `/config` filesystem perms and export redaction; impact is recoverable by rotation (which invalidates all live tokens). No KMS/HSM for v1 (consistent with the existing `settings.json`-stored credentials posture).
+- **Residual: authenticated-admin abuse — Low, inherent.** The single ECM admin can authorize Claude Desktop and then drive any MCP tool — that is the feature. The OAuth layer authenticates *that the admin* granted access; it does not constrain what the admin (or an agent acting on their behalf) may do beyond the single `mcp` scope. Bounded by single-admin identity (TB5) and the consent audit trail (R1). Per-tool scopes (a future epic) would narrow this.
+- **Residual: token-store growth — Low, deferred (A4/D4).** No reaper in v1; single-admin volume keeps `mcp_oauth.db` small. Additive cleanup is the lever if it grows.
+- **Residual: SDK/transport behavior on HTTP — Low (HT2).** The MCP SDK 1.27.0 http-issuer rejection means HTTP-only operators get a 404, which is intentional fail-closed but can read as "OAuth broken." Mitigated by docs (`buiqr.11`); not a security exposure, an operability one.
+
+---
+
+## 9. Related Work & References
+
+- `docs/adr/ADR-009-mcp-oauth-authorization-server-split.md` — **the architecture this model secures; every mitigation cites an ADR-009 §section.**
+- Epic `enhancedchannelmanager-buiqr` — PO-locked OAuth decisions (the source of truth).
+- `enhancedchannelmanager-buiqr.2`–`buiqr.9` — implementation children; the §4 checklist items are their acceptance criteria.
+- `enhancedchannelmanager-ak7xa` (closed) — CI gate for `mcp-server/tests/`; the precondition that keeps the §5 tests from rotting.
+- `docs/architecture.md` → MCP Server — current static-key auth baseline + `settings.json` credential schema (the `_SETTINGS_CREDENTIAL_FIELDS` redaction rule §3.4/ID5 reuses).
+- `backend/auth/tokens.py` — HS256 (`ALGORITHM = "HS256"`), `jti` revocation set, `revoke_token(jti)`, `hash_token()` (SHA-256) — the primitives this model's mitigations mirror.
+- `docs/security/threat_model_dbas_import.md` — template mirrored (sections, table shape, status/severity columns, residual-risk closing).
+- `docs/adr/ADR-005-code-security-gating-strategy.md` — CodeQL delta-zero gate covering the new OAuth routers at PR time.
+- RFC 8414 (AS metadata), RFC 9728 (protected-resource metadata), RFC 7636 (PKCE), RFC 6749/9700 (OAuth 2.0 / 2.1 security BCP), RFC 7591 (DCR — **not** implemented).


### PR DESCRIPTION
First child of epic `enhancedchannelmanager-buiqr`. Formalizes the PO-locked OAuth 2.1 AS/RS architecture + STRIDE threat model before any code child opens.

- **ADR-009** (Status: Proposed): AS/RS split, offline HS256 verify, **dual-path-by-shape routing (no fail-cascade)**, single-admin identity, hardcoded clients, PKCE S256-only, `oauth_allow_insecure` flag, SQLite token store w/ SHA-256 hashing, rate limiting, `dispatcharr_api_key` isolation.
- **STRIDE threat model**: all 8 grooming concerns as rows + 4 added (PKCE downgrade, alg-confusion, secret rotation, token-store at-rest).

Docs-only; version touchpoints untouched. **AC#5 (PO sign-off) delegated to async morning review** per the overnight directive — ADR stays Proposed until signed off; bead buiqr.1 remains open until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)