### PR TITLE
Re-target dev to 0.17.3-0000 (auto-creation stability patch line)

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,5 +479,5 @@ Interactive API docs are available at `/api/docs` (Swagger UI) and `/api/redoc`.
 - **v0.14.0** — Dummy EPG profiles, auto-creation pipeline, normalization engine
 - **v0.13.0** — Backend modularization (20+ routers), auth system, task engine
 
-### v0.18.0 — Next release
+### v0.17.3 — Next release
 See `CHANGELOG.md` `[Unreleased]` for the canonical list of fixes and features queued for the next cut.

--- a/backend/main.py
+++ b/backend/main.py
@@ -130,7 +130,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.0-0000",
+    version="0.17.3-0000",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.18.0-0000"
+APP_VERSION = "0.17.3-0000"
 
 REDACTED = "***REDACTED***"
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -44,7 +44,7 @@ An initial `0.16.0` build was tagged and pushed to GHCR on 2026-04-20 and then *
 
 **0.16.0 was successfully re-cut and shipped on 2026-05-12.** The shipping release incorporates everything that was intended for the first attempt plus the blocking bug fixes; see the `## [0.16.0]` entry in [`CHANGELOG.md`](../CHANGELOG.md). The `v0.16.0` tag and GHCR image from that date are the canonical promoted release — the 2026-04-20 rollback was the first attempt only, not a permanent yank of the 0.16.x line.
 
-Three further releases have since been promoted: **0.17.0** (2026-05-16), **0.17.1** (2026-05-22), and **0.17.2** (2026-05-23). `dev` now increments `BUILD` toward the next planned release as `0.18.0-NNNN` (tip is `0.18.0-0000` after the 0.17.2 cut). External users running `0.18.0-NNNN` images are on dev builds, not a promoted release; the `[Unreleased]` section of [`CHANGELOG.md`](../CHANGELOG.md) is the canonical list of fixes awaiting the next cut.
+Three further releases have since been promoted: **0.17.0** (2026-05-16), **0.17.1** (2026-05-22), and **0.17.2** (2026-05-23). `dev` now increments `BUILD` toward the next planned release as `0.17.3-NNNN` (tip is `0.17.3-0000`) — a 0.17.x patch line carrying auto-creation stability fixes ahead of the larger 0.18.0 work. External users running `0.17.3-NNNN` images are on dev builds, not a promoted release; the `[Unreleased]` section of [`CHANGELOG.md`](../CHANGELOG.md) is the canonical list of fixes awaiting the next cut.
 
 ## Where to read the version
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.0-0000",
+  "version": "0.17.3-0000",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
PO decision (2026-05-23): cut a **0.17.3** patch line carrying the auto-creation false-match + guard/audit fixes (epic `0emgo`) before moving to 0.18.0. ("Not ready to move to 0.18.0 until happier with these functions.")

- Re-points the dev build counter **`0.18.0-0000 → 0.17.3-0000`** across the 3 version touchpoints (package.json, backup.py APP_VERSION, main.py FastAPI version).
- Updates the "next release" pointer in `docs/versioning.md` and `README.md` to 0.17.3 (the 0.18.0 work is deferred).

No 0.18.0-NNNN build was ever promoted, so this is a clean re-point. 0.17.3 scope = the `0emgo` children (tagged `roadmap:v0.17.3`).