### PR TITLE
docs(release): refresh post-0.17.2 release-state docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,13 +470,14 @@ Interactive API docs are available at `/api/docs` (Swagger UI) and `/api/redoc`.
 
 ### Completed
 
+- **v0.17.2** — Full Stats v2 MCP coverage (8 new tools: provider stats, per-user watch time, trending, activity, channel bandwidth; media-server attribution now queryable via Claude); 30+ MCP correctness fixes from a live sweep of all tools; MCP API-key timing-attack hardening
+- **v0.17.1** — Plex + Jellyfin user attribution and multi-viewer display; real client IP threading through the attribution pipeline; SSRF hardening on media-server test-connection endpoints
+- **v0.17.0** — Stats v2 foundation: `session_telemetry` table, per-user watch-time API, Alembic schema migration system, Prometheus `/metrics`, structured JSON logging with trace IDs; ghost-source-channel fix after merge in edit mode
+- **v0.16.0** — MCP server for natural language channel management via Claude (124 tools, 14 domains, Streamable HTTP transport); auto-creation rule analyzer; Alembic migrations; structured logging; per-rule normalization and sort options _(an earlier 0.16.0 build was rolled back on 2026-04-20 before any external consumer pulled it; this is the shipping release, cut 2026-05-12)_
 - **v0.15.1** — OWASP hardening (security headers, CORS, rate limiting, NIST password policy, log redaction, path validation)
 - **v0.15.0** — Server-side EPG matching, stream normalization, PUID/PGID support, low FPS detection, export/publish pipeline
 - **v0.14.0** — Dummy EPG profiles, auto-creation pipeline, normalization engine
 - **v0.13.0** — Backend modularization (20+ routers), auth system, task engine
 
-### v0.16.0 — MCP Server & Claude Integration (Current)
-MCP server for natural language channel management via Claude. 124 tools across 14 domains, Streamable HTTP transport with API key auth, separate Docker container, frontend settings UI with connection status. Per-rule normalization group selection, video codec as smart sort criterion, configurable deprioritized stream ordering, diagnostic debug bundles, user identification in watch history and stats, and settings persistence hardening.
-
-### v0.17.0 — Dashboard & Analytics
-Enhanced dashboard with real-time stream monitoring, historical analytics, and customizable widgets.
+### v0.18.0 — Next release
+See `CHANGELOG.md` `[Unreleased]` for the canonical list of fixes and features queued for the next cut.

--- a/docs/discord_release_notes.md
+++ b/docs/discord_release_notes.md
@@ -57,22 +57,29 @@
 
 ## Pending release notes (copy-paste to Discord when cutting the release)
 
