### PR TITLE
refactor(mcp-oauth): re-home OAuth store to backend (ECM-owned) — Option A (bd-buiqr.2 + bd-gswk2, v0.17.1-0077)

### DIFF
--- a/backend/auth/oauth_store.py
+++ b/backend/auth/oauth_store.py
@@ -2,13 +2,24 @@
 
 Foundation layer of the OAuth 2.1 epic (``enhancedchannelmanager-buiqr``).
 This module is a clean, framework-agnostic data layer; it holds **no** HTTP
-logic, no MCP-SDK coupling, and no FastAPI/Starlette dependency. The
-Authorization Server (ECM, bead ``buiqr.3``) and the Resource Server (MCP,
-bead ``buiqr.8``) both consume this store. Per ADR-009 §1 and §5 the two
-containers **share the SQLite file, not an HTTP endpoint** — the AS *writes*
-hashed token/code/refresh/revocation records and the RS *reads* them for
-validation/revocation. Neither calls the other at runtime, preserving the
-failure-isolation envelope.
+logic, no MCP-SDK coupling, and no FastAPI/Starlette dependency.
+
+OWNERSHIP — ECM-OWNED, SINGLE WRITER (ADR-009 §1/§5, Option A — gswk2)
+================================================================================
+This store is owned **exclusively by the ECM container** (the Authorization
+Server, bead ``buiqr.3``). ECM mounts ``/config`` read-write and is the sole
+process that creates, reads, and writes ``/config/mcp_oauth.db``. The MCP
+container (the Resource Server, bead ``buiqr.8``) mounts ``/config``
+**read-only** and does **not** touch this DB at all: it validates Bearer JWTs
+purely offline (HS256 signature verify against the shared secret it already
+reads from ``settings.json``), and the revocation window is bounded by a short
+access-token TTL (≤ 15 min) rather than by the RS reading a revocation table.
+
+This re-homes the module from ``mcp-server/`` to ``backend/auth/`` and reverses
+the original "MCP-container-managed, RS-reads-the-shared-file" design (epic
+PO-locked decision #3): the MCP container's ``/config:ro`` mount makes both
+writing the DB and reliably reading a live WAL DB infeasible from MCP. See
+blocker ``enhancedchannelmanager-gswk2`` and ADR-009's revision history.
 
 Security posture (ADR-009 §5, threat model TS1/T3/SP*):
   - **Hashed-at-rest.** Token/code values are SHA-256 hashed before storage,
@@ -16,23 +27,24 @@ Security posture (ADR-009 §5, threat model TS1/T3/SP*):
     (``hashlib.sha256(value.encode()).hexdigest()``). A read of the DB yields
     hashes, not bearer credentials (TS1).
   - **jti revocation.** Revocation marks the ``jti`` revoked, mirroring
-    ``revoke_token(jti)`` in the existing JWT subsystem.
+    ``revoke_token(jti)`` in the existing JWT subsystem. Because the RS verifies
+    offline and never reads this store, revocation is enforced by the AS at
+    ``/token`` (a revoked refresh token cannot mint a new access token) and
+    backstopped by the short access-token TTL — not by a per-request RS lookup.
   - **Refresh rotation + reuse detection.** Refresh tokens rotate on use; a
     replayed (already-consumed) refresh token is rejected AND invalidates the
     whole token *family* — the standard breach response to refresh reuse (T3).
   - **Parameterized SQL only.** No string interpolation into SQL anywhere.
   - **0600 file mode.** The DB file is created/tightened to owner-only rw.
-  - **WAL mode.** Enables concurrent AS-write / RS-read access.
+  - **WAL mode.** Enables concurrent access from ECM's own worker threads.
 
 ================================================================================
-SCHEMA — THE CROSS-CONTAINER CONTRACT
+SCHEMA
 ================================================================================
-ECM (``buiqr.3``) opens the SAME ``/config/mcp_oauth.db`` file. It MUST use the
-identical DDL below (idempotent ``CREATE TABLE IF NOT EXISTS``). The canonical
-DDL lives in ``_SCHEMA_DDL`` in this module. The recommended pattern is for
-ECM to import this module's schema constant (shared schema, one source of
-truth) rather than mirroring the DDL by hand — see the bead report / ADR-009
-follow-up for ``buiqr.3``.
+The canonical DDL lives in ``_SCHEMA_DDL`` below (idempotent
+``CREATE TABLE IF NOT EXISTS``). The ECM AS endpoints (``buiqr.3``) import this
+module directly — one owner, one source of truth, no cross-process schema
+duplication.
 
 All time columns are **epoch seconds** (``int(time.time())``), consistent with
 JWT ``iat``/``exp`` and the second-resolution epoch used elsewhere in the
@@ -106,9 +118,9 @@ REFRESH_TOKEN_MAX_TTL_SECONDS = 30 * 24 * 60 * 60  # 2_592_000
 #: File mode for the DB file: owner read/write only (AC6).
 _DB_FILE_MODE = 0o600
 
-# ── Canonical schema DDL (idempotent). THE cross-container contract. ─────────
-# ECM (buiqr.3) MUST open the same file with this exact DDL. Importing this
-# constant is preferred over mirroring it by hand.
+# ── Canonical schema DDL (idempotent). ──────────────────────────────────────
+# ECM (buiqr.3) is the sole owner; the AS endpoints import this module and run
+# this DDL on init. One owner, one source of truth — no schema mirroring.
 _SCHEMA_DDL = """
 CREATE TABLE IF NOT EXISTS oauth_clients (
     client_id     TEXT PRIMARY KEY,
@@ -199,9 +211,9 @@ class OAuthStore:
 
     A single instance owns one ``sqlite3.Connection``. Instances are **not**
     shared across threads (sqlite3 connections are per-thread by default);
-    each writer/reader thread opens its own ``OAuthStore``. WAL mode lets
-    multiple connections (AS writer, RS reader, even across processes/
-    containers on the shared ``/config`` volume) operate concurrently.
+    each ECM worker thread opens its own ``OAuthStore``. WAL mode lets ECM's
+    concurrent worker connections operate without writer starvation. The store
+    is single-owner (ECM); the MCP RS never opens this file (ADR-009 §1/§5).
     """
 
     def __init__(self, db_path: Union[str, Path]):
@@ -214,7 +226,7 @@ class OAuthStore:
         """Open (or reuse) the connection, enforcing WAL + 0600 file mode.
 
         Idempotent: calling twice returns the same connection. Use this when
-        the schema already exists (e.g. a second container opening the file).
+        the schema already exists (e.g. a new ECM worker opening the file).
         """
         if self._conn is not None:
             return self._conn
@@ -235,7 +247,7 @@ class OAuthStore:
 
         conn = sqlite3.connect(str(self.db_path))
         conn.row_factory = sqlite3.Row
