### PR TITLE
ci(sentinel): cover all 7 required checks on docs-only PRs

### DIFF
--- a/.github/workflows/docs-only-pass.yml
+++ b/.github/workflows/docs-only-pass.yml
@@ -2,15 +2,18 @@
 # on PRs that touch ONLY paths the main CI workflows skip.
 #
 # ─── Why this exists ──────────────────────────────────────────────────
-# `dev` and `main` branch protection require these 5 status checks:
+# `dev` and `main` branch protection require these 7 status checks:
 #   - Backend Tests                              (test.yml: backend)
 #   - Frontend Tests                             (test.yml: frontend)
 #   - Semgrep Lint                               (test.yml: semgrep-lint)
+#   - Version Consistency                        (test.yml: version-consistency)
+#   - MCP Server Tests                           (test.yml: mcp-server)
 #   - CodeQL Analysis (python)                   (build.yml: codeql-analysis matrix)
 #   - CodeQL Analysis (javascript-typescript)    (build.yml: codeql-analysis matrix)
 #
-# build.yml ignores `**.md` and `.beads/**`. test.yml (PR trigger) ignores
-# `.beads/**`. So a PR touching only `**.md` produces no CodeQL check-runs —
+# build.yml ignores `**.md` and `.beads/**`. As of the test.yml PR-trigger
+# fix, test.yml also ignores `**.md` on PRs. So a PR touching only `**.md`
+# produces no real check-runs —
 # the required checks never report — and the PR is unmergeable. A PR
 # touching only `.beads/**` produces no check-runs at all and is doubly
 # blocked. See bd-pf82j (PR #139, the api.md backfill that surfaced this).
@@ -88,6 +91,20 @@ jobs:
     steps:
       - name: Doc-only PR — main CI skipped per paths-ignore in test.yml
         run: echo "Doc-only / beads-only change. Real Semgrep Lint would run if any non-doc file changed."
+
+  version-consistency:
+    name: Version Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Doc-only PR — main CI skipped per paths-ignore in test.yml
+        run: echo "Doc-only / beads-only change. Real Version Consistency would run if any non-doc file changed."
+
+  mcp-server-tests:
+    name: MCP Server Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Doc-only PR — main CI skipped per paths-ignore in test.yml
+        run: echo "Doc-only / beads-only change. Real MCP Server Tests would run if any non-doc file changed."
 
   codeql-analysis:
     # Mirrors the matrix in build.yml's `codeql-analysis` job so the


### PR DESCRIPTION
Follow-up to #401. dev requires 7 checks but the docs-only sentinel only posted 5; once test.yml started skipping docs PRs, `Version Consistency` + `MCP Server Tests` stopped reporting on Markdown-only PRs → BLOCKED (PR #400). Adds matching no-op sentinel jobs. 🤖 Generated with [Claude Code](https://claude.com/claude-code)