### PR TITLE
chore(ci): remove dead release/** trigger + -test docker tags from build.yml (bd-2ycz6)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,12 +5,6 @@ on:
     branches:
       - main
       - dev
-      # release/** branches produce pre-release test images so external users
-      # can validate hotfixes before a full release cut. See bd-sxv77 — the
-      # chicken-and-egg constraint is that GitHub Actions reads the workflow
-      # file from the commit being pushed, so this trigger MUST land on the
-      # release/** branch itself before the first build can fire.
-      - 'release/**'
     paths-ignore:
       - '.beads/**'
       - '**.md'
@@ -18,7 +12,6 @@ on:
     branches:
       - main
       - dev
-      - 'release/**'
     paths-ignore:
       - '.beads/**'
       - '**.md'
@@ -771,7 +764,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
           tags: |
-            # Branch name tag (release/v0.16.1 → release-v0.16.1 after docker-tag sanitization)
+            # Branch name tag (e.g. dev → dev after docker-tag sanitization)
             type=ref,event=branch
             # SHA tag for traceability
             type=sha,prefix={{branch}}-
@@ -785,11 +778,6 @@ jobs:
             # Minor version tags (e.g., 0.7-dev or 0.7)
             type=raw,value=${{ steps.version.outputs.minor }}-dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=raw,value=${{ steps.version.outputs.minor }},enable=${{ github.ref == 'refs/heads/main' }}
-            # Release-branch pre-release tag — -test suffix keeps the namespace
-            # separate from final {version} tags (which only main produces).
-            # Yields e.g. 0.16.1-0001-test from frontend/package.json on
-            # release/v0.16.1. See bd-sxv77.
-            type=raw,value=${{ steps.version.outputs.full }}-test,enable=${{ startsWith(github.ref, 'refs/heads/release/') }}
 
       - name: Create manifest list and push
         working-directory: /tmp
@@ -1056,8 +1044,6 @@ jobs:
             type=raw,value=${{ steps.version.outputs.full }},enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=${{ steps.version.outputs.minor }}-dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=raw,value=${{ steps.version.outputs.minor }},enable=${{ github.ref == 'refs/heads/main' }}
-            # Release-branch pre-release tag, see bd-sxv77
-            type=raw,value=${{ steps.version.outputs.full }}-test,enable=${{ startsWith(github.ref, 'refs/heads/release/') }}
 
       - name: Create manifest list and push
         working-directory: /tmp


### PR DESCRIPTION
## Summary

Removes the now-dead `release/**` CI configuration from `.github/workflows/build.yml`. ECM tracks releases by **git tags** (`v0.17.0` current), not `release/*` branches. All `release/*` branches were deleted and `delete_branch_on_merge` is now enabled, so this config (added by bd-sxv77 / PR #278) can only fire on a manually-created `release/*` branch the project no longer uses.

## Changes (build.yml only)
- Drop `- 'release/**'` from `on.push.branches` and `on.pull_request.branches` (kept `main`, `dev`) + its explanatory comment block.
- Drop the release-only pre-release `-test` docker tag (`enable=startsWith(github.ref, 'refs/heads/release/')`) from both the AMD64 and ARM64 metadata steps + their comments.
- Reword the `type=ref,event=branch` comment to drop the `release/v0.16.1` example.

## Not touched
- The five "Extract version and set release channel" steps (release *channel* = stable/beta from the version string — unrelated to `release/*` branches).
- All `dev`/`main` tag lines, `type=ref`/`type=sha`/latest/dev/semver/minor tags.
- No version bump (CI-only change; Version Consistency stays green).

## Verification
- `yaml.safe_load` parses OK; `on.push.branches` and `on.pull_request.branches` = `['main', 'dev']`.
- Post-edit grep: no `release/**`, no `refs/heads/release/`, no `bd-sxv77` references remain.
- 1 file changed, +1/−15.

Closes `enhancedchannelmanager-2ycz6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)