### PR TITLE
fix(channels): map upstream 404 in get_channel_streams; was opaque 500 (8w1ba)

### DIFF
--- a/backend/routers/channels.py
+++ b/backend/routers/channels.py
@@ -1959,7 +1959,19 @@ async def get_channel_streams(channel_id: int):
         elapsed_ms = (time.time() - start) * 1000
         logger.debug("[CHANNELS] Fetched streams for channel id=%s in %.1fms", channel_id, elapsed_ms)
         return result
+    except HTTPException:
+        raise
     except Exception as e:
+        # A missing channel id surfaces as an upstream 404 — return 404, not 500
+        # (bd-8w1ba). Common trigger: callers pass a channel NUMBER (shown in the
+        # UI) rather than the internal channel id.
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning(
+                "[CHANNELS] Upstream error fetching streams for channel id=%s: %s",
+                channel_id, e,
+            )
+            raise mapped
         logger.exception("[CHANNELS] Failed to fetch streams for channel id=%s", channel_id)
         raise HTTPException(status_code=500, detail="Internal server error")
 

--- a/backend/tests/routers/test_channels.py
+++ b/backend/tests/routers/test_channels.py
@@ -295,6 +295,37 @@ class TestGetChannelStreams:
         assert response.status_code == 200
         mock_client.get_channel_streams.assert_called_once_with(1)
 
+    @pytest.mark.asyncio
+    async def test_missing_channel_returns_404_not_500(self, async_client):
+        """A missing channel id surfaces upstream 404 as 404, not an opaque 500
+        (bd-8w1ba). The client's get_channel_streams raises httpx.HTTPStatusError
+        via raise_for_status() when Dispatcharr 404s the unknown channel."""
+        request = httpx.Request(
+            "GET", "http://disp/api/channels/channels/999999/streams/"
+        )
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.get_channel_streams.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.channels.get_client", return_value=mock_client):
+            response = await async_client.get("/api/channels/999999/streams")
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_non_upstream_error_stays_500(self, async_client):
+        """A non-upstream error (no embedded 4xx) stays a 500 (bd-8w1ba)."""
+        mock_client = AsyncMock()
+        mock_client.get_channel_streams.side_effect = RuntimeError("boom")
+
+        with patch("routers.channels.get_client", return_value=mock_client):
+            response = await async_client.get("/api/channels/1/streams")
+
+        assert response.status_code == 500
+
 
 class TestAddStream:
     """Tests for POST /api/channels/{channel_id}/add-stream."""

--- a/mcp-server/tests/test_lq38l_journal_and_nits.py
+++ b/mcp-server/tests/test_lq38l_journal_and_nits.py
@@ -227,6 +227,62 @@ class TestStreamGroupProviderResolution:
 
 
 # ===========================================================================
+# bd-8w1ba — get_streams_for_channel surfaces a clean not-found message when the
+# backend now returns 404 for a non-existent channel id (the backend fix maps the
+# upstream Dispatcharr 404 instead of an opaque 500). The MCP client wraps that
+# 404 in a RuntimeError chained from the original httpx.HTTPStatusError.
+# ===========================================================================
+
+class TestStreamsForChannelNotFound:
+    @staticmethod
+    def _not_found_runtime_error() -> RuntimeError:
+        """Mirror ecm_client._http_error(...) raise-from for a 404: a
+        RuntimeError chained (__cause__) to the httpx.HTTPStatusError."""
+        import httpx
+
+        request = httpx.Request(
+            "GET", "http://ecm/api/channels/999999/streams"
+        )
+        response = httpx.Response(
+            404, request=request, text='{"detail": "Not found."}'
+        )
+        status_err = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=response
+        )
+        err = RuntimeError(
+            "GET /api/channels/999999/streams -> HTTP 404 Not Found: Not found."
+        )
+        err.__cause__ = status_err
+        return err
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_clean_message(self):
+        mcp = _register("streams")
+        mock_client = _client(side_effect=self._not_found_runtime_error())
+        with patch("tools.streams.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "get_streams_for_channel", {"channel_id": 999999}
+            )
+        text = result[0][0].text
+        assert "Channel 999999 not found" in text
+        assert "internal channel id" in text
+        # the not-found message replaces the opaque "Error getting streams" wrap
+        assert "Error getting streams" not in text
+
+    @pytest.mark.asyncio
+    async def test_non_404_error_keeps_generic_wrap(self):
+        mcp = _register("streams")
+        mock_client = _client(side_effect=RuntimeError("upstream exploded"))
+        with patch("tools.streams.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "get_streams_for_channel", {"channel_id": 5}
+            )
+        text = result[0][0].text
+        assert "Error getting streams for channel 5" in text
+        assert "not found" not in text
+
+
+# ===========================================================================
 # lq38l.13 #3 — get_epg_grid resolves channel names via channel_uuid
 # ===========================================================================
 

