### PR TITLE
fix(normalization+probe): znc76.3 strip-rule repair + znc76.5 async bulk probe

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -790,6 +790,42 @@ async def startup_event():
     except Exception as e:
         logger.warning("[MAIN] Could not ensure Title Case rule: %s", e)
 
+    # Backfill tag_group_id on strip rules that were never wired (znc76.3).
+    # Pre-existing installs have tag_group rules with NULL tag_group_id, so the
+    # engine matcher short-circuits and the strips never fire. This repairs the
+    # config drift so quality/country/etc. tags get stripped again.
+    try:
+        from normalization_migration import backfill_tag_group_rule_ids
+        session = get_session()
+        try:
+            result = backfill_tag_group_rule_ids(session)
+            if result.get("rules_wired", 0) > 0:
+                logger.info(
+                    "[MAIN] Backfilled tag_group_id on %s normalization rule(s)",
+                    result["rules_wired"]
+                )
+        finally:
+            session.close()
+    except Exception as e:
+        logger.warning("[MAIN] Could not backfill tag_group rule ids: %s", e)
+
+    # Ensure US/UK/EU are in Abbreviation Tags so Title Case preserves them
+    # (otherwise US -> Us). Companion repair to the tag_group_id backfill.
+    try:
+        from normalization_migration import ensure_abbreviation_tags_acronyms
+        session = get_session()
+        try:
+            result = ensure_abbreviation_tags_acronyms(session)
+            if result.get("tags_added", 0) > 0:
+                logger.info(
+                    "[MAIN] Added %s acronym(s) to Abbreviation Tags",
+                    result["tags_added"]
+                )
+        finally:
+            session.close()
+    except Exception as e:
+        logger.warning("[MAIN] Could not ensure Abbreviation Tags acronyms: %s", e)
+
     # Repair duplicate auto-creation rule priorities
     try:
         from models import AutoCreationRule

--- a/backend/normalization_migration.py
+++ b/backend/normalization_migration.py
@@ -554,3 +554,199 @@ def ensure_title_case_rule(db: Session) -> dict:
 
     logger.info("[NORMALIZE-MIGRATE] Created 'Title Case' rule group")
     return {"created": True}
+
+
+# Map a strip rule group's name to the tag group it should match against.
+# Derived from DEMO_RULE_CONFIGS (the canonical wiring create_demo_rules uses)
+# so this stays in sync if the demo configs change. Legacy group names that
+# create_demo_rules has since renamed (e.g. the suffix-only State/Province
+# variant) are aliased explicitly.
+RULE_GROUP_TO_TAG_GROUP = {
+    cfg["rule_group_name"]: cfg["tag_group_name"] for cfg in DEMO_RULE_CONFIGS
+}
+RULE_GROUP_TO_TAG_GROUP["Strip State/Province Suffixes"] = "State/Province Tags"
+
+# Map a directional action_type to its tag_match_position. The strip rules
+# already encode position in their action_type (strip_prefix -> prefix,
+# strip_suffix -> suffix); 'remove' has no direction so it matches anywhere
+# (contains). This is the robust derivation requested by znc76.3 — position is
+# inferred from the rule, not hardcoded by index.
+ACTION_TYPE_TO_POSITION = {
+    "strip_prefix": "prefix",
+    "strip_suffix": "suffix",
+    "remove": "contains",
+}
+
+
+def backfill_tag_group_rule_ids(db: Session) -> dict:
+    """
+    Repair tag_group rules whose tag_group_id was never wired (CONFIG drift).
+
+    For pre-existing installations, the strip rule groups were created before
+    create_demo_rules learned to wire tag_group_id via a name->id map. Those
+    rules have condition_type='tag_group' but tag_group_id IS NULL, so the
+    engine matcher short-circuits to no-match (normalization_engine.py
+    _match_condition) and the strips never fire. This backfills the missing
+    tag_group_id (and tag_match_position) by matching each rule's parent group
+    to its tag group BY NAME — reusing the exact name->id approach
+    create_demo_rules uses.
+
+    Strictly idempotent:
+    - Only rules with condition_type='tag_group' AND tag_group_id IS NULL are
+      touched. Already-wired rules are left untouched, so re-running is a no-op.
+    - tag_match_position is derived from the rule's action_type (strip_prefix ->
+      prefix, strip_suffix -> suffix, remove -> contains), falling back to the
+      DEMO_RULE_CONFIGS match_position for the rule's group when action_type is
+      ambiguous. Position is only set when currently NULL.
+
+    Conservative: if a rule's parent group name does not map to a known tag
+    group, the rule is skipped (logged) rather than guessed.
+
+    Returns:
+        Dict with counts of rules wired and rules skipped.
+    """
+    # Find every tag_group rule that was never wired to a tag group.
+    null_rules = db.query(NormalizationRule).filter(
+        NormalizationRule.condition_type == "tag_group",
+        NormalizationRule.tag_group_id.is_(None)
+    ).all()
+
+    if not null_rules:
+        logger.info("[NORMALIZE-MIGRATE] No tag_group rules with NULL tag_group_id; backfill is a no-op")
+        return {"rules_wired": 0, "rules_skipped": 0}
+
+    # Build the name -> id map exactly like create_demo_rules does.
+    tag_group_map = {tg.name: tg.id for tg in db.query(TagGroup).all()}
+
+    # Cache parent group names so we can map rule -> rule group -> tag group.
+    group_name_by_id = {
+        g.id: g.name for g in db.query(NormalizationRuleGroup).all()
+    }
+
+    # Cache the demo match_position fallback keyed by tag group name.
+    demo_position_by_tag_group = {
+        cfg["tag_group_name"]: cfg["match_position"] for cfg in DEMO_RULE_CONFIGS
+    }
+
+    wired = 0
+    skipped = 0
+
+    for rule in null_rules:
+        parent_group_name = group_name_by_id.get(rule.group_id)
+        tag_group_name = RULE_GROUP_TO_TAG_GROUP.get(parent_group_name)
+
+        if not tag_group_name:
+            logger.warning(
+                "[NORMALIZE-MIGRATE] Rule id=%s in group '%s' has no known tag-group "
+                "mapping; skipping (conservative)",
+                rule.id, parent_group_name
+            )
+            skipped += 1
+            continue
+
+        tag_group_id = tag_group_map.get(tag_group_name)
+        if not tag_group_id:
+            logger.warning(
+                "[NORMALIZE-MIGRATE] Tag group '%s' not found for rule id=%s; skipping",
+                tag_group_name, rule.id
+            )
+            skipped += 1
+            continue
+
+        rule.tag_group_id = tag_group_id
+
+        # Only set position when it's missing; derive from action_type first,
+        # then fall back to the demo config for this tag group, then 'contains'.
+        if not rule.tag_match_position:
+            position = ACTION_TYPE_TO_POSITION.get(rule.action_type)
+            if not position:
+                position = demo_position_by_tag_group.get(tag_group_name, "contains")
+            rule.tag_match_position = position
+
+        wired += 1
+        logger.info(
+            "[NORMALIZE-MIGRATE] Wired rule id=%s ('%s') -> tag group '%s' (id=%s, position=%s)",
+            rule.id, parent_group_name, tag_group_name, tag_group_id, rule.tag_match_position
+        )
+
+    if wired > 0:
+        db.commit()
+        logger.info(
+            "[NORMALIZE-MIGRATE] Backfilled tag_group_id on %s rule(s); %s skipped",
+            wired, skipped
+        )
+    else:
+        logger.info(
+            "[NORMALIZE-MIGRATE] No tag_group rules wired (%s skipped)", skipped
+        )
+
+    return {"rules_wired": wired, "rules_skipped": skipped}
+
+
+# Acronyms that title-casing must preserve. "US" and "EU" contain a vowel and
+# are short, so the engine's structural heuristic would lowercase them
+# (US -> Us) unless they're in the Abbreviation Tags group. "UK" is vowel-free
+# and already preserved, but we ensure it for consistency / explicitness.
+REQUIRED_ABBREVIATION_ACRONYMS = ["US", "UK", "EU"]
+
+
+def ensure_abbreviation_tags_acronyms(db: Session) -> dict:
+    """
+    Ensure 'US', 'UK', 'EU' exist in the 'Abbreviation Tags' tag group so the
+    Title Case rule preserves them instead of lowercasing (US -> Us).
+
+    The Abbreviation Tags seed (database._seed_builtin_tags) includes "USA"
+    but not "US"/"UK"/"EU", so country acronyms left after stripping get
+    corrupted by Smart Title Case. This adds only the missing acronyms.
+
+    Strictly idempotent: only acronyms that are missing are added. After adding,
+    the engine's abbreviation cache is invalidated so the next normalization
+    reload picks them up.
+
+    Returns:
+        Dict with count of tags added.
+    """
+    from models import Tag
+
+    abbr_group = db.query(TagGroup).filter(
+        TagGroup.name == "Abbreviation Tags"
+    ).first()
+
+    if not abbr_group:
+        logger.warning(
+            "[NORMALIZE-MIGRATE] Abbreviation Tags tag group not found; skipping acronym fix"
+        )
+        return {"tags_added": 0, "skipped": True}
+
+    added = 0
+    for value in REQUIRED_ABBREVIATION_ACRONYMS:
+        existing = db.query(Tag).filter(
+            Tag.group_id == abbr_group.id,
+            Tag.value == value
+        ).first()
+        if not existing:
+            db.add(Tag(
+                group_id=abbr_group.id,
+                value=value,
+                case_sensitive=False,
+                enabled=True,
+                is_builtin=True
+            ))
+            added += 1
+
+    if added > 0:
+        db.commit()
+        # Drop the cached abbreviation set so the engine reloads the new tags.
+        try:
+            from normalization_engine import clear_abbreviation_cache
+            clear_abbreviation_cache()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("[NORMALIZE-MIGRATE] Could not clear abbreviation cache: %s", e)
+        logger.info(
+            "[NORMALIZE-MIGRATE] Added %s missing acronym(s) to Abbreviation Tags (US/UK/EU)",
+            added
+        )
+    else:
+        logger.info("[NORMALIZE-MIGRATE] Abbreviation Tags already has US/UK/EU")
+
+    return {"tags_added": added, "skipped": False}