-### v0.17.1
+### v0.17.2
 
 ```
 @here
 
-## 🚀 ECM v0.17.1
+## 🚀 ECM v0.17.2
 
-**🆕 Plex + Jellyfin User Attribution + Multi-Viewer**
-• Connected Clients now shows usernames for Plex and Jellyfin streams (was: Emby only)
-• When multiple users watch the same channel through the same media server, all their names are listed (was: only the most-recent user's name)
-• Configure under Settings → Integrations → Plex Integration / Jellyfin Integration
-• No re-migration required; new columns in session_telemetry are populated as new sessions arrive
+**🆕 Manage ECM through Claude — full Stats v2 coverage**
+• 8 new MCP tools so Claude can answer questions about your data: provider performance, per-user watch time, trending & popularity, the activity feed, and channel bandwidth
+• "Who's watching channel X?" — Claude can now read media-server attribution (Emby/Plex/Jellyfin usernames, client IPs, provider) on active channels
+• 124 MCP tools total — the MCP surface now covers the Stats v2 + attribution features that were previously UI-only
+
+**🐛 MCP reliability — a big correctness pass (30+ fixes)**
+• Static API-key auth now works across every tool (dedup, add-stream merge modes, and backups were previously rejected)
+• Fixed reorder / bulk-commit silently dropping streams from a channel
+• get_journal returns entries again; the EPG grid shows real channel names; stream provider/group show names instead of raw IDs
+• Channel numbers display as whole numbers (no more "#10440.0"); clearer "nothing to show" messages for probes
+• Found and fixed via a live sweep of every MCP tool
 
 **🔒 Security**
-• SSRF mitigation on test-connection endpoints for Emby, Plex, and Jellyfin (scheme allowlist + netloc-only URL reconstruction)
+• Constant-time comparison for the MCP API key (timing-attack hardening)
+• The MCP service key can no longer modify ECM user accounts (clean 403 instead of a 500)
 
-**📝 Documentation**
-• New Integrations operator guide covering Emby, Plex, and Jellyfin side-by-side (Settings → Integrations)
+**⚠️ Deprecation (still works — removed in v0.18.0)**
+• `ECM_TELEMETRY_EXCLUDE_USERS` is deprecated — the Stats attribution bug it worked around is now fixed, so you no longer need it. If it's set, you'll see a one-time log warning.
 ```

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -42,7 +42,7 @@ History — why this guard exists:
 
 Version `0.16.0` was tagged and pushed to GHCR on 2026-04-20 and then **hard-rolled-back the same day** — the tag, GitHub Release, and GHCR image were all deleted before any external consumer pulled them. See [`docs/runbooks/v0.16.0-rollback.md`](runbooks/v0.16.0-rollback.md) for the full incident and [ADR-004](adr/ADR-004-release-cut-promotion-discipline.md) for the pre-cut gate that now blocks a repeat.
 
-Because of the rollback, the current dev stream is still on `0.16.0-NNNN`. Per PO decision (grooming 2026-04-22, bd-eio04.10), there is no `0.16.1` release cut planned — dev continues to increment `BUILD` until a full `0.17.0` cut. External users running `0.16.0-NNNN` images are on dev builds, not a promoted release; the `[Unreleased]` section of [`CHANGELOG.md`](../CHANGELOG.md) is the canonical list of fixes awaiting a cut.
+The 0.16.x line was never re-cut after the yank. As of the 0.17.2 cut, three subsequent releases have since been promoted: **0.17.0** (2026-05-16), **0.17.1** (2026-05-22), and **0.17.2** (2026-05-23). `dev` now increments `BUILD` toward the next planned release as `0.18.0-NNNN` (tip is `0.18.0-0000` after the 0.17.2 cut). External users running `0.18.0-NNNN` images are on dev builds, not a promoted release; the `[Unreleased]` section of [`CHANGELOG.md`](../CHANGELOG.md) is the canonical list of fixes awaiting the next cut.
 
 ## Where to read the version
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -38,11 +38,13 @@ History — why this guard exists:
 - **PR #277** (cherry-pick of bd-lkyg5 from `release/v0.16.1` to `dev`, 2026-05-13): the cherry-pick agent noticed `backend/routers/backup.py` was at `"0.16.0"` while `frontend/package.json` had been bumped 27 times to `"0.17.0-0027"`. The skew had been latent for months — only caught because the cherry-picked commit happened to touch `backup.py`. Fixed inline; bd-9rtlc filed.
 - **bd-9rtlc audit** (2026-05-14): grep across the codebase surfaced a second long-standing skew — `backend/main.py` was at `"0.16.0-0003"` (FastAPI kwarg) while `frontend/package.json` was at `"0.17.0-0033"`. The FastAPI version only shows in the OpenAPI schema, which no external consumer cited, so nobody noticed for ~30 builds. Both touchpoints are now bumped in lockstep at `"0.17.0-0034"` and the CI guard (this job) blocks any future divergence.
 
-## Yanked release note — 0.16.0
+## 0.16.0 — yanked first attempt, then re-cut
 
