### PR TITLE
security(mcp): remove hardcoded api_key from committed .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "ecm": {
       "type": "http",
-      "url": "http://localhost:6101/mcp?api_key=kuU7wQT0IoyXqjJJCdn7QD8XHEDdvxPXfAvCN4oBpwo"
+      "url": "http://localhost:6101/mcp?api_key=${ECM_MCP_API_KEY}"
     }
   }
 }


### PR DESCRIPTION
**Finding:** the public repo's committed `.mcp.json` embedded a plaintext `mcp_api_key` in the URL. The committed key (`kuU7…`) is **already stale/rotated** — the live key was never committed — so there's no active credential exposure, but the pattern publicly leaked the old key and would leak every future one.

**Fix:** replace the literal key with env-var expansion — `?api_key=${ECM_MCP_API_KEY}`. The committed file now carries no secret; developers export `ECM_MCP_API_KEY` to use the `ecm` MCP from Claude Code in this repo.

History rewrite was deemed unnecessary (the committed key is dead). No rotation needed (already rotated). Found while wiring Claude Code to the ecm MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)