--- a/backend/routers/stream_stats.py
+++ b/backend/routers/stream_stats.py
@@ -13,7 +13,6 @@ from pydantic import BaseModel
 
 from config import get_settings
 from database import get_session
-import journal
 from dispatcharr_client import get_client
 from stream_prober import StreamProber, ensure_prober
 
@@ -371,14 +370,18 @@ async def get_stream_stats_by_ids(request: BulkStreamIdsRequest):
 # to avoid the path parameter matching "bulk" or "all" as a stream_id
 @router.post("/probe/bulk")
 async def probe_bulk_streams(request: BulkProbeRequest):
-    """Trigger on-demand probe for multiple streams.
+    """Start an on-demand background probe for a specific list of streams.
 
-    Returns an envelope with outcome tallies:
-        {total, success, failed, probed, results: [...]}
-    where ``results`` is the list of per-stream StreamStats dicts. ``success``
-    counts results whose ``probe_status`` is "success"; everything else
-    (failed / timeout) counts toward ``failed``. ``probed`` is retained as an
-    alias of ``total`` for backward compatibility.
+    This is the async sibling of POST /probe/all: instead of probing each stream
+    synchronously (which 504'd at batches >=~3 — enhancedchannelmanager-znc76.5),
+    it kicks off a background probe of the requested ``stream_ids`` using the
+    SAME prober job/progress/results-envelope machinery probe/all uses, then
+    returns immediately. Callers poll GET /probe/progress and read GET
+    /probe/results to get the outcome — those now reflect the bulk run.
+
+    Honors the single-probe-at-a-time invariant: if a probe is already running
+    (scheduled probe-all or another bulk run) this returns
+    ``{"status": "already_running"}`` rather than starting a second.
     """
     logger.debug("[STREAM-STATS-PROBE] POST /api/stream-stats/probe/bulk - %d streams", len(request.stream_ids))
 
@@ -389,164 +392,31 @@ async def probe_bulk_streams(request: BulkProbeRequest):
         logger.error("[STREAM-STATS-PROBE] Stream prober not available - returning 503")
         raise HTTPException(status_code=503, detail="Stream prober not available")
 
-    try:
-        logger.debug("[STREAM-STATS-PROBE] Fetching all streams for bulk probe")
-        all_streams = await prober._fetch_all_streams()
-        logger.debug("[STREAM-STATS-PROBE] Fetched %s total streams", len(all_streams))
+    # Single-probe-at-a-time guard: do NOT start a second probe over a running
+    # one (it would clobber the shared progress/results envelope). Report that a
+    # probe is already in progress so the caller can poll the existing run.
+    if prober._probing_in_progress:
+        logger.info("[STREAM-STATS-PROBE] Probe already in progress - rejecting bulk start")
+        return {
+            "status": "already_running",
+            "message": "A probe is already in progress; check /probe/progress",
+        }
 
-        stream_map = {s["id"]: s for s in all_streams}
-
-        results = []
-        for stream_id in request.stream_ids:
-            stream = stream_map.get(stream_id)
-            if stream:
-                logger.debug("[STREAM-STATS-PROBE] Probing stream %s", stream_id)
-                result = await prober.probe_stream(
-                    stream_id, stream.get("url"), stream.get("name")
-                )
-                results.append(result)
-                await asyncio.sleep(0.5)  # Rate limiting
-            else:
-                logger.warning("[STREAM-STATS-PROBE] Stream %s not found in stream list", stream_id)
-    except Exception as e:
-        logger.error("[STREAM-STATS-PROBE] Bulk probe failed: %s", e)
-        raise HTTPException(status_code=500, detail="Internal server error")
-
-    # Tally outcomes so callers (UI, MCP) get success/failed counts directly
-    # instead of having to re-derive them from the per-stream list. Each result
-    # is a StreamStats.to_dict() whose outcome lives under "probe_status"
-    # (values: success / failed / timeout). Anything that isn't "success" counts
-    # as a failure for accounting purposes.
-    success = sum(1 for r in results if r.get("probe_status") == "success")
-    failed = len(results) - success
-
-    logger.info(
-        "[STREAM-STATS-PROBE] Bulk probe completed: %s streams probed (%s success, %s failed)",
-        len(results), success, failed,
-    )
-
-    # Trigger smart sort if auto_reorder_after_probe is enabled
-    settings = get_settings()
-    if getattr(settings, 'auto_reorder_after_probe', False):
-        logger.info("[STREAM-STATS-PROBE] auto_reorder_after_probe=True, sorting channels with probed streams")
+    async def run_bulk_probe_with_logging():
+        """Wrapper to catch and log any errors from the background bulk probe."""
         try:
-            from stream_prober import smart_sort_streams, extract_m3u_account_id
-
-            # Find which channels contain the probed streams
-            client = get_client()
-            probed_ids = set(request.stream_ids)
-
-            # Fetch all channels and find those containing probed streams
-            all_channels = []
-            page = 1
-            while True:
-                ch_result = await client.get_channels(page=page, page_size=500)
-                batch = ch_result.get("results", [])
-                if not batch:
-                    break
-                all_channels.extend(batch)
-                if not ch_result.get("next"):
-                    break
-                page += 1
-
-            affected_channels = [
-                ch for ch in all_channels
-                if any(sid in probed_ids for sid in ch.get("streams", []))
-            ]
-
-            if affected_channels:
-                # Build stats map from DB
-                all_stream_ids = list({sid for ch in affected_channels for sid in ch.get("streams", [])})
-                from models import StreamStats as StreamStatsModel
-                session = get_session()
-                try:
-                    stats_map = {}
-                    for i in range(0, len(all_stream_ids), 500):
-                        batch = all_stream_ids[i:i + 500]
-                        stats = session.query(StreamStatsModel).filter(
-                            StreamStatsModel.stream_id.in_(batch)
-                        ).all()
-                        for s in stats:
-                            stats_map[s.stream_id] = s
-                finally:
-                    session.close()
-
-                # Build M3U map
-                stream_m3u_map = {}
-                try:
-                    streams_data = await client.get_streams_by_ids(all_stream_ids)
-                    for s in streams_data:
-                        stream_m3u_map[s["id"]] = extract_m3u_account_id(s.get("m3u_account"))
-                except Exception as e:
-                    logger.warning("[STREAM-STATS-PROBE] Failed to fetch M3U data for sort: %s", e)
-
-                reordered = 0
-                for ch in affected_channels:
-                    stream_ids = ch.get("streams", [])
-                    if len(stream_ids) < 2:
-                        continue
-                    sorted_ids = smart_sort_streams(
-                        stream_ids=stream_ids,
-                        stats_map=stats_map,
-                        stream_m3u_map=stream_m3u_map,
-                        stream_sort_priority=settings.stream_sort_priority,
-                        stream_sort_enabled=settings.stream_sort_enabled,
-                        m3u_account_priorities=settings.m3u_account_priorities,
-                        deprioritize_failed_streams=settings.deprioritize_failed_streams,
-                        deprioritize_black_screen=getattr(settings, 'deprioritize_black_screen', True),
-                        deprioritize_low_fps=getattr(settings, 'deprioritize_low_fps', True),
-                        failed_stream_sort_order=getattr(settings, 'failed_stream_sort_order', None),
-                        channel_name=ch.get("name", f"channel-{ch['id']}"),
-                    )
-                    if sorted_ids != stream_ids:
-                        await client.update_channel(ch["id"], {"streams": sorted_ids})
-                        reordered += 1
-                        ch_name = ch.get("name", f"channel-{ch['id']}")
-                        logger.info("[STREAM-STATS-PROBE] Reordered streams in '%s'", ch_name)
-
-                        # Journal with deprioritization details
-                        deprioritized = []
-                        for sid in sorted_ids:
-                            stat = stats_map.get(sid)
-                            if stat:
-                                if getattr(stat, 'is_black_screen', False):
-                                    deprioritized.append({"id": sid, "name": stat.stream_name, "reason": "black_screen"})
-                                elif getattr(stat, 'is_low_fps', False):
-                                    deprioritized.append({"id": sid, "name": stat.stream_name, "reason": "low_fps"})
-                                elif stat.probe_status in ('failed', 'timeout'):
-                                    deprioritized.append({"id": sid, "name": stat.stream_name, "reason": stat.probe_status})
-
-                        desc_parts = [f"Smart sort reordered {len(stream_ids)} streams in '{ch_name}'"]
-                        if deprioritized:
-                            reasons = {}
-                            for d in deprioritized:
-                                reasons.setdefault(d["reason"], []).append(d["name"])
-                            reason_strs = []
-                            for reason, names in reasons.items():
-                                label = {"black_screen": "black screen", "low_fps": "low FPS", "failed": "failed", "timeout": "timed out"}.get(reason, reason)
-                                reason_strs.append(f"{len(names)} {label}")
-                            desc_parts.append(f"({', '.join(reason_strs)} deprioritized)")
-
-                        journal.log_entry(
-                            category="channel",
-                            action_type="smart_sort",
-                            entity_id=ch["id"],
-                            entity_name=ch_name,
-                            description=" ".join(desc_parts),
-                            after_value={"deprioritized": deprioritized} if deprioritized else None,
-                        )
-
-                logger.info("[STREAM-STATS-PROBE] Smart sort after bulk probe: %d/%d channels reordered",
-                           reordered, len(affected_channels))
+            logger.info("[STREAM-STATS-PROBE] Background bulk probe task starting (%d streams)...", len(request.stream_ids))
+            await prober.probe_streams_by_ids(request.stream_ids)
+            logger.info("[STREAM-STATS-PROBE] Background bulk probe task completed successfully")
         except Exception as e:
-            logger.warning("[STREAM-STATS-PROBE] Smart sort after bulk probe failed: %s", e)
+            logger.exception("[STREAM-STATS-PROBE] Background bulk probe task failed: %s", e)
 
+    asyncio.create_task(run_bulk_probe_with_logging())
+    logger.debug("[STREAM-STATS-PROBE] Background bulk probe task created, returning response")
     return {
-        "total": len(results),
-        "success": success,
-        "failed": failed,
-        "probed": len(results),  # retained for backward compatibility
-        "results": results,
+        "status": "started",
+        "message": f"Background bulk probe started for {len(request.stream_ids)} streams",
+        "total": len(request.stream_ids),
     }
 
 

--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -2011,6 +2011,128 @@ class StreamProber:
 
         return reordered
 
+    async def _auto_reorder_channels_for_streams(self, probed_stream_ids: list[int]) -> list[dict]:
+        """Reorder only channels that contain one of ``probed_stream_ids``.
+
+        Used by the bulk-by-ID probe (probe_streams_by_ids) so auto-reorder stays
+        scoped to channels the operator actually touched — matching the prior
+        synchronous bulk endpoint's behavior — rather than reordering the whole
+        lineup the way the group-scoped _auto_reorder_channels would.
+        """
+        reordered = []
+        probed_set = set(probed_stream_ids)
+
+        # Fetch all channels and keep those containing a probed stream.
+        all_channels = []
+        page = 1
+        while True:
+            try:
+                result = await self.client.get_channels(page=page, page_size=500)
+                batch = result.get("results", [])
+                if not batch:
+                    break
+                all_channels.extend(batch)
+                if not result.get("next"):
+                    break
+                page += 1
+                if page > 50:  # Safety limit
+                    break
+            except Exception as e:
+                logger.error("[STREAM-PROBE-SORT] Failed to fetch channels page %s for bulk reorder: %s", page, e)
+                break
+
+        affected = [
+            ch for ch in all_channels
+            if any(sid in probed_set for sid in ch.get("streams", []))
+        ]
+        if not affected:
+            return []
+
+        # Build a stats map for every stream across the affected channels.
+        all_stream_ids = list({sid for ch in affected for sid in ch.get("streams", [])})
+        stats_map = {}
+        with get_session() as session:
+            for i in range(0, len(all_stream_ids), 500):
+                chunk = all_stream_ids[i:i + 500]
+                for stat in session.query(StreamStats).filter(StreamStats.stream_id.in_(chunk)).all():
+                    stats_map[stat.stream_id] = stat
+
+        # Build an M3U account map for m3u_priority sorting.
+        stream_m3u_map = {}
+        try:
+            streams_data = await self.client.get_streams_by_ids(all_stream_ids)
+            for s in streams_data:
+                sid = s.get("id", s.get("stream_id"))
+                if sid is not None:
+                    stream_m3u_map[int(sid)] = self._extract_m3u_account_id(s.get("m3u_account"))
+        except Exception as e:
+            logger.warning("[STREAM-PROBE-SORT] Failed to fetch M3U data for bulk reorder: %s", e)
+
+        for ch in affected:
+            channel_id = ch["id"]
+            channel_name = ch.get("name", f"Channel {channel_id}")
+            stream_ids = ch.get("streams", [])
+            if len(stream_ids) < 2:
+                continue
+            sorted_ids = smart_sort_streams(
+                stream_ids=stream_ids,
+                stats_map=stats_map,
+                stream_m3u_map=stream_m3u_map,
+                stream_sort_priority=self.stream_sort_priority,
+                stream_sort_enabled=self.stream_sort_enabled,
+                m3u_account_priorities=self.m3u_account_priorities,
+                deprioritize_failed_streams=self.deprioritize_failed_streams,
+                deprioritize_black_screen=self.deprioritize_black_screen,
+                deprioritize_low_fps=self.deprioritize_low_fps,
+                failed_stream_sort_order=self.failed_stream_sort_order,
+                channel_name=channel_name,
+            )
+            if sorted_ids == stream_ids:
+                continue
+            try:
+                await self.client.update_channel(channel_id, {"streams": sorted_ids})
+            except Exception as e:
+                logger.error("[STREAM-PROBE-SORT] Failed to update channel %s during bulk reorder: %s", channel_id, e)
+                continue
+
+            deprioritized = []
+            for sid in sorted_ids:
+                stat = stats_map.get(sid)
+                if stat:
+                    if getattr(stat, 'is_black_screen', False):
+                        deprioritized.append({"id": sid, "name": stat.stream_name, "reason": "black_screen"})
+                    elif getattr(stat, 'is_low_fps', False):
+                        deprioritized.append({"id": sid, "name": stat.stream_name, "reason": "low_fps"})
+                    elif stat.probe_status in ('failed', 'timeout'):
+                        deprioritized.append({"id": sid, "name": stat.stream_name, "reason": stat.probe_status})
+
+            desc_parts = [f"Smart sort reordered {len(stream_ids)} streams in '{channel_name}'"]
+            if deprioritized:
+                reasons = {}
+                for d in deprioritized:
+                    reasons.setdefault(d["reason"], []).append(d["name"])
+                reason_strs = []
+                for reason, names in reasons.items():
+                    label = {"black_screen": "black screen", "low_fps": "low FPS", "failed": "failed", "timeout": "timed out"}.get(reason, reason)
+                    reason_strs.append(f"{len(names)} {label}")
+                desc_parts.append(f"({', '.join(reason_strs)} deprioritized)")
+
+            journal.log_entry(
+                category="channel",
+                action_type="smart_sort",
+                entity_id=channel_id,
+                entity_name=channel_name,
+                description=" ".join(desc_parts),
+                after_value={"deprioritized": deprioritized} if deprioritized else None,
+            )
+            reordered.append({
+                "channel_id": channel_id,
+                "channel_name": channel_name,
+                "stream_count": len(stream_ids),
+            })
+
+        return reordered
+
     def _smart_sort_streams(
         self,
         stream_ids: list[int],
@@ -2722,6 +2844,172 @@ class StreamProber:
             # Finalize notification with error status
             await self._finalize_probe_notification()
 
+            return {"status": "failed", "error": str(e), "probed": probed_count}
+        finally:
+            self._probing_in_progress = False
+
+    async def probe_streams_by_ids(self, stream_ids: list[int]):
+        """Probe a specific list of stream IDs in the background (on-demand bulk probe).
+
+        This is the async backing for POST /api/stream-stats/probe/bulk. It reuses
+        the SAME progress / results / history envelope as ``probe_all_streams`` —
+        the very state that ``get_probe_progress``, ``get_probe_results`` and
+        ``get_probe_history`` read — so a manual bulk probe shows up there exactly
+        like a scheduled probe-all run (fixing the results-envelope half of
+        enhancedchannelmanager-znc76.5).
+
+        Unlike ``probe_all_streams`` it is NOT scoped to streams-in-channels: any
+        stream ID that exists in Dispatcharr is probed. It also skips the M3U
+        refresh and channel-capacity gating that the channel-scoped probe-all does
+        (those are meaningful for "probe everything in my lineup", not for an
+        explicit, operator-chosen list). Concurrency is bounded by the same
+        ``max_concurrent_probes`` semaphore probe-all uses.
+
+        Args:
+            stream_ids: Specific stream IDs to probe.
+
+        Returns:
+            Dict envelope: {status, probed, total, success, failed} or
+            {status: "already_running"} if a probe is in progress.
+        """
+        logger.info("[STREAM-PROBE] probe_streams_by_ids called with %s stream IDs", len(stream_ids))
+
+        if self._probing_in_progress:
+            logger.warning("[STREAM-PROBE] Probe already in progress — refusing bulk probe")
+            return {"status": "already_running"}
+
+        # Reset the shared probe envelope (mirrors probe_all_streams setup) so
+        # get_probe_progress / get_probe_results report THIS bulk run.
+        self._probing_in_progress = True
+        self._probe_cancelled = False
+        self._probe_paused = False
+        self._probe_progress_current = 0
+        self._probe_progress_total = 0
+        self._probe_progress_status = "fetching"
+        self._probe_progress_current_stream = ""
+        self._probe_progress_success_count = 0
+        self._probe_progress_failed_count = 0
+        self._probe_progress_skipped_count = 0
+        self._probe_success_streams = []
+        self._probe_failed_streams = []
+        self._probe_skipped_streams = []
+        self._probe_black_screen_streams = []
+        self._probe_progress_black_screen_count = 0
+        self._probe_low_fps_streams = []
+        self._probe_progress_low_fps_count = 0
+        self._account_ramp_state = {}
+
+        probed_count = 0
+        start_time = datetime.utcnow()
+        try:
+            # Fetch all streams once and select the requested IDs (preserving
+            # request order). Streams not found in Dispatcharr are recorded as
+            # failures so the tallies stay honest.
+            all_streams = await self._fetch_all_streams()
+            stream_map = {s["id"]: s for s in all_streams}
+            streams_to_probe = []
+            for sid in stream_ids:
+                stream = stream_map.get(sid)
+                if stream:
+                    streams_to_probe.append(stream)
+                else:
+                    logger.warning("[STREAM-PROBE] Bulk probe: stream %s not found in Dispatcharr", sid)
+                    self._probe_progress_failed_count += 1
+                    self._probe_failed_streams.append(
+                        {"id": sid, "name": f"Stream {sid}", "url": "", "error": "Stream not found"}
+                    )
+                    probed_count += 1
+
+            self._probe_progress_total = len(stream_ids)
+            self._probe_progress_current = probed_count
+            self._probe_progress_status = "probing"
+
+            await self._create_probe_notification(len(stream_ids))
+
+            # Bound concurrency with the same global semaphore probe-all uses.
+            semaphore = asyncio.Semaphore(self.max_concurrent_probes)
+            results_lock = asyncio.Lock()
+
+            async def _probe_one(stream: dict):
+                nonlocal probed_count
+                stream_id = stream["id"]
+                stream_name = stream.get("name", f"Stream {stream_id}")
+                stream_url = stream.get("url", "")
+                m3u_account_id = self._extract_m3u_account_id(stream.get("m3u_account"))
+                async with semaphore:
+                    if self._probe_cancelled:
+                        return
+                    self._probe_progress_current_stream = stream_name
+                    result = await self.probe_stream(stream_id, stream_url, stream_name)
+                    probe_status = result.get("probe_status", "failed")
+                    error_message = result.get("error_message", "")
+                    stream_info = {"id": stream_id, "name": stream_name, "url": stream_url}
+                    async with results_lock:
+                        if probe_status == "success":
+                            self._probe_progress_success_count += 1
+                            self._probe_success_streams.append(stream_info)
+                            if result.get("is_black_screen", False):
+                                self._probe_progress_black_screen_count += 1
+                                self._probe_black_screen_streams.append(stream_info)
+                            if result.get("is_low_fps", False):
+                                self._probe_progress_low_fps_count += 1
+                                self._probe_low_fps_streams.append(stream_info)
+                        else:
+                            self._probe_progress_failed_count += 1
+                            stream_info["error"] = error_message or "Unknown error"
+                            self._probe_failed_streams.append(stream_info)
+                        probed_count += 1
+                        self._probe_progress_current = probed_count
+                    await self._update_probe_notification()
+
+            if streams_to_probe and not self._probe_cancelled:
+                await asyncio.gather(*[_probe_one(s) for s in streams_to_probe])
+
+            if self._probe_cancelled:
+                self._probe_progress_status = "cancelled"
+            else:
+                self._probe_progress_status = "completed"
+            self._probe_progress_current_stream = ""
+
+            logger.info(
+                "[STREAM-PROBE] Bulk probe completed: %s/%s probed (%s success, %s failed)",
+                probed_count, len(stream_ids),
+                self._probe_progress_success_count, self._probe_progress_failed_count,
+            )
+
+            # Honor auto_reorder_after_probe (opt-in). Unlike probe-all (which can
+            # reorder a whole group), a bulk-by-ID probe only reorders channels
+            # that actually contain a probed stream — matching the prior bulk
+            # endpoint's scope so opted-in users don't lose that behavior.
+            reordered_channels = []
+            if self.auto_reorder_after_probe and not self._probe_cancelled:
+                self._probe_progress_status = "reordering"
+                self._probe_progress_current_stream = "Reordering streams..."
+                try:
+                    reordered_channels = await self._auto_reorder_channels_for_streams(stream_ids)
+                    logger.info("[STREAM-PROBE-SORT] Bulk probe auto-reordered %s channels", len(reordered_channels))
+                except Exception as e:
+                    logger.error("[STREAM-PROBE] Bulk probe auto-reorder failed: %s", e)
+                self._probe_progress_status = "completed"
+                self._probe_progress_current_stream = ""
+
+            # Reuse the shared history + notification finalization path.
+            self._save_probe_history(start_time, probed_count, reordered_channels=reordered_channels)
+            await self._finalize_probe_notification()
+
+            return {
+                "status": "cancelled" if self._probe_cancelled else "completed",
+                "probed": probed_count,
+                "total": len(stream_ids),
+                "success": self._probe_progress_success_count,
+                "failed": self._probe_progress_failed_count,
+            }
+        except Exception as e:
+            logger.exception("[STREAM-PROBE] Bulk probe failed: %s", e)
+            self._probe_progress_status = "failed"
+            self._probe_progress_current_stream = ""
+            self._save_probe_history(start_time, probed_count, error=str(e))
+            await self._finalize_probe_notification()
             return {"status": "failed", "error": str(e), "probed": probed_count}
         finally:
             self._probing_in_progress = False

--- a/backend/tests/routers/test_stream_stats.py
+++ b/backend/tests/routers/test_stream_stats.py
@@ -257,54 +257,28 @@ class TestGetStreamStatsByIds:
 
 
 class TestProbeBulkStreams:
-    """Tests for POST /api/stream-stats/probe/bulk."""
+    """Tests for POST /api/stream-stats/probe/bulk.
+
+    The bulk endpoint is now ASYNC (enhancedchannelmanager-znc76.5): it starts a
+    background probe of the requested stream_ids using the SAME prober
+    job/progress/results-envelope machinery probe/all uses, and returns
+    immediately instead of probing each stream synchronously (which 504'd at
+    batches >=~3). Callers poll /probe/progress + /probe/results for the outcome.
+    """
 
     @pytest.mark.asyncio
-    async def test_probes_streams(self, async_client):
-        """Probes requested streams and returns results."""
-        mock_prober = AsyncMock()
-        mock_prober._fetch_all_streams.return_value = [
-            {"id": 10, "url": "http://example.com/10", "name": "Stream 10"},
-        ]
-        # Per-stream result is a StreamStats.to_dict(): outcome under probe_status.
-        mock_prober.probe_stream.return_value = {"stream_id": 10, "probe_status": "success"}
+    async def test_starts_background_probe_without_blocking(self, async_client):
+        """Returns immediately with status=started; does NOT block on N probes.
 
-        with patch("routers.stream_stats.ensure_prober", return_value=mock_prober):
-            response = await async_client.post(
-                "/api/stream-stats/probe/bulk",
-                json={"stream_ids": [10]},
-            )
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["probed"] == 1
-        mock_prober.probe_stream.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_response_has_tally_envelope(self, async_client):
-        """Bulk-probe response carries total/success/failed tallies (bd-clb9a).
-
-        Regression for the 0/0 accounting bug: the endpoint must compute
-        success/failed counts from each result's probe_status so the MCP tool
-        can report real numbers instead of zeros.
+        The endpoint must NOT call probe_stream / probe_streams_by_ids inline —
+        it only schedules a background task. We assert the response comes back
+        before any probing happens (asyncio.create_task is patched out).
         """
-        mock_prober = AsyncMock()
-        mock_prober._fetch_all_streams.return_value = [
-            {"id": 10, "url": "http://example.com/10", "name": "Stream 10"},
-            {"id": 11, "url": "http://example.com/11", "name": "Stream 11"},
-            {"id": 12, "url": "http://example.com/12", "name": "Stream 12"},
-        ]
-        # 1 success, 1 failed, 1 timeout — timeout counts as failed.
-        outcomes = {
-            10: {"stream_id": 10, "probe_status": "success"},
-            11: {"stream_id": 11, "probe_status": "failed"},
-            12: {"stream_id": 12, "probe_status": "timeout"},
-        }
-        mock_prober.probe_stream.side_effect = (
-            lambda sid, url, name: outcomes[sid]
-        )
+        mock_prober = MagicMock()
+        mock_prober._probing_in_progress = False
 
-        with patch("routers.stream_stats.ensure_prober", return_value=mock_prober):
+        with patch("routers.stream_stats.ensure_prober", return_value=mock_prober), \
+             patch("asyncio.create_task") as mock_create_task:
             response = await async_client.post(
                 "/api/stream-stats/probe/bulk",
                 json={"stream_ids": [10, 11, 12]},
@@ -312,11 +286,61 @@ class TestProbeBulkStreams:
 
         assert response.status_code == 200
         data = response.json()
+        assert data["status"] == "started"
         assert data["total"] == 3
-        assert data["success"] == 1
-        assert data["failed"] == 2
-        assert data["probed"] == 3  # backward-compat alias of total
-        assert len(data["results"]) == 3
+        # A background task was scheduled rather than probing inline.
+        mock_create_task.assert_called_once()
+        # The endpoint itself never probed synchronously.
+        mock_prober.probe_streams_by_ids.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_concurrent_start_when_probe_running(self, async_client):
+        """Honors single-probe-at-a-time: refuses to start over a running probe."""
+        mock_prober = MagicMock()
+        mock_prober._probing_in_progress = True
+
+        with patch("routers.stream_stats.ensure_prober", return_value=mock_prober), \
+             patch("asyncio.create_task") as mock_create_task:
+            response = await async_client.post(
+                "/api/stream-stats/probe/bulk",
+                json={"stream_ids": [10, 11]},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "already_running"
+        # Must NOT have scheduled a second probe.
+        mock_create_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_background_task_calls_probe_streams_by_ids(self, async_client):
+        """The scheduled background task drives probe_streams_by_ids with the IDs.
+
+        We capture the coroutine handed to create_task and await it to confirm it
+        delegates to the shared prober method (which owns the results envelope).
+        """
+        mock_prober = MagicMock()
+        mock_prober._probing_in_progress = False
+        mock_prober.probe_streams_by_ids = AsyncMock(
+            return_value={"status": "completed", "probed": 2, "total": 2, "success": 2, "failed": 0}
+        )
+
+        captured = {}
+
+        def fake_create_task(coro):
+            captured["coro"] = coro
+            return MagicMock()
+
+        with patch("routers.stream_stats.ensure_prober", return_value=mock_prober), \
+             patch("asyncio.create_task", side_effect=fake_create_task):
+            response = await async_client.post(
+                "/api/stream-stats/probe/bulk",
+                json={"stream_ids": [10, 11]},
+            )
+
+        assert response.status_code == 200
+        # Drive the captured background coroutine to completion.
+        await captured["coro"]
+        mock_prober.probe_streams_by_ids.assert_awaited_once_with([10, 11])
 
     @pytest.mark.asyncio
     async def test_returns_503_when_prober_unavailable(self, async_client):

--- a/backend/tests/unit/test_normalization_migration_backfill.py
+++ b/backend/tests/unit/test_normalization_migration_backfill.py
@@ -1,0 +1,484 @@
+"""
+Unit + end-to-end tests for the normalization repair migration (znc76.3).
+
+Covers the two idempotent repair helpers added to normalization_migration.py:
+
+  - backfill_tag_group_rule_ids: wires tag_group_id (and tag_match_position)
+    onto tag_group rules whose tag_group_id was never set (CONFIG drift), by
+    matching each rule's parent group to its tag group BY NAME.
+  - ensure_abbreviation_tags_acronyms: adds US/UK/EU to the Abbreviation Tags
+    group so Smart Title Case preserves them (US -> US, not US -> Us).
+
+The end-to-end test reproduces the original bug ("US : ESPN HD" -> "Us : ESPN HD")
+and verifies that after the migration the strips fire and the acronym survives.
+"""
+import pytest
+
+from normalization_migration import (
+    backfill_tag_group_rule_ids,
+    ensure_abbreviation_tags_acronyms,
+    RULE_GROUP_TO_TAG_GROUP,
+    ACTION_TYPE_TO_POSITION,
+)
+from models import NormalizationRule, Tag, TagGroup
+from tests.fixtures.factories import (
+    create_tag_group,
+    create_tag,
+    create_normalization_rule_group,
+    create_normalization_rule,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_null_strip_rule(session, rule_group_name, tag_group, action_type):
+    """Create a strip rule group + a tag_group rule with tag_group_id NULL.
+
+    Mirrors the broken pre-existing state: condition_type='tag_group' but the
+    tag_group_id was never wired (and position left NULL).
+    """
+    rule_group = create_normalization_rule_group(
+        session, name=rule_group_name, enabled=True, priority=0,
+    )
+    rule = create_normalization_rule(
+        session,
+        group_id=rule_group.id,
+        name=f"Match {tag_group.name}",
+        condition_type="tag_group",
+        condition_value=None,
+        action_type=action_type,
+        tag_group_id=None,          # the bug: never wired
+        tag_match_position=None,    # the bug: never set
+    )
+    return rule_group, rule
+
+
+# ---------------------------------------------------------------------------
+# backfill_tag_group_rule_ids
+# ---------------------------------------------------------------------------
+
+class TestBackfillTagGroupRuleIds:
+    """Wiring NULL tag_group_id rules to the right tag group + position."""
+
+    def test_wires_suffix_rule_to_quality_tag_group(self, test_session):
+        """strip_suffix rule -> tag group by name, position 'suffix'."""
+        quality = create_tag_group(test_session, name="Quality Tags")
+        create_tag(test_session, group_id=quality.id, value="HD")
+        _, rule = _make_null_strip_rule(
+            test_session, "Strip Quality Suffixes", quality, "strip_suffix",
+        )
+
+        result = backfill_tag_group_rule_ids(test_session)
+
+        assert result["rules_wired"] == 1
+        assert result["rules_skipped"] == 0
+        test_session.refresh(rule)
+        assert rule.tag_group_id == quality.id
+        assert rule.tag_match_position == "suffix"
+
+    def test_wires_prefix_rule_to_country_tag_group(self, test_session):
+        """strip_prefix rule -> position 'prefix'."""
+        country = create_tag_group(test_session, name="Country Tags")
+        create_tag(test_session, group_id=country.id, value="US")
+        _, rule = _make_null_strip_rule(
+            test_session, "Strip Country Prefixes", country, "strip_prefix",
+        )
+
+        backfill_tag_group_rule_ids(test_session)
+
+        test_session.refresh(rule)
+        assert rule.tag_group_id == country.id
+        assert rule.tag_match_position == "prefix"
+
+    def test_wires_remove_rule_to_contains_position(self, test_session):
+        """'remove' action (State/Province) -> position 'contains'."""
+        state = create_tag_group(test_session, name="State/Province Tags")
+        create_tag(test_session, group_id=state.id, value="TX")
+        _, rule = _make_null_strip_rule(
+            test_session, "Strip State/Province Tags", state, "remove",
+        )
+
+        backfill_tag_group_rule_ids(test_session)
+
+        test_session.refresh(rule)
+        assert rule.tag_group_id == state.id
+        assert rule.tag_match_position == "contains"
+
+    def test_wires_all_seven_strip_groups(self, test_session):
+        """All 7 live strip groups get wired to the correct tag group/position."""
+        # (rule_group_name, tag_group_name, action_type, expected_position)
+        specs = [
+            ("Strip Quality Suffixes", "Quality Tags", "strip_suffix", "suffix"),
+            ("Strip Country Prefixes", "Country Tags", "strip_prefix", "prefix"),
+            ("Strip Timezone Suffixes", "Timezone Tags", "strip_suffix", "suffix"),
+            ("Strip League Prefixes", "League Tags", "strip_prefix", "prefix"),
+            ("Strip Network Tags", "Network Tags", "strip_suffix", "suffix"),
+            ("Strip State/Province Tags", "State/Province Tags", "remove", "contains"),
+            ("Strip Provider Tags", "Provider Tags", "strip_suffix", "suffix"),
+        ]
+        rules = {}
+        for rg_name, tg_name, action, _pos in specs:
+            tg = create_tag_group(test_session, name=tg_name)
+            _, rule = _make_null_strip_rule(test_session, rg_name, tg, action)
+            rules[rg_name] = (rule, tg)
+
+        result = backfill_tag_group_rule_ids(test_session)
+
+        assert result["rules_wired"] == 7
+        assert result["rules_skipped"] == 0
+        for rg_name, tg_name, _action, expected_pos in specs:
+            rule, tg = rules[rg_name]
+            test_session.refresh(rule)
+            assert rule.tag_group_id == tg.id, rg_name
+            assert rule.tag_match_position == expected_pos, rg_name
+
+    def test_legacy_state_province_suffixes_name_mapped(self, test_session):
+        """Legacy 'Strip State/Province Suffixes' group name is aliased."""
+        state = create_tag_group(test_session, name="State/Province Tags")
+        _, rule = _make_null_strip_rule(
+            test_session, "Strip State/Province Suffixes", state, "remove",
+        )
+
+        result = backfill_tag_group_rule_ids(test_session)
+
+        assert result["rules_wired"] == 1
+        test_session.refresh(rule)
+        assert rule.tag_group_id == state.id
+
+    def test_skips_already_wired_rules(self, test_session):
+        """Rules that already have tag_group_id are left untouched."""
+        quality = create_tag_group(test_session, name="Quality Tags")
+        rule_group = create_normalization_rule_group(
+            test_session, name="Strip Quality Suffixes", enabled=True,
+        )
+        rule = create_normalization_rule(
+            test_session,
+            group_id=rule_group.id,
+            name="Match Quality Tags",
+            condition_type="tag_group",
+            condition_value=None,
+            action_type="strip_suffix",
+            tag_group_id=quality.id,        # already wired
+            tag_match_position="suffix",
+        )
+
+        result = backfill_tag_group_rule_ids(test_session)
+
+        assert result["rules_wired"] == 0
+        test_session.refresh(rule)
+        assert rule.tag_group_id == quality.id
+
+    def test_skips_rule_with_unmapped_group_name(self, test_session):
+        """Conservative: unknown group name is skipped (not guessed)."""
+        create_tag_group(test_session, name="Quality Tags")
+        rule_group = create_normalization_rule_group(
+            test_session, name="Some Custom User Group", enabled=True,
+        )
+        rule = create_normalization_rule(
+            test_session,
+            group_id=rule_group.id,
+            name="Match something",
+            condition_type="tag_group",
+            condition_value=None,
+            action_type="strip_suffix",
+            tag_group_id=None,
+            tag_match_position=None,
+        )
+
+        result = backfill_tag_group_rule_ids(test_session)
+
+        assert result["rules_wired"] == 0
+        assert result["rules_skipped"] == 1
+        test_session.refresh(rule)
+        assert rule.tag_group_id is None
+
+    def test_skips_when_target_tag_group_missing(self, test_session):
+        """Group name maps to a tag group, but the tag group doesn't exist."""
+        # No Quality Tags group created.
+        rule_group = create_normalization_rule_group(
+            test_session, name="Strip Quality Suffixes", enabled=True,
+        )
+        rule = create_normalization_rule(
+            test_session,
+            group_id=rule_group.id,
+            name="Match Quality Tags",
+            condition_type="tag_group",
+            condition_value=None,
+            action_type="strip_suffix",
+            tag_group_id=None,
+            tag_match_position=None,
+        )
+
+        result = backfill_tag_group_rule_ids(test_session)
+
+        assert result["rules_wired"] == 0
+        assert result["rules_skipped"] == 1
+        test_session.refresh(rule)
+        assert rule.tag_group_id is None
+
+    def test_preserves_existing_position_when_set(self, test_session):
+        """If position is already set (only id is NULL), keep the position."""
+        quality = create_tag_group(test_session, name="Quality Tags")
+        rule_group = create_normalization_rule_group(
+            test_session, name="Strip Quality Suffixes", enabled=True,
+        )
+        rule = create_normalization_rule(
+            test_session,
+            group_id=rule_group.id,
+            name="Match Quality Tags",
+            condition_type="tag_group",
+            condition_value=None,
+            action_type="strip_suffix",
+            tag_group_id=None,
+            tag_match_position="prefix",  # unusual but explicitly set
+        )
+
+        backfill_tag_group_rule_ids(test_session)
+
+        test_session.refresh(rule)
+        assert rule.tag_group_id == quality.id
+        assert rule.tag_match_position == "prefix"  # not overwritten
+
+    def test_idempotent_on_rerun(self, test_session):
+        """Re-running after a successful wire is a no-op."""
+        quality = create_tag_group(test_session, name="Quality Tags")
+        _, rule = _make_null_strip_rule(
+            test_session, "Strip Quality Suffixes", quality, "strip_suffix",
+        )
+
+        first = backfill_tag_group_rule_ids(test_session)
+        second = backfill_tag_group_rule_ids(test_session)
+
+        assert first["rules_wired"] == 1
+        assert second["rules_wired"] == 0
+        assert second["rules_skipped"] == 0
+        test_session.refresh(rule)
+        assert rule.tag_group_id == quality.id
+
+    def test_no_rules_is_noop(self, test_session):
+        """Empty DB -> no-op."""
+        result = backfill_tag_group_rule_ids(test_session)
+        assert result == {"rules_wired": 0, "rules_skipped": 0}
+
+    def test_does_not_touch_non_tag_group_rules(self, test_session):
+        """A 'contains' rule with NULL tag_group_id is irrelevant and untouched."""
+        rule_group = create_normalization_rule_group(
+            test_session, name="Strip Quality Suffixes", enabled=True,
+        )
+        rule = create_normalization_rule(
+            test_session,
+            group_id=rule_group.id,
+            name="legacy contains rule",
+            condition_type="contains",
+            condition_value="HD",
+            action_type="remove",
+            tag_group_id=None,
+        )
+
+        result = backfill_tag_group_rule_ids(test_session)
+
+        assert result["rules_wired"] == 0
+        test_session.refresh(rule)
+        assert rule.tag_group_id is None
+
+
+class TestMappingConstants:
+    """Sanity checks on the derived mapping constants."""
+
+    def test_rule_group_map_covers_all_demo_strip_groups(self):
+        for name in (
+            "Strip Quality Suffixes", "Strip Country Prefixes",
+            "Strip Timezone Suffixes", "Strip League Prefixes",
+            "Strip Network Tags", "Strip State/Province Tags",
+            "Strip Provider Tags",
+        ):
+            assert name in RULE_GROUP_TO_TAG_GROUP
+
+    def test_action_type_position_map(self):
+        assert ACTION_TYPE_TO_POSITION["strip_prefix"] == "prefix"
+        assert ACTION_TYPE_TO_POSITION["strip_suffix"] == "suffix"
+        assert ACTION_TYPE_TO_POSITION["remove"] == "contains"
+
+
+# ---------------------------------------------------------------------------
+# ensure_abbreviation_tags_acronyms
+# ---------------------------------------------------------------------------
+
+class TestEnsureAbbreviationAcronyms:
+    """Adding US/UK/EU to the Abbreviation Tags group."""
+
+    def test_adds_all_three_when_missing(self, test_session):
+        create_tag_group(test_session, name="Abbreviation Tags")
+
+        result = ensure_abbreviation_tags_acronyms(test_session)
+
+        assert result["tags_added"] == 3
+        group = test_session.query(TagGroup).filter(
+            TagGroup.name == "Abbreviation Tags"
+        ).first()
+        values = {
+            t.value for t in test_session.query(Tag).filter(
+                Tag.group_id == group.id
+            ).all()
+        }
+        assert {"US", "UK", "EU"} <= values
+
+    def test_adds_only_missing(self, test_session):
+        group = create_tag_group(test_session, name="Abbreviation Tags")
+        create_tag(test_session, group_id=group.id, value="US")  # already there
+
+        result = ensure_abbreviation_tags_acronyms(test_session)
+
+        assert result["tags_added"] == 2  # only UK + EU
+        values = {
+            t.value for t in test_session.query(Tag).filter(
+                Tag.group_id == group.id
+            ).all()
+        }
+        assert {"US", "UK", "EU"} <= values
+
+    def test_idempotent_on_rerun(self, test_session):
+        create_tag_group(test_session, name="Abbreviation Tags")
+
+        first = ensure_abbreviation_tags_acronyms(test_session)
+        second = ensure_abbreviation_tags_acronyms(test_session)
+
+        assert first["tags_added"] == 3
+        assert second["tags_added"] == 0
+
+    def test_skips_when_group_missing(self, test_session):
+        result = ensure_abbreviation_tags_acronyms(test_session)
+        assert result == {"tags_added": 0, "skipped": True}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the original znc76.3 bug
+# ---------------------------------------------------------------------------
+
+class TestEndToEndAfterMigration:
+    """After the repair migration, 'US : ESPN HD' strips and preserves US."""
+
+    @pytest.fixture
+    def patched_engine_session(self, test_session, monkeypatch):
+        """Point the engine's abbreviation-tag loader at the test session.
+
+        _load_abbreviation_tags() opens its own get_session(); patch it so the
+        engine reads the same in-memory DB the test populates, and clear the
+        module-level abbreviation cache before/after.
+        """
+        import normalization_engine
+        import database
+
+        monkeypatch.setattr(database, "get_session", lambda: test_session)
+        normalization_engine.clear_abbreviation_cache()
+        normalization_engine._tag_group_cache.clear()
+        yield
+        normalization_engine.clear_abbreviation_cache()
+        normalization_engine._tag_group_cache.clear()
+
+    def _seed_broken_ruleset(self, session):
+        """Seed Quality + Country tag groups, Abbreviation Tags, and the
+        broken (NULL tag_group_id) Quality/Country strip rules + Title Case.
+        """
+        quality = create_tag_group(session, name="Quality Tags")
+        for v in ["HD", "FHD", "UHD", "4K", "SD"]:
+            create_tag(session, group_id=quality.id, value=v)
+
+        country = create_tag_group(session, name="Country Tags")
+        for v in ["US", "USA", "UK", "CA"]:
+            create_tag(session, group_id=country.id, value=v)
+
+        # Abbreviation Tags WITHOUT US (mirrors the seed: USA present, US absent)
+        create_tag_group(session, name="Abbreviation Tags")
+
+        # Broken strip rules: condition_type tag_group but tag_group_id NULL
+        _make_null_strip_rule(session, "Strip Quality Suffixes", quality, "strip_suffix")
+        _make_null_strip_rule(session, "Strip Country Prefixes", country, "strip_prefix")
+
+        # Title Case group (runs last)
+        tc_group = create_normalization_rule_group(
+            session, name="Title Case", enabled=True, priority=99,
+        )
+        create_normalization_rule(
+            session,
+            group_id=tc_group.id,
+            name="Smart Title Case",
+            condition_type="always",
+            condition_value=None,
+            action_type="capitalize",
+            action_value="title",
+        )
+
+    def test_bug_reproduces_before_migration(self, test_session, patched_engine_session):
+        """Sanity: before the repair, strips don't fire and US is lowercased."""
+        from normalization_engine import NormalizationEngine
+        self._seed_broken_ruleset(test_session)
+
+        engine = NormalizationEngine(test_session)
+        result = engine.normalize("US : ESPN HD")
+
+        # Strips never fired (HD survives) and US got title-cased to "Us".
+        assert "HD" in result.normalized
+        assert "Us" in result.normalized
+
+    def test_strips_and_preserves_us_after_migration(
+        self, test_session, patched_engine_session
+    ):
+        """After the repair migration: HD + US stripped, ESPN preserved."""
+        from normalization_engine import NormalizationEngine
+        self._seed_broken_ruleset(test_session)
+
+        # Run the repair.
+        backfill_tag_group_rule_ids(test_session)
+        ensure_abbreviation_tags_acronyms(test_session)
+
+        # Caches must reflect the freshly-added Abbreviation Tags.
+        import normalization_engine
+        normalization_engine.clear_abbreviation_cache()
+        normalization_engine._tag_group_cache.clear()
+
+        engine = NormalizationEngine(test_session)
+        result = engine.normalize("US : ESPN HD")
+
+        # Quality suffix stripped.
+        assert "HD" not in result.normalized
+        # Country prefix stripped (no leading "US ..." separator left).
+        assert not result.normalized.upper().startswith("US")
+        # ESPN survives and is not corrupted.
+        assert "ESPN" in result.normalized.upper()
+
+    def test_us_acronym_preserved_in_title_case(
+        self, test_session, patched_engine_session
+    ):
+        """With US in Abbreviation Tags, Title Case keeps it uppercase."""
+        from normalization_engine import NormalizationEngine
+
+        # Only Title Case + Abbreviation Tags (no strips) so we isolate the
+        # title-case acronym behavior on a trailing US.
+        abbr = create_tag_group(test_session, name="Abbreviation Tags")
+        create_tag(test_session, group_id=abbr.id, value="USA")
+
+        tc_group = create_normalization_rule_group(
+            test_session, name="Title Case", enabled=True, priority=99,
+        )
+        create_normalization_rule(
+            test_session,
+            group_id=tc_group.id,
+            name="Smart Title Case",
+            condition_type="always",
+            condition_value=None,
+            action_type="capitalize",
+            action_value="title",
+        )
+
+        ensure_abbreviation_tags_acronyms(test_session)
+        import normalization_engine
+        normalization_engine.clear_abbreviation_cache()
+
+        engine = NormalizationEngine(test_session)
+        result = engine.normalize("ESPN US")
+
+        assert "US" in result.normalized
+        assert "Us" not in result.normalized

--- a/backend/tests/unit/test_stream_prober_bulk.py
+++ b/backend/tests/unit/test_stream_prober_bulk.py
@@ -1,0 +1,156 @@
+"""Unit tests for StreamProber.probe_streams_by_ids — async bulk probe.
+
+Covers the redesign tracked in enhancedchannelmanager-znc76.5: the on-demand
+bulk probe must run through the SAME progress / results / history envelope as
+probe_all_streams, so a manual bulk run shows up in get_probe_progress /
+get_probe_results just like a scheduled probe-all run (the "manual probes don't
+feed the results envelope" half of the bug).
+"""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from stream_prober import StreamProber
+
+
+def _make_prober(client, **kwargs):
+    # Patch history persistence to disk so unit tests don't touch /config.
+    prober = StreamProber(client=client, **kwargs)
+    prober._persist_probe_history = lambda: None
+    return prober
+
+
+@pytest.mark.asyncio
+async def test_bulk_run_populates_results_envelope():
+    """probe_streams_by_ids writes the shared envelope that get_probe_results reads."""
+    client = AsyncMock()
+    prober = _make_prober(client)
+
+    streams = [
+        {"id": 10, "url": "http://example.com/10", "name": "Stream 10"},
+        {"id": 11, "url": "http://example.com/11", "name": "Stream 11"},
+        {"id": 12, "url": "http://example.com/12", "name": "Stream 12"},
+    ]
+    outcomes = {
+        10: {"stream_id": 10, "probe_status": "success"},
+        11: {"stream_id": 11, "probe_status": "failed", "error_message": "404"},
+        12: {"stream_id": 12, "probe_status": "timeout", "error_message": "timed out"},
+    }
+
+    async def fake_probe_stream(sid, url, name):
+        return outcomes[sid]
+
+    with patch.object(prober, "_fetch_all_streams", AsyncMock(return_value=streams)), \
+         patch.object(prober, "probe_stream", side_effect=fake_probe_stream):
+        result = await prober.probe_streams_by_ids([10, 11, 12])
+
+    # Envelope tallies on the return value.
+    assert result["status"] == "completed"
+    assert result["total"] == 3
+    assert result["success"] == 1
+    assert result["failed"] == 2  # failed + timeout
+
+    # The SHARED envelope (what get_probe_results / get_probe_progress expose)
+    # reflects this bulk run.
+    envelope = prober.get_probe_results()
+    assert envelope["success_count"] == 1
+    assert envelope["failed_count"] == 2
+    assert {s["id"] for s in envelope["success_streams"]} == {10}
+    assert {s["id"] for s in envelope["failed_streams"]} == {11, 12}
+
+    progress = prober.get_probe_progress()
+    assert progress["in_progress"] is False
+    assert progress["status"] == "completed"
+    assert progress["total"] == 3
+    assert progress["success_count"] == 1
+    assert progress["failed_count"] == 2
+
+    # And the run is recorded in history (shared with probe-all).
+    history = prober.get_probe_history()
+    assert len(history) == 1
+    assert history[0]["total"] == 3
+    assert history[0]["success_count"] == 1
+    assert history[0]["failed_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_bulk_run_rejected_when_probe_in_progress():
+    """Single-probe-at-a-time invariant: returns already_running, probes nothing."""
+    client = AsyncMock()
+    prober = _make_prober(client)
+    prober._probing_in_progress = True  # Simulate a probe already running.
+
+    probe_stream_mock = AsyncMock()
+    with patch.object(prober, "_fetch_all_streams", AsyncMock()) as fetch_mock, \
+         patch.object(prober, "probe_stream", probe_stream_mock):
+        result = await prober.probe_streams_by_ids([10, 11])
+
+    assert result["status"] == "already_running"
+    fetch_mock.assert_not_called()
+    probe_stream_mock.assert_not_called()
+    # The in-progress flag must be left untouched (we did not own the run).
+    assert prober._probing_in_progress is True
+
+
+@pytest.mark.asyncio
+async def test_bulk_run_honors_auto_reorder_setting():
+    """When auto_reorder_after_probe is on, bulk probe reorders affected channels."""
+    client = AsyncMock()
+    prober = _make_prober(client, auto_reorder_after_probe=True)
+
+    streams = [{"id": 10, "url": "http://example.com/10", "name": "Stream 10"}]
+
+    async def fake_probe_stream(sid, url, name):
+        return {"stream_id": sid, "probe_status": "success"}
+
+    reorder_mock = AsyncMock(return_value=[{"channel_id": 1, "channel_name": "Ch", "stream_count": 2}])
+
+    with patch.object(prober, "_fetch_all_streams", AsyncMock(return_value=streams)), \
+         patch.object(prober, "probe_stream", side_effect=fake_probe_stream), \
+         patch.object(prober, "_auto_reorder_channels_for_streams", reorder_mock):
+        await prober.probe_streams_by_ids([10])
+
+    reorder_mock.assert_awaited_once_with([10])
+
+
+@pytest.mark.asyncio
+async def test_bulk_run_skips_reorder_when_setting_off():
+    """Default (auto_reorder_after_probe off): bulk probe does not reorder."""
+    client = AsyncMock()
+    prober = _make_prober(client)  # default auto_reorder_after_probe=False
+
+    streams = [{"id": 10, "url": "http://example.com/10", "name": "Stream 10"}]
+
+    async def fake_probe_stream(sid, url, name):
+        return {"stream_id": sid, "probe_status": "success"}
+
+    reorder_mock = AsyncMock()
+    with patch.object(prober, "_fetch_all_streams", AsyncMock(return_value=streams)), \
+         patch.object(prober, "probe_stream", side_effect=fake_probe_stream), \
+         patch.object(prober, "_auto_reorder_channels_for_streams", reorder_mock):
+        await prober.probe_streams_by_ids([10])
+
+    reorder_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bulk_run_counts_missing_streams_as_failed():
+    """Stream IDs not present in Dispatcharr are tallied as failures, not dropped."""
+    client = AsyncMock()
+    prober = _make_prober(client)
+
+    streams = [{"id": 10, "url": "http://example.com/10", "name": "Stream 10"}]
+
+    async def fake_probe_stream(sid, url, name):
+        return {"stream_id": sid, "probe_status": "success"}
+
+    with patch.object(prober, "_fetch_all_streams", AsyncMock(return_value=streams)), \
+         patch.object(prober, "probe_stream", side_effect=fake_probe_stream):
+        # 99 does not exist in Dispatcharr.
+        result = await prober.probe_streams_by_ids([10, 99])
+
+    assert result["total"] == 2
+    assert result["success"] == 1
+    assert result["failed"] == 1
+    failed = prober.get_probe_results()["failed_streams"]
+    assert any(s["id"] == 99 for s in failed)

--- a/mcp-server/tests/test_p2_streams.py
+++ b/mcp-server/tests/test_p2_streams.py
@@ -217,84 +217,119 @@ class TestProbeSingleStreamTimeout:
 
 
 # ---------------------------------------------------------------------------
-# bd-clb9a (from enhancedchannelmanager-znc76.5) —
-# probe_bulk_streams must report the real success/failed counts from the
-# backend envelope instead of the old 0/0 accounting.
+# enhancedchannelmanager-znc76.5 — probe_bulk_streams async start+poll flow.
+#
+# probe_bulk_streams now START the background bulk probe (which 504'd when it
+# ran synchronously), POLL get_probe_progress to completion, then report the
+# real success/failed counts from get_probe_results. It must degrade gracefully
+# when the poll budget is exhausted and when a probe is already running.
 # ---------------------------------------------------------------------------
 
-class TestProbeBulkStreamsAccounting:
-    """Verify probe_bulk_streams reports real success/failed tallies."""
+def _endpoint_router(responses: dict):
+    """Build a call_endpoint side_effect that dispatches on the endpoint name.
+
+    ``responses`` maps endpoint name -> a value or a list of values consumed in
+    order across successive calls (so progress can transition in_progress ->
+    done across polls).
+    """
+    from itertools import count
+
+    cursors = {name: count() for name in responses}
+
+    async def _call(ep, *args, **kwargs):
+        name = ep.name
+        value = responses[name]
+        if isinstance(value, list):
+            idx = next(cursors[name])
+            return value[min(idx, len(value) - 1)]
+        return value
+
+    return _call
+
+
+class TestProbeBulkStreamsAsyncFlow:
+    """Verify probe_bulk_streams start+poll flow reports real counts."""
 
     @pytest.mark.asyncio
-    async def test_reports_real_success_and_failed_counts(self):
-        """The tool reads total/success/failed from the backend envelope.
-
-        Before the fix the backend returned only {probed, results} and the tool
-        defaulted success/failed to 0 -> "Success: 0 / Failed: 0" even on a
-        completed run. With the envelope it must surface the real numbers.
-        """
+    async def test_starts_polls_and_reports_real_counts(self):
+        """Starts the probe, polls progress to completion, reports envelope counts."""
         mcp = _make_mcp_and_register()
 
-        envelope = {
-            "total": 3,
-            "success": 2,
-            "failed": 1,
-            "probed": 3,
-            "results": [
-                {"stream_id": 10, "stream_name": "Stream 10", "probe_status": "success"},
-                {"stream_id": 11, "stream_name": "Stream 11", "probe_status": "success"},
-                {"stream_id": 12, "stream_name": "Stream 12", "probe_status": "failed",
-                 "error_message": "ffprobe failed: 404 Not Found"},
+        responses = {
+            "stream_stats_probe_bulk": {"status": "started", "total": 3},
+            # First poll: still running. Second poll: done.
+            "stream_stats_probe_progress": [
+                {"in_progress": True, "current": 1, "total": 3},
+                {"in_progress": False, "status": "completed", "total": 3,
+                 "success_count": 2, "failed_count": 1},
             ],
+            "stream_stats_probe_results": {
+                "success_count": 2,
+                "failed_count": 1,
+                "success_streams": [{"id": 10, "name": "Stream 10"},
+                                    {"id": 11, "name": "Stream 11"}],
+                "failed_streams": [{"id": 12, "name": "Bad Stream",
+                                    "error": "ffprobe failed: 404 Not Found"}],
+            },
         }
 
         client = AsyncMock()
-        client.call_endpoint.return_value = envelope
+        client.call_endpoint.side_effect = _endpoint_router(responses)
 
-        with patch("tools.streams.get_ecm_client", return_value=client):
+        # No real sleeping between polls.
+        with patch("tools.streams.get_ecm_client", return_value=client), \
+             patch("tools.streams.asyncio.sleep", new=AsyncMock()):
             result = await mcp.call_tool("probe_bulk_streams", {"stream_ids": [10, 11, 12]})
 
         text = result[0][0].text
         assert "Bulk probe completed for 3 streams" in text
         assert "Success: 2" in text
         assert "Failed: 1" in text
-        # 0/0 accounting bug must not reappear.
-        assert "Success: 0" not in text
-
-    @pytest.mark.asyncio
-    async def test_lists_failed_streams_with_name_and_error(self):
-        """Failed streams are listed using probe_status/stream_name/error_message keys.
-
-        The per-stream dicts are StreamStats.to_dict() — outcome under
-        probe_status (not status), name under stream_name (not name), error
-        under error_message (not error). Treats anything != success as failed.
-        """
-        mcp = _make_mcp_and_register()
-
-        envelope = {
-            "total": 2,
-            "success": 0,
-            "failed": 2,
-            "probed": 2,
-            "results": [
-                {"stream_id": 12, "stream_name": "Bad Stream", "probe_status": "failed",
-                 "error_message": "ffprobe failed: 404 Not Found"},
-                {"stream_id": 13, "stream_name": "Slow Stream", "probe_status": "timeout",
-                 "error_message": "Probe timed out after 30s"},
-            ],
-        }
-
-        client = AsyncMock()
-        client.call_endpoint.return_value = envelope
-
-        with patch("tools.streams.get_ecm_client", return_value=client):
-            result = await mcp.call_tool("probe_bulk_streams", {"stream_ids": [12, 13]})
-
-        text = result[0][0].text
-        assert "Failed: 2" in text
-        assert "Failed streams:" in text
-        # Name + error surfaced from the correct keys; timeout treated as failed.
+        assert "Success: 0" not in text  # 0/0 accounting bug must not reappear
+        # Failed stream listed with name + error from the results envelope.
         assert "Bad Stream" in text
         assert "404 Not Found" in text
-        assert "Slow Stream" in text
-        assert "timed out" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_returns_already_running_without_polling(self):
+        """If a probe is already running, report that instead of starting a second."""
+        mcp = _make_mcp_and_register()
+
+        responses = {
+            "stream_stats_probe_bulk": {"status": "already_running"},
+        }
+        client = AsyncMock()
+        client.call_endpoint.side_effect = _endpoint_router(responses)
+
+        with patch("tools.streams.get_ecm_client", return_value=client), \
+             patch("tools.streams.asyncio.sleep", new=AsyncMock()):
+            result = await mcp.call_tool("probe_bulk_streams", {"stream_ids": [10, 11]})
+
+        text = result[0][0].text
+        assert "already in progress" in text.lower()
+        # Should not have polled progress at all.
+        called_endpoints = [c.args[0].name for c in client.call_endpoint.call_args_list]
+        assert "stream_stats_probe_progress" not in called_endpoints
+
+    @pytest.mark.asyncio
+    async def test_degrades_gracefully_when_poll_cap_hit(self):
+        """If the probe never finishes within the poll budget, say so — don't hang/error."""
+        mcp = _make_mcp_and_register()
+
+        responses = {
+            "stream_stats_probe_bulk": {"status": "started", "total": 5},
+            # Always still in progress -> poll cap is exhausted.
+            "stream_stats_probe_progress": {"in_progress": True, "current": 2, "total": 5},
+        }
+        client = AsyncMock()
+        client.call_endpoint.side_effect = _endpoint_router(responses)
+
+        with patch("tools.streams.get_ecm_client", return_value=client), \
+             patch("tools.streams.asyncio.sleep", new=AsyncMock()):
+            result = await mcp.call_tool("probe_bulk_streams", {"stream_ids": [1, 2, 3, 4, 5]})
+
+        text = result[0][0].text
+        assert "still running" in text.lower()
+        assert "get_probe_progress" in text
+        # No exception leaked.
+        assert "Error probing" not in text

--- a/mcp-server/tools/streams.py
+++ b/mcp-server/tools/streams.py
@@ -1,4 +1,5 @@
 """Stream management and health tools."""
+import asyncio
 import logging
 import re
 
@@ -595,11 +596,12 @@ def register(mcp: FastMCP):
     async def get_probe_results() -> str:
         """Get results from the most recent completed probe run.
 
-        Note: this envelope is populated only by the scheduled stream probe task,
-        NOT by manual probe_single_stream / probe_bulk_streams calls. To see the
-        outcome of a manual probe, read its return value directly, or use
-        get_stream_health / get_struck_out_streams which draw from persisted
-        per-stream stats. (See bd enhancedchannelmanager-znc76.5.)
+        Populated by the scheduled stream probe task, by probe_streams (probe
+        all), and by probe_bulk_streams (which now runs as a background probe
+        through the same envelope). NOT populated by probe_single_stream, which
+        stays synchronous — read its return value, or use get_stream_health /
+        get_struck_out_streams (persisted per-stream stats) for a single probe.
+        (See bd enhancedchannelmanager-znc76.5.)
         """
         try:
             client = get_ecm_client()
@@ -737,53 +739,93 @@ def register(mcp: FastMCP):
 
     @mcp.tool()
     async def probe_bulk_streams(stream_ids: list[int]) -> str:
-        """Probe multiple streams at once and return health results summary.
+        """Probe multiple streams at once and return a health results summary.
 
-        Note: manual probes triggered here do NOT feed get_probe_results — that
-        "latest probe run" envelope is populated only by the scheduled stream
-        probe task. The per-stream stats ARE persisted, so get_stream_health,
-        get_struck_out_streams, and get_streams_by_ids reflect the new results.
-        Large batches may time out at the gateway (504); probe in smaller
-        batches if that happens. (See bd enhancedchannelmanager-znc76.5.)
+        Starts an asynchronous background probe of the given streams (the same
+        job/progress/results machinery probe_streams uses), then polls progress
+        until it completes and reports the real success/failed counts.
+
+        The probe feeds get_probe_progress / get_probe_results, and the per-stream
+        stats are persisted, so get_stream_health, get_struck_out_streams, and
+        get_streams_by_ids also reflect the new results. Because it is async, it
+        no longer times out at the gateway (504) on larger batches. If a probe is
+        already running, this returns without starting a second one. If the probe
+        is still running when the poll budget is exhausted, this returns a
+        "still running" message — use get_probe_progress / get_probe_results to
+        follow it. (Fixes enhancedchannelmanager-znc76.5.)
 
         Args:
             stream_ids: List of stream IDs to probe
         """
+        # Bounded polling: cap how long we wait for the background probe before
+        # handing back to the caller. ~5 minutes total at 3s intervals — enough
+        # for sizable batches without hanging the tool indefinitely.
+        poll_interval_s = 3.0
+        max_polls = 100
+
         try:
             client = get_ecm_client()
-            result = await client.call_endpoint(
-                ENDPOINTS["stream_stats_probe_bulk"], body={"stream_ids": stream_ids}, timeout=300.0,
+            start = await client.call_endpoint(
+                ENDPOINTS["stream_stats_probe_bulk"], body={"stream_ids": stream_ids}, timeout=60.0,
             )
 
-            if isinstance(result, dict):
-                total = result.get("total", len(stream_ids))
-                success = result.get("success", 0)
-                failed = result.get("failed", 0)
-                lines = [
-                    f"Bulk probe completed for {total} streams:",
-                    f"  Success: {success}",
-                    f"  Failed: {failed}",
-                ]
-                results_list = result.get("results", [])
-                if results_list:
-                    # Per-stream results are StreamStats dicts: the outcome is
-                    # under "probe_status" (success/failed/timeout) and the
-                    # human-readable error under "error_message". Anything that
-                    # isn't "success" is a failure for reporting purposes.
-                    failed_streams = [
-                        r for r in results_list if r.get("probe_status") != "success"
-                    ]
-                    if failed_streams:
-                        lines.append("  Failed streams:")
-                        for r in failed_streams[:20]:
-                            name = r.get("stream_name") or f"id={r.get('stream_id', '?')}"
-                            error = r.get("error_message") or "unknown error"
-                            lines.append(f"    - {name}: {error}")
-                        if len(failed_streams) > 20:
-                            lines.append(f"    ... and {len(failed_streams) - 20} more failures")
-                return "\n".join(lines)
+            status = start.get("status") if isinstance(start, dict) else None
+            if status == "already_running":
+                return (
+                    "A stream probe is already in progress, so this bulk probe was "
+                    "not started. Check get_probe_progress, or cancel_probe first."
+                )
 
-            return f"Bulk probe started for {len(stream_ids)} streams. {result}"
+            # Poll progress until the run leaves the in_progress state.
+            final = None
+            for _ in range(max_polls):
+                await asyncio.sleep(poll_interval_s)
+                progress = await client.call_endpoint(ENDPOINTS["stream_stats_probe_progress"])
+                if not progress.get("in_progress"):
+                    final = progress
+                    break
+
+            if final is None:
+                # Poll budget exhausted while still running — don't hang or error.
+                progress = await client.call_endpoint(ENDPOINTS["stream_stats_probe_progress"])
+                current = progress.get("current", 0)
+                total = progress.get("total", len(stream_ids))
+                return (
+                    f"Bulk probe still running ({current}/{total}) after the poll "
+                    "window — check get_probe_progress / get_probe_results for the "
+                    "final outcome."
+                )
+
+            # Completed (or cancelled/failed): report real counts from the
+            # results envelope, falling back to the final progress snapshot.
+            results = await client.call_endpoint(ENDPOINTS["stream_stats_probe_results"])
+            success = results.get("success_count", final.get("success_count", 0))
+            failed = results.get("failed_count", final.get("failed_count", 0))
+            total = final.get("total", len(stream_ids))
+
+            run_status = final.get("status", "completed")
+            if run_status == "cancelled":
+                header = f"Bulk probe cancelled after {success + failed} of {total} streams:"
+            elif run_status == "failed":
+                header = f"Bulk probe failed after {success + failed} of {total} streams:"
+            else:
+                header = f"Bulk probe completed for {total} streams:"
+
+            lines = [
+                header,
+                f"  Success: {success}",
+                f"  Failed: {failed}",
+            ]
+            failed_streams = results.get("failed_streams", [])
+            if failed_streams:
+                lines.append("  Failed streams:")
+                for r in failed_streams[:20]:
+                    name = r.get("name") or f"id={r.get('id', '?')}"
+                    error = r.get("error") or "unknown error"
+                    lines.append(f"    - {name}: {error}")
+                if len(failed_streams) > 20:
+                    lines.append(f"    ... and {len(failed_streams) - 20} more failures")
+            return "\n".join(lines)
         except Exception as e:
             logger.error("[MCP] probe_bulk_streams failed: %s", e)
             return f"Error probing streams in bulk: {e}"


### PR DESCRIPTION
## What

The two larger `znc76` follow-ups. Both gate-green and **live-verified** on the dev containers.

### znc76.3 — normalization strip rules repaired (config drift → idempotent boot migration)
The 7 "Strip *" rule groups had `tag_group_id` unset, so they never matched (engine was correct). Adds two idempotent repair helpers in `normalization_migration.py`, wired into startup:
- `backfill_tag_group_rule_ids` — wires NULL `tag_group_id` strip rules to their tag group by name (reusing the seed map) + derives `tag_match_position` from `action_type`. Conservative: only touches NULL rules; skips unmapped.
- `ensure_abbreviation_tags_acronyms` — adds `US`/`UK`/`EU` to Abbreviation Tags so Title Case stops lowercasing them.

**Live result:** `US : ESPN HD → ESPN`, `ESPN FHD → ESPN`, `AR| BEIN SPORTS HD → Bein Sports` (was `Us : ESPN HD`, nothing stripped).

### znc76.5 — bulk stream probe made async
`probe_bulk_streams` was synchronous and 504'd on batches ≥~3. Now `POST /probe/bulk` starts a background probe reusing the **same** prober job/progress/results machinery as `probe/all` (single-probe invariant respected; missing ids tallied as failures), and the MCP tool starts + polls `get_probe_progress` to completion, then reports real counts from `get_probe_results`. This also fixes the results-envelope gap (bulk runs now surface in `get_probe_results`).

**Live result:** `probe_bulk_streams([3 streams])` → "Bulk probe completed: Success 2, Failed 1" — no 504.

## Verification
- mcp suite 296 passed; backend: normalization-migration 21 passed, bulk-prober + stream_stats router 40 passed.
- Live re-tested both on `ecm-ecm-1` + `ecm-ecm-mcp-1` after deploy (migration ran on boot; bulk probe completed async).

Closes znc76.3 and znc76.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)