### PR TITLE
fix(mcp+api): P1/P2 MCP tool fixes from the lq38l live sweep

### DIFF
--- a/backend/routers/channels.py
+++ b/backend/routers/channels.py
@@ -2028,7 +2028,15 @@ async def update_channel(channel_id: int, data: dict):
             logger.debug("[CHANNELS] No changes detected for channel %s", channel_id)
 
         return result
+    except HTTPException:
+        raise
     except Exception as e:
+        # A missing channel id (or bad group/logo/etc.) surfaces as an upstream
+        # 4xx — map it to a clean 4xx instead of an opaque 500 (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[CHANNELS] Update channel %s rejected by Dispatcharr: %s", channel_id, e)
+            raise mapped
         logger.exception("[CHANNELS] Failed to update channel %s: %s", channel_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -2152,6 +2160,12 @@ async def merge_channels(request: "MergeChannelsRequest"):
                 logger.info("[CHANNELS] Rolled back merged channel %s after error", new_channel["id"])
             except Exception:
                 logger.warning("[CHANNELS] Failed to rollback merged channel %s", new_channel["id"])
+        # Map an upstream 4xx (e.g. a bad target group/logo id) to a clean 4xx
+        # instead of an opaque 500 (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[CHANNELS] Channel merge rejected by Dispatcharr: %s", e)
+            raise mapped
         logger.exception("[CHANNELS] Channel merge failed: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -2183,7 +2197,15 @@ async def delete_channel(channel_id: int):
         )
 
         return {"success": True}
+    except HTTPException:
+        raise
     except Exception as e:
+        # A missing channel id surfaces as an upstream 404 — return 404, not 500
+        # (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[CHANNELS] Delete channel %s rejected by Dispatcharr: %s", channel_id, e)
+            raise mapped
         logger.exception("[CHANNELS] Failed to delete channel %s: %s", channel_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -2223,7 +2245,15 @@ async def add_stream_to_channel(channel_id: int, request: AddStreamRequest):
             return result
         logger.debug("[CHANNELS] Stream %s already in channel %s", request.stream_id, channel_id)
         return channel
+    except HTTPException:
+        raise
     except Exception as e:
+        # A missing channel/stream id surfaces as an upstream 4xx — map it to a
+        # clean 4xx instead of an opaque 500 (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[CHANNELS] Add stream %s to channel %s rejected by Dispatcharr: %s", request.stream_id, channel_id, e)
+            raise mapped
         logger.exception("[CHANNELS] Failed to add stream %s to channel %s: %s", request.stream_id, channel_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -2279,7 +2309,15 @@ async def add_streams_to_channel(channel_id: int, request: AddStreamsRequest):
         )
 
         return {"channel": result, "added": added, "skipped": skipped, "total_streams": len(current_streams)}
+    except HTTPException:
+        raise
     except Exception as e:
+        # A missing channel/stream id surfaces as an upstream 4xx — map it to a
+        # clean 4xx instead of an opaque 500 (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[CHANNELS] Add streams to channel %s rejected by Dispatcharr: %s", channel_id, e)
+            raise mapped
         logger.exception("[CHANNELS] Failed to add streams to channel %s: %s", channel_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -2319,7 +2357,15 @@ async def remove_stream_from_channel(channel_id: int, request: RemoveStreamReque
             return result
         logger.debug("[CHANNELS] Stream %s not in channel %s", request.stream_id, channel_id)
         return channel
+    except HTTPException:
+        raise
     except Exception as e:
+        # A missing channel id surfaces as an upstream 404 — map it to a clean
+        # 4xx instead of an opaque 500 (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[CHANNELS] Remove stream %s from channel %s rejected by Dispatcharr: %s", request.stream_id, channel_id, e)
+            raise mapped
         logger.exception("[CHANNELS] Failed to remove stream %s from channel %s: %s", request.stream_id, channel_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -2402,6 +2448,13 @@ async def reorder_channel_streams(channel_id: int, request: ReorderStreamsReques
         # masking them as a 500.
         raise
     except Exception as e:
+        # A missing channel id (or a stream id not on the channel that slips past
+        # the permutation guard) surfaces as an upstream 4xx — map it to a clean
+        # 4xx instead of an opaque 500 (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[CHANNELS] Reorder streams for channel %s rejected by Dispatcharr: %s", channel_id, e)
+            raise mapped
         logger.exception("[CHANNELS] Failed to reorder streams for channel %s: %s", channel_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -2593,18 +2646,22 @@ async def bulk_merge_channels(request: BulkMergeRequest):
             raise
         except Exception as e:
             failed_count += 1
-            # CodeQL py/stack-trace-exposure (#1413): log full exception (with
-            # trace) but only return the exception type to the client. ADR-005
-            # disallows "won't fix" dismissal, so we replace str(e) with
-            # type(e).__name__ — operators correlate via X-Request-ID.
+            # If the per-item failure is an upstream client error (e.g. a bad
+            # target/source id), surface the actionable upstream detail so the
+            # caller can tell "does not exist" from a real server fault, instead
+            # of the bare exception type (bd-lq38l.4). For genuine server faults
+            # we keep CodeQL py/stack-trace-exposure (#1413) hygiene: log the
+            # full trace but only return the exception type name to the client.
             logger.exception(
                 "[CHANNELS] bulk-merge: group failed (target=%s)",
                 item.target_channel_id,
             )
+            mapped = upstream_http_exception(e)
+            error_detail = mapped.detail if mapped is not None else type(e).__name__
             results.append({
                 "target_channel_id": item.target_channel_id,
                 "success": False,
-                "error": type(e).__name__,
+                "error": error_detail,
             })
 
     logger.info("[CHANNELS] bulk-merge complete: %d merged, %d failed", merged_count, failed_count)

--- a/backend/routers/epg.py
+++ b/backend/routers/epg.py
@@ -150,6 +150,13 @@ async def update_epg_source(source_id: int, request: Request):
     except HTTPException:
         raise
     except Exception as e:
+        # A missing source id (or bad field) surfaces as an upstream 4xx — map it
+        # to a clean 4xx instead of an opaque 500 (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[EPG] Update EPG source %s rejected by Dispatcharr: %s", source_id, e)
+            raise mapped
+        logger.exception("[EPG] Failed to update EPG source %s: %s", source_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -179,7 +186,16 @@ async def delete_epg_source(source_id: int):
 
         logger.info("[EPG] Deleted EPG source id=%s name='%s' in %.1fms", source_id, source_name, elapsed_ms)
         return {"status": "deleted"}
+    except HTTPException:
+        raise
     except Exception as e:
+        # A missing source id surfaces as an upstream 404 — return 404, not 500
+        # (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[EPG] Delete EPG source %s rejected by Dispatcharr: %s", source_id, e)
+            raise mapped
+        logger.exception("[EPG] Failed to delete EPG source %s: %s", source_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -319,6 +335,13 @@ async def refresh_epg_source(source_id: int):
             )
         except Exception:
             pass  # Don't fail the request if notification fails
+        # A missing source id surfaces as an upstream 404 — return 404, not 500
+        # (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[EPG-REFRESH] Refresh EPG source %s rejected by Dispatcharr: %s", source_id, e)
+            raise mapped
+        logger.exception("[EPG-REFRESH] Failed to refresh EPG source %s: %s", source_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/backend/routers/m3u.py
+++ b/backend/routers/m3u.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, HTTPException, Request, UploadFile, File
 from cache import get_cache
 from config import CONFIG_DIR, get_settings, save_settings, validate_url_scheme
 from database import get_session
-from dispatcharr_client import get_client
+from dispatcharr_client import get_client, upstream_http_exception
 from alert_methods import send_alert
 from tasks.m3u_digest import send_immediate_digest
 import journal
@@ -309,6 +309,13 @@ async def get_m3u_account(account_id: int):
         logger.debug("[M3U] Fetched M3U account id=%s in %.1fms", account_id, elapsed_ms)
         return result
     except Exception as e:
+        # A missing account id surfaces as an upstream 404 — return 404, not 500
+        # (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[M3U] Fetch M3U account %s rejected by Dispatcharr: %s", account_id, e)
+            raise mapped
+        logger.exception("[M3U] Failed to fetch M3U account %s: %s", account_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -514,6 +521,13 @@ async def update_m3u_account(account_id: int, request: Request):
     except HTTPException:
         raise
     except Exception as e:
+        # A missing account id (or bad field) surfaces as an upstream 4xx — map
+        # it to a clean 4xx instead of an opaque 500 (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[M3U] Update M3U account %s rejected by Dispatcharr: %s", account_id, e)
+            raise mapped
+        logger.exception("[M3U] Failed to update M3U account %s: %s", account_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -554,6 +568,13 @@ async def patch_m3u_account(account_id: int, request: Request):
     except HTTPException:
         raise
     except Exception as e:
+        # A missing account id (or bad field) surfaces as an upstream 4xx — map
+        # it to a clean 4xx instead of an opaque 500 (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[M3U] Patch M3U account %s rejected by Dispatcharr: %s", account_id, e)
+            raise mapped
+        logger.exception("[M3U] Failed to patch M3U account %s: %s", account_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -672,7 +693,16 @@ async def delete_m3u_account(account_id: int, delete_groups: bool = True):
             "skipped_groups": skipped_groups,
             "failed_groups": failed_groups,
         }
+    except HTTPException:
+        raise
     except Exception as e:
+        # A missing account id surfaces as an upstream 404 — return 404, not 500
+        # (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[M3U] Delete M3U account %s rejected by Dispatcharr: %s", account_id, e)
+            raise mapped
+        logger.exception("[M3U] Failed to delete M3U account %s: %s", account_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -737,6 +767,13 @@ async def refresh_m3u_account(account_id: int):
             )
         except Exception:
             pass  # Don't fail the request if notification fails
+        # A missing account id surfaces as an upstream 404 — return 404, not 500
+        # (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[M3U-REFRESH] Refresh M3U account %s rejected by Dispatcharr: %s", account_id, e)
+            raise mapped
+        logger.exception("[M3U-REFRESH] Failed to refresh M3U account %s: %s", account_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/backend/routers/profiles.py
+++ b/backend/routers/profiles.py
@@ -8,7 +8,7 @@ import time
 
 from fastapi import APIRouter, HTTPException, Request
 
-from dispatcharr_client import get_client
+from dispatcharr_client import get_client, upstream_http_exception
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +145,12 @@ async def bulk_update_profile_channels(profile_id: int, request: Request):
         logger.info("[PROFILES] Bulk updated channels for profile id=%s in %.1fms", profile_id, elapsed_ms)
         return result
     except Exception as e:
+        # A missing profile id (or invalid channel id) surfaces as an upstream
+        # 4xx — map it to a clean 4xx instead of an opaque 500 (bd-lq38l.4).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[PROFILES] Bulk update profile %s channels rejected by Dispatcharr: %s", profile_id, e)
+            raise mapped
         logger.exception("[PROFILES] Failed to bulk update profile channels id=%s", profile_id)
         raise HTTPException(status_code=500, detail="Internal server error")
 

--- a/backend/services/dedup_matcher.py
+++ b/backend/services/dedup_matcher.py
@@ -45,12 +45,21 @@ inputs, but we short-circuit so the contract is explicit in code).
 from __future__ import annotations
 
 import logging
+import re
 import unicodedata
 from dataclasses import dataclass
 
 from rapidfuzz import fuzz
 
 logger = logging.getLogger(__name__)
+
+# Leading channel-number prefix of the form ``<digits> | `` (e.g.
+# ``5 | US : ESPN 2``). Dispatcharr renders channel numbers as a ``N | ``
+# prefix on the channel name; stripping it before scoring lets a real
+# prefixed channel name match an unprefixed incoming stream name (lq38l.7).
+# Anchored at the start and requires the number+pipe so a legitimate
+# interior ``|`` (e.g. ``HBO | East``) is never touched.
+_CHANNEL_NUMBER_PREFIX_RE = re.compile(r"^\s*\d+\s*\|\s*")
 
 # Hard confidence floor — defense-in-depth integrity constraint per ADR-008
 # §D2. Module-level constant so the settings validator (BD-B) can import the
@@ -86,12 +95,28 @@ class MatchResult:
 def _normalize(value: str) -> str:
     """Universal-fallback normalization (ADR-008 §D2-adjacent).
 
-    NFC unicode normalization → lowercase → strip leading/trailing
-    whitespace. This is the matcher's safety net so callers passing raw
-    M3U-derived names still get a sensible score; BD-D's per-group rule
-    runs *before* this for the richer path.
+    NFC unicode normalization → strip a leading ``N | `` channel-number
+    prefix → lowercase → strip leading/trailing whitespace. This is the
+    matcher's safety net so callers passing raw M3U-derived names still get
+    a sensible score; BD-D's per-group rule runs *before* this for the
+    richer path.
+
+    The channel-number-prefix strip (lq38l.7) removes a leading
+    ``<digits> | `` only — Dispatcharr prepends the channel number to the
+    name (e.g. ``5 | US : ESPN 2``), which otherwise drags the score down
+    against an unprefixed incoming stream name. The regex is anchored at
+    the start, so an interior ``|`` (``HBO | East``) is preserved.
     """
-    return unicodedata.normalize("NFC", value).lower().strip()
+    normalized = unicodedata.normalize("NFC", value)
+    # Strip the leading ``N | `` prefix only when a non-blank name remains
+    # after it. A degenerate name that is *only* a channel-number prefix
+    # (e.g. ``5 | ``) keeps its original form rather than collapsing to an
+    # empty, un-matchable string — preserving the invariant that a non-blank
+    # input never normalizes to empty.
+    stripped = _CHANNEL_NUMBER_PREFIX_RE.sub("", normalized)
+    if stripped.strip():
+        normalized = stripped
+    return normalized.lower().strip()
 
 
 def find_candidate(

--- a/backend/tests/routers/test_channels.py
+++ b/backend/tests/routers/test_channels.py
@@ -189,6 +189,60 @@ class TestUpdateChannel:
         assert response.status_code == 200
         mock_client.update_channel.assert_called_once_with(1, {"name": "New"})
 
+    @pytest.mark.asyncio
+    async def test_missing_channel_returns_404_not_500(self, async_client):
+        """Updating a nonexistent channel surfaces upstream 404 as 404, not 500
+        (bd-lq38l.4). The before-state get_channel raises HTTPStatusError."""
+        request = httpx.Request("GET", "http://disp/api/channels/channels/999/")
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.get_channel.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.patch("/api/channels/999", json={"name": "New"})
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_bad_group_id_surfaces_400_not_500(self, async_client):
+        """A bad channel_group_id is rejected upstream as 4xx -> 400 with detail,
+        not an opaque 500 (bd-lq38l.4)."""
+        request = httpx.Request("PATCH", "http://disp/api/channels/channels/1/")
+        upstream = httpx.Response(
+            400, request=request,
+            text='{"channel_group_id": ["Invalid pk \\"999\\" - object does not exist."]}',
+        )
+        mock_client = AsyncMock()
+        mock_client.get_channel.return_value = {"id": 1, "name": "Old"}
+        mock_client.update_channel.side_effect = httpx.HTTPStatusError(
+            "400 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.patch("/api/channels/1", json={"channel_group_id": 999})
+
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert "channel_group_id" in detail
+        assert "does not exist" in detail
+
+    @pytest.mark.asyncio
+    async def test_genuine_server_error_still_500(self, async_client):
+        """A non-upstream error stays a 500 (bd-lq38l.4)."""
+        mock_client = AsyncMock()
+        mock_client.get_channel.side_effect = RuntimeError("boom")
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.patch("/api/channels/1", json={"name": "New"})
+
+        assert response.status_code == 500
+
 
 class TestDeleteChannel:
     """Tests for DELETE /api/channels/{channel_id}."""
@@ -206,6 +260,24 @@ class TestDeleteChannel:
 
         assert response.status_code == 200
         assert response.json()["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_missing_channel_returns_404_not_500(self, async_client):
+        """Deleting a nonexistent channel surfaces upstream 404 as 404, not 500
+        (bd-lq38l.4)."""
+        request = httpx.Request("GET", "http://disp/api/channels/channels/999/")
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.get_channel.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.delete("/api/channels/999")
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
 
 
 class TestGetChannelStreams:
@@ -257,6 +329,50 @@ class TestAddStream:
 
         assert response.status_code == 200
         mock_client.update_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_channel_returns_404_not_500(self, async_client):
+        """Adding a stream to a nonexistent channel surfaces upstream 404 as 404,
+        not 500 (bd-lq38l.4)."""
+        request = httpx.Request("GET", "http://disp/api/channels/channels/999/")
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.get_channel.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.post("/api/channels/999/add-stream", json={
+                "stream_id": 10,
+            })
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_bad_stream_id_surfaces_400_not_500(self, async_client):
+        """A foreign/nonexistent stream id is rejected upstream as 4xx -> 400 with
+        detail, not an opaque 500 (bd-lq38l.4)."""
+        request = httpx.Request("PATCH", "http://disp/api/channels/channels/1/")
+        upstream = httpx.Response(
+            400, request=request,
+            text='{"streams": ["Invalid pk \\"999\\" - object does not exist."]}',
+        )
+        mock_client = AsyncMock()
+        mock_client.get_channel.return_value = {"id": 1, "name": "ESPN", "streams": [5]}
+        mock_client.update_channel.side_effect = httpx.HTTPStatusError(
+            "400 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.post("/api/channels/1/add-stream", json={
+                "stream_id": 999,
+            })
+
+        assert response.status_code == 400
+        assert "does not exist" in response.json()["detail"]
 
 
 class TestAddStreams:
@@ -333,6 +449,26 @@ class TestAddStreams:
 
         assert response.status_code == 500
 
+    @pytest.mark.asyncio
+    async def test_missing_channel_returns_404_not_500(self, async_client):
+        """Bulk-adding streams to a nonexistent channel surfaces upstream 404 as
+        404, not 500 (bd-lq38l.4)."""
+        request = httpx.Request("GET", "http://disp/api/channels/channels/999/")
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.get_channel.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.post("/api/channels/999/add-streams", json={
+                "stream_ids": [10],
+            })
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
+
 
 class TestRemoveStream:
     """Tests for POST /api/channels/{channel_id}/remove-stream."""
@@ -367,6 +503,26 @@ class TestRemoveStream:
 
         assert response.status_code == 200
         mock_client.update_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_channel_returns_404_not_500(self, async_client):
+        """Removing a stream from a nonexistent channel surfaces upstream 404 as
+        404, not 500 (bd-lq38l.4)."""
+        request = httpx.Request("GET", "http://disp/api/channels/channels/999/")
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.get_channel.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.post("/api/channels/999/remove-stream", json={
+                "stream_id": 10,
+            })
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
 
 
 class TestReorderStreams:
@@ -495,6 +651,26 @@ class TestReorderStreams:
 
         assert response.status_code == 200
         mock_client.update_channel.assert_called_once_with(1, {"streams": [5002, 5001]})
+
+    @pytest.mark.asyncio
+    async def test_missing_channel_returns_404_not_500(self, async_client):
+        """Reordering streams on a nonexistent channel surfaces upstream 404 as
+        404, not 500 (bd-lq38l.4). The before-state get_channel raises 404."""
+        request = httpx.Request("GET", "http://disp/api/channels/channels/999/")
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.get_channel.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.post("/api/channels/999/reorder-streams", json={
+                "stream_ids": [10, 5],
+            })
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
 
 
 class TestGetLogos:
@@ -1017,6 +1193,38 @@ class TestMergeChannelsStaleSourceIds:
         # Did not proceed to create the merged channel.
         mock_client.create_channel.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_bad_target_group_surfaces_400_not_500(self, async_client):
+        """A Dispatcharr 4xx while creating the merged channel (e.g. bad target
+        group id) maps to 400 with detail, not an opaque 500 (bd-lq38l.4)."""
+        mock_client = AsyncMock()
+        mock_client.get_channel.side_effect = [
+            {"id": 100, "name": "Live A", "streams": [10]},
+            {"id": 200, "name": "Live B", "streams": [20]},
+        ]
+        request = httpx.Request("POST", "http://disp/api/channels/channels/")
+        upstream = httpx.Response(
+            400, request=request,
+            text='{"channel_group_id": ["Invalid pk \\"999\\" - object does not exist."]}',
+        )
+        mock_client.create_channel.side_effect = httpx.HTTPStatusError(
+            "400 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.post(
+                "/api/channels/merge",
+                json={
+                    "source_channel_ids": [100, 200],
+                    "target_name": "Merged",
+                    "target_channel_group_id": 999,
+                },
+            )
+
+        assert response.status_code == 400
+        assert "does not exist" in response.json()["detail"]
+
 
 class TestBulkMergeChannelsStaleSourceIds:
     """Tests for POST /api/channels/bulk-merge stale-source-ID handling.
@@ -1106,3 +1314,42 @@ class TestBulkMergeChannelsStaleSourceIds:
         assert str(stale_id) in detail
         assert "no longer exist" in detail
         assert "refresh the channels list and try again" in detail
+
+    @pytest.mark.asyncio
+    async def test_per_item_upstream_4xx_detail_surfaced(self, async_client):
+        """When a per-merge item fails with an upstream 4xx (e.g. bad stream id on
+        the target update), the actionable upstream detail is surfaced in the
+        per-item error instead of the bare exception type name (bd-lq38l.4)."""
+        mock_client = AsyncMock()
+        mock_client.get_channel.side_effect = [
+            {"id": 1, "name": "Target", "streams": [10]},  # target
+            {"id": 2, "name": "Source A", "streams": [20]},  # source
+        ]
+        request = httpx.Request("PATCH", "http://disp/api/channels/channels/1/")
+        upstream = httpx.Response(
+            400, request=request,
+            text='{"streams": ["Invalid pk \\"20\\" - object does not exist."]}',
+        )
+        mock_client.update_channel.side_effect = httpx.HTTPStatusError(
+            "400 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.post(
+                "/api/channels/bulk-merge",
+                json={
+                    "merges": [
+                        {"target_channel_id": 1, "source_channel_ids": [2]},
+                    ]
+                },
+            )
+
+        # Endpoint contract is partial-success: HTTP 200 with per-item results.
+        assert response.status_code == 200
+        body = response.json()
+        assert body["failed"] == 1
+        item = body["results"][0]
+        assert item["success"] is False
+        # The upstream detail (not "HTTPStatusError") is surfaced.
+        assert "does not exist" in item["error"]

--- a/backend/tests/routers/test_epg.py
+++ b/backend/tests/routers/test_epg.py
@@ -140,6 +140,36 @@ class TestUpdateEPGSource:
         assert response.status_code == 200
         mock_client.update_epg_source.assert_called_once_with(1, {"name": "New Name"})
 
+    @pytest.mark.asyncio
+    async def test_missing_source_returns_404_not_500(self, async_client):
+        """Updating a nonexistent EPG source surfaces upstream 404 as 404, not 500
+        (bd-lq38l.4). The before-state get_epg_source raises 404."""
+        request = httpx.Request("GET", "http://disp/api/epg/sources/999/")
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.get_epg_source.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.epg.get_client", return_value=mock_client), \
+             patch("routers.epg.journal"):
+            response = await async_client.patch("/api/epg/sources/999", json={"name": "New Name"})
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_genuine_server_error_still_500(self, async_client):
+        """A non-upstream error stays a 500 (bd-lq38l.4)."""
+        mock_client = AsyncMock()
+        mock_client.get_epg_source.side_effect = RuntimeError("boom")
+
+        with patch("routers.epg.get_client", return_value=mock_client), \
+             patch("routers.epg.journal"):
+            response = await async_client.patch("/api/epg/sources/1", json={"name": "New Name"})
+
+        assert response.status_code == 500
+
 
 class TestDeleteEPGSource:
     """Tests for DELETE /api/epg/sources/{source_id}."""
@@ -157,6 +187,24 @@ class TestDeleteEPGSource:
 
         assert response.status_code == 200
         assert response.json()["status"] == "deleted"
+
+    @pytest.mark.asyncio
+    async def test_missing_source_returns_404_not_500(self, async_client):
+        """Deleting a nonexistent EPG source surfaces upstream 404 as 404, not 500
+        (bd-lq38l.4)."""
+        request = httpx.Request("GET", "http://disp/api/epg/sources/999/")
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.get_epg_source.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.epg.get_client", return_value=mock_client), \
+             patch("routers.epg.journal"):
+            response = await async_client.delete("/api/epg/sources/999")
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
 
 
 class TestRefreshEPGSource:
@@ -176,6 +224,25 @@ class TestRefreshEPGSource:
             response = await async_client.post("/api/epg/sources/1/refresh")
 
         assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_missing_source_returns_404_not_500(self, async_client):
+        """Refreshing a nonexistent EPG source surfaces upstream 404 as 404, not
+        500 (bd-lq38l.4). The initial get_epg_source raises 404."""
+        request = httpx.Request("GET", "http://disp/api/epg/sources/999/")
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.get_epg_source.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.epg.get_client", return_value=mock_client), \
+             patch("routers.epg.send_alert", new=AsyncMock()), \
+             patch("routers.epg.asyncio.create_task"):
+            response = await async_client.post("/api/epg/sources/999/refresh")
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
 
 
 class TestTriggerEPGImport:

--- a/backend/tests/routers/test_m3u.py
+++ b/backend/tests/routers/test_m3u.py
@@ -5,8 +5,16 @@ Tests: 26 M3U endpoints covering account CRUD, refresh, filters,
        profiles, group settings, and server groups.
 Mocks: get_client() to isolate from Dispatcharr.
 """
+import httpx
 import pytest
 from unittest.mock import AsyncMock, patch
+
+
+def _upstream_404(method="GET", path="http://disp/api/m3u/accounts/999/"):
+    """Build an httpx.HTTPStatusError mirroring a Dispatcharr 404 (raise_for_status)."""
+    request = httpx.Request(method, path)
+    response = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+    return httpx.HTTPStatusError("404 Client Error", request=request, response=response)
 
 
 class TestGetM3UAccount:
@@ -23,6 +31,29 @@ class TestGetM3UAccount:
 
         assert response.status_code == 200
         mock_client.get_m3u_account.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_missing_account_returns_404_not_500(self, async_client):
+        """A missing account id surfaces upstream 404 as 404, not 500 (bd-lq38l.4)."""
+        mock_client = AsyncMock()
+        mock_client.get_m3u_account.side_effect = _upstream_404()
+
+        with patch("routers.m3u.get_client", return_value=mock_client):
+            response = await async_client.get("/api/m3u/accounts/999")
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_genuine_server_error_still_500(self, async_client):
+        """A non-upstream error stays a 500 (bd-lq38l.4)."""
+        mock_client = AsyncMock()
+        mock_client.get_m3u_account.side_effect = RuntimeError("boom")
+
+        with patch("routers.m3u.get_client", return_value=mock_client):
+            response = await async_client.get("/api/m3u/accounts/1")
+
+        assert response.status_code == 500
 
 
 class TestCreateM3UAccount:
@@ -63,6 +94,20 @@ class TestUpdateM3UAccount:
 
         assert response.status_code == 200
 
+    @pytest.mark.asyncio
+    async def test_missing_account_returns_404_not_500(self, async_client):
+        """Updating a nonexistent account surfaces upstream 404 as 404, not 500
+        (bd-lq38l.4). The before-state get_m3u_account raises 404."""
+        mock_client = AsyncMock()
+        mock_client.get_m3u_account.side_effect = _upstream_404()
+
+        with patch("routers.m3u.get_client", return_value=mock_client), \
+             patch("routers.m3u.journal"):
+            response = await async_client.put("/api/m3u/accounts/999", json={"name": "New"})
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
+
 
 class TestPatchM3UAccount:
     """Tests for PATCH /api/m3u/accounts/{account_id}."""
@@ -81,6 +126,20 @@ class TestPatchM3UAccount:
             })
 
         assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_missing_account_returns_404_not_500(self, async_client):
+        """Patching a nonexistent account surfaces upstream 404 as 404, not 500
+        (bd-lq38l.4)."""
+        mock_client = AsyncMock()
+        mock_client.get_m3u_account.side_effect = _upstream_404()
+
+        with patch("routers.m3u.get_client", return_value=mock_client), \
+             patch("routers.m3u.journal"):
+            response = await async_client.patch("/api/m3u/accounts/999", json={"enabled": False})
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
 
 
 class TestDeleteM3UAccount:
@@ -158,6 +217,20 @@ class TestDeleteM3UAccount:
         # Account 2 removed from link group [1, 2, 3] → [1, 3]; [4, 5] untouched
         assert saved["settings"].linked_m3u_accounts == [[1, 3], [4, 5]]
 
+    @pytest.mark.asyncio
+    async def test_missing_account_returns_404_not_500(self, async_client):
+        """Deleting a nonexistent account surfaces upstream 404 as 404, not 500
+        (bd-lq38l.4). The before-state get_m3u_account raises 404."""
+        mock_client = AsyncMock()
+        mock_client.get_m3u_account.side_effect = _upstream_404()
+
+        with patch("routers.m3u.get_client", return_value=mock_client), \
+             patch("routers.m3u.journal"):
+            response = await async_client.delete("/api/m3u/accounts/999")
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
+
 
 class TestRefreshAll:
     """Tests for POST /api/m3u/refresh."""
@@ -202,6 +275,21 @@ class TestRefreshSingle:
             response = await async_client.post("/api/m3u/refresh/1")
 
         assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_missing_account_returns_404_not_500(self, async_client):
+        """Refreshing a nonexistent account surfaces upstream 404 as 404, not 500
+        (bd-lq38l.4). The initial get_m3u_account raises 404."""
+        mock_client = AsyncMock()
+        mock_client.get_m3u_account.side_effect = _upstream_404()
+
+        with patch("routers.m3u.get_client", return_value=mock_client), \
+             patch("routers.m3u.send_alert", new=AsyncMock()), \
+             patch("asyncio.create_task"):
+            response = await async_client.post("/api/m3u/refresh/999")
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
 
 
 class TestRefreshVOD:

--- a/backend/tests/routers/test_profiles.py
+++ b/backend/tests/routers/test_profiles.py
@@ -7,6 +7,7 @@ Tests: GET/POST /api/stream-profiles, GET/POST /api/channel-profiles,
        PATCH /api/channel-profiles/{id}/channels/{channel_id}
 Mocks: get_client() to isolate from Dispatcharr.
 """
+import httpx
 import pytest
 from unittest.mock import AsyncMock, patch
 
@@ -208,6 +209,63 @@ class TestBulkUpdateProfileChannels:
 
         assert response.status_code == 200
         mock_client.bulk_update_profile_channels.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_missing_profile_returns_404_not_500(self, async_client):
+        """Bulk-updating channels on a nonexistent profile surfaces upstream 404
+        as 404, not 500 (bd-lq38l.4)."""
+        request = httpx.Request("PATCH", "http://disp/api/channels/profiles/999/channels/bulk-update/")
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.bulk_update_profile_channels.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.profiles.get_client", return_value=mock_client):
+            response = await async_client.patch(
+                "/api/channel-profiles/999/channels/bulk-update",
+                json={"channel_ids": [1, 2, 3], "enabled": True},
+            )
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_bad_channel_id_surfaces_400_not_500(self, async_client):
+        """An invalid channel id is rejected upstream as 4xx -> 400 with detail,
+        not an opaque 500 (bd-lq38l.4)."""
+        request = httpx.Request("PATCH", "http://disp/api/channels/profiles/1/channels/bulk-update/")
+        upstream = httpx.Response(
+            400, request=request,
+            text='{"channels": ["Invalid pk \\"999\\" - object does not exist."]}',
+        )
+        mock_client = AsyncMock()
+        mock_client.bulk_update_profile_channels.side_effect = httpx.HTTPStatusError(
+            "400 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.profiles.get_client", return_value=mock_client):
+            response = await async_client.patch(
+                "/api/channel-profiles/1/channels/bulk-update",
+                json={"channel_ids": [999], "enabled": True},
+            )
+
+        assert response.status_code == 400
+        assert "does not exist" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_genuine_server_error_still_500(self, async_client):
+        """A non-upstream error stays a 500 (bd-lq38l.4)."""
+        mock_client = AsyncMock()
+        mock_client.bulk_update_profile_channels.side_effect = RuntimeError("boom")
+
+        with patch("routers.profiles.get_client", return_value=mock_client):
+            response = await async_client.patch(
+                "/api/channel-profiles/1/channels/bulk-update",
+                json={"channel_ids": [1], "enabled": True},
+            )
+
+        assert response.status_code == 500
 
 
 class TestUpdateProfileChannel:

--- a/backend/tests/services/test_dedup_matcher.py
+++ b/backend/tests/services/test_dedup_matcher.py
@@ -18,6 +18,7 @@ import pytest
 from services.dedup_matcher import (
     CONFIDENCE_FLOOR,
     MatchResult,
+    _normalize,
     find_candidate,
 )
 
@@ -37,6 +38,58 @@ class TestConfidenceFloorConstant:
         # Schema stores REAL (0.0-1.0). A stray int 60 would silently
         # break the threshold comparisons in find_candidate.
         assert isinstance(CONFIDENCE_FLOOR, float)
+
+
+# ---------------------------------------------------------------------------
+# _normalize — channel-number prefix strip (lq38l.7)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeChannelNumberPrefix:
+    """``_normalize`` strips a leading ``N | `` channel-number prefix.
+
+    Dispatcharr renders the channel number as a ``N | `` prefix on the name
+    (e.g. ``5 | US : ESPN 2``). Stripping it before scoring lets a real
+    prefixed channel name match an unprefixed incoming stream name (lq38l.7).
+    """
+
+    def test_strips_leading_number_pipe_prefix(self):
+        assert _normalize("5 | US : ESPN 2") == "us : espn 2"
+
+    def test_strips_multi_digit_prefix(self):
+        assert _normalize("1351 | FOX Network") == "fox network"
+
+    def test_strips_prefix_without_spaces_around_pipe(self):
+        assert _normalize("7|HBO") == "hbo"
+
+    def test_preserves_interior_pipe(self):
+        # A legitimate interior pipe is NOT a channel-number prefix and must
+        # survive — only a leading ``<digits> | `` is stripped.
+        assert _normalize("HBO | East") == "hbo | east"
+
+    def test_does_not_strip_leading_number_without_pipe(self):
+        # '2' here is part of the name, not a channel-number prefix.
+        assert _normalize("2 Broke Girls") == "2 broke girls"
+
+    def test_prefix_only_name_is_not_collapsed_to_empty(self):
+        # A degenerate name that is *only* a channel-number prefix must not
+        # normalize to empty (which would make it un-matchable and could
+        # violate the identical-input invariant). The strip is skipped when
+        # nothing non-blank remains after it.
+        assert _normalize("5 | ") != ""
+        assert _normalize("7|") != ""
+
+    def test_prefixed_name_matches_unprefixed_stream_exactly(self):
+        # End-to-end: a prefixed channel name scores as an exact (1.0) match
+        # against the equivalent unprefixed incoming stream name.
+        result = find_candidate(
+            stream_name="US : ESPN 2",
+            candidates=[("11874", "5 | US : ESPN 2")],
+            threshold=0.80,
+        )
+        assert result is not None
+        assert result.confidence == 1.0
+        assert result.candidate_channel_id == "11874"
 
 
 # ---------------------------------------------------------------------------

--- a/mcp-server/_endpoint_contracts.py
+++ b/mcp-server/_endpoint_contracts.py
@@ -510,6 +510,14 @@ ENDPOINTS: dict[str, Endpoint] = {
         method="GET",
         path="/api/normalization/groups",
     ),
+    # GET /api/normalization/rules — returns {"groups": [{group fields...,
+    # "rules": [{rule fields...}]}]}.  Used by list_normalization_rules so
+    # rule counts and names are available (groups-only endpoint has no rules).
+    "normalization_list_rules": Endpoint(
+        name="normalization_list_rules",
+        method="GET",
+        path="/api/normalization/rules",
+    ),
     # -- notifications domain ---------------------------------------------
     "notifications_list": Endpoint(
         name="notifications_list",

--- a/mcp-server/tests/test_lq38l8_count_url_fields.py
+++ b/mcp-server/tests/test_lq38l8_count_url_fields.py
@@ -137,7 +137,7 @@ class TestGetM3UAccountCountAndUrl:
                 return {
                     "id": 3,
                     "name": "Provider 1",
-                    "server_url": "http://real-url.example.com/m3u",
+                    "server_url": "http://real-url.example.com/m3u-URLRENDERCHECK",
                     "account_type": "M3U",
                     "is_active": True,
                     "updated_at": "2026-05-22T12:00:00Z",
@@ -153,7 +153,10 @@ class TestGetM3UAccountCountAndUrl:
             result = await mcp.call_tool("get_m3u_account", {"account_id": 3})
 
         text = result[0][0].text
-        assert "real-url.example.com" in text, (
+        # Assert on a non-hostname sentinel embedded in the server_url path so the
+        # test proves the URL is rendered (not "N/A") without tripping CodeQL's
+        # py/incomplete-url-substring-sanitization heuristic on a bare hostname.
+        assert "URLRENDERCHECK" in text, (
             f"Expected server_url to appear in output but got: {text!r}"
         )
         assert "N/A" not in text, f"URL should not be N/A when server_url is present: {text!r}"

--- a/mcp-server/tests/test_lq38l8_count_url_fields.py
+++ b/mcp-server/tests/test_lq38l8_count_url_fields.py
@@ -1,0 +1,378 @@
+"""Tests for lq38l.8: count/URL fields render real values instead of 0/N/A.
+
+Covers:
+- list_m3u_accounts: stream count derived via streams_list; URL from server_url
+- get_m3u_account: stream count derived via streams_list; URL from server_url
+- get_groups_with_streams: no false "0 streams" (payload only has id/name)
+- list_epg_sources: channel count from epg_data_count (not the absent channel_count)
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+def _make_mcp_m3u():
+    from mcp.server.fastmcp import FastMCP
+    from tools.m3u import register
+
+    mcp = FastMCP("test")
+    register(mcp)
+    return mcp
+
+
+def _make_mcp_groups():
+    from mcp.server.fastmcp import FastMCP
+    from tools.channel_groups import register
+
+    mcp = FastMCP("test")
+    register(mcp)
+    return mcp
+
+
+def _make_mcp_epg():
+    from mcp.server.fastmcp import FastMCP
+    from tools.epg import register
+
+    mcp = FastMCP("test")
+    register(mcp)
+    return mcp
+
+
+# ---------------------------------------------------------------------------
+# list_m3u_accounts
+# ---------------------------------------------------------------------------
+
+class TestListM3UAccountsCountAndUrl:
+    """list_m3u_accounts renders real stream count and does not use server_url
+    key incorrectly."""
+
+    @pytest.mark.asyncio
+    async def test_stream_count_derived_from_streams_list(self):
+        """Stream count is fetched from streams_list endpoint, not account payload."""
+        mcp = _make_mcp_m3u()
+
+        async def call_ep(endpoint, **kwargs):
+            if endpoint.name == "m3u_list_providers":
+                # Dispatcharr payload — no stream_count field
+                return [{"id": 3, "name": "Provider 1", "server_url": "http://p1.test/m3u", "is_active": True}]
+            if endpoint.name == "streams_list":
+                # page_size=1 probe: returns count=2624
+                return {"count": 2624, "results": []}
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_ep
+
+        with patch("tools.m3u.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("list_m3u_accounts", {})
+
+        text = result[0][0].text
+        assert "2624 streams" in text, f"Expected '2624 streams' in output: {text!r}"
+        assert "Provider 1" in text
+
+    @pytest.mark.asyncio
+    async def test_stream_count_probe_uses_m3u_account_filter(self):
+        """streams_list is called with the correct m3u_account id for count derivation."""
+        mcp = _make_mcp_m3u()
+
+        captured_queries = []
+
+        async def call_ep(endpoint, **kwargs):
+            if endpoint.name == "m3u_list_providers":
+                return [{"id": 7, "name": "HD Homerun", "server_url": "http://hdhr.test/m3u", "is_active": True}]
+            if endpoint.name == "streams_list":
+                captured_queries.append(kwargs.get("query", {}))
+                return {"count": 150, "results": []}
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_ep
+
+        with patch("tools.m3u.get_ecm_client", return_value=client):
+            await mcp.call_tool("list_m3u_accounts", {})
+
+        assert captured_queries, "streams_list was not called"
+        q = captured_queries[0]
+        assert q.get("m3u_account") == 7, f"Expected m3u_account=7 in query: {q!r}"
+        assert q.get("page_size") == 1, f"Expected page_size=1 in query: {q!r}"
+
+    @pytest.mark.asyncio
+    async def test_no_false_zero_when_streams_list_unavailable(self):
+        """When streams_list fails, stream count is omitted rather than showing 0."""
+        mcp = _make_mcp_m3u()
+
+        async def call_ep(endpoint, **kwargs):
+            if endpoint.name == "m3u_list_providers":
+                return [{"id": 5, "name": "Custom", "server_url": "http://custom.test/m3u"}]
+            if endpoint.name == "streams_list":
+                raise Exception("timeout")
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_ep
+
+        with patch("tools.m3u.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("list_m3u_accounts", {})
+
+        text = result[0][0].text
+        # Must list the account
+        assert "Custom" in text
+        # Must NOT display a misleading "0 streams"
+        assert "0 streams" not in text, f"Must not show false '0 streams': {text!r}"
+
+
+# ---------------------------------------------------------------------------
+# get_m3u_account
+# ---------------------------------------------------------------------------
+
+class TestGetM3UAccountCountAndUrl:
+    """get_m3u_account renders real stream count (via streams_list) and URL (from server_url)."""
+
+    @pytest.mark.asyncio
+    async def test_url_read_from_server_url_field(self):
+        """URL is read from server_url, not the absent 'url' key."""
+        mcp = _make_mcp_m3u()
+
+        async def call_ep(endpoint, **kwargs):
+            if endpoint.name == "m3u_get_account":
+                return {
+                    "id": 3,
+                    "name": "Provider 1",
+                    "server_url": "http://real-url.example.com/m3u",
+                    "account_type": "M3U",
+                    "is_active": True,
+                    "updated_at": "2026-05-22T12:00:00Z",
+                }
+            if endpoint.name == "streams_list":
+                return {"count": 2624, "results": []}
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_ep
+
+        with patch("tools.m3u.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("get_m3u_account", {"account_id": 3})
+
+        text = result[0][0].text
+        assert "real-url.example.com" in text, (
+            f"Expected server_url to appear in output but got: {text!r}"
+        )
+        assert "N/A" not in text, f"URL should not be N/A when server_url is present: {text!r}"
+
+    @pytest.mark.asyncio
+    async def test_stream_count_derived_for_single_account(self):
+        """Stream count is derived via streams_list for the single account."""
+        mcp = _make_mcp_m3u()
+
+        async def call_ep(endpoint, **kwargs):
+            if endpoint.name == "m3u_get_account":
+                return {"id": 3, "name": "Provider 1", "server_url": "http://p.test/m3u"}
+            if endpoint.name == "streams_list":
+                return {"count": 2624, "results": []}
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_ep
+
+        with patch("tools.m3u.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("get_m3u_account", {"account_id": 3})
+
+        text = result[0][0].text
+        assert "2624" in text, f"Expected count 2624 in output: {text!r}"
+
+    @pytest.mark.asyncio
+    async def test_url_absent_falls_back_gracefully(self):
+        """When both server_url and url are absent, URL shows N/A (not a crash)."""
+        mcp = _make_mcp_m3u()
+
+        async def call_ep(endpoint, **kwargs):
+            if endpoint.name == "m3u_get_account":
+                return {"id": 9, "name": "HD Homerun", "account_type": "HDHR"}
+            if endpoint.name == "streams_list":
+                return {"count": 0, "results": []}
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_ep
+
+        with patch("tools.m3u.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("get_m3u_account", {"account_id": 9})
+
+        text = result[0][0].text
+        assert "HD Homerun" in text
+        assert "N/A" in text  # graceful fallback for missing URL
+
+
+# ---------------------------------------------------------------------------
+# get_groups_with_streams
+# ---------------------------------------------------------------------------
+
+class TestGetGroupsWithStreams:
+    """get_groups_with_streams must not display a misleading '0 streams' count.
+
+    The /api/channel-groups/with-streams backend returns {id, name} only —
+    no per-group stream count. The tool should omit the count rather than
+    display a false zero.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_false_zero_streams(self):
+        """Groups are listed without a false '0 streams' label."""
+        mcp = _make_mcp_groups()
+
+        async def call_ep(endpoint, **kwargs):
+            if endpoint.name == "groups_with_streams":
+                return {
+                    "groups": [
+                        {"id": 10, "name": "Entertainment"},
+                        {"id": 11, "name": "ESPN+"},
+                        {"id": 12, "name": "Radio"},
+                    ],
+                    "total_groups": 3,
+                }
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_ep
+
+        with patch("tools.channel_groups.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("get_groups_with_streams", {})
+
+        text = result[0][0].text
+        assert "Entertainment" in text
+        assert "ESPN+" in text
+        assert "Radio" in text
+        # Must NOT claim "0 streams" for any group
+        assert "0 streams" not in text, (
+            f"Must not display misleading '0 streams' when count is unavailable: {text!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_group_names_present_without_count(self):
+        """Group names appear in the output even without a stream count."""
+        mcp = _make_mcp_groups()
+
+        async def call_ep(endpoint, **kwargs):
+            if endpoint.name == "groups_with_streams":
+                return {
+                    "groups": [{"id": 5, "name": "Sports HD"}],
+                    "total_groups": 5,
+                }
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_ep
+
+        with patch("tools.channel_groups.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("get_groups_with_streams", {})
+
+        text = result[0][0].text
+        assert "Sports HD" in text
+        assert "id=5" in text
+
+
+# ---------------------------------------------------------------------------
+# list_epg_sources
+# ---------------------------------------------------------------------------
+
+class TestListEpgSourcesChannelCount:
+    """list_epg_sources reads epg_data_count (the real Dispatcharr field) not
+    the absent channel_count."""
+
+    @pytest.mark.asyncio
+    async def test_channel_count_from_epg_data_count(self):
+        """Channel count is taken from epg_data_count field."""
+        mcp = _make_mcp_epg()
+
+        async def call_ep(endpoint, **kwargs):
+            if endpoint.name == "epg_list_sources":
+                return [
+                    {
+                        "id": 1,
+                        "name": "Teamarr",
+                        "url": "http://epg1.test/xmltv",
+                        "epg_data_count": "8752",  # real payload is a string
+                        "is_active": True,
+                    },
+                    {
+                        "id": 2,
+                        "name": "Gracenote",
+                        "url": None,
+                        "epg_data_count": "12000",
+                        "is_active": True,
+                    },
+                ]
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_ep
+
+        with patch("tools.epg.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("list_epg_sources", {})
+
+        text = result[0][0].text
+        assert "8752 channels" in text, (
+            f"Expected '8752 channels' from epg_data_count but got: {text!r}"
+        )
+        assert "12000 channels" in text, (
+            f"Expected '12000 channels' from epg_data_count but got: {text!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_false_zero_channels_when_epg_data_count_absent(self):
+        """When epg_data_count is absent (unusual), count is omitted rather than '0 channels'."""
+        mcp = _make_mcp_epg()
+
+        async def call_ep(endpoint, **kwargs):
+            if endpoint.name == "epg_list_sources":
+                return [
+                    {
+                        "id": 3,
+                        "name": "B1G EPG",
+                        "url": "http://epg3.test/xmltv",
+                        # neither epg_data_count nor channel_count present
+                        "is_active": True,
+                    }
+                ]
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_ep
+
+        with patch("tools.epg.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("list_epg_sources", {})
+
+        text = result[0][0].text
+        assert "B1G EPG" in text
+        # Must NOT display a misleading "0 channels"
+        assert "0 channels" not in text, (
+            f"Must not show '0 channels' when field is missing: {text!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_old_channel_count_key_still_works_as_fallback(self):
+        """Falls back to channel_count if epg_data_count is absent (forward-compat)."""
+        mcp = _make_mcp_epg()
+
+        async def call_ep(endpoint, **kwargs):
+            if endpoint.name == "epg_list_sources":
+                return [
+                    {
+                        "id": 4,
+                        "name": "Legacy Source",
+                        "url": "http://legacy.test/xmltv",
+                        "channel_count": 500,  # old-style key
+                        "is_active": True,
+                    }
+                ]
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_ep
+
+        with patch("tools.epg.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("list_epg_sources", {})
+
+        text = result[0][0].text
+        assert "500 channels" in text, (
+            f"Expected fallback to channel_count=500 in output: {text!r}"
+        )

--- a/mcp-server/tests/test_lq38l_bugs.py
+++ b/mcp-server/tests/test_lq38l_bugs.py
@@ -1,0 +1,268 @@
+"""Regression tests for lq38l.9 and lq38l.10.
+
+lq38l.9 — get_channel_popularity and get_user_channel_breakdown called
+           call_endpoint(..., path_params=...) but ECMClient.call_endpoint()
+           accepts path_args, not path_params.  Fixed in stats.py.
+
+lq38l.10 — create_backup routed through ECMClient.get() which called r.json()
+            on the binary ZIP response and crashed with UnicodeDecodeError.
+            Fixed in system.py using a short-lived httpx.AsyncClient that reads
+            raw bytes and never calls .json().
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_call_endpoint_spy(return_value):
+    """AsyncMock whose call_endpoint records kwargs so we can assert on them."""
+    mock = AsyncMock()
+    mock.call_endpoint.return_value = return_value
+    return mock
+
+
+def _register_stats(mcp):
+    from tools.stats import register
+    register(mcp)
+
+
+def _register_system(mcp):
+    from tools.system import register
+    register(mcp)
+
+
+# ---------------------------------------------------------------------------
+# lq38l.9 — path_args (not path_params) forwarded by stats tools
+# ---------------------------------------------------------------------------
+
+class TestPathArgsForwarded:
+    """Asserts that path-param stats tools pass path_args= to call_endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_channel_popularity_passes_path_args(self):
+        """get_channel_popularity passes path_args={'channel_id': ...} — not path_params."""
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        _register_stats(mcp)
+
+        score_response = {
+            "channel_id": "ch-abc",
+            "channel_name": "ESPN",
+            "score": 75.0,
+            "rank": 5,
+            "trend": "stable",
+            "trend_percent": 0.0,
+            "watch_count_7d": 80,
+            "watch_time_7d": 28800,
+            "unique_viewers_7d": 20,
+            "bandwidth_7d": 1_000_000_000,
+            "calculated_at": "2026-05-22T06:00:00Z",
+        }
+
+        mock_client = _make_call_endpoint_spy(score_response)
+        with patch("tools.stats.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("get_channel_popularity", {"channel_id": "ch-abc"})
+
+        # Must have been called exactly once
+        mock_client.call_endpoint.assert_called_once()
+        _, kwargs = mock_client.call_endpoint.call_args
+
+        # path_args must be present with the correct key
+        assert "path_args" in kwargs, (
+            "call_endpoint must receive path_args= (not path_params=)"
+        )
+        assert kwargs["path_args"] == {"channel_id": "ch-abc"}
+
+        # path_params must NOT be passed — that was the bug
+        assert "path_params" not in kwargs, (
+            "path_params= must not appear; it is not a valid call_endpoint kwarg"
+        )
+
+        # Sanity: the tool returned useful output, not an error
+        text = result[0][0].text
+        assert "ESPN" in text
+        assert "Error" not in text
+
+    @pytest.mark.asyncio
+    async def test_get_user_channel_breakdown_dispatcharr_passes_path_args(self):
+        """get_user_channel_breakdown source=dispatcharr passes path_args={'user_id': ...}."""
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        _register_stats(mcp)
+
+        breakdown_response = {
+            "data": [
+                {
+                    "channel_id": "ch-abc",
+                    "channel_name": "ESPN",
+                    "total_watch_seconds": 3600,
+                    "session_count": 2,
+                    "last_watched": "2026-05-22T10:00:00Z",
+                    "latest_stream_name": None,
+                }
+            ],
+            "meta": {"from_iso": None, "to_iso": None, "group_by": "channel", "total_rows": 1},
+            "pagination": None,
+        }
+
+        mock_client = _make_call_endpoint_spy(breakdown_response)
+        with patch("tools.stats.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "get_user_channel_breakdown", {"user_id": "2", "source": "dispatcharr"}
+            )
+
+        mock_client.call_endpoint.assert_called_once()
+        _, kwargs = mock_client.call_endpoint.call_args
+        assert "path_args" in kwargs
+        assert kwargs["path_args"] == {"user_id": "2"}
+        assert "path_params" not in kwargs
+
+        text = result[0][0].text
+        assert "ESPN" in text
+        assert "Error" not in text
+
+    @pytest.mark.asyncio
+    async def test_get_user_channel_breakdown_emby_passes_path_args(self):
+        """get_user_channel_breakdown source=emby passes path_args={'emby_user_id': ...}."""
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        _register_stats(mcp)
+
+        breakdown_response = {
+            "data": [
+                {
+                    "channel_id": "ch-xyz",
+                    "channel_name": "CNN",
+                    "total_watch_seconds": 1800,
+                    "session_count": 1,
+                    "last_watched": "2026-05-21T20:00:00Z",
+                    "latest_stream_name": None,
+                }
+            ],
+            "meta": {"from_iso": None, "to_iso": None, "group_by": "channel", "total_rows": 1},
+            "pagination": None,
+        }
+
+        mock_client = _make_call_endpoint_spy(breakdown_response)
+        with patch("tools.stats.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "get_user_channel_breakdown",
+                {"user_id": "emby-guid-abc", "source": "emby"},
+            )
+
+        mock_client.call_endpoint.assert_called_once()
+        _, kwargs = mock_client.call_endpoint.call_args
+        assert "path_args" in kwargs
+        assert kwargs["path_args"] == {"emby_user_id": "emby-guid-abc"}
+        assert "path_params" not in kwargs
+
+        text = result[0][0].text
+        assert "CNN" in text
+        assert "Error" not in text
+
+
+# ---------------------------------------------------------------------------
+# lq38l.10 — create_backup reads binary content, never calls .json()
+# ---------------------------------------------------------------------------
+
+class TestCreateBackupBinaryHandling:
+    """Asserts that create_backup handles a binary ZIP response correctly."""
+
+    @pytest.mark.asyncio
+    async def test_create_backup_returns_success_with_size(self):
+        """create_backup reports KB size from binary content and returns success."""
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        _register_system(mcp)
+
+        # Simulate a 2 048-byte binary response (e.g. a small ZIP stub)
+        fake_zip_bytes = b"PK\x03\x04" + b"\xb7" * 2044  # starts with PK magic + binary bytes
+
+        mock_response = MagicMock()
+        mock_response.content = fake_zip_bytes
+        mock_response.raise_for_status = MagicMock()  # no-op — 200 OK
+
+        # The fix uses a short-lived httpx.AsyncClient as an async context manager.
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("tools.system.httpx.AsyncClient", return_value=mock_http),
+            patch("tools.system.ECM_URL", "http://ecm:6100"),
+            patch("tools.system.get_mcp_api_key", return_value="test-key"),
+        ):
+            result = await mcp.call_tool("create_backup", {})
+
+        text = result[0][0].text
+        assert "successfully" in text.lower(), f"Expected success message, got: {text!r}"
+        # Size should appear (2048 bytes → 2.0 KB)
+        assert "2.0 KB" in text, f"Expected size in output, got: {text!r}"
+        # Must not contain an error
+        assert "Error" not in text, f"Got an error response: {text!r}"
+
+    @pytest.mark.asyncio
+    async def test_create_backup_never_calls_json_on_response(self):
+        """create_backup must not call .json() on the binary response."""
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        _register_system(mcp)
+
+        fake_zip_bytes = b"PK\x03\x04" + b"\xb7" * 100
+
+        mock_response = MagicMock()
+        mock_response.content = fake_zip_bytes
+        mock_response.raise_for_status = MagicMock()
+        # .json() is present on the mock but must never be called
+        mock_response.json = MagicMock(side_effect=AssertionError(".json() must not be called on binary ZIP"))
+
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("tools.system.httpx.AsyncClient", return_value=mock_http),
+            patch("tools.system.ECM_URL", "http://ecm:6100"),
+            patch("tools.system.get_mcp_api_key", return_value="test-key"),
+        ):
+            result = await mcp.call_tool("create_backup", {})
+
+        # .json() was not called — if it had been, the side_effect would have raised
+        mock_response.json.assert_not_called()
+
+        text = result[0][0].text
+        assert "Error" not in text
+
+    @pytest.mark.asyncio
+    async def test_create_backup_returns_error_on_http_failure(self):
+        """create_backup wraps HTTP errors and returns a clean error message."""
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        _register_system(mcp)
+
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.get = AsyncMock(side_effect=RuntimeError("connection refused"))
+
+        with (
+            patch("tools.system.httpx.AsyncClient", return_value=mock_http),
+            patch("tools.system.ECM_URL", "http://ecm:6100"),
+            patch("tools.system.get_mcp_api_key", return_value="test-key"),
+        ):
+            result = await mcp.call_tool("create_backup", {})
+
+        text = result[0][0].text
+        assert "Error creating backup" in text
+        assert "connection refused" in text

--- a/mcp-server/tests/test_lq38l_channel_safety.py
+++ b/mcp-server/tests/test_lq38l_channel_safety.py
@@ -1,0 +1,331 @@
+"""TDD tests for lq38l channel-tool safety fixes.
+
+bd-lq38l.3: reorder_streams must not silently detach/clear omitted streams —
+    only a genuine permutation of the channel's current streams may proceed.
+bd-lq38l.5: merge_channels must guard self-merge (data loss) and report the
+    backend's per-result outcome instead of the requested count (false success).
+bd-lq38l.6: build_channel_lineup must count/match ONLY channels created by THIS
+    call (via the bulk-commit tempIdMap), never pre-existing group channels.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+def _make_mcp_and_register():
+    """Register channels tools on a fresh FastMCP and return the mcp instance."""
+    from mcp.server.fastmcp import FastMCP
+    from tools.channels import register
+
+    mcp = FastMCP("test")
+    register(mcp)
+    return mcp
+
+
+# ---------------------------------------------------------------------------
+# bd-lq38l.3 — reorder_streams permutation guard
+# ---------------------------------------------------------------------------
+
+class TestReorderStreamsPermutationGuard:
+    @pytest.mark.asyncio
+    async def test_omitting_a_current_stream_is_refused(self):
+        """[5001,5002,5204] then reorder([5001,5002]) must refuse — 5204 dropped."""
+        mcp = _make_mcp_and_register()
+
+        reorder_called = {"count": 0}
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            name = endpoint.name
+            if name == "channels_get":
+                return {"id": 12340, "streams": [5001, 5002, 5204]}
+            if name == "channels_reorder_streams":
+                reorder_called["count"] += 1
+                return {"streams": kwargs.get("body", {}).get("stream_ids", [])}
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.channels.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "reorder_streams", {"channel_id": 12340, "stream_ids": [5001, 5002]}
+            )
+
+        text = result[0][0].text
+        assert "5204" in text, f"Dropped stream id must be named: {text!r}"
+        assert "Refused" in text or "detach" in text.lower()
+        assert reorder_called["count"] == 0, "Backend reorder must NOT be called"
+
+    @pytest.mark.asyncio
+    async def test_empty_list_is_refused(self):
+        """reorder([]) must refuse — an empty list would clear all streams."""
+        mcp = _make_mcp_and_register()
+
+        reorder_called = {"count": 0}
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            name = endpoint.name
+            if name == "channels_get":
+                return {"id": 12340, "streams": [5001, 5002, 5204]}
+            if name == "channels_reorder_streams":
+                reorder_called["count"] += 1
+                return {"streams": []}
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.channels.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "reorder_streams", {"channel_id": 12340, "stream_ids": []}
+            )
+
+        text = result[0][0].text
+        assert "Refused" in text or "clear" in text.lower()
+        assert "3" in text, f"Should report the count that would be cleared: {text!r}"
+        assert reorder_called["count"] == 0, "Backend reorder must NOT be called"
+
+    @pytest.mark.asyncio
+    async def test_foreign_id_is_refused(self):
+        """A stream id not on the channel must be refused and named."""
+        mcp = _make_mcp_and_register()
+
+        reorder_called = {"count": 0}
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            name = endpoint.name
+            if name == "channels_get":
+                return {"id": 12340, "streams": [5001, 5002]}
+            if name == "channels_reorder_streams":
+                reorder_called["count"] += 1
+                return {"streams": kwargs.get("body", {}).get("stream_ids", [])}
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.channels.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "reorder_streams", {"channel_id": 12340, "stream_ids": [5001, 9999]}
+            )
+
+        text = result[0][0].text
+        assert "9999" in text, f"Foreign stream id must be named: {text!r}"
+        assert reorder_called["count"] == 0, "Backend reorder must NOT be called"
+
+    @pytest.mark.asyncio
+    async def test_genuine_permutation_proceeds(self):
+        """A true permutation reorders via the backend and reports the new order."""
+        mcp = _make_mcp_and_register()
+
+        reorder_called = {"count": 0}
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            name = endpoint.name
+            if name == "channels_get":
+                return {"id": 12340, "streams": [5001, 5002, 5204]}
+            if name == "channels_reorder_streams":
+                reorder_called["count"] += 1
+                return {"streams": kwargs.get("body", {}).get("stream_ids", [])}
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.channels.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "reorder_streams",
+                {"channel_id": 12340, "stream_ids": [5204, 5001, 5002]},
+            )
+
+        text = result[0][0].text
+        assert reorder_called["count"] == 1, "Backend reorder MUST be called for a permutation"
+        assert "reordered" in text.lower()
+        assert "5204" in text
+
+
+# ---------------------------------------------------------------------------
+# bd-lq38l.5 — merge_channels self-merge + per-result reporting
+# ---------------------------------------------------------------------------
+
+class TestMergeChannelsSafety:
+    @pytest.mark.asyncio
+    async def test_self_merge_is_refused_before_backend_call(self):
+        """merge_channels(X, [X]) must refuse without any backend call (data loss)."""
+        mcp = _make_mcp_and_register()
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = AssertionError("backend must NOT be called")
+
+        with patch("tools.channels.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "merge_channels",
+                {"target_channel_id": 12343, "source_channel_ids": [12343]},
+            )
+
+        text = result[0][0].text
+        assert "Refused" in text or "itself" in text.lower()
+        assert "12343" in text
+        client.call_endpoint.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_target_reports_failure_not_success(self):
+        """A per-result failure (bad target) must be reported, not the requested count."""
+        mcp = _make_mcp_and_register()
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            # Mirror backend: bad target -> per-result success=False, error set.
+            return {
+                "merged": 0,
+                "failed": 1,
+                "results": [
+                    {
+                        "target_channel_id": 99999999,
+                        "success": False,
+                        "error": "HTTPStatusError",
+                    }
+                ],
+            }
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.channels.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "merge_channels",
+                {"target_channel_id": 99999999, "source_channel_ids": [12342]},
+            )
+
+        text = result[0][0].text
+        assert "fail" in text.lower(), f"Expected failure report: {text!r}"
+        assert "Merged 1" not in text, f"Must NOT claim false success: {text!r}"
+        assert "HTTPStatusError" in text
+
+    @pytest.mark.asyncio
+    async def test_successful_merge_reports_actual_count(self):
+        """A genuine success reports the backend's sources_deleted count."""
+        mcp = _make_mcp_and_register()
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            return {
+                "merged": 1,
+                "failed": 0,
+                "results": [
+                    {
+                        "target_channel_id": 100,
+                        "target_name": "Keeper",
+                        "sources_deleted": 2,
+                        "total_streams": 5,
+                        "success": True,
+                    }
+                ],
+            }
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.channels.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "merge_channels",
+                {"target_channel_id": 100, "source_channel_ids": [101, 102]},
+            )
+
+        text = result[0][0].text
+        assert "Merged 2 channels into channel 100" in text
+
+
+# ---------------------------------------------------------------------------
+# bd-lq38l.6 — build_channel_lineup created-only count + matching
+# ---------------------------------------------------------------------------
+
+class TestBuildChannelLineupCreatedOnly:
+    @pytest.mark.asyncio
+    async def test_counts_only_newly_created_via_tempidmap(self):
+        """Pre-existing group channels must not be counted as created or matched."""
+        mcp = _make_mcp_and_register()
+
+        # Group already has 3 pre-existing channels; we ask to create ONE (id 555).
+        group_channels = [
+            {"id": 12340, "name": "MCPTEST_FoxNewsHD", "channel_number": 360, "streams": []},
+            {"id": 12341, "name": "US: ESPN U", "channel_number": 12, "streams": [1, 2]},
+            {"id": 12344, "name": "MCPTEST_Sac2", "channel_number": 12, "streams": []},
+            {"id": 555, "name": "MCPTEST Lineup ESPN", "channel_number": 901, "streams": []},
+        ]
+
+        async def post_side_effect(path, **kwargs):
+            if path == "/api/channels/bulk-commit":
+                # tempId -1 -> realId 555 (the only channel this call created)
+                return {"success": True, "tempIdMap": {"-1": 555}}
+            # add-stream: nothing matched in this scenario
+            return {}
+
+        async def get_side_effect(path, **kwargs):
+            if path == "/api/channels":
+                return {"results": group_channels, "next": None}
+            if path == "/api/streams":
+                return {"results": []}  # no streams available -> 0 matched
+            return {}
+
+        client = AsyncMock()
+        client.post.side_effect = post_side_effect
+        client.get.side_effect = get_side_effect
+
+        with patch("tools.channels.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "build_channel_lineup",
+                {
+                    "channels": [{"name": "MCPTEST Lineup ESPN", "number": 901}],
+                    "group_id": 1351,
+                    "provider_id": 3,
+                },
+            )
+
+        text = result[0][0].text
+        assert "1 channels created" in text, f"Must count ONLY the created channel: {text!r}"
+        assert "4 channels created" not in text, f"Must not count the whole group: {text!r}"
+        # Pre-existing channels must never appear in the unmatched list.
+        assert "MCPTEST_FoxNewsHD" not in text
+        assert "MCPTEST_Sac2" not in text
+        # The single created channel is the only unmatched one (no streams available).
+        assert "1 unmatched" in text
+        assert "MCPTEST Lineup ESPN" in text
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_name_number_when_tempidmap_absent(self):
+        """Without tempIdMap, fall back to name+number — still excludes pre-existing."""
+        mcp = _make_mcp_and_register()
+
+        group_channels = [
+            {"id": 12340, "name": "Pre A", "channel_number": 1, "streams": []},
+            {"id": 12341, "name": "Pre B", "channel_number": 2, "streams": []},
+            {"id": 700, "name": "New One", "channel_number": 700, "streams": []},
+        ]
+
+        async def post_side_effect(path, **kwargs):
+            if path == "/api/channels/bulk-commit":
+                return {"success": True}  # no tempIdMap
+            return {}
+
+        async def get_side_effect(path, **kwargs):
+            if path == "/api/channels":
+                return {"results": group_channels, "next": None}
+            if path == "/api/streams":
+                return {"results": []}
+            return {}
+
+        client = AsyncMock()
+        client.post.side_effect = post_side_effect
+        client.get.side_effect = get_side_effect
+
+        with patch("tools.channels.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "build_channel_lineup",
+                {
+                    "channels": [{"name": "New One", "number": 700}],
+                    "group_id": 99,
+                },
+            )
+
+        text = result[0][0].text
+        assert "1 channels created" in text, f"Fallback must count only requested: {text!r}"
+        assert "Pre A" not in text
+        assert "Pre B" not in text

--- a/mcp-server/tests/test_tools.py
+++ b/mcp-server/tests/test_tools.py
@@ -1207,7 +1207,9 @@ class TestListTasksEnvelopeUnwrap:
 
     @pytest.mark.asyncio
     async def test_unwraps_tasks_envelope(self):
-        """Backend returns {"tasks": [...]}; tool must iterate the list, not dict keys."""
+        """Backend returns {"tasks": [...]}; tool must iterate the list, not dict keys.
+        Backend uses task_name (not name) for the human-readable label (lq38l.1).
+        """
         from tools.tasks import register
         from mcp.server.fastmcp import FastMCP
 
@@ -1216,8 +1218,8 @@ class TestListTasksEnvelopeUnwrap:
 
         mock_client = _make_ecm_client_mock(call_endpoint={
             "tasks": [
-                {"task_id": "m3u_refresh", "name": "M3U Refresh", "enabled": True, "status": "idle", "last_run": "2026-05-22"},
-                {"task_id": "stream_probe", "name": "Stream Probe", "enabled": False, "status": "idle", "last_run": "never"},
+                {"task_id": "m3u_refresh", "task_name": "M3U Refresh", "enabled": True, "status": "idle", "last_run": "2026-05-22"},
+                {"task_id": "stream_probe", "task_name": "Stream Probe", "enabled": False, "status": "idle", "last_run": "never"},
             ]
         })
 
@@ -1229,6 +1231,7 @@ class TestListTasksEnvelopeUnwrap:
         assert "M3U Refresh" in text
         assert "Stream Probe" in text
         assert "m3u_refresh" in text
+        assert "Unknown" not in text
         assert "has no attribute" not in text
 
     @pytest.mark.asyncio
@@ -1246,6 +1249,76 @@ class TestListTasksEnvelopeUnwrap:
             result = await mcp.call_tool("list_tasks", {})
 
         assert "No tasks" in result[0][0].text
+
+
+class TestListTasksTaskNameRendering:
+    """list_tasks reads task_name (not name) from backend payload (lq38l.1)."""
+
+    @pytest.mark.asyncio
+    async def test_task_name_field_rendered(self):
+        """Backend payload carries task_name; tool must render it, not 'Unknown'."""
+        from tools.tasks import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = _make_ecm_client_mock(call_endpoint={
+            "tasks": [
+                {
+                    "task_id": "epg_refresh",
+                    "task_name": "EPG Refresh",
+                    "enabled": True,
+                    "status": "idle",
+                    "last_run": "never",
+                },
+                {
+                    "task_id": "popularity_calculation",
+                    "task_name": "Stats v2 Rollup & Prune",
+                    "enabled": True,
+                    "status": "running",
+                    "last_run": "2026-05-22T10:00:00Z",
+                },
+            ]
+        })
+
+        with patch("tools.tasks.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("list_tasks", {})
+
+        text = result[0][0].text
+        assert "EPG Refresh" in text, "task_name must be rendered"
+        assert "Stats v2 Rollup & Prune" in text, "task_name must be rendered"
+        assert "Unknown" not in text, "Unknown must not appear when task_name is present"
+        assert "id=epg_refresh" in text
+        assert "id=popularity_calculation" in text
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_prettified_task_id_when_no_task_name(self):
+        """When task_name is absent, tool prettifies task_id rather than 'Unknown'."""
+        from tools.tasks import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = _make_ecm_client_mock(call_endpoint={
+            "tasks": [
+                {
+                    "task_id": "stream_probe",
+                    "enabled": True,
+                    "status": "idle",
+                    "last_run": "never",
+                    # no task_name key at all
+                },
+            ]
+        })
+
+        with patch("tools.tasks.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("list_tasks", {})
+
+        text = result[0][0].text
+        assert "Unknown" not in text, "Unknown must not appear; prettified task_id used instead"
+        assert "stream_probe" in text  # task_id still in output as id=...
 
 
 # --- TestDeleteOrphanedGroupsResultKeys (A1) ---

--- a/mcp-server/tests/test_tools.py
+++ b/mcp-server/tests/test_tools.py
@@ -115,17 +115,34 @@ class TestListM3UAccounts:
 
     @pytest.mark.asyncio
     async def test_returns_accounts(self):
-        """Returns formatted M3U account list."""
+        """Returns formatted M3U account list with stream count derived via streams_list."""
         from tools.m3u import register
         from mcp.server.fastmcp import FastMCP
+        from _endpoint_contracts import ENDPOINTS
 
         mcp = FastMCP("test")
         register(mcp)
 
-        mock_client = _make_ecm_client_mock(call_endpoint=[
-            {"id": 1, "name": "Provider A", "stream_count": 5000, "status": "success"},
-            {"id": 2, "name": "Provider B", "stream_count": 3000, "status": "error"},
-        ])
+        # stream_count is NOT in the Dispatcharr account payload; the tool
+        # derives it by calling streams_list with m3u_account=<id>&page_size=1.
+        # Use side_effect to return the right value per endpoint call.
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            if endpoint.name == "m3u_list_providers":
+                return [
+                    {"id": 1, "name": "Provider A", "server_url": "http://provider-a.example.com/m3u", "status": "active"},
+                    {"id": 2, "name": "Provider B", "server_url": "http://provider-b.example.com/m3u", "status": "error"},
+                ]
+            if endpoint.name == "streams_list":
+                query = kwargs.get("query", {})
+                m3u_id = query.get("m3u_account")
+                if m3u_id == 1:
+                    return {"count": 5000, "results": []}
+                if m3u_id == 2:
+                    return {"count": 3000, "results": []}
+            return {}
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = call_endpoint_side_effect
 
         with patch("tools.m3u.get_ecm_client", return_value=mock_client):
             result = await mcp.call_tool("list_m3u_accounts", {})

--- a/mcp-server/tests/test_tools.py
+++ b/mcp-server/tests/test_tools.py
@@ -2372,3 +2372,162 @@ class TestDeleteAllNotificationsReadOnly:
             f"notifications_delete_all must declare read_only in query_params, "
             f"got query_params={ep.query_params}"
         )
+
+
+# --- TestListNormalizationRules (lq38l.2) ---
+class TestListNormalizationRules:
+    """list_normalization_rules sources rule data from /rules (not /groups) endpoint.
+
+    The /groups endpoint returns group metadata only — no nested rules, no
+    rule count.  The /rules endpoint returns groups WITH rules nested.
+    This class pins that the fix is in place and stays in place.
+    """
+
+    @pytest.mark.asyncio
+    async def test_shows_nonzero_rule_count_and_names(self):
+        """Groups with rules show correct count and up to 5 rule names."""
+        from tools.normalization import register
+        from mcp.server.fastmcp import FastMCP
+        from _endpoint_contracts import ENDPOINTS
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = _make_ecm_client_mock(call_endpoint={
+            "groups": [
+                {
+                    "id": 1,
+                    "name": "Title Case",
+                    "enabled": True,
+                    "priority": 0,
+                    "rules": [
+                        {"id": 10, "name": "Title-case all", "action_type": "replace", "condition_type": "always", "enabled": True},
+                        {"id": 11, "name": "Fix abbreviations", "action_type": "replace", "condition_type": "regex", "enabled": True},
+                    ],
+                },
+                {
+                    "id": 2,
+                    "name": "Strip Quality",
+                    "enabled": True,
+                    "priority": 1,
+                    "rules": [
+                        {"id": 20, "name": "Strip HD suffix", "action_type": "strip_suffix", "condition_type": "ends_with", "enabled": True},
+                        {"id": 21, "name": "Strip FHD", "action_type": "remove", "condition_type": "contains", "enabled": True},
+                        {"id": 22, "name": "Strip 4K", "action_type": "remove", "condition_type": "contains", "enabled": True},
+                    ],
+                },
+            ]
+        })
+
+        with patch("tools.normalization.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("list_normalization_rules", {})
+
+        text = result[0][0].text
+        # Correct group count.
+        assert "2 groups" in text
+        # Group names present.
+        assert "Title Case" in text
+        assert "Strip Quality" in text
+        # Non-zero rule counts — the key regression guard.
+        assert "2 rules" in text
+        assert "3 rules" in text
+        # Rule names surface.
+        assert "Title-case all" in text
+        assert "Strip HD suffix" in text
+        # Called the rules endpoint, not the groups-only endpoint.
+        mock_client.call_endpoint.assert_awaited_once_with(ENDPOINTS["normalization_list_rules"])
+
+    @pytest.mark.asyncio
+    async def test_empty_groups(self):
+        """Empty groups list returns 'no rules' message."""
+        from tools.normalization import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = _make_ecm_client_mock(call_endpoint={"groups": []})
+
+        with patch("tools.normalization.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("list_normalization_rules", {})
+
+        assert "No normalization rules" in result[0][0].text
+
+    @pytest.mark.asyncio
+    async def test_group_with_zero_rules_shows_zero(self):
+        """A group whose rules list is empty renders '0 rules' (not crashing)."""
+        from tools.normalization import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = _make_ecm_client_mock(call_endpoint={
+            "groups": [
+                {"id": 5, "name": "Empty Group", "enabled": True, "priority": 0, "rules": []},
+            ]
+        })
+
+        with patch("tools.normalization.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("list_normalization_rules", {})
+
+        text = result[0][0].text
+        assert "Empty Group" in text
+        assert "0 rules" in text
+
+    @pytest.mark.asyncio
+    async def test_more_than_five_rules_truncated(self):
+        """When a group has >5 rules, only 5 names are shown plus an overflow line."""
+        from tools.normalization import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        rules = [
+            {"id": i, "name": f"Rule {i}", "action_type": "remove", "condition_type": "contains", "enabled": True}
+            for i in range(1, 9)
+        ]
+        mock_client = _make_ecm_client_mock(call_endpoint={
+            "groups": [{"id": 3, "name": "Big Group", "enabled": True, "priority": 0, "rules": rules}]
+        })
+
+        with patch("tools.normalization.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("list_normalization_rules", {})
+
+        text = result[0][0].text
+        assert "8 rules" in text
+        assert "Rule 1" in text
+        assert "Rule 5" in text
+        # Rule 6-8 are suppressed — the overflow line must appear.
+        assert "3 more" in text
+
+    @pytest.mark.asyncio
+    async def test_group_with_none_rules_key_handled_gracefully(self):
+        """A group where 'rules' key is None or absent does not crash."""
+        from tools.normalization import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = _make_ecm_client_mock(call_endpoint={
+            "groups": [
+                {"id": 7, "name": "No Key Group", "enabled": False, "priority": 0},
+            ]
+        })
+
+        with patch("tools.normalization.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("list_normalization_rules", {})
+
+        text = result[0][0].text
+        assert "No Key Group" in text
+        assert "0 rules" in text
+
+    def test_normalization_list_rules_endpoint_registered(self):
+        """The normalization_list_rules endpoint is in the registry with correct method/path."""
+        from _endpoint_contracts import ENDPOINTS
+
+        ep = ENDPOINTS["normalization_list_rules"]
+        assert ep.method == "GET"
+        assert ep.path == "/api/normalization/rules"

--- a/mcp-server/tests/test_tools.py
+++ b/mcp-server/tests/test_tools.py
@@ -905,8 +905,8 @@ class TestAddStream:
         assert call.kwargs["body"]["group_id"] == 5
 
     @pytest.mark.asyncio
-    async def test_merge_if_found_above_threshold_auto_accepts(self):
-        """merge_if_found with an at/above-threshold candidate auto-accepts the merge."""
+    async def test_merge_if_found_exact_match_auto_accepts(self):
+        """merge_if_found auto-accepts ONLY on an exact name match (confidence 1.0)."""
         from tools.channels import register
         from mcp.server.fastmcp import FastMCP
         from _endpoint_contracts import ENDPOINTS
@@ -915,7 +915,7 @@ class TestAddStream:
         register(mcp)
 
         # call_endpoint order:
-        #   1st: channel_merges_enqueue → candidate above threshold (merge_id 88)
+        #   1st: channel_merges_enqueue → exact-match candidate (merge_id 88)
         #   2nd: channel_merges_accept → auto-accept the queued merge
         mock_client = AsyncMock()
         mock_client.call_endpoint.side_effect = [
@@ -924,7 +924,7 @@ class TestAddStream:
                 "created": True,
                 "candidate_channel_id": "uuid-fox",
                 "candidate_channel_name": "FOX Network",
-                "confidence": 0.85,
+                "confidence": 1.0,  # exact normalized-name match
                 "meets_threshold": True,
                 "status": "pending",
             },
@@ -932,7 +932,7 @@ class TestAddStream:
                 "merged_into_channel_id": "uuid-fox",
                 "journal_entry_id": 5,
                 "source_stream_id": "303",
-                "confidence": 0.85,
+                "confidence": 1.0,
                 "status": "merged",
             },
         ]
@@ -940,19 +940,69 @@ class TestAddStream:
         with patch("tools.channels.get_ecm_client", return_value=mock_client):
             result = await mcp.call_tool(
                 "add_stream",
-                {"stream_name": "FOX", "group_id": 2, "dedup_action": "merge_if_found"},
+                {"stream_name": "FOX Network", "group_id": 2, "dedup_action": "merge_if_found"},
             )
 
         text = result[0][0].text
         assert "merge_if_found" in text
         assert "FOX Network" in text or "uuid-fox" in text
         assert "merge_id=88" in text
+        # Did NOT fall back to prompt — the row was auto-accepted.
+        assert "pending_merge" not in text
 
         calls = mock_client.call_endpoint.call_args_list
         assert calls[0].args[0] is ENDPOINTS["channel_merges_enqueue"]
         # Auto-accept goes through accept_channel_merge (not direct add-stream).
         assert calls[1].args[0] is ENDPOINTS["channel_merges_accept"]
         assert calls[1].kwargs["path_args"]["merge_id"] == 88
+
+    @pytest.mark.asyncio
+    async def test_merge_if_found_fuzzy_above_threshold_does_not_auto_accept(self):
+        """merge_if_found does NOT auto-accept a fuzzy candidate even above threshold.
+
+        Regression for lq38l.7: a 90% token-set over-match ('US: ESPN 2' vs
+        'US: ESPN U') met the operator threshold and was wrongly auto-merged.
+        Under the exact-match-only rule, any confidence < 1.0 — even with
+        meets_threshold True — must fall back to prompt semantics so the
+        operator/agent confirms via accept/dismiss before the stream attaches.
+        """
+        from tools.channels import register
+        from mcp.server.fastmcp import FastMCP
+        from _endpoint_contracts import ENDPOINTS
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = [
+            {
+                "merge_id": 2,
+                "created": True,
+                "candidate_channel_id": "12341",
+                "candidate_channel_name": "US: ESPN U",
+                "confidence": 0.90,  # fuzzy over-match — NOT exact
+                "meets_threshold": True,  # above the operator threshold...
+                "status": "pending",
+            },
+        ]
+
+        with patch("tools.channels.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "add_stream",
+                {"stream_name": "US: ESPN 2", "group_id": 1351, "dedup_action": "merge_if_found"},
+            )
+
+        text = result[0][0].text
+        # ...yet it falls back to prompt — no auto-accept.
+        assert "pending_merge" in text
+        assert "merge_id: 2" in text
+        assert "accept_channel_merge(2)" in text
+        assert "dismiss_channel_merge(2)" in text
+        # Only the enqueue call — accept was NOT invoked for a non-exact match.
+        mock_client.call_endpoint.assert_awaited_once()
+        called_endpoints = [c.args[0] for c in mock_client.call_endpoint.call_args_list]
+        assert ENDPOINTS["channel_merges_enqueue"] in called_endpoints
+        assert ENDPOINTS["channel_merges_accept"] not in called_endpoints
 
     @pytest.mark.asyncio
     async def test_merge_if_found_below_threshold_enqueues_and_prompts(self):
@@ -965,7 +1015,7 @@ class TestAddStream:
         register(mcp)
 
         # The enqueue returns a candidate above the floor but below the
-        # auto-merge threshold → meets_threshold False → prompt fallback.
+        # auto-merge threshold → not exact → prompt fallback.
         mock_client = AsyncMock()
         mock_client.call_endpoint.side_effect = [
             {

--- a/mcp-server/tools/channel_groups.py
+++ b/mcp-server/tools/channel_groups.py
@@ -256,12 +256,13 @@ def register(mcp: FastMCP):
             if not groups:
                 return "No channel groups found."
 
-            lines = [f"Found {len(groups)} groups with stream info:"]
+            # The /api/channel-groups/with-streams endpoint returns {id, name}
+            # only — no per-group stream count is available in this payload.
+            lines = [f"Found {len(groups)} groups that have channels with streams:"]
             for g in groups:
                 name = g.get("name", "Unknown")
                 gid = g.get("id", "?")
-                stream_count = g.get("stream_count", 0)
-                lines.append(f"  {name} (id={gid}) — {stream_count} streams")
+                lines.append(f"  {name} (id={gid})")
 
             return "\n".join(lines)
         except Exception as e:

--- a/mcp-server/tools/channels.py
+++ b/mcp-server/tools/channels.py
@@ -602,15 +602,48 @@ def register(mcp: FastMCP):
         """
         try:
             client = get_ecm_client()
+            # Guard against silent detachment: the backend treats the supplied
+            # list as the AUTHORITATIVE full stream set, so any omitted current
+            # stream is dropped and an empty list clears the channel. Reorder is
+            # a *pure* reorder — only proceed when stream_ids is a permutation of
+            # the channel's current streams (bd-lq38l.3).
+            channel = await client.call_endpoint(
+                ENDPOINTS["channels_get"], path_args={"channel_id": channel_id}
+            )
+            current_ids = list(channel.get("streams", []) or []) if isinstance(channel, dict) else []
+            current_set = set(current_ids)
+
+            if not stream_ids:
+                return (
+                    f"Refused to reorder channel {channel_id}: an empty stream_ids list "
+                    f"would clear all {len(current_ids)} streams. reorder_streams only "
+                    f"changes priority — use remove_stream_from_channel to detach streams."
+                )
+
+            supplied_set = set(stream_ids)
+            dropped = [sid for sid in current_ids if sid not in supplied_set]
+            foreign = [sid for sid in stream_ids if sid not in current_set]
+            if dropped or foreign:
+                parts = []
+                if dropped:
+                    parts.append(f"omits current stream(s) {dropped} (they would be detached)")
+                if foreign:
+                    parts.append(f"includes stream(s) {foreign} not on this channel")
+                return (
+                    f"Refused to reorder channel {channel_id}: stream_ids is not a "
+                    f"permutation of the channel's current streams {current_ids} — it "
+                    f"{' and '.join(parts)}. reorder_streams only changes priority. "
+                    f"Use bulk_add_streams_to_channel to add streams or "
+                    f"remove_stream_from_channel to detach them."
+                )
+
             result = await client.call_endpoint(
                 ENDPOINTS["channels_reorder_streams"],
                 path_args={"channel_id": channel_id},
                 body={"stream_ids": stream_ids},
             )
-            # reorder-streams is a pure reorder: the backend rejects (HTTP 400)
-            # any list that isn't a permutation of the channel's current streams,
-            # so it can't silently detach streams. Report the order the backend
-            # confirmed rather than blindly echoing the input.
+            # Report the order the backend confirmed rather than blindly echoing
+            # the input.
             new_order = result.get("streams", stream_ids) if isinstance(result, dict) else stream_ids
             return f"Streams reordered for channel {channel_id}. New order: {new_order}"
         except Exception as e:
@@ -652,13 +685,23 @@ def register(mcp: FastMCP):
         """
         try:
             client = get_ecm_client()
+            # Self-merge guard: merging a channel into itself absorbs+deletes the
+            # target, destroying it while the backend still reports success. Reject
+            # before any backend call (bd-lq38l.5a).
+            if target_channel_id in source_channel_ids:
+                return (
+                    f"Refused to merge: target channel {target_channel_id} appears in "
+                    f"source_channel_ids — merging a channel into itself would delete it. "
+                    f"Remove {target_channel_id} from the sources."
+                )
+
             # Routes through POST /api/channels/bulk-merge with a single merge
             # item — the backend's POST /api/channels/merge endpoint creates a
             # *new* channel from a `target_name` and never accepted
             # `target_channel_id` (the old payload here was silently 422'd —
             # contract drift fixed in bd-vtghg Phase 1). bulk-merge has the
             # "keep target channel, absorb sources" semantics this tool wants.
-            await client.call_endpoint(
+            result = await client.call_endpoint(
                 ENDPOINTS["channels_bulk_merge"],
                 body={"merges": [{
                     "target_channel_id": target_channel_id,
@@ -666,7 +709,28 @@ def register(mcp: FastMCP):
                 }]},
                 timeout=300.0,
             )
-            merged = len(source_channel_ids)
+
+            # Validate the per-result outcome rather than reporting the requested
+            # count as merged: a nonexistent target reports success at the wrapper
+            # level but fails per-result (bd-lq38l.5b). Mirror the per-result
+            # checking in bulk_merge_duplicate_channels.
+            results = result.get("results", []) if isinstance(result, dict) else []
+            outcome = next(
+                (r for r in results if r.get("target_channel_id") == target_channel_id),
+                results[0] if results else None,
+            )
+            if outcome is not None and not outcome.get("success", False):
+                return (
+                    f"Merge failed for channel {target_channel_id}: "
+                    f"{outcome.get('error', 'unknown error')}. No channels were merged."
+                )
+            if outcome is None:
+                return (
+                    f"Merge into channel {target_channel_id} returned no result — "
+                    f"nothing was merged."
+                )
+
+            merged = outcome.get("sources_deleted", len(source_channel_ids))
             return f"Merged {merged} channels into channel {target_channel_id}."
         except Exception as e:
             logger.error("[MCP] merge_channels failed: %s", e)
@@ -987,8 +1051,18 @@ def register(mcp: FastMCP):
                 issues = bulk_result.get("validationIssues", [])
                 return f"Bulk create failed: {issues[:5]}"
 
-            # Step 2: Fetch newly created channels from the group
-            created_channels = []
+            # Identify ONLY the channels created by THIS call via the bulk-commit
+            # tempId -> realId map. Counting/matching all channels in the group
+            # would (mis)report pre-existing channels as created and run the
+            # fuzzy-match pass over them (bd-lq38l.6). Fall back to name+number
+            # identification if tempIdMap is absent.
+            temp_id_map = bulk_result.get("tempIdMap") or {}
+            created_real_ids = {int(v) for v in temp_id_map.values()}
+            requested_keys = {(ch["name"], ch["number"]) for ch in channels}
+
+            # Step 2: Fetch channels from the group, then filter to only the ones
+            # created by this call.
+            group_channels = []
             page = 1
             while True:
                 result = await client.get(  # contract-exempt: see above
@@ -1000,10 +1074,21 @@ def register(mcp: FastMCP):
                     batch = result
                 if not batch:
                     break
-                created_channels.extend(batch)
+                group_channels.extend(batch)
                 if isinstance(result, dict) and not result.get("next"):
                     break
                 page += 1
+
+            if created_real_ids:
+                created_channels = [
+                    ch for ch in group_channels if ch.get("id") in created_real_ids
+                ]
+            else:
+                # Fallback: match on (name, channel_number) requested by this call.
+                created_channels = [
+                    ch for ch in group_channels
+                    if (ch.get("name"), ch.get("channel_number")) in requested_keys
+                ]
 
             # Step 3: For each channel with 0 streams, fuzzy-match a stream
             # Import shared fuzzy matching from streams module

--- a/mcp-server/tools/channels.py
+++ b/mcp-server/tools/channels.py
@@ -309,13 +309,16 @@ def register(mcp: FastMCP):
         * ``force_new`` — skip dedup entirely; always create a new channel
           regardless of any existing match.
         * ``merge_if_found`` — async-queue the candidate, then auto-accept it
-          when its confidence is at or above the operator-configured threshold
-          (the merge is applied and the row resolved for you).  When the
-          confidence is below the threshold (but above the ADR-008 §D2 floor),
-          fall back to ``prompt`` semantics: the row stays queued and the
-          ``merge_id`` is returned for you to ``accept_channel_merge`` /
-          ``dismiss_channel_merge``.  If no candidate is found, proceed with
-          normal channel creation.
+          **only on an exact normalized-name match** (the enqueue response's
+          ``confidence`` is ``1.0``).  An exact match is the only signal strong
+          enough to merge without confirmation; any fuzzy candidate
+          (``confidence < 1.0``), even one above the operator's auto-merge
+          threshold, falls back to ``prompt`` semantics — the row stays queued
+          and the ``merge_id`` is returned for you to ``accept_channel_merge`` /
+          ``dismiss_channel_merge`` so the merge target is confirmed before the
+          stream is attached (lq38l.7: a 90% token-set over-match auto-merged
+          'US: ESPN 2' into 'US: ESPN U').  If no candidate is found, proceed
+          with normal channel creation.
 
         In all cases where channel creation proceeds, the tool creates a new
         channel with the stream name as the channel name, assigns it to
@@ -374,9 +377,15 @@ def register(mcp: FastMCP):
                     candidate_channel_id = enqueue_resp.get("candidate_channel_id", "?")
                     candidate_channel_name = enqueue_resp.get("candidate_channel_name", "?")
                     confidence = enqueue_resp.get("confidence", 0.0)
-                    meets_threshold = bool(enqueue_resp.get("meets_threshold"))
+                    # Auto-accept ONLY on an exact normalized-name match
+                    # (confidence == 1.0). The matcher emits 1.0 exclusively
+                    # for an exact match (dedup_matcher._normalize equality);
+                    # any fuzzy candidate — even above the operator's
+                    # meets_threshold — must be confirmed via accept/dismiss
+                    # rather than auto-merged (lq38l.7).
+                    is_exact_match = (confidence or 0.0) >= 1.0
 
-                    if dedup_action == "merge_if_found" and meets_threshold:
+                    if dedup_action == "merge_if_found" and is_exact_match:
                         # Auto-accept the queued merge — accept_channel_merge
                         # applies the Dispatcharr-side merge and resolves the
                         # row, with the full §D6 audit trail.
@@ -405,11 +414,11 @@ def register(mcp: FastMCP):
                             f"via merge_id={merge_id}."
                         )
 
-                    # prompt, OR merge_if_found below-threshold fallback: the row
-                    # is queued; hand the merge_id to the agent to accept/dismiss.
+                    # prompt, OR merge_if_found non-exact fallback: the row is
+                    # queued; hand the merge_id to the agent to accept/dismiss.
                     fallback_note = (
-                        " (below the auto-merge threshold — falling back to "
-                        "prompt semantics)"
+                        " (not an exact name match — falling back to prompt "
+                        "semantics for operator confirmation)"
                         if dedup_action == "merge_if_found"
                         else ""
                     )

--- a/mcp-server/tools/epg.py
+++ b/mcp-server/tools/epg.py
@@ -28,8 +28,10 @@ def register(mcp: FastMCP):
                 sid = s.get("id", "?")
                 # url may be present-but-None (4 of 8 real sources); `or ""` handles that
                 url = (s.get("url") or "")[:50]
-                channel_count = s.get("channel_count", 0)
-                lines.append(f"  {name} (id={sid}) — {channel_count} channels, url: {url}...")
+                # Dispatcharr payload uses epg_data_count for channel count; channel_count is absent
+                epg_count = s.get("epg_data_count", s.get("channel_count"))
+                count_str = f"{epg_count} channels, " if epg_count is not None else ""
+                lines.append(f"  {name} (id={sid}) — {count_str}url: {url}...")
 
             return "\n".join(lines)
         except Exception as e:

--- a/mcp-server/tools/m3u.py
+++ b/mcp-server/tools/m3u.py
@@ -24,9 +24,21 @@ def register(mcp: FastMCP):
             for p in providers:
                 name = p.get("name", "Unknown")
                 pid = p.get("id", "?")
-                stream_count = p.get("stream_count", 0)
-                status = p.get("status", "unknown")
-                lines.append(f"  {name} (id={pid}) — {stream_count} streams, status: {status}")
+                # Dispatcharr payload uses server_url; there is no stream_count
+                # in the account payload — derive it via a page_size=1 probe.
+                stream_count_str = ""
+                if pid != "?":
+                    try:
+                        sc_resp = await client.call_endpoint(
+                            ENDPOINTS["streams_list"],
+                            query={"m3u_account": pid, "page_size": 1, "enrich": False},
+                        )
+                        stream_count = sc_resp.get("count", 0) if isinstance(sc_resp, dict) else 0
+                        stream_count_str = f"{stream_count} streams, "
+                    except Exception:
+                        pass
+                status = p.get("status", p.get("is_active", "unknown"))
+                lines.append(f"  {name} (id={pid}) — {stream_count_str}status: {status}")
 
             return "\n".join(lines)
         except Exception as e:
@@ -74,13 +86,28 @@ def register(mcp: FastMCP):
             client = get_ecm_client()
             a = await client.call_endpoint(ENDPOINTS["m3u_get_account"], path_args={"account_id": account_id})
 
+            # Dispatcharr payload: server_url holds the URL; stream_count is
+            # not present in the account object — derive via streams_list.
+            url_raw = a.get("server_url") or a.get("url") or ""
+            url_display = url_raw[:60] + ("..." if len(url_raw) > 60 else "") if url_raw else "N/A"
+            stream_count = 0
+            aid = a.get("id")
+            if aid is not None:
+                try:
+                    sc_resp = await client.call_endpoint(
+                        ENDPOINTS["streams_list"],
+                        query={"m3u_account": aid, "page_size": 1, "enrich": False},
+                    )
+                    stream_count = sc_resp.get("count", 0) if isinstance(sc_resp, dict) else 0
+                except Exception:
+                    pass
             lines = [
                 f"M3U Account: {a.get('name', 'Unknown')}",
-                f"  ID: {a.get('id')}",
-                f"  Type: {a.get('type', a.get('server_type', 'standard'))}",
-                f"  URL: {a.get('url', 'N/A')[:60]}{'...' if len(a.get('url', '')) > 60 else ''}",
-                f"  Status: {a.get('status', 'unknown')}",
-                f"  Streams: {a.get('stream_count', 0)}",
+                f"  ID: {aid}",
+                f"  Type: {a.get('account_type', a.get('server_type', 'standard'))}",
+                f"  URL: {url_display}",
+                f"  Status: {a.get('status', a.get('is_active', 'unknown'))}",
+                f"  Streams: {stream_count}",
                 f"  Last refresh: {a.get('last_refresh', a.get('updated_at', 'never'))}",
             ]
 
@@ -144,7 +171,7 @@ def register(mcp: FastMCP):
             )
             if isinstance(result, dict):
                 rname = result.get("name", "?")
-                rurl = (result.get("url") or "")[:60]
+                rurl = (result.get("server_url") or result.get("url") or "")[:60]
                 return f"M3U account {account_id} updated: name='{rname}', url='{rurl}'"
             return f"M3U account {account_id} updated."
         except Exception as e:

--- a/mcp-server/tools/normalization.py
+++ b/mcp-server/tools/normalization.py
@@ -52,7 +52,9 @@ def register(mcp: FastMCP):
         """List all normalization rule groups and their rules."""
         try:
             client = get_ecm_client()
-            result = await client.call_endpoint(ENDPOINTS["normalization_list_groups"])
+            # Use the /rules endpoint — it returns groups WITH nested rules.
+            # The /groups endpoint returns group metadata only (no rules).
+            result = await client.call_endpoint(ENDPOINTS["normalization_list_rules"])
 
             groups = result.get("groups", []) if isinstance(result, dict) else result
 
@@ -64,11 +66,11 @@ def register(mcp: FastMCP):
                 name = g.get("name", "Unknown")
                 gid = g.get("id", "?")
                 enabled = "enabled" if g.get("enabled", True) else "disabled"
-                rules = g.get("rules", [])
+                rules = g.get("rules") or []
                 lines.append(f"\n  {name} (id={gid}) — {enabled}, {len(rules)} rules")
                 for r in rules[:5]:
-                    rname = r.get("name", r.get("pattern", "?"))
-                    rtype = r.get("type", "?")
+                    rname = r.get("name", "?")
+                    rtype = r.get("action_type", r.get("condition_type", "?"))
                     lines.append(f"    - {rname} ({rtype})")
                 if len(rules) > 5:
                     lines.append(f"    ... and {len(rules) - 5} more")

--- a/mcp-server/tools/stats.py
+++ b/mcp-server/tools/stats.py
@@ -571,12 +571,12 @@ def register(mcp: FastMCP):
             if source == "dispatcharr":
                 result = await client.call_endpoint(
                     ENDPOINTS["stats_users_dispatcharr"],
-                    path_params={"user_id": user_id},
+                    path_args={"user_id": user_id},
                 )
             else:  # emby
                 result = await client.call_endpoint(
                     ENDPOINTS["stats_users_emby"],
-                    path_params={"emby_user_id": user_id},
+                    path_args={"emby_user_id": user_id},
                 )
 
             # Response envelope: {data: [...], meta: {...}, pagination: null}
@@ -670,7 +670,7 @@ def register(mcp: FastMCP):
             client = get_ecm_client()
             result = await client.call_endpoint(
                 ENDPOINTS["stats_popularity_channel"],
-                path_params={"channel_id": channel_id},
+                path_args={"channel_id": channel_id},
             )
 
             if not result:

--- a/mcp-server/tools/system.py
+++ b/mcp-server/tools/system.py
@@ -1,9 +1,11 @@
 """System management tools (settings, backup, journal)."""
 import logging
 
+import httpx
 from mcp.server.fastmcp import FastMCP
 
 from _endpoint_contracts import ENDPOINTS
+from config import ECM_URL, get_mcp_api_key
 from ecm_client import get_ecm_client
 
 logger = logging.getLogger(__name__)
@@ -45,11 +47,20 @@ def register(mcp: FastMCP):
     async def create_backup() -> str:
         """Create a backup of all ECM configuration (settings, database, logos)."""
         try:
-            client = get_ecm_client()
-            # The backup endpoint returns a file download — we just trigger it
-            # and report success. The actual download happens through the ECM UI.
-            await client.call_endpoint(ENDPOINTS["backup_create"])
-            return "Backup created successfully. Download it from the ECM Settings page."
+            # /api/backup/create streams a binary ZIP — reading it via the shared
+            # ECMClient would call r.json() on binary bytes and crash with a
+            # UnicodeDecodeError (lq38l.10).  Use a short-lived httpx client to
+            # consume the raw bytes instead.
+            url = f"{ECM_URL.rstrip('/')}/api/backup/create"
+            headers = {"Authorization": f"Bearer {get_mcp_api_key()}"}
+            async with httpx.AsyncClient(timeout=60.0) as http:
+                r = await http.get(url, headers=headers)
+                r.raise_for_status()
+                size_kb = len(r.content) / 1024
+            return (
+                f"Backup created successfully ({size_kb:.1f} KB). "
+                "Download it from the ECM Settings page."
+            )
         except Exception as e:
             logger.error("[MCP] create_backup failed: %s", e)
             return f"Error creating backup: {e}"

--- a/mcp-server/tools/tasks.py
+++ b/mcp-server/tools/tasks.py
@@ -25,8 +25,9 @@ def register(mcp: FastMCP):
 
             lines = [f"Found {len(tasks)} tasks:"]
             for t in tasks:
-                name = t.get("name", "Unknown")
                 tid = t.get("task_id", t.get("id", "?"))
+                raw_name = t.get("task_name") or t.get("name")
+                name = raw_name if raw_name else tid.replace("_", " ").title() if tid != "?" else "Unknown"
                 enabled = "enabled" if t.get("enabled") else "disabled"
                 last_run = t.get("last_run", "never")
                 status = t.get("status", "idle")


### PR DESCRIPTION
## What

Fixes the P1/P2 findings from the live MCP test sweep (epic `enhancedchannelmanager-lq38l`). All changes are gate-green and **live-verified** against the running MCP/backend containers.

| Bead | Pri | Fix |
|------|-----|-----|
| lq38l.5 | **P1** | `merge_channels`: guard self-merge (target in sources) before any backend call; report per-result outcome instead of false success on a bad target |
| lq38l.1 | P2 | `list_tasks` reads the real `task_name` field (was always "Unknown") |
| lq38l.2 | P2 | `list_normalization_rules` sources from the rules endpoint → real per-group counts + names (was "0 rules"); adds `normalization_list_rules` to `_endpoint_contracts.py` |
| lq38l.3 | P2 | `reorder_streams` permutation guard — refuses partial/empty lists that would silently detach streams |
| lq38l.4 | P2 | backend write routes map upstream Dispatcharr 4xx → clean 400/404 (were opaque 500): channels/m3u/epg/profiles routers |
| lq38l.6 | P2 | `build_channel_lineup` counts/matches only channels created by the call (was counting the whole group) |
| lq38l.8 | P2 | real count/URL keys: m3u stream count (derived) + `server_url`; epg `epg_data_count`; groups-with-streams no longer shows a false "0 streams" |
| lq38l.9 | P2 | `stats` tools use `path_args` (not `path_params`) — `get_channel_popularity` + `get_user_channel_breakdown` no longer crash |
| lq38l.10 | P2 | `create_backup` reads the binary zip response (no more UnicodeDecodeError) |

(lq38l.7 — exact-match-only dedup auto-accept — is being added to this branch next.)

## Verification

- mcp-server suite: **284 passed, 0 failed**; backend router suite: **131 passed, 0 failed** (verified on the integration branch, not just isolated worktrees).
- Each fix re-tested live against the connected MCP after deploying to `ecm-ecm-1` + `ecm-ecm-mcp-1` (e.g. `list_tasks` shows real names; `update_channel(badid)` returns 404 not 500; `reorder_streams` partial list is refused; `create_backup` succeeds; Provider 1 shows 2624 streams).
- Disposable `MCPTEST_` entities used for write tests were all reverted (cleanup verified).

## Notes

No version bump (fix PR to dev; versioning handled at release cut). Findings filed/tracked under epic `enhancedchannelmanager-lq38l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)