### PR TITLE
docs(mcp): Custom Connector needs public reachability; private deploys use mcp-remote / .mcp.json (bd-xft2g)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,19 +217,27 @@ Things you can ask Claude to do:
 
 ### Choose your connection method
 
-| Method | Prerequisite | Best for |
-|---|---|---|
-| [Claude Desktop — Custom Connector](#claude-desktop-custom-connector-https-required) | HTTPS in front of MCP (port 6101) | No Node.js; OAuth 2.1 flow; lowest friction once HTTPS is set up |
-| [Claude Desktop — mcp-remote bridge](#claude-desktop-mcp-remote-bridge-node-required) | Node.js (LTS 18+) on the same machine as Claude Desktop | Plain HTTP deploys; existing setups; no reverse proxy needed |
-| [Claude Code — `.mcp.json`](#claude-code-mcp-json) | None | Claude Code in any project directory; direct HTTP, no auth UI |
+> ⚠️ **Public vs. private — read this first.** Claude Desktop's **Custom Connector** is *brokered by Anthropic's infrastructure*: Anthropic's servers connect **out** to your MCP server, so it must be reachable from the **public internet** (HTTPS + a public DNS name/tunnel). A purely private/LAN or homelab deployment (e.g. an internal `*.home.lan` name on a `10.x`/`172.16.x`/`192.168.x` address) will fail the Custom Connector with **"Couldn't reach the MCP server"** even though your own browser on the LAN loads it fine — because Anthropic's cloud can't route to your private network.
+>
+> **If you want to keep ECM private (no public exposure), use the `mcp-remote` bridge (Claude Desktop) or `.mcp.json` (Claude Code) instead** — both run on *your* machine and connect over your LAN/VPN, so nothing is exposed to the internet. This is a "pick two of {Claude Desktop · no Node.js · stays private}" trade-off; the Custom Connector is the only option that gives no-Node, and it's the one that requires public exposure.
+
+| Method | Node.js? | Network | Best for |
+|---|---|---|---|
+| [Claude Desktop — Custom Connector](#claude-desktop-custom-connector-public-internet-facing) | No | **Public** — Anthropic's cloud must reach your MCP server (HTTPS + internet-reachable) | Internet-exposed deploys that want the no-Node, in-app OAuth experience |
+| [Claude Desktop — mcp-remote bridge](#claude-desktop-mcp-remote-bridge-node-required) | Yes (LTS 18+ on the Claude Desktop machine) | **Private OK** — the bridge runs on your machine and connects over your LAN/VPN | Private/homelab deploys; plain-HTTP deploys; existing setups |
+| [Claude Code — `.mcp.json`](#claude-code-mcp-json) | No | **Private OK** — Claude Code connects directly from your machine | Private/homelab; Claude Code in any project; direct HTTP, no auth UI |
 
 ---
 
-### Claude Desktop — Custom Connector (HTTPS required)
+### Claude Desktop — Custom Connector (public, internet-facing)
 
 Claude Desktop's built-in **Connectors** UI (Settings → Connectors → Add custom connector) uses OAuth 2.1 + PKCE. ECM acts as the Authorization Server; you authorize in a browser window and Claude Desktop stores the token automatically. **No Node.js required.**
 
-**Prerequisite: HTTPS.** The MCP SDK rejects plain-HTTP issuers for non-loopback hostnames. You must front the MCP container (port 6101) with a TLS reverse proxy. See **[docs/runbooks/mcp-https-reverse-proxy.md](docs/runbooks/mcp-https-reverse-proxy.md)** for Caddy, nginx, and Traefik recipes.
+> ⚠️ **This path requires your MCP server (and ECM) to be reachable from the public internet.** The Custom Connector is brokered by Anthropic's infrastructure — Anthropic's servers, not the desktop app, connect out to your MCP URL — so a LAN-only / private deployment cannot use it (you'll get "Couldn't reach the MCP server"). **If you don't want to expose ECM publicly, skip this section and use [mcp-remote](#claude-desktop-mcp-remote-bridge-node-required) (Claude Desktop) or [`.mcp.json`](#claude-code-mcp-json) (Claude Code)** — both connect locally over your LAN/VPN with no public exposure.
+
+**Prerequisites:**
+- **Public reachability.** Expose `ecm` and `ecm-mcp` to the internet — a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) (no inbound ports) is the cleanest homelab option, or a public DNS name + port-forward to your reverse proxy.
+- **HTTPS.** The MCP SDK rejects plain-HTTP issuers for non-loopback hostnames. Front the MCP container (port 6101) — and ECM (port 6100) — with a TLS reverse proxy. See **[docs/runbooks/mcp-https-reverse-proxy.md](docs/runbooks/mcp-https-reverse-proxy.md)** for Caddy, nginx, and Traefik recipes.
 
 **Required: `OAUTH_ISSUER` must be identical on both containers.** Set the same external HTTPS origin on the ECM container and the MCP container. If they differ, every OAuth Bearer token fails verification with a silent 401.
 
@@ -258,6 +266,8 @@ environment:
 
 ### Claude Desktop — mcp-remote bridge (Node required)
 
+✅ **Works on a private network — no public exposure.** Unlike the Custom Connector, `mcp-remote` runs **on your machine** and connects to ECM over your LAN/VPN, so ECM never has to be reachable from the internet. This is the recommended Claude Desktop path for a private/homelab deployment (the cost is needing Node.js on the Claude Desktop machine).
+
 Claude Desktop talks to remote MCP servers through the `mcp-remote` bridge. Add this to your `claude_desktop_config.json`:
 
 > **Prerequisite:** Claude Desktop does **not** bundle Node.js. The `mcp-remote` bridge is an npm package that Claude Desktop runs via `npx`, so you need Node.js installed on the same machine as Claude Desktop (any current LTS — Node 18+ — is fine). Install it from [nodejs.org](https://nodejs.org/) (or via a package manager: `winget install OpenJS.NodeJS.LTS` on Windows, `brew install node` on macOS, `apt install nodejs npm` on Debian/Ubuntu). Without Node on PATH, Claude Desktop fails to launch the MCP server with a `spawn npx ENOENT` error in its logs.
@@ -283,6 +293,8 @@ Claude Desktop talks to remote MCP servers through the `mcp-remote` bridge. Add 
 ---
 
 ### Claude Code (`.mcp.json`)
+
+✅ **Works on a private network — no Node.js, no public exposure.** Claude Code speaks the HTTP transport natively and connects directly from your machine, so a LAN/VPN-reachable ECM is all you need. This is the simplest private path if you use Claude Code.
 
 Create a `.mcp.json` file in any project directory where you want ECM tools available:
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.1-0087",
+    version="0.17.1-0088",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.1-0087"
+APP_VERSION = "0.17.1-0088"
 
 REDACTED = "***REDACTED***"
 

--- a/docs/runbooks/mcp-https-reverse-proxy.md
+++ b/docs/runbooks/mcp-https-reverse-proxy.md
@@ -14,7 +14,11 @@
 
 Claude Desktop's **Custom Connector** UI (Settings → Connectors → Add custom connector) uses OAuth 2.1 + PKCE. ECM acts as the OAuth Authorization Server; the MCP container acts as the Resource Server.
 
-The MCP SDK (1.27.0+) **rejects `http://` issuer URLs for non-loopback hostnames** during OAuth discovery. A typical ECM deployment on `http://192.168.x.x:6101` or `http://my-server:6101` falls into this category — the SDK refuses to proceed, and the Custom Connector flow cannot complete.
+> ⚠️ **This runbook is only for the Custom Connector path, which requires PUBLIC internet exposure.** The Custom Connector is brokered by Anthropic's infrastructure — **Anthropic's servers connect *out* to your MCP server**, so it must be reachable from the public internet, not just over HTTPS on your LAN. A private/homelab deployment (internal DNS, RFC-1918 address) will fail the Custom Connector with *"Couldn't reach the MCP server"* — HTTPS alone does **not** fix that, because Anthropic's cloud can't route into your private network. **If you want to keep ECM private, you do not need this runbook at all** — use the `mcp-remote` bridge (Claude Desktop) or `.mcp.json` (Claude Code) instead; both run on your machine and connect over your LAN/VPN. See the README "Choose your connection method" and `docs/user_guide/integrations/mcp.md`.
+
+So this runbook covers **two** requirements for the Custom Connector path: (1) **public reachability** — a public DNS name + a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) (no inbound ports, cleanest for homelab) or a port-forward; and (2) **HTTPS** — described below.
+
+The MCP SDK (1.27.0+) **rejects `http://` issuer URLs for non-loopback hostnames** during OAuth discovery. A deployment on `http://192.168.x.x:6101` or `http://my-server:6101` falls into this category — the SDK refuses to proceed. (Note this is a *second*, separate reason the Custom Connector needs HTTPS, on top of the public-reachability requirement above.)
 
 **Solution**: front the MCP container with HTTPS using a reverse proxy (Caddy, nginx, or Traefik). The proxy terminates TLS on a public port (e.g., 443) and forwards traffic to the MCP container's plain-HTTP port 6101 on the local network.
 
@@ -226,6 +230,29 @@ curl -s https://mcp.yourdomain.com/health
 
 curl -s https://mcp.yourdomain.com/.well-known/oauth-protected-resource | python3 -m json.tool
 # Expect: {"issuer": "https://mcp.yourdomain.com", ...}
+```
+
+---
+
+## Nginx Proxy Manager (NPM) — field notes
+
+NPM is a UI over nginx, so the nginx guidance applies. Add **one** Proxy Host per hostname (`ecm.yourdomain.com` → `:6100`, `ecm-mcp.yourdomain.com` → `:6101`), Scheme `http`, Force SSL + HTTP/2, Websockets Support ON. Two gotchas that have cost operators hours:
+
+**1. Do NOT put `proxy_http_version 1.1;` in the Advanced tab when Websockets Support is on.** NPM already emits `proxy_http_version 1.1;` (and the `Connection`/`Upgrade` headers) when Websockets Support is enabled. If your Advanced (SSE) block *also* sets it, nginx fails with `"proxy_http_version" directive is duplicate` — and **NPM silently rolls back that host's config file**. The host + cert still look fine in the UI, but nginx serves no server block for the hostname, so TLS fails with `unrecognized name` and clients get *"couldn't reach the server."* For the MCP host, the Advanced tab should contain **only**:
+```nginx
+proxy_buffering off;
+proxy_request_buffering off;
+proxy_read_timeout 3600s;
+proxy_send_timeout 3600s;
+```
+
+**2. Each hostname needs its own cert (or a wildcard).** A per-host cert for `ecm.yourdomain.com` does **not** cover `ecm-mcp.yourdomain.com`. Either issue a cert per host, or — cleanest for internal/homelab names — a `*.yourdomain.com` **wildcard via DNS-01** (e.g. Cloudflare/Route53), assigned to both Proxy Hosts.
+
+**Confirm a host is really being served** (vs. a UI-only / rolled-back config), from any box that can reach NPM:
+```bash
+echo | openssl s_client -connect <npm-ip>:443 -servername ecm-mcp.yourdomain.com 2>&1 | openssl x509 -noout -subject
+# A subject line = good. "tlsv1 unrecognized name" = nginx has no server block for that SNI
+# (rolled-back conf or missing cert) — check the Advanced tab for a duplicate directive.
 ```
 
 ---

--- a/docs/user_guide/integrations/mcp.md
+++ b/docs/user_guide/integrations/mcp.md
@@ -17,11 +17,14 @@ walkthrough, key rotation details, or troubleshooting.
 Two paths connect Claude to ECM. They run in parallel — you can use both at the
 same time.
 
+> ⚠️ **Public vs. private — decide this first.** The **Custom Connector is brokered by Anthropic's infrastructure**: Anthropic's servers connect *out* to your MCP server, so it must be reachable from the **public internet**. A private/LAN/homelab deployment (an internal DNS name on an RFC-1918 address like `10.x` / `172.16.x` / `192.168.x`) **cannot** use the Custom Connector — it fails with *"Couldn't reach the MCP server"* even though your own browser on the LAN loads it fine, because Anthropic's cloud can't route into your private network. **To keep ECM private, use the mcp-remote bridge (Path B below) or [Claude Code](#claude-code-mcp-json)** — both run on *your* machine and connect over your LAN/VPN, so nothing is exposed to the internet.
+
 | | Custom Connector (OAuth) | mcp-remote bridge |
 |---|---|---|
-| **Best for** | Claude Desktop without Node.js installed | Claude Desktop when Node.js is already installed; advanced users who want static-key control |
+| **Network reachability** | **Public** — Anthropic's cloud must reach your MCP server | **Private OK** — bridge runs on your machine, connects over LAN/VPN |
+| **Best for** | Internet-exposed deploys; no Node.js; in-app OAuth | Private/homelab; existing setups; static-key control |
 | **Auth model** | OAuth 2.1 + PKCE — ECM issues a short-lived JWT; Claude Desktop stores and refreshes it | Static API key embedded in the MCP URL |
-| **Prerequisites** | HTTPS reverse proxy in front of MCP port 6101; `OAUTH_ISSUER` set on both containers | Node.js LTS 18+ on the Claude Desktop machine |
+| **Prerequisites** | Public internet reachability + HTTPS reverse proxy (MCP port 6101 and ECM port 6100); `OAUTH_ISSUER` set on both containers | Node.js LTS 18+ on the Claude Desktop machine |
 | **Config file edits** | None — Claude Desktop's connector UI handles everything | `claude_desktop_config.json` |
 | **Claude Code** | Not applicable — Claude Code uses the static-key `.mcp.json` path | Not applicable |
 
@@ -41,25 +44,40 @@ the consent screen, issues short-lived Bearer JWTs, and manages grant records.
 The MCP container acts as the Resource Server (RS): it validates Bearer JWTs
 offline on every tool call without calling back to ECM.
 
-No Node.js or `npx` is involved. The trade-off is that you need HTTPS in front
-of the MCP container before starting.
+No Node.js or `npx` is involved. The trade-off is that **your MCP server (and
+ECM) must be reachable from the public internet** — Anthropic's cloud connects
+out to your MCP URL — fronted by HTTPS. If you want to keep ECM private, use
+[Path B (mcp-remote)](#path-b-mcp-remote-bridge-node-required) or
+[Claude Code](#claude-code-mcp-json) instead.
 
-> **ECM is the Authorization Server, not Anthropic.** ECM issues the OAuth
-> tokens that Claude Desktop stores. Anthropic is not in the trust chain.
-> See [ADR-009](../../adr/ADR-009-mcp-oauth-authorization-server-split.md) for
-> the full architecture rationale.
+> **ECM is the Authorization Server, not Anthropic — but Anthropic is in the
+> network path.** ECM (not Anthropic) issues and signs the OAuth tokens, so
+> Anthropic is **not in the trust chain**. However, the Custom Connector is
+> *brokered* by Anthropic's servers, which connect **out** to your MCP URL —
+> which is why this path requires public reachability. That's a **network**
+> requirement, not a trust one. See
+> [ADR-009](../../adr/ADR-009-mcp-oauth-authorization-server-split.md) for the
+> full architecture rationale.
 
 ### Prerequisites
 
 Before adding the connector in Claude Desktop:
 
-1. **MCP container is running.** Verify: `curl http://YOUR_ECM_HOST:6101/health`
+1. **Public internet reachability.** Anthropic's infrastructure must be able to
+   reach your MCP server **and** ECM. Expose `ecm` and `ecm-mcp` via a
+   [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
+   (no inbound ports — cleanest for a homelab) or a public DNS name + a
+   port-forward to your reverse proxy. **A LAN-only / private deployment cannot
+   use this path** — it fails with "Couldn't reach the MCP server." Use
+   [Path B (mcp-remote)](#path-b-mcp-remote-bridge-node-required) or
+   [Claude Code](#claude-code-mcp-json) if you don't want to expose ECM.
+2. **MCP container is running.** Verify: `curl http://YOUR_ECM_HOST:6101/health`
    should return `{"status": "ok", ...}`.
-2. **HTTPS reverse proxy in front of port 6101.** The MCP SDK rejects plain-HTTP
+3. **HTTPS reverse proxy in front of port 6101.** The MCP SDK rejects plain-HTTP
    issuer URLs for non-loopback hosts. See the
    [HTTPS reverse-proxy runbook](../../runbooks/mcp-https-reverse-proxy.md) for
    Caddy (recommended, auto TLS), nginx, and Traefik recipes.
-3. **`OAUTH_ISSUER` set identically on both containers.** This is the single
+4. **`OAUTH_ISSUER` set identically on both containers.** This is the single
    most common misconfiguration. Both the ECM container and the MCP container
    must have `OAUTH_ISSUER` set to the same external HTTPS origin.
 
@@ -78,7 +96,7 @@ Before adding the connector in Claude Desktop:
    silent 401. Without this variable, both containers default to
    `https://ecm.local`, which only works loopback.
 
-4. **ECM API key generated** (Settings → MCP Integration → Generate Key). The
+5. **ECM API key generated** (Settings → MCP Integration → Generate Key). The
    static key and OAuth operate independently, but the key must be generated for
    the MCP container's health endpoint to report `api_key_configured: true`.
 
@@ -285,6 +303,31 @@ Custom Connector OAuth flow.
 ---
 
 ## Troubleshooting
+
+### Custom Connector: "Couldn't reach the MCP server" (no browser/consent opens)
+
+**Cause:** the Custom Connector is brokered by Anthropic's infrastructure —
+Anthropic's servers connect *out* to your MCP URL. If ECM is on a private/LAN
+network (internal DNS, RFC-1918 address), Anthropic's cloud cannot route to it,
+so the connector never even starts the OAuth flow (no browser opens). A telltale
+sign: your own browser on the LAN loads
+`https://YOUR_MCP_HOST/.well-known/oauth-protected-resource` fine, but the MCP
+server's access log shows **no** request from Anthropic during the attempt.
+
+**Fix — pick one:**
+- **Keep it private (recommended for homelab):** don't use the Custom Connector.
+  Use [Path B (mcp-remote)](#path-b-mcp-remote-bridge-node-required) or
+  [Claude Code](#claude-code-mcp-json) — both run on your machine and reach ECM
+  over your LAN/VPN, no public exposure.
+- **Expose it:** make `ecm` and `ecm-mcp` reachable from the internet (a
+  [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
+  is the cleanest, no inbound ports), then retry. The OAuth consent + admin login
+  is the gate that keeps that exposure safe.
+
+To confirm it's a reachability problem (not config): on the MCP host, watch the
+reverse-proxy access log while you click *Add* in Claude Desktop. **No log entry =
+Anthropic can't reach you** (private-network issue, above). A log entry that 4xxs
+is a different problem (see the other entries here).
 
 ### The connector authorization fails with `redirect_uri mismatch`
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.1-0087",
+  "version": "0.17.1-0088",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/settings/MCPSettingsSection.tsx
+++ b/frontend/src/components/settings/MCPSettingsSection.tsx
@@ -374,9 +374,15 @@ export function MCPSettingsSection({ isAdmin }: Props) {
             </p>
 
             {/* Custom Connector (OAuth) — bd-buiqr.11 */}
-            <label className="form-label">Claude Desktop — Custom Connector (no Node required)</label>
+            <label className="form-label">Claude Desktop — Custom Connector (no Node required, public internet-facing)</label>
             <p className="form-description">
               Claude Desktop&apos;s built-in <strong>Settings → Connectors → Add custom connector</strong> uses OAuth 2.1. ECM authorizes the connection in your browser; Claude Desktop stores the token automatically. No Node.js needed.
+            </p>
+            <p className="form-description mcp-prereq-note">
+              <span className="material-icons" aria-hidden="true">public</span>
+              <span>
+                <strong>Prerequisite: the MCP server must be reachable from the public internet.</strong> Custom Connectors are <em>Anthropic-brokered</em> — Anthropic&apos;s cloud connects <em>out</em> to your MCP URL on ECM&apos;s behalf, so a LAN-only / VPN-only / split-horizon-DNS hostname will never be reachable and you&apos;ll get <em>&quot;Couldn&apos;t reach the MCP server.&quot;</em> This is a connector-architecture requirement, <strong>not</strong> an OAuth one. If you don&apos;t want to expose ECM publicly, use the <strong>mcp-remote bridge</strong> (below) or <strong>Claude Code with <code>.mcp.json</code></strong> instead — both keep all traffic on your private network.
+              </span>
             </p>
             <p className="form-description mcp-prereq-note">
               <span className="material-icons" aria-hidden="true">https</span>
@@ -402,7 +408,10 @@ export function MCPSettingsSection({ isAdmin }: Props) {
             </ol>
 
             {/* mcp-remote bridge (Node) — existing path */}
-            <label className="form-label" style={{ marginTop: '1.25rem' }}>Claude Desktop — mcp-remote bridge (Node required)</label>
+            <label className="form-label" style={{ marginTop: '1.25rem' }}>Claude Desktop — mcp-remote bridge (Node required, private-network OK)</label>
+            <p className="form-description" style={{ color: 'var(--accent-green, #4caf50)' }}>
+              ✅ Runs entirely on your machine — works on a LAN/VPN-only ECM with no public exposure.
+            </p>
             <p className="form-description">
               If you have Node.js installed on the same machine as Claude Desktop (LTS 18+ — install from{' '}
               <a href="https://nodejs.org/" target="_blank" rel="noopener noreferrer">nodejs.org</a>
@@ -436,7 +445,10 @@ export function MCPSettingsSection({ isAdmin }: Props) {
               </button>
             </div>
 
-            <label className="form-label" style={{ marginTop: '1rem' }}>Claude Code Config (.mcp.json)</label>
+            <label className="form-label" style={{ marginTop: '1rem' }}>Claude Code Config (.mcp.json) — private-network OK, no Node</label>
+            <p className="form-description" style={{ color: 'var(--accent-green, #4caf50)' }}>
+              ✅ Connects directly over HTTP from your machine — works on a LAN/VPN-only ECM with no public exposure and no Node.js.
+            </p>
             <p className="form-description">
               Save this as <code>.mcp.json</code> in a project directory where you want ECM tools available.
             </p>


### PR DESCRIPTION
## Summary

Clarifies across all MCP-connection docs (and the in-app Settings panel) that Claude Desktop's **Custom Connector is brokered by Anthropic's infrastructure** — Anthropic's cloud connects *out* to the MCP server — so it requires the MCP server (and ECM) to be reachable from the **public internet**. This is a connector-architecture requirement, **not** an OAuth one. A LAN-only / homelab deployment fails with *"Couldn't reach the MCP server"* even when HTTPS is correct and the LAN browser loads it fine.

Private deployments are steered to the paths that stay on the local network: **mcp-remote bridge** (Claude Desktop) and **`.mcp.json`** (Claude Code).

## Changes

- **README.md** — public/private warning callout; method table rewritten with **Node.js?** and **Network** columns; Custom Connector retitled *(public, internet-facing)* with a public-reachability prerequisite (Cloudflare Tunnel); "✅ Works on a private network" notes on mcp-remote + Claude Code.
- **docs/user_guide/integrations/mcp.md** — comparison callout + Network row; Path A trust-chain-vs-network-path clarification; public reachability as prerequisite #1; new troubleshooting entry *"Couldn't reach the MCP server (no browser/consent opens)."*
- **docs/runbooks/mcp-https-reverse-proxy.md** — Background callout scoping the runbook to the Custom Connector / public-exposure path; new **Nginx Proxy Manager field notes** documenting the `proxy_http_version 1.1;` duplicate-directive trap (NPM silently rolls back the host conf → `unrecognized name`) and the per-host cert requirement.
- **frontend/.../MCPSettingsSection.tsx** — in-app public-reachability caveat on the Custom Connector; private-network-OK reassurance on mcp-remote + Claude Code.

Frontend component touched → version bump **0.17.1-0087 → 0.17.1-0088** (3 touchpoints).

## Verification

lint ✓ · typecheck ✓ · build ✓ · `MCPSettingsSection` tests 22/22 ✓

## Beads

Closes `enhancedchannelmanager-xft2g`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)