-        # WAL mode for concurrent AS-write / RS-read (AC5, ADR-009 §5).
+        # WAL mode for concurrent access from ECM worker threads (AC5, ADR-009 §5).
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA foreign_keys=ON")
         # Wait up to 5s for a write lock rather than failing immediately —
@@ -250,7 +262,7 @@ class OAuthStore:
     def init_schema(self) -> None:
         """Create all tables (idempotent) and confirm WAL + 0600.
 
-        Safe to call from either container — ``CREATE TABLE IF NOT EXISTS``.
+        Safe to call repeatedly (any ECM worker) — ``CREATE TABLE IF NOT EXISTS``.
         """
         conn = self.connect()
         conn.executescript(_SCHEMA_DDL)

--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0076",
+    version="0.17.1-0077",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0076"
+APP_VERSION = "0.17.1-0077"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/tests/unit/test_oauth_store.py
+++ b/backend/tests/unit/test_oauth_store.py
@@ -1,10 +1,14 @@
-"""Tests for the OAuth state store (oauth_store.py) — bead buiqr.2.
+"""Tests for the OAuth state store (auth/oauth_store.py) — bead buiqr.2.
 
 The store is the foundation layer of the OAuth 2.1 epic (ADR-009 §5). It is a
-framework-agnostic SQLite data layer that the Authorization Server (ECM,
-buiqr.3) writes to and the Resource Server (MCP, buiqr.8) reads from. Neither
-container calls the other at runtime — they share the file at
-/config/mcp_oauth.db (WAL mode).
+framework-agnostic SQLite data layer owned **exclusively by ECM** (the
+Authorization Server, buiqr.3). ECM mounts /config read-write and is the sole
+process that reads/writes /config/mcp_oauth.db. The MCP Resource Server
+(buiqr.8) mounts /config read-only and never opens this file — it verifies
+Bearer JWTs offline, with the revocation window bounded by a short access-token
+TTL. WAL mode covers concurrent access from ECM's own worker threads. (This is
+Option A from blocker gswk2, which re-homed the store here from mcp-server/ and
+reversed the original "MCP-managed, RS-reads-the-file" design.)
 
 These tests cover every acceptance criterion:
   AC1 — clean store API round-trips (create/lookup/consume/revoke) per table.
@@ -24,7 +28,7 @@ import threading
 
 import pytest
 
