### PR TITLE
ci(test): skip real test suite on docs-only PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ on:
       - dev
     paths-ignore:
       - '.beads/**'
+      # Docs-only PRs are satisfied by docs-only-pass.yml (the sentinel posts
+      # the required Backend/Frontend/Semgrep check-runs). Without this, the
+      # real suite ALSO runs and needlessly gates a Markdown-only merge.
+      # Keep in sync with the push trigger above + build.yml's paths-ignore.
+      - '**.md'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**Problem:** `test.yml`'s `push` trigger ignores `**.md`, but its `pull_request` trigger ignored only `.beads/**`. So a Markdown-only PR ran the **full real Backend/Frontend/Semgrep suite** *and* the `docs-only-pass.yml` sentinel — and the slow real run needlessly **gated the merge** (PR #400 sat BLOCKED ~5 min for a docs change). The sentinel's own design doc assumes test.yml's PR trigger also skips `**.md`; `build.yml` already does.

**Fix:** add `**.md` to `test.yml`'s `pull_request` `paths-ignore`. Docs-only PRs are then satisfied by the sentinel alone (which posts the required Backend/Frontend/Semgrep check-runs); mixed code+docs PRs still run the real suite (paths-ignore skips only when *every* changed file matches).

bd filed. 🤖 Generated with [Claude Code](https://claude.com/claude-code)