--- a/mcp-server/tools/streams.py
+++ b/mcp-server/tools/streams.py
@@ -11,6 +11,21 @@ from ecm_client import get_ecm_client
 logger = logging.getLogger(__name__)
 
 
+def _is_not_found(exc: Exception) -> bool:
+    """True if ``exc`` represents an upstream HTTP 404.
+
+    The ECM client wraps upstream failures in a ``RuntimeError`` (built by
+    ``ecm_client._http_error``) chained via ``raise ... from e`` to the original
+    ``httpx.HTTPStatusError``. Prefer the precise status code on the chained
+    cause; fall back to the message text (``-> HTTP 404``) for robustness.
+    """
+    cause = getattr(exc, "__cause__", None)
+    resp = getattr(cause, "response", None)
+    if resp is not None and getattr(resp, "status_code", None) == 404:
+        return True
+    return "HTTP 404" in str(exc)
+
+
 # ---- Shared fuzzy matching helpers (used by both streams and channels tools) ----
 
 def _strip_stream_prefix(name: str) -> str:
@@ -727,6 +742,12 @@ def register(mcp: FastMCP):
             return "\n".join(lines)
         except Exception as e:
             logger.error("[MCP] get_streams_for_channel failed: %s", e)
+            if _is_not_found(e):
+                return (
+                    f"Channel {channel_id} not found "
+                    "(channel_id is the internal channel id, not the channel "
+                    "number shown in the UI). Use list_channels to find the id."
+                )
             return f"Error getting streams for channel {channel_id}: {e}"
 
     @mcp.tool()


### PR DESCRIPTION
Closes **8w1ba**. `GET /api/channels/{id}/streams` returned an opaque **HTTP 500** for any non-existent channel_id instead of a clean **404**.

## Root cause
`backend/routers/channels.py` `get_channel_streams` had a blanket `except Exception: raise HTTPException(500, "Internal server error")`, flattening the upstream Dispatcharr 404 into a 500. This route was the lone channel handler missing the `upstream_http_exception` mapping that ~9 siblings in the same file already use (lq38l.4 / 1wq7z.22 sweep).

## Fix
- `get_channel_streams` now applies the same `upstream_http_exception` pattern (with the `except HTTPException: raise` guard) → a missing channel returns the mapped **404**; genuine internal faults still → 500. Matches the sibling `get_channel` handler exactly.
- **MCP** `get_streams_for_channel` now detects the 404 and returns a clear message: *"Channel {id} not found (channel_id is the internal channel id, not the channel number shown in the UI). Use list_channels to find the id."* — the common trigger is passing a channel **number** (e.g. `472` = "472 | NESN") as the id.

## Verification
- **Live-repro (deployed to ecm-ecm-1 / ecm-ecm-mcp-1):** `GET /api/channels/472/streams` and `/999999/streams` → **404** ("No Channel matches the given query"); real channel `11738` → **200** with streams. MCP `get_streams_for_channel(472)` → the clean not-found message.
- **Tests:** backend `test_channels.py` → 63 passed (incl. new `test_missing_channel_returns_404_not_500` — proven to fail on the unpatched route — and `test_non_upstream_error_stays_500`); mcp-server suite → 334 passed.

Not a 0.17.2 regression — long-standing backend defect; reproduced + root-caused before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)