-from oauth_store import (
+from auth.oauth_store import (
     AUTH_CODE_MAX_TTL_SECONDS,
     REFRESH_TOKEN_MAX_TTL_SECONDS,
     OAuthStore,
@@ -607,7 +611,8 @@ class TestConcurrentWrites:
 
 
 class TestSchemaContract:
-    """The schema is the cross-container contract (ECM AS + MCP RS share it)."""
+    """The schema is ECM-owned; these assert idempotent init + multi-connection
+    (multiple ECM worker connections) integrity, not any cross-container share."""
 
     def test_all_five_tables_exist(self, store):
         names = {
@@ -626,7 +631,7 @@ class TestSchemaContract:
             assert table in names, f"missing table {table}"
 
     def test_init_schema_is_idempotent(self, tmp_path):
-        """init_schema() can run twice (both containers open the same file)."""
+        """init_schema() can run twice (any ECM worker may re-open the file)."""
         db_path = tmp_path / "idem.db"
         s = OAuthStore(db_path)
         s.init_schema()
@@ -634,12 +639,12 @@ class TestSchemaContract:
         s.init_schema()
         s.close()
 
-    def test_second_process_can_open_same_db(self, tmp_path):
-        """Mirrors the cross-container contract: AS writes, RS reads same file."""
+    def test_second_connection_can_open_same_db(self, tmp_path):
+        """A second ECM connection (e.g. another worker) sees the first's writes."""
         db_path = tmp_path / "shared.db"
-        as_side = OAuthStore(db_path)
-        as_side.init_schema()
-        as_side.store_access_token(
+        writer = OAuthStore(db_path)
+        writer.init_schema()
+        writer.store_access_token(
             token="cross-token",
             jti="cross-jti",
             client_id="c",
@@ -647,16 +652,16 @@ class TestSchemaContract:
             scope="mcp",
             ttl_seconds=1800,
         )
-        as_side.close()
+        writer.close()
 
-        rs_side = OAuthStore(db_path)
-        rs_side.connect()
+        reader = OAuthStore(db_path)
+        reader.connect()
         try:
-            record = rs_side.get_access_token("cross-token")
+            record = reader.get_access_token("cross-token")
             assert record is not None
             assert record["jti"] == "cross-jti"
         finally:
-            rs_side.close()
+            reader.close()
 
     def test_parameterized_sql_resists_injection(self, store):
         """A client_id containing SQL metacharacters is stored/looked up safely."""

--- a/docs/adr/ADR-009-mcp-oauth-authorization-server-split.md
+++ b/docs/adr/ADR-009-mcp-oauth-authorization-server-split.md
@@ -54,27 +54,38 @@ graph LR
     subgraph MCPContainer["MCP Container (:6101, RS)"]
         Route["Auth router<br/>(dual-path by SHAPE)"]
         DiscRS["/.well-known/<br/>oauth-protected-resource"]
-        Verify["Offline JWT verify<br/>(HS256, no callback to ECM)"]
+        Verify["Offline JWT verify<br/>(HS256, no callback to ECM,<br/>no token-store read)"]
         Tools["~110 MCP tools"]
     end
 
-    Store["/config/mcp_oauth.db<br/>(SQLite WAL, MCP-managed,<br/>tokens hashed-at-rest)"]
-    Settings["/config/settings.json<br/>(shared volume)"]
+    Store["/config/mcp_oauth.db<br/>(SQLite WAL, ECM-managed,<br/>tokens hashed-at-rest)"]
+    Settings["/config/settings.json<br/>(shared volume, MCP reads :ro)"]
 
     Desktop -->|"1. discover"| DiscRS
     Desktop -->|"2. /authorize"| AuthZ
     AuthZ --> Session
     Desktop -->|"3. /token + PKCE verifier"| Token
     Token --> HS256
-    Token -.writes hash.-> Store
+    Token -.writes + reads hash.-> Store
     Desktop -->|"4. /mcp + Bearer JWT"| Route
     Code -->|"/mcp + static key"| Route
     Route --> Verify
     Verify --> HS256
-    Verify -.reads hash.-> Store
     Route --> Tools
     HS256 -.same secret.-> Settings
 ```
+
+> **Amendment (2026-05-21, Option A — blocker `gswk2`).** The token store is
+> **ECM-managed**, not MCP-managed. The MCP container mounts `/config`
+> **read-only**, so it can neither write `mcp_oauth.db` nor reliably read a live
+> WAL DB (WAL readers must create `-shm`/`-wal` sidecars). The RS therefore does
+> **pure offline JWT verification and never opens the token store**; the
+> access-token revocation window is bounded by the short access-token TTL alone.
+> ECM (the AS) is the sole owner: it writes issued/refresh/revocation records
+> **and** reads them at `/token` (refresh rotation + family-reuse detection).
+> This reverses epic PO-locked decision #3 ("MCP-container-managed"). The
+> module `oauth_store.py` lives in `backend/auth/`, not `mcp-server/`. See the
+> Revision History and §1/§5 below.
 
 ## Decision
 
@@ -96,7 +107,7 @@ The OAuth roles are split across the two existing containers along the line that
 
   - **Performance.** A per-request HTTP callback from MCP to ECM would add a network round-trip to every tool call. AC#11 caps the p50 latency increase at ≤ 5 ms vs the static-key baseline; an in-process HMAC verification meets that, a callback does not.
   - **Failure isolation.** The current MCP server can serve cached/tool operations even under ECM backend stress; coupling token validation to a live ECM call would mean an ECM hiccup takes down all authenticated MCP traffic. Offline verification preserves the existing failure-isolation envelope.
-  - **The trade-off is acknowledged:** offline verification means revocation is not instantaneous — a revoked token is rejected only once the RS sees the revocation state (via the shared token store, §6) or the token's short TTL expires. This is the standard JWT trade and is mitigated by short access-token TTLs (§3) and the shared hashed-token store the RS reads (§6). See the threat model's *token-replay* and *secret-rotation* rows.
+  - **The trade-off is acknowledged:** offline verification means revocation is not instantaneous. **Per the 2026-05-21 Option A amendment (§5, blocker `gswk2`), the RS does NOT read the token store** — it verifies purely offline — so a revoked *access token* is honored until its short TTL expires. Session revocation is still effective: the AS enforces *refresh-token* revocation at `/token` (a revoked refresh token / killed family cannot mint a new access token), so revoking a grant stops renewal and the live access token dies within ≤ 15 min (§3). This is the standard JWT trade, mitigated by short access-token TTLs (§3). See the threat model's *revocation gap* (TS2), *token-replay*, and *secret-rotation* rows.
 
 HS256 (symmetric) is chosen over RS256 (asymmetric) because the two containers already co-locate on one host and share a config volume; a symmetric secret is the simplest primitive that fits the deployment, and it mirrors ECM's existing JWT subsystem (`backend/auth/tokens.py`, `ALGORITHM = "HS256"`). The exit path to RS256 (publish a JWKS from ECM, have MCP fetch + cache it) exists if a future multi-host split needs it, but is out of scope here.
 
@@ -125,7 +136,7 @@ This is the security-critical routing rule (epic AC#2 / AC#7). The RS's auth rou
 - **Single ECM-admin identity model.** Per the PO-locked decision, OAuth grants are made by the **single ECM admin on behalf of the deployment**. The issued token's `sub` claim binds to the admin user. There is no multi-tenant / per-end-user identity in v1 (out of scope, §8). The consent screen (§ below) is the admin saying "this deployment authorizes Claude Desktop."
 - **PKCE S256 only.** The `code_challenge_method` accepted at `/authorize` and enforced at `/token` is **`S256` only**. The `plain` method is **rejected with HTTP 400 `invalid_request`** (AC#5). PKCE is mandatory (no non-PKCE authorization-code flow); a missing or `plain` challenge is a 400.
 - **Hardcoded client registry; no Dynamic Client Registration.** The set of OAuth clients is a fixed, in-code registry (`buiqr.6`) containing the Claude Desktop and Claude Code client identifiers and their exact redirect URIs. **RFC 7591 Dynamic Client Registration is not implemented** (out of scope, §8). An unknown `client_id` is rejected; a `redirect_uri` that is not an exact match for the registered client's allowlisted URI(s) is rejected (threat model: redirect-URI validation, open-redirect).
-- **Token shape and TTL.** Access tokens are HS256 JWTs carrying at minimum `sub` (admin user binding), `jti` (unique id for revocation, mirroring `backend/auth/tokens.py`), `iss` (the ECM AS), `aud` (the MCP RS), `scope` (`mcp`, §8), `iat`, and `exp`. Access-token TTL is **short** (mirroring ECM's existing `ACCESS_TOKEN_EXPIRE_MINUTES = 30` posture; the exact value is `buiqr.3`'s call within that envelope) to bound the offline-verification revocation gap (§1). Refresh handling, if issued, follows the existing one-time-use rotation pattern in `backend/auth/tokens.py`.
+- **Token shape and TTL.** Access tokens are HS256 JWTs carrying at minimum `sub` (admin user binding), `jti` (unique id for revocation, mirroring `backend/auth/tokens.py`), `iss` (the ECM AS), `aud` (the MCP RS), `scope` (`mcp`, §8), `iat`, and `exp`. Access-token TTL is **short** to bound the offline-verification revocation gap (§1). **Under the Option A amendment (§5), the access-token TTL is the *sole* backstop for access-token revocation** (the RS does not read the token store), so it should sit at the **short end of the envelope — ≤ 15 min recommended** — rather than the 30-min `ACCESS_TOKEN_EXPIRE_MINUTES` ceiling; the exact value is `buiqr.3`'s call. Refresh handling follows the existing one-time-use rotation pattern in `backend/auth/tokens.py`, with rotation + family-reuse detection enforced by the store at `/token` (`buiqr.2`).
 - **Consent UI.** Rendered by the AS at the `/authorize` step (`buiqr.7`), shown to the authenticated admin. Copy is the PO-locked single-`mcp`-scope wording: *"Claude Desktop will be able to read and manage your ECM channels, streams, M3U accounts, and EPG sources."* The consent screen pins the requesting client's name (from the hardcoded registry, not from attacker-supplied input) and enforces same-origin / allowlist on any `return_to`-style parameter (threat model: consent-phishing, open-redirect).
 
 ### §4 — `oauth_allow_insecure` flag policy
@@ -137,11 +148,21 @@ A single boolean in `/config/settings.json`, **default `false`**, governs whethe
 
 **Rationale.** This flag exists because of the MCP SDK 1.27.0 http-issuer rejection finding (see Context). Rather than silently failing on the typical `http://<LAN-IP>:6101` shape, ECM defaults to refusing the insecure posture (404, fail-closed) and makes the operator make an explicit, documented choice to weaken it. The default is the safe value; weakening it is a deliberate act recorded in `settings.json`. The flag never weakens the static-key path — that path is unchanged and HTTP-or-HTTPS as today.
 
-### §5 — Token store: SQLite at `/config/mcp_oauth.db`, MCP-container-managed, hashed-at-rest
+### §5 — Token store: SQLite at `/config/mcp_oauth.db`, **ECM-managed**, hashed-at-rest
 
-- **Location & engine.** A dedicated SQLite database at **`/config/mcp_oauth.db`**, in **WAL mode** (consistent with ECM's other SQLite stores). It is **MCP-container-managed** — the RS owns its lifecycle (`buiqr.2`). This deliberately avoids any runtime HTTP coupling to ECM for token state, preserving the §1 failure-isolation property: the AS issues tokens and writes their hashed records; the RS reads/validates against the same store; neither calls the other at request time.
+> **Amended 2026-05-21 (Option A, blocker `gswk2`).** This section originally
+> specified an **MCP-container-managed** store that the RS read for revocation.
+> That is infeasible: the MCP container mounts `/config` **read-only** (it cannot
+> write the DB, and a `:ro` mount cannot reliably host a live WAL DB whose readers
+> must create `-shm`/`-wal` sidecars). The store is therefore **ECM-managed** and
+> the RS **does not read it**. This reverses epic PO-locked decision #3; the
+> alternative (flip the MCP mount to `:rw`) was rejected as a hardening regression
+> — it would give the MCP container write access to the volume holding the HS256
+> secret and `mcp_api_key`. The store module lives in `backend/auth/oauth_store.py`.
+
+- **Location & engine.** A dedicated SQLite database at **`/config/mcp_oauth.db`**, in **WAL mode** (consistent with ECM's other SQLite stores). It is **ECM-managed** — ECM (the AS) is the *only* container with `/config` read-write, and owns the store's full lifecycle (`buiqr.2`): create, schema, write, and read. WAL covers concurrent access from ECM's own worker threads. This still avoids any runtime HTTP coupling between the two containers for token state (the §1 failure-isolation property): the AS issues tokens and writes their hashed records and reads them at `/token`; **the RS validates Bearer JWTs purely offline and never opens this file.**
 - **Hashed-at-rest.** Tokens are **never stored in plaintext.** The store holds **SHA-256 hashes** of the token (or of the `jti`, per `buiqr.2`/`buiqr.4` implementation), mirroring the established `hash_token()` pattern in `backend/auth/tokens.py` (`hashlib.sha256(token.encode()).hexdigest()`) and that module's `jti`-based revocation set. A read of `mcp_oauth.db` yields hashes, not bearer credentials — so a compromised store leaks revocation/audit metadata, not usable tokens (threat model: token-store at-rest compromise).
-- **Revocation.** Revocation marks the `jti`/hash record revoked; the RS's offline verifier consults the store to reject revoked tokens (the §1 revocation-gap mitigation), exactly mirroring `revoke_token(jti)` in the existing JWT subsystem.
+- **Revocation.** Revocation marks the `jti`/hash record revoked, mirroring `revoke_token(jti)` in the existing JWT subsystem. **Enforcement point (Option A):** because the RS verifies offline and never reads the store, revocation is enforced **at the AS `/token` endpoint** — a revoked refresh token (or a killed refresh *family*, the rotation-reuse breach response) cannot be exchanged for a new access token, so renewal stops immediately. A revoked *access* token is not rejected mid-flight by the RS; it simply expires within its short TTL (§3). The `access_tokens`/`revocations` tables remain the issuance/revocation **audit ledger** (threat model R2/R3) and the substrate for the AS-side checks; access-token-level instant revocation is the documented residual gap (§1, threat model TS2), bounded by the ≤ 15 min TTL.
 
 ### §6 — Rate limiting; `dispatcharr_api_key` isolation
 
@@ -171,7 +192,7 @@ Explicitly **not** built in v1. Each is a future-epic candidate, not a silent om
 
 | # | Option | Pros | Cons | Portability | Decision |
 |---|--------|------|------|-------------|----------|
-| 1 | **Chosen — ECM=AS, MCP=RS, offline HS256 verify, dual-path-by-shape** | Consent lives where the user session lives; no per-request callback (meets ≤5 ms AC#11); failure-isolation preserved; shape-routing closes the auth-bypass class | Revocation is not instantaneous (TTL/shared-store mitigated); one shared secret to rotate | High — symmetric secret on a co-located shared volume, no new infra | **Adopted** (PO-locked) |
+| 1 | **Chosen — ECM=AS, MCP=RS, offline HS256 verify, dual-path-by-shape** | Consent lives where the user session lives; no per-request callback (meets ≤5 ms AC#11); failure-isolation preserved; shape-routing closes the auth-bypass class | Access-token revocation is not instantaneous (TTL-bounded; refresh revocation enforced at AS `/token` — §5); one shared secret to rotate | High — symmetric secret on a co-located shared volume, no new infra | **Adopted** (PO-locked) |
 | 2 | MCP=AS (MCP hosts `/authorize` + consent) | Single container owns the whole OAuth surface | MCP has no user session — would have to proxy/re-implement ECM login; wider attack surface; consent UI divorced from identity | Med | Rejected — consent must live with identity |
 | 3 | Per-request runtime callback MCP→ECM to validate every token | Instant revocation; single source of truth at request time | Adds a network round-trip per tool call (blows AC#11); couples MCP availability to ECM; destroys failure isolation | Med | Rejected — perf + isolation |
 | 4 | RS256 (asymmetric) instead of HS256 | No shared secret; RS only needs the public key; cleaner multi-host story | More moving parts (JWKS publish/fetch/cache) for two co-located containers that already share a volume; doesn't mirror ECM's existing HS256 JWT subsystem | High | Rejected for v1; documented exit path if multi-host split appears |
@@ -194,7 +215,7 @@ Explicitly **not** built in v1. Each is a future-epic candidate, not a silent om
 ### Negative
 
 - **One shared HS256 secret to protect and rotate.** Both containers read it from `/config/settings.json`. Compromise of the secret allows token forgery; rotation invalidates all live tokens (acceptable given short TTLs). The threat model's secret-rotation / alg-confusion rows track this; protecting `settings.json` file permissions is the compensating control.
-- **Revocation is not instantaneous.** The offline-verification trade means a revoked token is honored until the RS sees the revocation (shared store, §6) or the TTL expires. Mitigated by short TTLs and the shared hashed-token store, but it is a real gap vs a callback design.
+- **Access-token revocation is not instantaneous.** The offline-verification trade means a revoked *access* token is honored until its short TTL expires — the RS verifies offline and (per the Option A amendment, §5) does not read the token store. Refresh-token revocation *is* enforced at the AS `/token` endpoint, so revoking a grant stops renewal and the live access token dies within ≤ 15 min. Mitigated by short TTLs, but the per-access-token gap is real vs a callback design.
 - **A second auth path is permanent operational surface.** The dual-path matrix must be maintained forever (PO-locked). Every future change to either path must re-verify the shape-routing invariant.
 - **The HTTPS prerequisite shifts operator burden.** Operators on the typical `http://<LAN-IP>:6101` shape must set up a reverse proxy or accept the `oauth_allow_insecure` risk. This is documented (`buiqr.11`) but it is a real friction wall the epic explicitly accepted.
 
@@ -227,7 +248,7 @@ No external vendor relationship is introduced; no new infrastructure beyond the 
 - **PKCE method?** → S256 only; `plain` → 400 `invalid_request` (§3).
 - **Dynamic Client Registration?** → No; hardcoded client registry (§3).
 - **HTTP posture?** → `oauth_allow_insecure` default false; discovery 404 on plain HTTP unless set (§4).
-- **Token store?** → SQLite `/config/mcp_oauth.db`, WAL, MCP-managed, SHA-256 hashed-at-rest (§5).
+- **Token store?** → SQLite `/config/mcp_oauth.db`, WAL, **ECM-managed** (amended 2026-05-21, Option A / `gswk2` — was MCP-managed; the MCP `/config:ro` mount made that infeasible), SHA-256 hashed-at-rest, RS never reads it (§5).
 - **Scope model?** → Single `mcp` scope in v1 (§3, §8).
 - **Static `?api_key=` path?** → Permanent, no deprecation (§8); dual-path matrix is a permanent CI fixture.
 
@@ -253,3 +274,4 @@ No external vendor relationship is introduced; no new infrastructure beyond the 
 | Date | Bead | Change | Rationale |
 |---|---|---|---|
 | 2026-05-20 | `enhancedchannelmanager-buiqr.1` | Proposed | Formalizes the PO-locked OAuth split from epic `buiqr` (2026-05-19 grooming). Contract-lock for `buiqr.2`–`buiqr.9`. Status Proposed pending AC#5 PO sign-off before any implementation child opens. |
+| 2026-05-21 | `enhancedchannelmanager-buiqr.2` / `gswk2` | Amended — **Option A** (token store re-homed to ECM) | Discovered during `buiqr.2` that the MCP container mounts `ecm-config:/config` **read-only**, so an MCP-managed store (decision #3) cannot write the DB, and a `:ro` mount cannot host a live WAL DB (readers must create `-shm`/`-wal` sidecars). **Resolution (PO-approved Option A):** the token store is **ECM-managed** (`backend/auth/oauth_store.py`, was `mcp-server/`); ECM is the sole reader/writer; the **RS verifies purely offline and never reads the store**; the access-token revocation window is **TTL-bounded** and refresh-token revocation is enforced at the AS `/token`. Reverses epic decision #3. Rejected alternative: flip the MCP mount to `:rw` (hardening regression — would expose the HS256 secret + `mcp_api_key` volume to MCP writes). Amends §1, §5, the architecture diagram, Alternatives row 1, Consequences, and Open Questions. Threat model amended in lockstep. |

--- a/docs/security/threat_model_mcp_oauth.md
+++ b/docs/security/threat_model_mcp_oauth.md
@@ -6,6 +6,18 @@
 **Status:** Draft — pending PO review (AC#5 sign-off on ADR-009 + Assumptions §6 + Residual Risks §8)
 **Related:** epic `enhancedchannelmanager-buiqr` (PO-locked decisions), ADR-009 (the architecture this model secures — every mitigation below ties to an ADR-009 §section), `enhancedchannelmanager-ak7xa` (closed — CI gate precondition), `docs/architecture.md` (MCP Server static-key baseline + `settings.json` credential schema), `backend/auth/tokens.py` (HS256 + `jti` revocation + `hash_token()` patterns reused), `docs/adr/ADR-008-interactive-stream-dedup.md`, `docs/security/threat_model_dbas_import.md` (template mirrored)
 
+> **Amendment 2026-05-21 (Option A — `buiqr.2` / blocker `gswk2`).** The MCP
+> container mounts `ecm-config:/config` **read-only**, making an MCP-managed
+> token store and any RS read of `mcp_oauth.db` infeasible. The token store is
+> therefore **ECM-managed** (`backend/auth/oauth_store.py`); the **RS verifies
+> Bearer JWTs purely offline and never opens the store.** Consequences for this
+> model: the AS↔store↔RS shared-state boundary collapses to **ECM-only**
+> (the RS no longer touches `mcp_oauth.db`); the revocation-gap row **TS2** and
+> hardening item **#15** change from "RS reads the revocation table" to
+> "refresh-token revocation enforced at the AS `/token` + access-token window
+> bounded solely by the short TTL (≤ 15 min)." Rows below are updated in place;
+> see ADR-009's Revision History for the full rationale and rejected alternative.
+
 ---
 
 ## 1. Scope & System Overview
@@ -15,7 +27,7 @@ Epic `buiqr` adds OAuth 2.1 + PKCE so Claude Desktop's **Custom Connector** UI c
 - **ECM container = Authorization Server (AS):** hosts `GET /authorize` + consent UI, `POST /token` (PKCE S256), and `GET /.well-known/oauth-authorization-server`. It owns the admin user session.
 - **MCP container = Resource Server (RS):** hosts `GET /.well-known/oauth-protected-resource`, validates Bearer JWTs **offline** (HS256, shared secret from `/config/settings.json`, **no per-request callback to ECM**), and serves the `/mcp` tools surface.
 
-A **second** authentication path now coexists with the **permanent** static `?api_key=` path. The RS routes by credential **shape** (JWT-shaped → OAuth-only; static-key-shaped → static-key-only) and **never** fail-cascades from a failed OAuth validation to the static-key check (ADR-009 §2). Tokens are stored hashed-at-rest (SHA-256) in a MCP-managed SQLite DB at `/config/mcp_oauth.db` (WAL).
+A **second** authentication path now coexists with the **permanent** static `?api_key=` path. The RS routes by credential **shape** (JWT-shaped → OAuth-only; static-key-shaped → static-key-only) and **never** fail-cascades from a failed OAuth validation to the static-key check (ADR-009 §2). Tokens are stored hashed-at-rest (SHA-256) in an **ECM-managed** SQLite DB at `/config/mcp_oauth.db` (WAL), written and read **only by ECM** (the RS does not access it — Option A).
 
 This threat model covers the **OAuth subsystem ECM + MCP will build.** The current static-key MCP auth (`APIKeyAuthMiddleware`, `mcp_api_key`, per `docs/architecture.md`) is the **inherited baseline**; its protections are table stakes and the dual-path interaction is modeled here (§3.6) because two paths sharing one RS is precisely where auth-bypass bugs live.
 
@@ -44,11 +56,11 @@ Attack surfaces modeled:
    |<--(redirect to allowlisted redirect_uri + code)--
    |
    |--(/token: code + PKCE verifier)--> [ECM AS] --HS256 sign--> JWT (sub=admin, jti, aud=RS)
-   |                                            --writes hash--> [/config/mcp_oauth.db]
+   |                                            --writes + reads hash--> [/config/mcp_oauth.db] (ECM rw, sole owner)
+   |                                            --refresh rotation + family-reuse check on refresh
    |
    |--(/mcp + Authorization: Bearer <JWT>)--> [MCP RS dual-path-by-shape router]
-   |                                            --offline HS256 verify (shared secret)
-   |                                            --reads revocation--> [/config/mcp_oauth.db]
+   |                                            --offline HS256 verify (shared secret; NO store read)
    |                                            --> ~110 MCP tools --> [ECM backend :6100]
    |                                                                 --> [Dispatcharr (separate boundary)]
 [Claude Code / scripts] --(/mcp + ?api_key= OR Bearer static-key)--> [static-key path only]
@@ -57,8 +69,8 @@ Attack surfaces modeled:
 Trust boundaries crossed:
 
 - **Client → operator-supplied TLS proxy → ECM AS / MCP RS** (the network boundary; **TLS is operator-supplied**, not ECM-managed — ADR-009 §4/§8).
-- **AS ⇄ shared `/config/settings.json`** (HS256 secret, `oauth_allow_insecure`, `mcp_api_key`).
-- **AS ⇄ `/config/mcp_oauth.db` ⇄ RS** (hashed tokens; the **only** shared OAuth state — no runtime HTTP coupling between AS and RS, ADR-009 §1/§5).
+- **AS ⇄ shared `/config/settings.json`** (HS256 secret, `oauth_allow_insecure`, `mcp_api_key`). ECM mounts `/config` **rw**; the MCP RS mounts it **read-only** and reads only the secret + flag it needs for offline verify.
+- **AS ⇄ `/config/mcp_oauth.db` (ECM-only).** Hashed tokens/codes/refresh/revocation records. **Option A:** the store is owned and accessed **exclusively by ECM** — the RS does **not** read or write it (it verifies offline). There is no shared OAuth *state* across the two containers and no runtime HTTP coupling between AS and RS (ADR-009 §1/§5).
 - **MCP RS → ECM backend → Dispatcharr** (the existing service boundary; Dispatcharr is admin-configured & trusted per the existing model; the OAuth token must **not** widen authority beyond the admin's existing reach — §3.6 / threat O1).
 
 ---
@@ -86,7 +98,7 @@ Each row's mitigation cites the ADR-009 §section it derives from. Severity is r
 | T1 | Token in transit | MITM modifies the Bearer token / authorization code in flight | Plain-HTTP deploy; attacker on the LAN rewrites the token | TLS (operator-supplied) is the in-transit integrity control; on plain HTTP, OAuth is **off by default** (discovery 404, §4) — the operator must explicitly opt in (HT1) | baseline + to-build | High |
 | T2 | Token contents | Attacker mutates JWT claims (e.g., extends `exp`, changes `scope`) | Edit the payload segment of a captured token | HS256 signature covers header+payload; any claim mutation invalidates the signature → 401 (§1) | to-build (`buiqr.8`) | High |
 | T3 | PKCE | **PKCE downgrade** — attacker forces `plain` to defeat code-interception protection | Client/attacker sends `code_challenge_method=plain` | **S256 only**; `plain` (or missing challenge) rejected with **400 `invalid_request`** at `/authorize` and `/token` (§3, AC#5) | to-build (`buiqr.3`) | **High** |
-| T4 | Token store | Attacker tampers with `mcp_oauth.db` to un-revoke or forge a token record | Write access to `/config/mcp_oauth.db` | Store holds **hashes**, not tokens — cannot reconstruct a usable token from a record (§5); file lives on the protected `/config` volume (filesystem perms = compensating control, §6/TS1) | to-build (`buiqr.2`) | Med |
+| T4 | Token store | Attacker tampers with `mcp_oauth.db` to un-revoke or forge a token record | Write access to `/config/mcp_oauth.db` | Store holds **hashes**, not tokens — cannot reconstruct a usable token from a record (§5); file lives on the protected `/config` volume (filesystem perms = compensating control, §6/TS1); **Option A narrows the writers**: only ECM mounts `/config` rw — the MCP container mounts it `:ro` and cannot write the DB at all, so an MCP-side compromise cannot tamper with the store | to-build (`buiqr.2`) | Med |
 | T5 | Settings flag | Attacker flips `oauth_allow_insecure=true` to enable HTTP OAuth | Write access to `settings.json` | Flag default false; flipping it requires write access to `settings.json` (same trust level as the HS256 secret itself — if an attacker has that, the secret is already lost). Change is operator-visible in `settings.json` (§4) | to-build (`buiqr.5`) | Med |
 | T6 | Consent params | Tampered `redirect_uri` / `return_to` to redirect the code/flow | Attacker alters the redirect target in the authorize request | **Exact-match allowlist** of `redirect_uri` against the hardcoded client registry; consent `return_to` enforced same-origin/allowlist (§3 — see RD1, OR1) | to-build (`buiqr.6`/`buiqr.7`) | High |
 
@@ -149,7 +161,7 @@ Each row's mitigation cites the ADR-009 §section it derives from. Severity is r
 | # | Surface | STRIDE | Threat | Attack scenario | Mitigation (ADR-009 ref) | Status | Sev |
 |---|---------|--------|--------|-----------------|--------------------------|--------|-----|
 | TS1 | `mcp_oauth.db` | Info-Disclosure / Tampering | At-rest compromise or tamper of the token store | See ID2 (disclosure) + T4 (tamper) | Hashes-not-tokens (§5); `/config` volume perms; WAL durability; (cross-ref ID2/T4) | to-build (`buiqr.2`) | Med |
-| TS2 | Revocation read | EoP | **Revocation gap** — a revoked token keeps working because the RS verifies offline and hasn't seen the revocation | Admin revokes a token; offline RS honors it until TTL or until it reads the revocation record | RS consults the shared store's revocation state on validation (§5); **short TTL** is the backstop (§3); the gap is the documented offline-verification trade-off (ADR-009 §1) | to-build (`buiqr.8`) | Med |
+| TS2 | Revocation enforcement | EoP | **Revocation gap** — a revoked *access* token keeps working because the RS verifies offline and (Option A) never reads the store | Admin revokes a grant; the offline RS honors a still-live access token until its TTL expires | **Option A enforcement:** the RS does **not** read the store; revocation is enforced at the **AS `/token`** — a revoked refresh token / killed family cannot mint a new access token, so renewal stops at once and the live access token dies within the **short TTL (≤ 15 min, §3)**, which is the sole access-token backstop. The gap is the documented offline-verification trade-off (ADR-009 §1/§5). | to-build (`buiqr.3` AS-side; access-token TTL `buiqr.3`) | Med |
 
 **Cell coverage note.** The six canonical STRIDE dimensions are all covered (§3.1–§3.6), plus three deployment/secret/store dimension tables (§3.7–§3.9) where a single surface warranted dedicated rows. Every grooming-named concern from AC#4 appears as an explicit row — see the AC#4 coverage map in §7.
 
@@ -173,15 +185,15 @@ The OAuth implementation must satisfy **all** of the following, each mapped to S
 12. **Secret + token-store redaction in exports** — the HS256 secret and `mcp_oauth.db` are credential-class; covered by `_SETTINGS_CREDENTIAL_FIELDS` / export redaction. *(ID5, SR1)*
 13. **Audience + scope enforcement** — `aud` bound to the MCP RS and checked; `scope=mcp` carried and enforced. *(EP1)*
 14. **Single-use, short-TTL authorization codes + short-TTL access tokens** — bounds code-replay and the offline revocation gap. *(D1, TS2, HT1)*
-15. **Revocation read on validation** — RS consults the shared store's revocation state; mirrors `revoke_token(jti)`. *(TS2, R3)*
+15. **Revocation enforced at the AS, not the RS (Option A)** — the RS verifies offline and does **not** read the store; refresh-token / family revocation is enforced at `/token` (a revoked refresh cannot mint a new access token), and the access-token window is bounded solely by the short TTL. Mirrors `revoke_token(jti)` on the AS side. *(TS2, R3)*
 16. **Audit on consent / issuance / revocation** — AS journals consent (admin `sub`, client, scope, request id), token issuance (`jti`+hash), and revocation; RS records auth-mode per request. *(R1, R2, R3, R4)*
 17. **Error-response hygiene** — OAuth-standard short error codes; full detail server-side only. *(ID4)*
 
 ---
 
-## 5. Test Cases (for `mcp-server/tests/` and `backend/tests/security/`)
+## 5. Test Cases (split by container: `mcp-server/tests/` for RS, `backend/tests/` for AS + store)
 
-> The `mcp-server/tests/` suite is now CI-gated (precondition `enhancedchannelmanager-ak7xa`, closed), so these tests will not rot silently. Detailed test infrastructure lands in `buiqr.9`.
+> The `mcp-server/tests/` suite is now CI-gated (precondition `enhancedchannelmanager-ak7xa`, closed), so the RS tests will not rot silently. **Under Option A** the token-store tests live in `backend/tests/unit/test_oauth_store.py` (the store is ECM-managed) — already merged with `buiqr.2` — and the AS endpoint tests land in the backend suite with `buiqr.3`. RS-side tests (dual-path routing, offline verify, discovery) stay in `mcp-server/tests/`. Detailed test infrastructure lands in `buiqr.9`.
 
 - `test_dual_path_routing.py` *(CD1 — the headline)*
   - `test_invalid_jwt_not_evaluated_as_static_key` — JWT-shaped Bearer with bad signature → 401, and the value is **never** compared to `mcp_api_key`.
@@ -203,9 +215,9 @@ The OAuth implementation must satisfy **all** of the following, each mapped to S
   - `test_discovery_no_secret_or_internal_host` — grep response for the HS256 secret, `ecm:6100`, paths, `mcp_api_key` → absent.
   - `test_discovery_404_on_plain_http_when_insecure_false`.
   - `test_discovery_200_on_plain_http_when_insecure_true`.
-- `test_token_store.py` *(ID2, TS2)*
-  - `test_tokens_hashed_at_rest` — DB row contains a SHA-256 hash, not the token.
-  - `test_revoked_token_rejected` — revoke then validate → 401.
+- `backend/tests/unit/test_oauth_store.py` *(ID2, TS2 — ECM-side, merged with `buiqr.2`)*
+  - `test_*_hashed_at_rest` — DB rows contain SHA-256 hashes, not the raw token/code.
+  - refresh-rotation + reuse-detection: a replayed refresh token raises and kills the family (the AS-side revocation enforcement point — `buiqr.3` wires this into `/token` so a revoked refresh cannot mint a new access token). The RS performs **no** store read, so there is no RS-side "revoke then validate → 401" test; access-token revocation is bounded by the short TTL.
 - `test_rate_limit.py` *(D1, D2)*
   - `test_token_endpoint_rate_limited` / `test_authorize_endpoint_rate_limited`.
 - `test_dispatcharr_isolation.py` *(O1)*
@@ -218,12 +230,12 @@ The OAuth implementation must satisfy **all** of the following, each mapped to S
 This preamble states what the model assumes; deviations change the risk picture and need PO confirmation.
 
 - **TB1 — TLS is operator-supplied, not ECM-managed.** ECM does not terminate TLS for the OAuth surface; the operator fronts MCP with a reverse proxy (Caddy/nginx/Traefik) or ECM's `:6143`. In-transit confidentiality/integrity (T1, ID3, HT1) **depends on the operator doing this.** PO-locked (ADR-009 §4/§8). The `oauth_allow_insecure` flag is the explicit acknowledgment that an operator may run without it.
-- **TB2 — Both containers co-locate and share `/config`.** The AS/RS split assumes the two containers share the `/config` volume (HS256 secret, `oauth_allow_insecure`, `mcp_oauth.db`). HS256 (symmetric) is justified by this co-location (ADR-009 §1). A future multi-host split is the documented RS256/JWKS exit path, **out of scope** here.
+- **TB2 — Both containers co-locate on `/config`, with asymmetric access.** The AS/RS split assumes both containers see the `/config` volume, but **ECM mounts it read-write and the MCP RS mounts it read-only** (Option A). The RS reads only the HS256 secret + `oauth_allow_insecure` flag from `settings.json` for offline verify; `mcp_oauth.db` is **ECM-only** (the RS never opens it). HS256 (symmetric) is justified by this co-location (ADR-009 §1). A future multi-host split is the documented RS256/JWKS exit path, **out of scope** here.
 - **TB3 — `/config/settings.json` write access ≈ full trust.** Anyone who can write `settings.json` already controls the HS256 secret, so threats whose precondition is `settings.json` write access (T5, SR1) are bounded by the same trust level as secret compromise. The mitigation is filesystem perms on `/config`, which is an operational/deployment control, not OAuth code.
 - **TB4 — Dispatcharr is the existing admin-configured, trusted boundary.** The OAuth token does not change the MCP→Dispatcharr relationship; Dispatcharr is reached with `dispatcharr_api_key` as today (O1). Cross-instance / untrusted-Dispatcharr scenarios are out of scope (consistent with the existing model).
 - **TB5 — Single ECM admin identity.** v1 binds tokens to the single admin (`sub`). **Multi-tenant per-user grants are out of scope** (ADR-009 §8). If multi-admin/multi-user ECM auth lands later, this model must be revisited for per-user token scoping. **PO to confirm** single-admin is the v1 posture (it is, per epic — flagged for traceability).
-- **A1 — Offline-verification revocation gap is acceptable.** Tokens are verified offline; revocation propagates via the shared store + TTL, not instantly (TS2, ADR-009 §1). **PO to confirm** that a bounded revocation gap (≤ token TTL) is acceptable for v1 in exchange for the latency (AC#11) and failure-isolation properties. *(This is the central security/perf trade — the PO already accepted offline verification at grooming; restated here for the AC#5 sign-off.)*
-- **A2 — Access-token TTL value.** The model assumes a short TTL (in the spirit of ECM's existing `ACCESS_TOKEN_EXPIRE_MINUTES = 30`). The exact value is `buiqr.3`'s call within that envelope; a longer TTL widens HT1 (replay) and TS2 (revocation gap). **PO to ratify** the TTL ceiling.
+- **A1 — Offline-verification revocation gap is acceptable.** Tokens are verified offline; under Option A the RS does not read the store, so access-token revocation is bounded **solely by the short TTL**, while refresh-token revocation is enforced at the AS `/token` (renewal stops immediately) (TS2, ADR-009 §1/§5). **PO to confirm** that a bounded access-token revocation gap (≤ TTL, ≤ 15 min recommended) is acceptable for v1 in exchange for the latency (AC#11) and failure-isolation properties. *(This is the central security/perf trade — the PO accepted offline verification at grooming and Option A on 2026-05-21; restated here for the AC#5 sign-off.)*
+- **A2 — Access-token TTL value.** The model assumes a short TTL. **Under Option A the access-token TTL is the *sole* backstop for access-token revocation** (the RS does not read the store), so it should sit at the short end — **≤ 15 min recommended**, tighter than ECM's 30-min `ACCESS_TOKEN_EXPIRE_MINUTES`. The exact value is `buiqr.3`'s call; a longer TTL widens HT1 (replay) and TS2 (revocation gap). **PO to ratify** the TTL ceiling.
 - **A3 — Rate-limit thresholds.** Per-IP + per-user limits on `/authorize` and `/token` are mandated (D1, D2); the concrete numbers are `buiqr.4`'s call. **PO to ratify** thresholds sized to single-admin usage.
 - **A4 — Token-store reaper deferred.** Expired/revoked rows in `mcp_oauth.db` are not auto-pruned in v1 (D4); single-admin volume keeps this small. An additive reaper is a backlog candidate if the table grows. **PO to confirm** deferral is acceptable.
 
@@ -259,7 +271,7 @@ All eight grooming-named concerns from AC#4 are present, plus seven Security-Eng
 
 These remain after the §4 mitigations; each is bounded and noted for the PO's AC#5 sign-off.
 
-- **Residual: offline-verification revocation gap — Medium, accepted (A1/TS2).** A revoked token is honored until the RS reads the revocation or the TTL expires. Mitigated by short TTL + shared-store revocation read. Not closeable without a per-request callback, which the architecture deliberately rejects (latency AC#11 + failure isolation). The narrower the TTL, the smaller the gap.
+- **Residual: offline-verification revocation gap — Medium, accepted (A1/TS2).** A revoked *access* token is honored until its TTL expires; under Option A the RS does not read the store, so the access-token gap is **purely TTL-bounded** (refresh-token revocation, by contrast, is enforced immediately at the AS `/token`). Not closeable without a per-request callback or an RS store read, both of which the architecture deliberately rejects (latency AC#11 + failure isolation + the MCP `/config:ro` mount). The narrower the TTL (≤ 15 min), the smaller the gap.
 - **Residual: token-replay on opt-in HTTP — Medium, operator-accepted (HT1).** When `oauth_allow_insecure=true`, tokens traverse cleartext and can be replayed within their TTL. Bounded by the explicit opt-in (default fails closed) and short TTL. The operator chose this; the safe default is HTTPS.
 - **Residual: shared-secret compromise → token forgery — High impact / Low likelihood, accepted with compensating controls (SR1).** Whoever can read the HS256 secret can forge admin tokens. Likelihood is gated by `/config` filesystem perms and export redaction; impact is recoverable by rotation (which invalidates all live tokens). No KMS/HSM for v1 (consistent with the existing `settings.json`-stored credentials posture).
 - **Residual: authenticated-admin abuse — Low, inherent.** The single ECM admin can authorize Claude Desktop and then drive any MCP tool — that is the feature. The OAuth layer authenticates *that the admin* granted access; it does not constrain what the admin (or an agent acting on their behalf) may do beyond the single `mcp` scope. Bounded by single-admin identity (TB5) and the consent audit trail (R1). Per-tool scopes (a future epic) would narrow this.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0076",
+  "version": "0.17.1-0077",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What & why

The OAuth state store (`bd-buiqr.2`) was merged into `mcp-server/` (PR #373) but was **dormant and architecturally infeasible**: the MCP container mounts `ecm-config:/config` **read-only**, so it can neither write `/config/mcp_oauth.db` nor reliably read a live WAL DB (WAL readers must create `-shm`/`-wal` sidecars). Blocker **`bd-gswk2`**.

This PR implements the **PO-approved Option A** resolution.

## Changes

**Code (logic byte-identical — relocation + framing only):**
- Moved `oauth_store.py` and its tests from `mcp-server/` → `backend/auth/` (preserving git history). ECM owns `/config` rw and is now the **sole reader/writer** of the store.
- Reframed module/test docstrings away from "AS writes / RS reads the shared file" → **ECM is the single owner; the MCP Resource Server verifies Bearer JWTs purely offline and never opens the store.**
- Import path `from oauth_store import …` → `from auth.oauth_store import …`.

**Architecture posture (Option A):**
- Access-token revocation is bounded by a **short TTL (≤ 15 min)**; refresh-token / family revocation is enforced at the **AS `/token`** endpoint (a revoked refresh can't mint a new access token).
- **Reverses epic PO-locked decision #3** ("MCP-container-managed store").
- Rejected alternative (flip MCP mount to `:rw`) = hardening regression — would give the MCP container write access to the volume holding the HS256 secret + `mcp_api_key`. The MCP `:ro` mount is preserved.

**Docs amended in lockstep:**
- `docs/adr/ADR-009-…md`: §1, §5, architecture diagram, Alternatives row 1, Consequences, Open Questions, + Revision History entry.
- `docs/security/threat_model_mcp_oauth.md`: data-flow, trust boundaries, T4, **TS2** (revocation gap), TB2, hardening item **#15**, assumptions A1/A2, residual risks, test-case section.

## Verification
- **Backend suite (CI-equivalent, `--ignore=tests/e2e --ignore=tests/performance`): green** — all pass, coverage 66.36% ≥ 56%. The 38 store tests pass at their new home.
- **mcp-server coverage: 28.28% ≥ 26% floor** (removing `oauth_store.py` + its tests nets neutral; back to documented baseline).
- **version-consistency:** all 3 touchpoints at `0.17.1-0077`.
- **semgrep:** clean. Module imports cleanly.

> Note: `buiqr.2` is the dormant foundation data layer — nothing imports `auth.oauth_store` at runtime yet (that's `buiqr.3`), so there is no operator-visible behavior to verify beyond the test suite + clean import.

Closes `bd-buiqr.2`. Resolves blocker `bd-gswk2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)