-Version `0.16.0` was tagged and pushed to GHCR on 2026-04-20 and then **hard-rolled-back the same day** — the tag, GitHub Release, and GHCR image were all deleted before any external consumer pulled them. See [`docs/runbooks/v0.16.0-rollback.md`](runbooks/v0.16.0-rollback.md) for the full incident and [ADR-004](adr/ADR-004-release-cut-promotion-discipline.md) for the pre-cut gate that now blocks a repeat.
+An initial `0.16.0` build was tagged and pushed to GHCR on 2026-04-20 and then **hard-rolled-back the same day** — the tag, GitHub Release, and GHCR image were all deleted before any external consumer pulled them. See [`docs/runbooks/v0.16.0-rollback.md`](runbooks/v0.16.0-rollback.md) for the full incident and [ADR-004](adr/ADR-004-release-cut-promotion-discipline.md) for the pre-cut gate that now blocks a repeat.
 
-The 0.16.x line was never re-cut after the yank. As of the 0.17.2 cut, three subsequent releases have since been promoted: **0.17.0** (2026-05-16), **0.17.1** (2026-05-22), and **0.17.2** (2026-05-23). `dev` now increments `BUILD` toward the next planned release as `0.18.0-NNNN` (tip is `0.18.0-0000` after the 0.17.2 cut). External users running `0.18.0-NNNN` images are on dev builds, not a promoted release; the `[Unreleased]` section of [`CHANGELOG.md`](../CHANGELOG.md) is the canonical list of fixes awaiting the next cut.
+**0.16.0 was successfully re-cut and shipped on 2026-05-12.** The shipping release incorporates everything that was intended for the first attempt plus the blocking bug fixes; see the `## [0.16.0]` entry in [`CHANGELOG.md`](../CHANGELOG.md). The `v0.16.0` tag and GHCR image from that date are the canonical promoted release — the 2026-04-20 rollback was the first attempt only, not a permanent yank of the 0.16.x line.
+
+Three further releases have since been promoted: **0.17.0** (2026-05-16), **0.17.1** (2026-05-22), and **0.17.2** (2026-05-23). `dev` now increments `BUILD` toward the next planned release as `0.18.0-NNNN` (tip is `0.18.0-0000` after the 0.17.2 cut). External users running `0.18.0-NNNN` images are on dev builds, not a promoted release; the `[Unreleased]` section of [`CHANGELOG.md`](../CHANGELOG.md) is the canonical list of fixes awaiting the next cut.
 
 ## Where to read the version
 


### PR DESCRIPTION
Refreshes three docs whose *current-state* claims went stale after the v0.17.2 cut (the release merge only updates the CHANGELOG + version touchpoints, which are CI-gated; these are not).

- **`docs/versioning.md`** — the "Yanked release note — 0.16.0" section claimed dev was *"still on `0.16.0-NNNN`… until a full `0.17.0` cut."* Rewritten to reflect reality: the 2026-04-20 0.16.0 build was rolled back (first attempt), **0.16.0 was successfully re-cut and shipped 2026-05-12**, then 0.17.0/0.17.1/0.17.2 followed, and dev now increments toward `0.18.0-NNNN` (tip `0.18.0-0000`). Yank-incident history + rollback-runbook/ADR-004 links preserved; section retitled "0.16.0 — yanked first attempt, then re-cut."
- **`docs/discord_release_notes.md`** — dropped the already-shipped `v0.17.1` pending block; added the `v0.17.2` block (the copy-paste Discord notes).
- **`README.md`** — version-history list stopped at v0.15.1; added v0.17.2 / v0.17.1 / v0.17.0 (summaries sourced from CHANGELOG) and corrected v0.16.0's entry (shipped 2026-05-12, with the yank as context); replaced the stale "(Current)" / future-roadmap blocks with a `v0.18.0 — Next release` pointer to CHANGELOG `[Unreleased]`.

Docs-only (`.md`). Authored by the technical-writer persona; orchestrator verified the 0.16.0 re-cut history against CHANGELOG + git tags (caught and fixed an initial "never re-cut" error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)