### PR TITLE
docs(mcp): fix broken in-page anchor links in README + mcp.md (bd-kevsg)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Things you can ask Claude to do:
 > | `api_key` | **DEPRECATED legacy alias for `dispatcharr_api_key`.** ECM still reads this for one release of back-compat (v0.17.x). The first read after upgrade emits a deprecation WARN and silently mirrors the value into `dispatcharr_api_key` on the next save. Rename or remove this field once you confirm `dispatcharr_api_key` is populated. |
 > | `mcp_api_key` | **ECM MCP static key** — the `ecm-mcp` sidecar uses this to authenticate calls to ECM via the `?api_key=` path. This is what the Generate / Regenerate button in Settings > MCP Integration writes. The `?api_key=` path is **permanent** — it will never be deprecated. |
 > | `mcp_oauth_signing_secret` | **OAuth HS256 signing secret** — auto-generated and managed by ECM; operators do not set this manually. It is the shared secret ECM and the MCP container use to sign and verify OAuth Bearer JWTs. Treat as credential-class; it is redacted in backup exports. |
-> | `oauth_allow_insecure` | **Default: `false`.** Set to `true` to enable OAuth on plain-HTTP (non-loopback) deployments. Without HTTPS, the MCP SDK rejects the OAuth flow. Only set this if you have a closed LAN and accept the token-interception risk. See [HTTPS Reverse Proxy](#claude-desktop-custom-connector-https-required) below for the standard HTTPS setup. |
+> | `oauth_allow_insecure` | **Default: `false`.** Set to `true` to enable OAuth on plain-HTTP (non-loopback) deployments. Without HTTPS, the MCP SDK rejects the OAuth flow. Only set this if you have a closed LAN and accept the token-interception risk. See [HTTPS Reverse Proxy](#claude-desktop--custom-connector-public-internet-facing) below for the standard HTTPS setup. |
 >
 > When rotating an MCP key, the new key goes in `mcp_api_key`. Do **not** touch `dispatcharr_api_key` (or its legacy `api_key` alias) — overwriting either with an MCP key breaks every channel and stream operation (ECM returns 401 to Dispatcharr). If you see `api_key_configured: false` from the `/health` endpoint after a rotation, the diagnostic's `status` field will indicate whether `mcp_api_key` is missing from the file (`field_missing`), blank (`field_empty`), or the file itself is unreadable (`file_not_found` / `invalid_json`) — use `GET http://YOUR_ECM_HOST:6100/api/health` to check.
 >
@@ -223,9 +223,9 @@ Things you can ask Claude to do:
 
 | Method | Node.js? | Network | Best for |
 |---|---|---|---|
-| [Claude Desktop — Custom Connector](#claude-desktop-custom-connector-public-internet-facing) | No | **Public** — Anthropic's cloud must reach your MCP server (HTTPS + internet-reachable) | Internet-exposed deploys that want the no-Node, in-app OAuth experience |
-| [Claude Desktop — mcp-remote bridge](#claude-desktop-mcp-remote-bridge-node-required) | Yes (LTS 18+ on the Claude Desktop machine) | **Private OK** — the bridge runs on your machine and connects over your LAN/VPN | Private/homelab deploys; plain-HTTP deploys; existing setups |
-| [Claude Code — `.mcp.json`](#claude-code-mcp-json) | No | **Private OK** — Claude Code connects directly from your machine | Private/homelab; Claude Code in any project; direct HTTP, no auth UI |
+| [Claude Desktop — Custom Connector](#claude-desktop--custom-connector-public-internet-facing) | No | **Public** — Anthropic's cloud must reach your MCP server (HTTPS + internet-reachable) | Internet-exposed deploys that want the no-Node, in-app OAuth experience |
+| [Claude Desktop — mcp-remote bridge](#claude-desktop--mcp-remote-bridge-node-required) | Yes (LTS 18+ on the Claude Desktop machine) | **Private OK** — the bridge runs on your machine and connects over your LAN/VPN | Private/homelab deploys; plain-HTTP deploys; existing setups |
+| [Claude Code — `.mcp.json`](#claude-code-mcpjson) | No | **Private OK** — Claude Code connects directly from your machine | Private/homelab; Claude Code in any project; direct HTTP, no auth UI |
 
 ---
 
@@ -233,7 +233,7 @@ Things you can ask Claude to do:
 
 Claude Desktop's built-in **Connectors** UI (Settings → Connectors → Add custom connector) uses OAuth 2.1 + PKCE. ECM acts as the Authorization Server; you authorize in a browser window and Claude Desktop stores the token automatically. **No Node.js required.**
 
-> ⚠️ **This path requires your MCP server (and ECM) to be reachable from the public internet.** The Custom Connector is brokered by Anthropic's infrastructure — Anthropic's servers, not the desktop app, connect out to your MCP URL — so a LAN-only / private deployment cannot use it (you'll get "Couldn't reach the MCP server"). **If you don't want to expose ECM publicly, skip this section and use [mcp-remote](#claude-desktop-mcp-remote-bridge-node-required) (Claude Desktop) or [`.mcp.json`](#claude-code-mcp-json) (Claude Code)** — both connect locally over your LAN/VPN with no public exposure.
+> ⚠️ **This path requires your MCP server (and ECM) to be reachable from the public internet.** The Custom Connector is brokered by Anthropic's infrastructure — Anthropic's servers, not the desktop app, connect out to your MCP URL — so a LAN-only / private deployment cannot use it (you'll get "Couldn't reach the MCP server"). **If you don't want to expose ECM publicly, skip this section and use [mcp-remote](#claude-desktop--mcp-remote-bridge-node-required) (Claude Desktop) or [`.mcp.json`](#claude-code-mcpjson) (Claude Code)** — both connect locally over your LAN/VPN with no public exposure.
 
 **Prerequisites:**
 - **Public reachability.** Expose `ecm` and `ecm-mcp` to the internet — a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) (no inbound ports) is the cleanest homelab option, or a public DNS name + port-forward to your reverse proxy.

--- a/docs/user_guide/integrations/mcp.md
+++ b/docs/user_guide/integrations/mcp.md
@@ -17,7 +17,7 @@ walkthrough, key rotation details, or troubleshooting.
 Two paths connect Claude to ECM. They run in parallel — you can use both at the
 same time.
 
-> ⚠️ **Public vs. private — decide this first.** The **Custom Connector is brokered by Anthropic's infrastructure**: Anthropic's servers connect *out* to your MCP server, so it must be reachable from the **public internet**. A private/LAN/homelab deployment (an internal DNS name on an RFC-1918 address like `10.x` / `172.16.x` / `192.168.x`) **cannot** use the Custom Connector — it fails with *"Couldn't reach the MCP server"* even though your own browser on the LAN loads it fine, because Anthropic's cloud can't route into your private network. **To keep ECM private, use the mcp-remote bridge (Path B below) or [Claude Code](#claude-code-mcp-json)** — both run on *your* machine and connect over your LAN/VPN, so nothing is exposed to the internet.
+> ⚠️ **Public vs. private — decide this first.** The **Custom Connector is brokered by Anthropic's infrastructure**: Anthropic's servers connect *out* to your MCP server, so it must be reachable from the **public internet**. A private/LAN/homelab deployment (an internal DNS name on an RFC-1918 address like `10.x` / `172.16.x` / `192.168.x`) **cannot** use the Custom Connector — it fails with *"Couldn't reach the MCP server"* even though your own browser on the LAN loads it fine, because Anthropic's cloud can't route into your private network. **To keep ECM private, use the mcp-remote bridge (Path B below) or [Claude Code](#claude-code-mcpjson)** — both run on *your* machine and connect over your LAN/VPN, so nothing is exposed to the internet.
 
 | | Custom Connector (OAuth) | mcp-remote bridge |
 |---|---|---|
@@ -30,7 +30,7 @@ same time.
 
 **Claude Code** uses neither path above. It talks Streamable HTTP directly:
 create a `.mcp.json` file with the `?api_key=` URL and Claude Code picks it up
-automatically. See [Claude Code](#claude-code-mcp-json) below.
+automatically. See [Claude Code](#claude-code-mcpjson) below.
 
 ---
 
@@ -48,7 +48,7 @@ No Node.js or `npx` is involved. The trade-off is that **your MCP server (and
 ECM) must be reachable from the public internet** — Anthropic's cloud connects
 out to your MCP URL — fronted by HTTPS. If you want to keep ECM private, use
 [Path B (mcp-remote)](#path-b-mcp-remote-bridge-node-required) or
-[Claude Code](#claude-code-mcp-json) instead.
+[Claude Code](#claude-code-mcpjson) instead.
 
 > **ECM is the Authorization Server, not Anthropic — but Anthropic is in the
 > network path.** ECM (not Anthropic) issues and signs the OAuth tokens, so
@@ -70,7 +70,7 @@ Before adding the connector in Claude Desktop:
    port-forward to your reverse proxy. **A LAN-only / private deployment cannot
    use this path** — it fails with "Couldn't reach the MCP server." Use
    [Path B (mcp-remote)](#path-b-mcp-remote-bridge-node-required) or
-   [Claude Code](#claude-code-mcp-json) if you don't want to expose ECM.
+   [Claude Code](#claude-code-mcpjson) if you don't want to expose ECM.
 2. **MCP container is running.** Verify: `curl http://YOUR_ECM_HOST:6101/health`
    should return `{"status": "ok", ...}`.
 3. **HTTPS reverse proxy in front of port 6101.** The MCP SDK rejects plain-HTTP
@@ -317,7 +317,7 @@ server's access log shows **no** request from Anthropic during the attempt.
 **Fix — pick one:**
 - **Keep it private (recommended for homelab):** don't use the Custom Connector.
   Use [Path B (mcp-remote)](#path-b-mcp-remote-bridge-node-required) or
-  [Claude Code](#claude-code-mcp-json) — both run on your machine and reach ECM
+  [Claude Code](#claude-code-mcpjson) — both run on your machine and reach ECM
   over your LAN/VPN, no public exposure.
 - **Expose it:** make `ecm` and `ecm-mcp` reachable from the internet (a
   [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)


### PR DESCRIPTION
## Summary

Follow-up to #389. The "Choose your connection method" links resolved to the **top of the page** instead of their target sections because the anchor targets didn't match GitHub's auto-generated heading slugs.

## Root causes

1. **`.mcp.json` dot-stripping** — GitHub strips dots, so `## Claude Code (`.mcp.json`)` slugs to `claude-code-mcpjson`, not `claude-code-mcp-json`.
2. **Em-dash → double hyphen** — GitHub removes the `—` but keeps the spaces around it, so `### Claude Desktop — Custom Connector …` slugs to `claude-desktop--custom-connector-…` (double hyphen), not single.
3. **Stale anchor** — one link still pointed at the pre-rename `#claude-desktop-custom-connector-https-required` heading (renamed to "public, internet-facing" in #389).

## Verification

Every in-page anchor in both files was checked against the github-slugger algorithm: **8/8 resolve.** No heading text was changed; all inbound links to these sections are self-contained to the two files (confirmed via repo-wide grep).

## Beads

Closes `enhancedchannelmanager-kevsg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)