### PR TITLE
fix(mcp+api): compound test-plan seam findings (znc76)

### DIFF
--- a/backend/routers/m3u.py
+++ b/backend/routers/m3u.py
@@ -411,6 +411,14 @@ async def create_m3u_account(request: Request):
     start = time.time()
     try:
         data = await request.json()
+        # Normalize: callers (including MCP) may send `url`; Dispatcharr
+        # expects `server_url`.  Promote `url` → `server_url` when only
+        # `url` is supplied so the round-trip works for standard accounts
+        # (bd-znc76.4 / bd-ma5qn).
+        if data.get("url") and not data.get("server_url"):
+            url_val = data["url"]
+            data = {k: v for k, v in data.items() if k != "url"}
+            data["server_url"] = url_val
         if data.get("server_url"):
             validate_url_scheme(data["server_url"], "server URL")
         result = await client.create_m3u_account(data)

--- a/backend/routers/stream_stats.py
+++ b/backend/routers/stream_stats.py
@@ -371,7 +371,15 @@ async def get_stream_stats_by_ids(request: BulkStreamIdsRequest):
 # to avoid the path parameter matching "bulk" or "all" as a stream_id
 @router.post("/probe/bulk")
 async def probe_bulk_streams(request: BulkProbeRequest):
-    """Trigger on-demand probe for multiple streams."""
+    """Trigger on-demand probe for multiple streams.
+
+    Returns an envelope with outcome tallies:
+        {total, success, failed, probed, results: [...]}
+    where ``results`` is the list of per-stream StreamStats dicts. ``success``
+    counts results whose ``probe_status`` is "success"; everything else
+    (failed / timeout) counts toward ``failed``. ``probed`` is retained as an
+    alias of ``total`` for backward compatibility.
+    """
     logger.debug("[STREAM-STATS-PROBE] POST /api/stream-stats/probe/bulk - %d streams", len(request.stream_ids))
 
     prober = ensure_prober()
