### PR TITLE
feat(epg): link a chosen EPG candidate to a channel (znc76.2 — close match→logo seam)

### DIFF
--- a/backend/routers/epg.py
+++ b/backend/routers/epg.py
@@ -794,6 +794,19 @@ class EPGMatchRequest(BaseModel):
     source_order: list[int] = []
 
 
+class EPGLinkRequest(BaseModel):
+    """Link one chosen EPG candidate to a channel.
+
+    Supply either ``epg_data_id`` (the EPG data row id — preferred, exact) or
+    ``tvg_id`` (resolved server-side to its EPG data row). ``epg_data_id`` wins
+    if both are given. Both are the fields the ``match`` endpoint already
+    surfaces per candidate (``epg_id`` + ``tvg_id``), closing the
+    match -> link -> set-logo chain.
+    """
+    epg_data_id: int | None = None
+    tvg_id: str | None = None
+
+
 @router.post("/match")
 async def match_channels_to_epg(request: EPGMatchRequest):
     """Batch match channels to EPG data with confidence scoring.
@@ -939,3 +952,74 @@ async def match_channels_to_epg(request: EPGMatchRequest):
     except Exception as e:
         logger.exception("[EPG-MATCH] Failed: %s", e)
         raise HTTPException(status_code=500, detail="EPG matching failed")
+
+
+@router.post("/channels/{channel_id}/link")
+async def link_channel_to_epg(channel_id: int, request: EPGLinkRequest):
+    """Link a channel to a chosen EPG candidate (sets its ``epg_data_id``).
+
+    The ``match`` endpoint reports ``multiple`` candidates per channel but never
+    establishes the EPG association — only an exact match would. This endpoint
+    closes that seam: given the operator's chosen candidate (by ``epg_data_id``
+    or ``tvg_id``, both surfaced by ``match``), it sets the channel's
+    ``epg_data_id`` via the *same* ``update_channel`` PATCH the merge path uses,
+    so a downstream "Set Logo from EPG" can then resolve the linked entry.
+
+    Returns the updated channel (the linked state).
+    """
+    if request.epg_data_id is None and not request.tvg_id:
+        raise HTTPException(
+            status_code=400,
+            detail="Provide either epg_data_id or tvg_id to link.",
+        )
+
+    client = get_client()
+    try:
+        epg_data_id = request.epg_data_id
+
+        # Resolve a tvg_id to its EPG data row id when no explicit id was given.
+        if epg_data_id is None:
+            tvg_id = request.tvg_id
+            candidates = await client.get_epg_data(search=tvg_id)
+            match = next(
+                (e for e in candidates if e.get("tvg_id") == tvg_id),
+                None,
+            )
+            if match is None:
+                logger.warning(
+                    "[EPG-LINK] No EPG data row found for tvg_id=%r (channel=%s)",
+                    tvg_id, channel_id,
+                )
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No EPG data found for tvg_id '{tvg_id}'.",
+                )
+            epg_data_id = match.get("id")
+
+        # Establish the link with the same mechanism the exact-match/merge path
+        # uses: PATCH the channel's epg_data_id.
+        result = await client.update_channel(channel_id, {"epg_data_id": epg_data_id})
+
+        journal.log_entry(
+            category="channel",
+            action_type="update",
+            entity_id=channel_id,
+            entity_name=result.get("name") if isinstance(result, dict) else None,
+            description=f"Linked channel to EPG data id={epg_data_id}",
+            after_value={"epg_data_id": epg_data_id},
+        )
+
+        logger.info(
+            "[EPG-LINK] Linked channel=%s -> epg_data_id=%s", channel_id, epg_data_id,
+        )
+        return result
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[EPG-LINK] Link rejected by Dispatcharr: %s", e)
+            raise mapped
+        logger.exception("[EPG-LINK] Failed to link channel %s: %s", channel_id, e)
+        raise HTTPException(status_code=500, detail="EPG link failed")

--- a/backend/tests/routers/test_epg.py
+++ b/backend/tests/routers/test_epg.py
@@ -368,3 +368,127 @@ class TestBatchLCN:
 
         assert response.status_code == 200
         assert response.json()["results"] == {}
+
+
+class TestLinkChannelToEPG:
+    """Tests for POST /api/epg/channels/{channel_id}/link.
+
+    Closes the Scenario 6 seam: picking a 'multiple candidate' tvg_id/epg_data_id
+    and establishing the channel's epg_data link (so set_logo_from_epg works).
+    """
+
+    @pytest.mark.asyncio
+    async def test_links_by_explicit_epg_data_id(self, async_client):
+        """Sets the channel's epg_data_id via update_channel when given an id."""
+        mock_client = AsyncMock()
+        mock_client.update_channel.return_value = {
+            "id": 7, "name": "ESPN", "epg_data_id": 42,
+        }
+
+        with patch("routers.epg.get_client", return_value=mock_client), \
+             patch("routers.epg.journal"):
+            response = await async_client.post(
+                "/api/epg/channels/7/link", json={"epg_data_id": 42},
+            )
+
+        assert response.status_code == 200
+        # The link is established with the exact-match mechanism: PATCH epg_data_id.
+        mock_client.update_channel.assert_called_once_with(7, {"epg_data_id": 42})
+        mock_client.get_epg_data.assert_not_called()
+        assert response.json()["epg_data_id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_links_by_tvg_id_resolves_to_epg_data_row(self, async_client):
+        """Resolves a tvg_id to its EPG data row id, then sets epg_data_id."""
+        mock_client = AsyncMock()
+        mock_client.get_epg_data.return_value = [
+            {"id": 11, "tvg_id": "CNN.us", "name": "CNN"},
+            {"id": 99, "tvg_id": "ESPN.us", "name": "ESPN"},
+        ]
+        mock_client.update_channel.return_value = {
+            "id": 7, "name": "ESPN", "epg_data_id": 99,
+        }
+
+        with patch("routers.epg.get_client", return_value=mock_client), \
+             patch("routers.epg.journal"):
+            response = await async_client.post(
+                "/api/epg/channels/7/link", json={"tvg_id": "ESPN.us"},
+            )
+
+        assert response.status_code == 200
+        mock_client.get_epg_data.assert_called_once_with(search="ESPN.us")
+        mock_client.update_channel.assert_called_once_with(7, {"epg_data_id": 99})
+
+    @pytest.mark.asyncio
+    async def test_epg_data_id_wins_over_tvg_id(self, async_client):
+        """When both are supplied, epg_data_id is used (no tvg_id resolution)."""
+        mock_client = AsyncMock()
+        mock_client.update_channel.return_value = {"id": 7, "epg_data_id": 5}
+
+        with patch("routers.epg.get_client", return_value=mock_client), \
+             patch("routers.epg.journal"):
+            response = await async_client.post(
+                "/api/epg/channels/7/link",
+                json={"epg_data_id": 5, "tvg_id": "ESPN.us"},
+            )
+
+        assert response.status_code == 200
+        mock_client.get_epg_data.assert_not_called()
+        mock_client.update_channel.assert_called_once_with(7, {"epg_data_id": 5})
+
+    @pytest.mark.asyncio
+    async def test_missing_both_returns_400(self, async_client):
+        """Returns 400 when neither epg_data_id nor tvg_id is provided."""
+        mock_client = AsyncMock()
+
+        with patch("routers.epg.get_client", return_value=mock_client):
+            response = await async_client.post("/api/epg/channels/7/link", json={})
+
+        assert response.status_code == 400
+        mock_client.update_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_tvg_id_returns_404(self, async_client):
+        """Returns 404 when no EPG data row matches the given tvg_id."""
+        mock_client = AsyncMock()
+        mock_client.get_epg_data.return_value = [
+            {"id": 11, "tvg_id": "CNN.us", "name": "CNN"},
+        ]
+
+        with patch("routers.epg.get_client", return_value=mock_client):
+            response = await async_client.post(
+                "/api/epg/channels/7/link", json={"tvg_id": "NOPE.us"},
+            )
+
+        assert response.status_code == 404
+        mock_client.update_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upstream_4xx_surfaces_400_not_500(self, async_client):
+        """A Dispatcharr 4xx on the PATCH maps to a clean 4xx, not an opaque 500."""
+        request = httpx.Request("PATCH", "http://x/api/channels/channels/7/")
+        bad_response = httpx.Response(400, request=request, text="bad epg_data_id")
+        mock_client = AsyncMock()
+        mock_client.update_channel.side_effect = httpx.HTTPStatusError(
+            "400", request=request, response=bad_response,
+        )
+
+        with patch("routers.epg.get_client", return_value=mock_client):
+            response = await async_client.post(
+                "/api/epg/channels/7/link", json={"epg_data_id": 42},
+            )
+
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_genuine_server_error_still_500(self, async_client):
+        """A non-HTTP error still surfaces as 500."""
+        mock_client = AsyncMock()
+        mock_client.update_channel.side_effect = Exception("boom")
+
+        with patch("routers.epg.get_client", return_value=mock_client):
+            response = await async_client.post(
+                "/api/epg/channels/7/link", json={"epg_data_id": 42},
+            )
+
+        assert response.status_code == 500

--- a/mcp-server/_endpoint_contracts.py
+++ b/mcp-server/_endpoint_contracts.py
@@ -382,6 +382,13 @@ ENDPOINTS: dict[str, Endpoint] = {
         path="/api/epg/match",
         request_fields=frozenset({"channel_ids", "epg_source_ids", "source_order"}),  # EPGMatchRequest
     ),
+    "epg_link_channel": Endpoint(
+        name="epg_link_channel",
+        method="POST",
+        path="/api/epg/channels/{channel_id}/link",
+        request_fields=frozenset({"epg_data_id", "tvg_id"}),  # EPGLinkRequest
+        # Returns the updated channel dict (linked state) — not a list.
+    ),
     "epg_grid": Endpoint(
         name="epg_grid",
         method="GET",

--- a/mcp-server/tests/test_tools.py
+++ b/mcp-server/tests/test_tools.py
@@ -1887,9 +1887,121 @@ class TestMatchChannelsEpg:
         assert "no candidate details available" in text
 
 
+# --- TestLinkChannelEpg (znc76.2 / r5pu5) ---
+class TestLinkChannelEpg:
+    """link_channel_epg picks a 'multiple' candidate and links it to a channel.
+
+    Closes the Scenario 6 seam: match_channels_epg lists candidates, but only
+    this tool establishes the channel's epg_data link so set_logo_from_epg works.
+    """
+
+    @pytest.mark.asyncio
+    async def test_links_by_tvg_id_calls_endpoint(self):
+        """Resolves channel + tvg_id through the link endpoint with path_args+body."""
+        from tools.epg import register
+        from mcp.server.fastmcp import FastMCP
+        from _endpoint_contracts import ENDPOINTS
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.return_value = {
+            "id": 20, "name": "Fox News", "epg_data_id": 555,
+        }
+
+        with patch("tools.epg.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "link_channel_epg", {"channel_id": 20, "tvg_id": "FoxNews.us"},
+            )
+
+        # Calls the registered link endpoint with the channel in path_args and
+        # the chosen tvg_id in the body.
+        call = mock_client.call_endpoint.call_args
+        assert call.args[0] is ENDPOINTS["epg_link_channel"]
+        assert call.kwargs["path_args"] == {"channel_id": 20}
+        assert call.kwargs["body"] == {"tvg_id": "FoxNews.us"}
+
+        text = result[0][0].text
+        assert "Fox News" in text
+        assert "555" in text  # linked epg_data_id surfaced
+        assert "set_logo_from_epg" in text
+
+    @pytest.mark.asyncio
+    async def test_links_by_epg_data_id(self):
+        """epg_data_id is forwarded in the body when provided."""
+        from tools.epg import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.return_value = {"id": 7, "epg_data_id": 42}
+
+        with patch("tools.epg.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "link_channel_epg", {"channel_id": 7, "epg_data_id": 42},
+            )
+
+        body = mock_client.call_endpoint.call_args.kwargs["body"]
+        assert body == {"epg_data_id": 42}
+        assert "42" in result[0][0].text
+
+    @pytest.mark.asyncio
+    async def test_requires_a_candidate(self):
+        """Neither tvg_id nor epg_data_id -> guidance, no backend call."""
+        from tools.epg import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = AsyncMock()
+
+        with patch("tools.epg.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("link_channel_epg", {"channel_id": 7})
+
+        text = result[0][0].text
+        assert "tvg_id" in text and "epg_data_id" in text
+        mock_client.call_endpoint.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_api_error_returns_message(self):
+        """Backend error surfaces as a readable message."""
+        from tools.epg import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = Exception("HTTP 404: channel not found")
+
+        with patch("tools.epg.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "link_channel_epg", {"channel_id": 999, "tvg_id": "X.us"},
+            )
+
+        text = result[0][0].text
+        assert "Error" in text
+        assert "404" in text
+
+
 # --- TestEpgContractRegistry (A2) ---
 class TestEpgContractRegistry:
     """Verify endpoint contracts are correct for the EPG domain after fixes."""
+
+    def test_epg_link_channel_registered(self):
+        """epg_link_channel endpoint is registered with correct method/path/fields."""
+        from _endpoint_contracts import ENDPOINTS
+
+        ep = ENDPOINTS["epg_link_channel"]
+        assert ep.method == "POST"
+        assert ep.path == "/api/epg/channels/{channel_id}/link"
+        assert "epg_data_id" in ep.request_fields
+        assert "tvg_id" in ep.request_fields
+        assert ep.response_is_list is False
 
     def test_epg_create_source_includes_source_type(self):
         """epg_create_source contract must declare source_type as a request field."""

--- a/mcp-server/tools/epg.py
+++ b/mcp-server/tools/epg.py
@@ -163,6 +163,55 @@ def register(mcp: FastMCP):
             return f"Error running EPG auto-match: {e}"
 
     @mcp.tool()
+    async def link_channel_epg(
+        channel_id: int,
+        tvg_id: str | None = None,
+        epg_data_id: int | None = None,
+    ) -> str:
+        """Link a channel to a chosen EPG candidate so its guide data attaches.
+
+        Use this after ``match_channels_epg`` reports a channel with *multiple
+        candidates*: pick one candidate's ``tvg_id`` (shown in that output) and
+        link it here. This sets the channel's EPG data association (epg_data_id),
+        which ``bulk_assign_epg`` does NOT do — and which ``set_logo_from_epg``
+        needs to find the linked entry. Completes the
+        match -> link -> set-logo workflow without dropping to the UI.
+
+        Args:
+            channel_id: The channel to link.
+            tvg_id: The chosen candidate's tvg_id (resolved server-side to its
+                EPG data row). Either tvg_id or epg_data_id is required.
+            epg_data_id: The EPG data row id directly (preferred when known —
+                e.g. a candidate's "epg_id"). Wins over tvg_id if both given.
+        """
+        if tvg_id is None and epg_data_id is None:
+            return "Provide either tvg_id or epg_data_id to link."
+        try:
+            client = get_ecm_client()
+            body: dict = {}
+            if epg_data_id is not None:
+                body["epg_data_id"] = epg_data_id
+            if tvg_id is not None:
+                body["tvg_id"] = tvg_id
+
+            result = await client.call_endpoint(
+                ENDPOINTS["epg_link_channel"],
+                path_args={"channel_id": channel_id},
+                body=body,
+            )
+
+            linked_id = result.get("epg_data_id") if isinstance(result, dict) else None
+            ch_name = result.get("name") if isinstance(result, dict) else None
+            label = f"'{ch_name}' (id={channel_id})" if ch_name else f"channel {channel_id}"
+            return (
+                f"Linked {label} to EPG data id={linked_id}. "
+                "set_logo_from_epg can now resolve this channel's EPG entry."
+            )
+        except Exception as e:
+            logger.error("[MCP] link_channel_epg failed: %s", e)
+            return f"Error linking channel {channel_id} to EPG: {e}"
+
+    @mcp.tool()
     async def create_epg_source(name: str, url: str, source_type: str = "xmltv") -> str:
         """Create a new EPG data source.
 


### PR DESCRIPTION
## What

Closes the remaining `znc76.2` seam: after `match_channels_epg` reports "multiple candidates", there was no MCP way to PICK one and LINK it, so `set_logo_from_epg` (which needs the channel's `epg_data_id`, not just a tvg_id string) dead-ended. (The candidate *visibility* half shipped in #408.)

- **Backend:** `POST /api/epg/channels/{channel_id}/link` (accepts `epg_data_id` and/or `tvg_id`; tvg_id resolved server-side) sets the channel's EPG data association via the same `update_channel(epg_data_id=…)` mechanism the exact-match/merge path uses, and journals it. Clean 4xx on bad input/unresolvable tvg_id.
- **MCP:** new `link_channel_epg(channel_id, tvg_id=None, epg_data_id=None)` tool + `epg_link_channel` contract entry.

Enables the full workflow without the UI: `match_channels_epg` (multiple) → read a candidate's tvg_id → `link_channel_epg` → `set_logo_from_epg`.

## Verification
- mcp suite 301 passed; backend epg + the live-OpenAPI contract test 150 passed (contract test confirms the new route, 121→122).
- **Live end-to-end on dev:** linked US : ESPN to candidate `ESPN(ESPN).us` (→ EPG data id 11259), then `set_logo_from_epg` reported **"1 assigned, 0 skipped (no EPG link)"** (was "0 assigned, 1 skipped" pre-fix).

Closes znc76.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)