@@ -404,7 +412,18 @@ async def probe_bulk_streams(request: BulkProbeRequest):
         logger.error("[STREAM-STATS-PROBE] Bulk probe failed: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
-    logger.info("[STREAM-STATS-PROBE] Bulk probe completed: %s streams probed", len(results))
+    # Tally outcomes so callers (UI, MCP) get success/failed counts directly
+    # instead of having to re-derive them from the per-stream list. Each result
+    # is a StreamStats.to_dict() whose outcome lives under "probe_status"
+    # (values: success / failed / timeout). Anything that isn't "success" counts
+    # as a failure for accounting purposes.
+    success = sum(1 for r in results if r.get("probe_status") == "success")
+    failed = len(results) - success
+
+    logger.info(
+        "[STREAM-STATS-PROBE] Bulk probe completed: %s streams probed (%s success, %s failed)",
+        len(results), success, failed,
+    )
 
     # Trigger smart sort if auto_reorder_after_probe is enabled
     settings = get_settings()
@@ -522,7 +541,13 @@ async def probe_bulk_streams(request: BulkProbeRequest):
         except Exception as e:
             logger.warning("[STREAM-STATS-PROBE] Smart sort after bulk probe failed: %s", e)
 
-    return {"probed": len(results), "results": results}
+    return {
+        "total": len(results),
+        "success": success,
+        "failed": failed,
+        "probed": len(results),  # retained for backward compatibility
+        "results": results,
+    }
 
 
 @router.post("/probe/all")

--- a/backend/tests/routers/test_m3u.py
+++ b/backend/tests/routers/test_m3u.py
@@ -75,6 +75,61 @@ class TestCreateM3UAccount:
         assert response.status_code == 200
         assert response.json()["name"] == "New M3U"
 
+    @pytest.mark.asyncio
+    async def test_standard_account_url_persisted_as_server_url(self, async_client):
+        """url field is normalized to server_url before forwarding to Dispatcharr.
+
+        The MCP create_m3u_account tool sends {name, url, server_type} but
+        Dispatcharr expects server_url.  The router must promote url → server_url
+        so the playlist URL round-trips correctly (bd-znc76.4).
+        """
+        mock_client = AsyncMock()
+        mock_client.create_m3u_account.return_value = {
+            "id": 7,
+            "name": "StandardProvider",
+            "server_url": "https://example.com/playlist.m3u8",
+        }
+
+        with patch("routers.m3u.get_client", return_value=mock_client), \
+             patch("routers.m3u.journal"):
+            response = await async_client.post("/api/m3u/accounts", json={
+                "name": "StandardProvider",
+                "url": "https://example.com/playlist.m3u8",
+                "server_type": "standard",
+            })
+
+        assert response.status_code == 200
+        # The payload forwarded to Dispatcharr must use server_url, not url
+        called_data = mock_client.create_m3u_account.call_args[0][0]
+        assert called_data.get("server_url") == "https://example.com/playlist.m3u8", (
+            f"Expected server_url in forwarded payload; got: {called_data!r}"
+        )
+        assert "url" not in called_data, (
+            f"'url' key must be promoted to 'server_url'; got: {called_data!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_url_not_overwritten_if_already_present(self, async_client):
+        """When the caller already provides server_url, it is not overwritten."""
+        mock_client = AsyncMock()
+        mock_client.create_m3u_account.return_value = {
+            "id": 8,
+            "name": "XtreamProvider",
+            "server_url": "https://xtream.example.com",
+        }
+
+        with patch("routers.m3u.get_client", return_value=mock_client), \
+             patch("routers.m3u.journal"):
+            response = await async_client.post("/api/m3u/accounts", json={
+                "name": "XtreamProvider",
+                "server_url": "https://xtream.example.com",
+                "server_type": "xtream",
+            })
+
+        assert response.status_code == 200
+        called_data = mock_client.create_m3u_account.call_args[0][0]
+        assert called_data.get("server_url") == "https://xtream.example.com"
+
 
 class TestUpdateM3UAccount:
     """Tests for PUT /api/m3u/accounts/{account_id}."""

--- a/backend/tests/routers/test_stream_stats.py
+++ b/backend/tests/routers/test_stream_stats.py
@@ -266,7 +266,8 @@ class TestProbeBulkStreams:
         mock_prober._fetch_all_streams.return_value = [
             {"id": 10, "url": "http://example.com/10", "name": "Stream 10"},
         ]
-        mock_prober.probe_stream.return_value = {"stream_id": 10, "status": "success"}
+        # Per-stream result is a StreamStats.to_dict(): outcome under probe_status.
+        mock_prober.probe_stream.return_value = {"stream_id": 10, "probe_status": "success"}
 
         with patch("routers.stream_stats.ensure_prober", return_value=mock_prober):
             response = await async_client.post(
@@ -278,6 +279,44 @@ class TestProbeBulkStreams:
         data = response.json()
         assert data["probed"] == 1
         mock_prober.probe_stream.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_response_has_tally_envelope(self, async_client):
+        """Bulk-probe response carries total/success/failed tallies (bd-clb9a).
+
+        Regression for the 0/0 accounting bug: the endpoint must compute
+        success/failed counts from each result's probe_status so the MCP tool
+        can report real numbers instead of zeros.
+        """
+        mock_prober = AsyncMock()
+        mock_prober._fetch_all_streams.return_value = [
+            {"id": 10, "url": "http://example.com/10", "name": "Stream 10"},
+            {"id": 11, "url": "http://example.com/11", "name": "Stream 11"},
+            {"id": 12, "url": "http://example.com/12", "name": "Stream 12"},
+        ]
+        # 1 success, 1 failed, 1 timeout — timeout counts as failed.
+        outcomes = {
+            10: {"stream_id": 10, "probe_status": "success"},
+            11: {"stream_id": 11, "probe_status": "failed"},
+            12: {"stream_id": 12, "probe_status": "timeout"},
+        }
+        mock_prober.probe_stream.side_effect = (
+            lambda sid, url, name: outcomes[sid]
+        )
+
+        with patch("routers.stream_stats.ensure_prober", return_value=mock_prober):
+            response = await async_client.post(
+                "/api/stream-stats/probe/bulk",
+                json={"stream_ids": [10, 11, 12]},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+        assert data["success"] == 1
+        assert data["failed"] == 2
+        assert data["probed"] == 3  # backward-compat alias of total
+        assert len(data["results"]) == 3
 
     @pytest.mark.asyncio
     async def test_returns_503_when_prober_unavailable(self, async_client):

--- a/docs/mcp_compound_test_plan.md
+++ b/docs/mcp_compound_test_plan.md
@@ -372,17 +372,30 @@ dedup/duplicate tools rely on — a cross-feature consistency seam.
 
 | # | Scenario | Result |
 |---|----------|--------|
-| 1 | Build channel from streams under new group + EPG + logo | ☐ |
-| 2 | Fuzzy-match provider streams onto a fresh lineup | ☐ |
-| 3 | Add-stream dedup decision loop | ☐ |
-| 4 | Provider onboarding → auto-creation → rollback | ☐ |
-| 5 | Duplicate cleanup: find → merge → renumber → reorder | ☐ |
-| 6 | EPG source lifecycle → grid → match → logos | ☐ |
-| 7 | Stream-health triage loop | ☐ |
-| 8 | Stats cross-reference (consistency) | ☐ |
-| 9 | Export profile → generate → publish discovery | ☐ |
-| 10 | Backup-guarded destructive operation | ☐ |
-| 11 | Task + schedule lifecycle | ☐ |
-| 12 | Normalization-driven dedup preview | ☐ |
+| 1 | Build channel from streams under new group + EPG + logo | ✅ PASS |
+| 2 | Fuzzy-match provider streams onto a fresh lineup | ✅ PASS |
+| 3 | Add-stream dedup decision loop | ✅ PASS |
+| 4 | Provider onboarding → auto-creation → rollback | ✅ PASS |
+| 5 | Duplicate cleanup: find → merge → renumber → reorder | ✅ PASS |
+| 6 | EPG source lifecycle → grid → match → logos | ✅ PASS (seam fix: znc76.2) |
+| 7 | Stream-health triage loop | ⚠️ PARTIAL (znc76.5) |
+| 8 | Stats cross-reference (consistency) | ✅ PASS (seam fix: znc76.1) |
+| 9 | Export profile → generate → publish discovery | ✅ PASS |
+| 10 | Backup-guarded destructive operation | ✅ PASS |
+| 11 | Task + schedule lifecycle | ✅ PASS |
+| 12 | Normalization-driven dedup preview | ❌ FAIL (znc76.3 — config) |
 
 **Filing findings:** a chain failure is usually a *seam* bug — record which step's output the next step failed to consume, and whether each individual tool behaves correctly on its own. If both tools pass alone but fail chained, that's the high-value finding this plan exists to catch.
+
+## Execution results — 2026-05-23 (live dev instance, agent-driven)
+
+First full run, executed by agents against the live dev ECM. 9/12 PASS; the seam findings were filed under epic `enhancedchannelmanager-znc76` and most were fixed the same day:
+
+- **znc76.1** (S8) — `get_popularity_rankings` / `get_top_watched` now surface the channel `id`, so `get_channel_popularity` is reachable from the chain. **Fixed.**
+- **znc76.2** (S6) — `match_channels_epg` now lists the per-channel candidate tvg_ids (with confidence) on a "multiple candidates" result, so the operator can see the options. **Fixed (visibility).** Remaining follow-up: an MCP affordance to *pick + link* a chosen candidate so `set_logo_from_epg` can then proceed.
+- **znc76.4** (S4) — `get_m3u_account` now shows the URL for a standard-type account (create normalizes `url`→`server_url`). **Fixed.**
+- **znc76.5** (S7) — `probe_bulk_streams` now returns a correct `{total, success, failed}` accounting envelope. **Partly fixed.** Remaining: the bulk endpoint is synchronous and 504s on batches ≥ ~3 — needs an async/background redesign (start+poll); and manual probes still don't populate the `get_probe_results` "latest run" envelope (documented in the tool docstrings).
+- **znc76.3** (S12) — the normalization strip rules are **config, not code**: the 7 strip rule groups have `tag_group_id` unset, so they never match (the engine is correct); and Title Case lowercases `US`→`Us` because "US" isn't in the Abbreviation Tags group. **Remedy is rule-data repair** (wire each strip rule's `tag_group_id`/`tag_match_position`; add "US"/"UK"/"EU" to Abbreviation Tags), or a one-shot backfill migration — not an engine change.
+- S7's `cleanup_struck_out_streams` was run separately (operator-authorized): 135 struck streams cleared, all unassigned → 0 channels affected.
+
+Reconfirmed pre-existing open items: `lq38l.11` (journal empty for all mutations), `lq38l.12` (probe_bulk 504), `lq38l.13` (cosmetic cluster).

--- a/mcp-server/tests/test_co5wh_coverage.py
+++ b/mcp-server/tests/test_co5wh_coverage.py
@@ -971,3 +971,139 @@ class TestGetChannelBandwidth:
             result = await mcp.call_tool("get_channel_bandwidth", {})
 
         assert "No channel bandwidth data" in result[0][0].text
+
+
+# =============================================================================
+# znc76.1 — channel_id surfaced in get_popularity_rankings + get_top_watched
+# =============================================================================
+
+
+class TestChannelIdSurfacedInRankings:
+    """channel_id must appear in get_popularity_rankings output so operators
+    can pass it directly to get_channel_popularity(channel_id=...)."""
+
+    @pytest.mark.asyncio
+    async def test_popularity_rankings_includes_channel_id(self):
+        """get_popularity_rankings renders (id=<channel_id>) in each line."""
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        _register_stats(mcp)
+
+        # Real shape: PopularityCalculator.get_rankings() →
+        # {"total": N, "rankings": [ChannelPopularityScore.to_dict(), ...]}
+        rankings_response = {
+            "total": 1,
+            "rankings": [
+                {
+                    "id": 1,
+                    "channel_id": "uuid-brewers-0001",
+                    "channel_name": "Milwaukee Brewers",
+                    "score": 93.8,
+                    "rank": 1,
+                    "trend": "up",
+                    "trend_percent": 5.0,
+                    "watch_count_7d": 200,
+                    "watch_time_7d": 72000,
+                    "unique_viewers_7d": 60,
+                    "bandwidth_7d": 8_000_000_000,
+                    "previous_score": 89.2,
+                    "previous_rank": 2,
+                    "calculated_at": "2026-05-23T06:00:00Z",
+                    "created_at": "2026-05-01T00:00:00Z",
+                    "updated_at": "2026-05-23T06:00:00Z",
+                }
+            ],
+        }
+
+        mock_client = _make_mock(rankings_response)
+        with patch("tools.stats.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("get_popularity_rankings", {"limit": 10})
+
+        text = result[0][0].text
+        assert "Milwaukee Brewers" in text
+        assert "id=uuid-brewers-0001" in text
+        assert "score: 93.8" in text
+
+    @pytest.mark.asyncio
+    async def test_top_watched_includes_channel_id(self):
+        """get_top_watched renders (id=<channel_id>) in each line."""
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        _register_stats(mcp)
+
+        # Real shape: BandwidthTracker.get_top_watched_channels() →
+        # [{"channel_id", "channel_name", "watch_count", "total_watch_seconds",
+        #   "last_watched"}, ...]
+        top_watched_response = [
+            {
+                "channel_id": "uuid-nesn-0002",
+                "channel_name": "NESN",
+                "watch_count": 150,
+                "total_watch_seconds": 54000,
+                "last_watched": "2026-05-23T10:00:00Z",
+            }
+        ]
+
+        mock_client = _make_mock(top_watched_response)
+        with patch("tools.stats.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("get_top_watched", {"limit": 10})
+
+        text = result[0][0].text
+        assert "NESN" in text
+        assert "id=uuid-nesn-0002" in text
+        assert "15.0h watched" in text
+
+    @pytest.mark.asyncio
+    async def test_rankings_without_channel_id_still_renders(self):
+        """If channel_id is absent (legacy response), line still renders without crash."""
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        _register_stats(mcp)
+
+        rankings_response = {
+            "total": 1,
+            "rankings": [
+                {
+                    "channel_name": "ESPN",
+                    "score": 70.0,
+                    "trend": "stable",
+                }
+            ],
+        }
+
+        mock_client = _make_mock(rankings_response)
+        with patch("tools.stats.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("get_popularity_rankings", {})
+
+        text = result[0][0].text
+        assert "ESPN" in text
+        assert "score: 70.0" in text
+        # No (id=...) fragment when channel_id is absent
+        assert "(id=" not in text
+
+    @pytest.mark.asyncio
+    async def test_top_watched_without_channel_id_still_renders(self):
+        """If channel_id is absent (legacy response), line still renders without crash."""
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        _register_stats(mcp)
+
+        top_watched_response = [
+            {
+                "channel_name": "CNN",
+                "total_watch_seconds": 3600,
+                "unique_viewers": 5,
+            }
+        ]
+
+        mock_client = _make_mock(top_watched_response)
+        with patch("tools.stats.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("get_top_watched", {})
+
+        text = result[0][0].text
+        assert "CNN" in text
+        assert "(id=" not in text

--- a/mcp-server/tests/test_lq38l8_count_url_fields.py
+++ b/mcp-server/tests/test_lq38l8_count_url_fields.py
@@ -204,6 +204,83 @@ class TestGetM3UAccountCountAndUrl:
         assert "HD Homerun" in text
         assert "N/A" in text  # graceful fallback for missing URL
 
+    @pytest.mark.asyncio
+    async def test_standard_account_url_rendered_from_server_url(self):
+        """A freshly-created standard account shows its URL, not 'N/A'.
+
+        After the bd-znc76.4 fix the backend router normalises url→server_url
+        before persisting to Dispatcharr.  On read-back the payload carries
+        server_url — verify get_m3u_account renders it (not N/A).
+        """
+        mcp = _make_mcp_m3u()
+
+        async def call_ep(endpoint, **kwargs):
+            if endpoint.name == "m3u_get_account":
+                # Standard account as returned by Dispatcharr after the
+                # url→server_url normalisation in the backend router.
+                return {
+                    "id": 42,
+                    "name": "StandardM3U",
+                    "server_url": "https://provider.example.com/list-STDCHECK.m3u8",
+                    "account_type": "M3U",
+                    "is_active": True,
+                }
+            if endpoint.name == "streams_list":
+                return {"count": 0, "results": []}
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_ep
+
+        with patch("tools.m3u.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("get_m3u_account", {"account_id": 42})
+
+        text = result[0][0].text
+        assert "StandardM3U" in text
+        assert "STDCHECK" in text, (
+            f"Expected server_url to appear in output; got: {text!r}"
+        )
+        assert "N/A" not in text, (
+            f"URL must not be N/A for a standard account with server_url; got: {text!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_standard_account_url_rendered_from_url_field(self):
+        """URL renders correctly when Dispatcharr returns it under 'url' (not server_url).
+
+        The get_m3u_account tool reads server_url-or-url; verify the fallback
+        branch also works for payloads where only 'url' is present (bd-znc76.4).
+        """
+        mcp = _make_mcp_m3u()
+
+        async def call_ep(endpoint, **kwargs):
+            if endpoint.name == "m3u_get_account":
+                return {
+                    "id": 43,
+                    "name": "LegacyStandard",
+                    "url": "https://legacy.example.com/feed-LEGACYCHECK.m3u",
+                    "account_type": "M3U",
+                    "is_active": True,
+                }
+            if endpoint.name == "streams_list":
+                return {"count": 0, "results": []}
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_ep
+
+        with patch("tools.m3u.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("get_m3u_account", {"account_id": 43})
+
+        text = result[0][0].text
+        assert "LegacyStandard" in text
+        assert "LEGACYCHECK" in text, (
+            f"Expected 'url' field to appear in output; got: {text!r}"
+        )
+        assert "N/A" not in text, (
+            f"URL must not be N/A when 'url' field is present; got: {text!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # get_groups_with_streams

--- a/mcp-server/tests/test_p2_streams.py
+++ b/mcp-server/tests/test_p2_streams.py
@@ -214,3 +214,87 @@ class TestProbeSingleStreamTimeout:
         text = result[0][0].text
         assert "healthy" in text
         assert "7" in text
+
+
+# ---------------------------------------------------------------------------
+# bd-clb9a (from enhancedchannelmanager-znc76.5) —
+# probe_bulk_streams must report the real success/failed counts from the
+# backend envelope instead of the old 0/0 accounting.
+# ---------------------------------------------------------------------------
+
+class TestProbeBulkStreamsAccounting:
+    """Verify probe_bulk_streams reports real success/failed tallies."""
+
+    @pytest.mark.asyncio
+    async def test_reports_real_success_and_failed_counts(self):
+        """The tool reads total/success/failed from the backend envelope.
+
+        Before the fix the backend returned only {probed, results} and the tool
+        defaulted success/failed to 0 -> "Success: 0 / Failed: 0" even on a
+        completed run. With the envelope it must surface the real numbers.
+        """
+        mcp = _make_mcp_and_register()
+
+        envelope = {
+            "total": 3,
+            "success": 2,
+            "failed": 1,
+            "probed": 3,
+            "results": [
+                {"stream_id": 10, "stream_name": "Stream 10", "probe_status": "success"},
+                {"stream_id": 11, "stream_name": "Stream 11", "probe_status": "success"},
+                {"stream_id": 12, "stream_name": "Stream 12", "probe_status": "failed",
+                 "error_message": "ffprobe failed: 404 Not Found"},
+            ],
+        }
+
+        client = AsyncMock()
+        client.call_endpoint.return_value = envelope
+
+        with patch("tools.streams.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("probe_bulk_streams", {"stream_ids": [10, 11, 12]})
+
+        text = result[0][0].text
+        assert "Bulk probe completed for 3 streams" in text
+        assert "Success: 2" in text
+        assert "Failed: 1" in text
+        # 0/0 accounting bug must not reappear.
+        assert "Success: 0" not in text
+
+    @pytest.mark.asyncio
+    async def test_lists_failed_streams_with_name_and_error(self):
+        """Failed streams are listed using probe_status/stream_name/error_message keys.
+
+        The per-stream dicts are StreamStats.to_dict() — outcome under
+        probe_status (not status), name under stream_name (not name), error
+        under error_message (not error). Treats anything != success as failed.
+        """
+        mcp = _make_mcp_and_register()
+
+        envelope = {
+            "total": 2,
+            "success": 0,
+            "failed": 2,
+            "probed": 2,
+            "results": [
+                {"stream_id": 12, "stream_name": "Bad Stream", "probe_status": "failed",
+                 "error_message": "ffprobe failed: 404 Not Found"},
+                {"stream_id": 13, "stream_name": "Slow Stream", "probe_status": "timeout",
+                 "error_message": "Probe timed out after 30s"},
+            ],
+        }
+
+        client = AsyncMock()
+        client.call_endpoint.return_value = envelope
+
+        with patch("tools.streams.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("probe_bulk_streams", {"stream_ids": [12, 13]})
+
+        text = result[0][0].text
+        assert "Failed: 2" in text
+        assert "Failed streams:" in text
+        # Name + error surfaced from the correct keys; timeout treated as failed.
+        assert "Bad Stream" in text
+        assert "404 Not Found" in text
+        assert "Slow Stream" in text
+        assert "timed out" in text.lower()

--- a/mcp-server/tests/test_tools.py
+++ b/mcp-server/tests/test_tools.py
@@ -1797,8 +1797,8 @@ class TestMatchChannelsEpg:
                     "status": "multiple",
                     "best_score": 0.92,
                     "matches": [
-                        {"tvg_id": "FoxNews.us", "epg_name": "Fox News Channel", "confidence": 0.92, "match_type": "fuzzy"},
-                        {"tvg_id": "FoxNews.int", "epg_name": "Fox News Int", "confidence": 0.85, "match_type": "fuzzy"},
+                        {"tvg_id": "FoxNews.us", "epg_name": "Fox News Channel", "confidence": 92.0, "match_type": "fuzzy"},
+                        {"tvg_id": "FoxNews.int", "epg_name": "Fox News Int", "confidence": 85.0, "match_type": "fuzzy"},
                     ],
                 },
                 {
@@ -1807,7 +1807,7 @@ class TestMatchChannelsEpg:
                     "status": "multiple",
                     "best_score": 0.80,
                     "matches": [
-                        {"tvg_id": "Discovery.us", "epg_name": "Discovery Channel", "confidence": 0.80, "match_type": "fuzzy"},
+                        {"tvg_id": "Discovery.us", "epg_name": "Discovery Channel", "confidence": 80.0, "match_type": "fuzzy"},
                     ],
                 },
             ],

--- a/mcp-server/tests/test_tools.py
+++ b/mcp-server/tests/test_tools.py
@@ -1777,6 +1777,115 @@ class TestMatchChannelsEpg:
         text = result[0][0].text
         assert "Error" in text
 
+    @pytest.mark.asyncio
+    async def test_multiple_candidates_surfaced_in_output(self):
+        """Channels with status=multiple show candidate tvg_ids, names, and confidence (bd-1icn8)."""
+        from tools.epg import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        response = {
+            "exact": [{"channel_id": 10, "channel_name": "ESPN", "matches": [
+                {"tvg_id": "ESPN.us", "epg_name": "ESPN", "confidence": 1.0, "match_type": "exact"},
+            ]}],
+            "multiple": [
+                {
+                    "channel_id": 20,
+                    "channel_name": "Fox News",
+                    "status": "multiple",
+                    "best_score": 0.92,
+                    "matches": [
+                        {"tvg_id": "FoxNews.us", "epg_name": "Fox News Channel", "confidence": 0.92, "match_type": "fuzzy"},
+                        {"tvg_id": "FoxNews.int", "epg_name": "Fox News Int", "confidence": 0.85, "match_type": "fuzzy"},
+                    ],
+                },
+                {
+                    "channel_id": 21,
+                    "channel_name": "Discovery",
+                    "status": "multiple",
+                    "best_score": 0.80,
+                    "matches": [
+                        {"tvg_id": "Discovery.us", "epg_name": "Discovery Channel", "confidence": 0.80, "match_type": "fuzzy"},
+                    ],
+                },
+            ],
+            "none": [],
+            "summary": {
+                "total_channels": 3,
+                "exact_count": 1,
+                "multiple_count": 2,
+                "none_count": 0,
+                "match_time_ms": 75.0,
+            },
+        }
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.return_value = response
+
+        with patch("tools.epg.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("match_channels_epg", {})
+
+        text = result[0][0].text
+
+        # Summary line still present
+        assert "3" in text
+        assert "1" in text   # exact_count
+        assert "2" in text   # multiple_count
+
+        # Channel names for ambiguous channels listed
+        assert "Fox News" in text
+        assert "Discovery" in text
+
+        # Candidate tvg_ids surfaced
+        assert "FoxNews.us" in text
+        assert "FoxNews.int" in text
+        assert "Discovery.us" in text
+
+        # Candidate EPG names surfaced
+        assert "Fox News Channel" in text
+        assert "Discovery Channel" in text
+
+        # Confidence values rendered (92%, 85%, 80%)
+        assert "92%" in text
+        assert "85%" in text
+        assert "80%" in text
+
+    @pytest.mark.asyncio
+    async def test_multiple_candidates_missing_matches_key_handled(self):
+        """Defensive: if a multiple entry has no 'matches' key, renders graceful fallback (bd-1icn8)."""
+        from tools.epg import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        response = {
+            "exact": [],
+            "multiple": [
+                # Entry missing 'matches' key entirely — defensive handling
+                {"channel_id": 30, "channel_name": "CNN"},
+            ],
+            "none": [],
+            "summary": {
+                "total_channels": 1,
+                "exact_count": 0,
+                "multiple_count": 1,
+                "none_count": 0,
+                "match_time_ms": 10.0,
+            },
+        }
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.return_value = response
+
+        with patch("tools.epg.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("match_channels_epg", {})
+
+        text = result[0][0].text
+        # Must not raise; channel name must appear; fallback message present
+        assert "CNN" in text
+        assert "no candidate details available" in text
+
 
 # --- TestEpgContractRegistry (A2) ---
 class TestEpgContractRegistry:

--- a/mcp-server/tools/epg.py
+++ b/mcp-server/tools/epg.py
@@ -130,10 +130,34 @@ def register(mcp: FastMCP):
             multiple_count = summary.get("multiple_count", len(result.get("multiple", [])) if isinstance(result, dict) else 0)
             none_count = summary.get("none_count", len(result.get("none", [])) if isinstance(result, dict) else 0)
 
-            return (
+            lines = [
                 f"EPG auto-match complete: {total} channels total — "
                 f"{exact_count} exact, {multiple_count} multiple candidates, {none_count} unmatched."
-            )
+            ]
+
+            # Surface candidate details for ambiguous channels so the operator
+            # can see the options without dropping to the UI (bd-1icn8).
+            # The backend returns result["multiple"] as a list of per-channel
+            # entries, each with a "matches" list capped at 10 candidates.
+            multiple_entries = result.get("multiple", []) if isinstance(result, dict) else []
+            if multiple_entries:
+                lines.append(f"\nChannels with multiple candidates ({len(multiple_entries)}):")
+                for entry in multiple_entries:
+                    ch_name = entry.get("channel_name", f"channel {entry.get('channel_id', '?')}")
+                    candidates = entry.get("matches", [])
+                    lines.append(f"  {ch_name}:")
+                    if candidates:
+                        for c in candidates:
+                            tvg_id = c.get("tvg_id", "?")
+                            epg_name = c.get("epg_name", "")
+                            confidence = c.get("confidence")
+                            conf_str = f" ({confidence:.0%})" if confidence is not None else ""
+                            name_str = f" — {epg_name}" if epg_name else ""
+                            lines.append(f"    • {tvg_id}{name_str}{conf_str}")
+                    else:
+                        lines.append("    (no candidate details available)")
+
+            return "\n".join(lines)
         except Exception as e:
             logger.error("[MCP] match_channels_epg failed: %s", e)
             return f"Error running EPG auto-match: {e}"

--- a/mcp-server/tools/epg.py
+++ b/mcp-server/tools/epg.py
@@ -151,7 +151,7 @@ def register(mcp: FastMCP):
                             tvg_id = c.get("tvg_id", "?")
                             epg_name = c.get("epg_name", "")
                             confidence = c.get("confidence")
-                            conf_str = f" ({confidence:.0%})" if confidence is not None else ""
+                            conf_str = f" ({confidence:.0f}%)" if confidence is not None else ""
                             name_str = f" — {epg_name}" if epg_name else ""
                             lines.append(f"    • {tvg_id}{name_str}{conf_str}")
                     else:

--- a/mcp-server/tools/stats.py
+++ b/mcp-server/tools/stats.py
@@ -118,7 +118,9 @@ def register(mcp: FastMCP):
                 watch_time = c.get("total_watch_seconds", c.get("total_watch_time", 0))
                 hours = watch_time / 3600 if watch_time else 0
                 viewers = c.get("unique_viewers", c.get("viewer_count", "?"))
-                lines.append(f"  {i}. {name} — {hours:.1f}h watched, {viewers} unique viewers")
+                channel_id = c.get("channel_id", "")
+                id_suffix = f" (id={channel_id})" if channel_id else ""
+                lines.append(f"  {i}. {name}{id_suffix} — {hours:.1f}h watched, {viewers} unique viewers")
 
             return "\n".join(lines)
         except Exception as e:
@@ -182,7 +184,9 @@ def register(mcp: FastMCP):
                 score = r.get("score", r.get("popularity_score", 0))
                 trend = r.get("trend", "")
                 trend_icon = " ↑" if trend == "up" else " ↓" if trend == "down" else ""
-                lines.append(f"  {name} — score: {score:.1f}{trend_icon}")
+                channel_id = r.get("channel_id", "")
+                id_suffix = f" (id={channel_id})" if channel_id else ""
+                lines.append(f"  {name}{id_suffix} — score: {score:.1f}{trend_icon}")
 
             return "\n".join(lines)
         except Exception as e:

--- a/mcp-server/tools/streams.py
+++ b/mcp-server/tools/streams.py
@@ -385,6 +385,11 @@ def register(mcp: FastMCP):
     async def probe_single_stream(stream_id: int) -> str:
         """Probe a single stream to check its health.
 
+        Note: this manual probe does NOT feed get_probe_results (only the
+        scheduled probe task does), but the result IS persisted, so
+        get_stream_health and get_streams_by_ids reflect it.
+        (See bd enhancedchannelmanager-znc76.5.)
+
         Args:
             stream_id: The stream ID to probe
         """
@@ -588,7 +593,14 @@ def register(mcp: FastMCP):
 
     @mcp.tool()
     async def get_probe_results() -> str:
-        """Get results from the most recent completed probe run."""
+        """Get results from the most recent completed probe run.
+
+        Note: this envelope is populated only by the scheduled stream probe task,
+        NOT by manual probe_single_stream / probe_bulk_streams calls. To see the
+        outcome of a manual probe, read its return value directly, or use
+        get_stream_health / get_struck_out_streams which draw from persisted
+        per-stream stats. (See bd enhancedchannelmanager-znc76.5.)
+        """
         try:
             client = get_ecm_client()
             result = await client.call_endpoint(ENDPOINTS["stream_stats_probe_results"])
@@ -727,6 +739,13 @@ def register(mcp: FastMCP):
     async def probe_bulk_streams(stream_ids: list[int]) -> str:
         """Probe multiple streams at once and return health results summary.
 
+        Note: manual probes triggered here do NOT feed get_probe_results — that
+        "latest probe run" envelope is populated only by the scheduled stream
+        probe task. The per-stream stats ARE persisted, so get_stream_health,
+        get_struck_out_streams, and get_streams_by_ids reflect the new results.
+        Large batches may time out at the gateway (504); probe in smaller
+        batches if that happens. (See bd enhancedchannelmanager-znc76.5.)
+
         Args:
             stream_ids: List of stream IDs to probe
         """
@@ -747,12 +766,18 @@ def register(mcp: FastMCP):
                 ]
                 results_list = result.get("results", [])
                 if results_list:
-                    failed_streams = [r for r in results_list if r.get("status") == "failed"]
+                    # Per-stream results are StreamStats dicts: the outcome is
+                    # under "probe_status" (success/failed/timeout) and the
+                    # human-readable error under "error_message". Anything that
+                    # isn't "success" is a failure for reporting purposes.
+                    failed_streams = [
+                        r for r in results_list if r.get("probe_status") != "success"
+                    ]
                     if failed_streams:
                         lines.append("  Failed streams:")
                         for r in failed_streams[:20]:
-                            name = r.get("name", f"id={r.get('stream_id', '?')}")
-                            error = r.get("error", "unknown error")
+                            name = r.get("stream_name") or f"id={r.get('stream_id', '?')}"
+                            error = r.get("error_message") or "unknown error"
                             lines.append(f"    - {name}: {error}")
                         if len(failed_streams) > 20:
                             lines.append(f"    ... and {len(failed_streams) - 20} more failures")


### PR DESCRIPTION
## What

Fixes the seam/chain findings from the compound test-plan execution (epic `enhancedchannelmanager-znc76`). All code fixes are gate-green and **live-verified** on the dev containers.

| Bead | Fix |
|------|-----|
| znc76.1 | `get_popularity_rankings` / `get_top_watched` surface the channel `id` → `get_channel_popularity` is reachable from the chain (verified end-to-end: rankings id → score 93.8) |
| znc76.2 | `match_channels_epg` lists per-channel candidate tvg_ids + confidence on "multiple candidates" (renders e.g. `ESPN HD (90%)`); pick+link remains a follow-up |
| znc76.4 | `create_m3u_account` normalizes `url`→`server_url` so a standard account's URL round-trips (`get_m3u_account` no longer shows N/A) |
| znc76.5 | `probe_bulk_streams` returns a correct `{total, success, failed}` accounting envelope (was 0/0). The bulk-endpoint 504 on large batches needs an async redesign — out of scope here, noted |

**znc76.3 (normalization strip rules) is NOT in this PR** — it's config, not code: the strip rule groups have `tag_group_id` unset, so they never match (engine is correct); remedy is rule-data repair. Documented in the bead + the test-plan doc.

Also records the compound test-plan execution results into `docs/mcp_compound_test_plan.md` (9/12 PASS; findings + resolutions).

## Verification
- mcp-server suite: 295 passed; backend m3u + stream_stats router suites: 68 passed.
- Live re-tested each fix on `ecm-ecm-1` + `ecm-ecm-mcp-1` after deploy (popularity chain end-to-end, EPG candidates with correct %, standard m3u URL shown, struck-stream cleanup ran clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)