### PR TITLE
fix(auto-creation): merge-into-existing defaults to exact name match + loosen checkbox (0emgo.1)

### DIFF
--- a/backend/auto_creation_executor.py
+++ b/backend/auto_creation_executor.py
@@ -1110,6 +1110,13 @@ class ActionExecutor:
         max_streams = params.get("max_streams_per_channel", 0)  # 0 = unlimited
         find_channel_value = params.get("find_channel_value")
         remove_non_matching = params.get("remove_non_matching", False) is True
+        # bd-0emgo.1: merge_streams target=auto defaults to EXACT normalized-name
+        # equality. The legacy fuzzy cascade (core-name / deparen / word-prefix
+        # containment / call-sign) caused production over-matching (a "SKY Sport
+        # 4K" channel — core "sky sport" — absorbed 75 unrelated "Sky Sport *"
+        # streams via the word-prefix step). Set loose_name_match=True on the
+        # action to restore the legacy cascade.
+        loose_name_match = params.get("loose_name_match", False) is True
         # Effective scope group for merge lookups (GH #298). merge_streams has no
         # action group_id, so the explicit rule scope group is the only source.
         # None when scope is off or no explicit group is pinned — preserves the
@@ -1147,11 +1154,21 @@ class ActionExecutor:
                     except Exception as e:
                         logger.warning("[AUTO-CREATE-EXEC] Normalization failed for stream '%s': %s", stream_ctx.stream_name, e)
                 logger.debug("[AUTO-CREATE-EXEC] Auto-lookup by normalized name: '%s'", lookup_name)
-                channel = self._find_channel_by_name(lookup_name, scope_group_id=effective_scope_group_id)
+                # bd-0emgo.1: default to exact normalized-name equality. With
+                # exact_only=True the GH-104 re-normalize/core-name fuzzy
+                # fallbacks inside _find_channel_by_name are skipped; only the
+                # exact-key indices are consulted. loose_name_match=True restores
+                # the legacy fuzzy lookup.
+                channel = self._find_channel_by_name(
+                    lookup_name, scope_group_id=effective_scope_group_id,
+                    exact_only=not loose_name_match
+                )
 
-            # Core-name fallback: strip country prefix + quality suffix using
-            # tag groups directly (works even when normalization rules are disabled)
-            if not channel and normalization_group_ids and self._normalization_engine:
+            # Core-name fallback (LEGACY FUZZY — bd-0emgo.1): strip country prefix
+            # + quality suffix, deparenthesize, and do word-prefix containment.
+            # This is the over-matching cascade; gated behind loose_name_match so
+            # the default (exact) merge does not run it.
+            if loose_name_match and not channel and normalization_group_ids and self._normalization_engine:
                 try:
                     core_name = self._normalization_engine.extract_core_name(stream_ctx.stream_name)
                     if core_name:
@@ -1193,9 +1210,11 @@ class ActionExecutor:
                 except Exception as e:
                     logger.debug("[AUTO-CREATE-EXEC] Core name fallback failed: %s", e)
 
-            # Call-sign fallback: match local affiliates by FCC call sign
-            # (W/K + 2-3 letters) extracted from both stream and channel names
-            if not channel and normalization_group_ids and self._normalization_engine:
+            # Call-sign fallback (LEGACY FUZZY — bd-0emgo.1): match local
+            # affiliates by FCC call sign (W/K + 2-3 letters) extracted from both
+            # stream and channel names. Gated behind loose_name_match so the
+            # default (exact) merge does not run it.
+            if loose_name_match and not channel and normalization_group_ids and self._normalization_engine:
                 try:
                     cs = self._normalization_engine.extract_call_sign(stream_ctx.stream_name)
                     if cs:
@@ -2483,7 +2502,8 @@ class ActionExecutor:
             return desc
         return ""
 
-    def _find_channel_by_name(self, name: str, scope_group_id: Optional[int] = None) -> Optional[dict]:
+    def _find_channel_by_name(self, name: str, scope_group_id: Optional[int] = None,
+                              exact_only: bool = False) -> Optional[dict]:
         """Find channel by exact name (case-insensitive).
 
         Also checks the base-name mapping so that a lookup for "USA Network"
@@ -2504,6 +2524,13 @@ class ActionExecutor:
         will create a new channel in the desired group instead of merging
         across groups. Passing ``None`` (default) preserves the prior
         group-agnostic behavior.
+
+        When ``exact_only`` is True (bd-0emgo.1), only the exact-key indices are
+        consulted (created/base-name/by-name/normalized-name maps); the
+        re-normalize and core-name *fuzzy* fallbacks below are SKIPPED. This is
+        used by merge_streams target=auto to default to exact normalized-name
+        equality. ``exact_only=False`` (default) preserves the GH-104
+        duplicate-prevention fallbacks for channel CREATION.
         """
         def _in_scope(c: Optional[dict]) -> bool:
             if c is None:
@@ -2541,7 +2568,11 @@ class ActionExecutor:
         # equals the normalized form (e.g., stored "RTL", searching for
         # "RTL ᴿᴬᵂ") — symmetric to the normalized-name map above which
         # handles the opposite direction.
-        if self._normalization_engine is not None:
+        #
+        # bd-0emgo.1: skipped when exact_only=True (merge_streams target=auto
+        # default). These fuzzy fallbacks remain active for channel CREATION
+        # (exact_only=False) where they prevent duplicate channels (GH-104).
+        if not exact_only and self._normalization_engine is not None:
             try:
                 norm = self._normalization_engine.normalize(name)
                 norm_lower = (norm.normalized or "").strip().lower()

--- a/backend/auto_creation_schema.py
+++ b/backend/auto_creation_schema.py
@@ -399,6 +399,12 @@ class Action:
             if target not in ("new_channel", "existing_channel", "auto"):
                 errors.append(f"merge_streams.target must be 'new_channel', 'existing_channel', or 'auto'")
 
+            # NOTE (bd-0emgo.1): match_by is validated here and surfaced in the
+            # OpenAPI enum but is a runtime NO-OP — it is never consumed by the
+            # executor. It is retained for backward compatibility of stored
+            # rules. The control that actually selects fuzzy vs exact matching
+            # for merge_streams target=auto is the ``loose_name_match`` boolean
+            # below. Do not rely on match_by to change matching behavior.
             match_by = self.params.get("match_by", "tvg_id")
             if match_by not in ("tvg_id", "normalized_name", "stream_group"):
                 errors.append(f"merge_streams.match_by must be 'tvg_id', 'normalized_name', or 'stream_group'")
@@ -415,6 +421,16 @@ class Action:
                 errors.append("merge_streams.remove_non_matching must be a boolean")
             if "remove_non_matching" not in self.params:
                 self.params["remove_non_matching"] = False
+
+            # bd-0emgo.1: opt-in loose (legacy fuzzy) matching for target=auto.
+            # Default False — merge into existing channel uses EXACT normalized-
+            # name equality. True restores the legacy core-name / deparen /
+            # word-prefix / call-sign cascade.
+            loose_name_match = self.params.get("loose_name_match", False)
+            if loose_name_match is not None and not isinstance(loose_name_match, bool):
+                errors.append("merge_streams.loose_name_match must be a boolean")
+            if "loose_name_match" not in self.params:
+                self.params["loose_name_match"] = False
 
         # Validate assign_logo
         elif action_type == ActionType.ASSIGN_LOGO:

--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -1781,7 +1781,8 @@ async def get_auto_creation_action_schema():
             "description": "Merge multiple streams into one channel",
             "params": {
                 "target": {"type": "string", "enum": ["new_channel", "existing_channel", "auto"], "default": "auto"},
-                "match_by": {"type": "string", "enum": ["tvg_id", "normalized_name", "stream_group"], "default": "tvg_id"},
+                "match_by": {"type": "string", "enum": ["tvg_id", "normalized_name", "stream_group"], "default": "tvg_id", "description": "DEPRECATED no-op (bd-0emgo.1): validated but never consumed at runtime. Use loose_name_match to control fuzzy vs exact matching."},
+                "loose_name_match": {"type": "boolean", "default": False, "description": "When false (default), target=auto merges only on EXACT normalized-name equality. When true, restores the legacy fuzzy cascade (core-name/deparen/word-prefix/call-sign)."},
                 "find_channel_by": {"type": "string", "enum": ["name_exact", "name_regex", "tvg_id"], "optional": True},
                 "find_channel_value": {"type": "string", "optional": True},
                 "quality_preference": {"type": "array", "default": [1080, 720, 480], "description": "Quality order preference"},

--- a/backend/tests/unit/test_auto_creation_executor.py
+++ b/backend/tests/unit/test_auto_creation_executor.py
@@ -952,6 +952,119 @@ class TestActionExecutorMergeStreams:
         assert any("Would remove" in r.get("action", "") for r in results["dry_run_results"])
 
 
+class TestMergeStreamsExactDefaultMatch:
+    """Regression tests for bd-0emgo.1: merge_streams target=auto must default
+    to EXACT normalized-name equality and must NOT run the legacy fuzzy cascade
+    (core-name / deparen / word-prefix containment / call-sign) unless the
+    ``loose_name_match`` action flag is True.
+
+    Reproduces the production failure: a "SKY Sport 4K" channel (core name
+    "sky sport" because "4K" is stripped as a quality suffix) over-matched 75
+    unrelated streams ("Sky Sport Bundesliga", "SKY SPORT TENNIS", ...) because
+    "sky sport" is a leading word-prefix of all of them.
+    """
+
+    def _make_engine(self, core_map):
+        """Fake normalization engine.
+
+        ``core_map`` maps a raw name -> its core name (lowercased core used by
+        the executor's _core_name_to_channel index and the word-prefix step).
+        normalize() returns the core as the normalized form so the exact-key
+        indices (_normalized_name_to_channel) are keyed under the core too.
+        """
+        engine = MagicMock()
+
+        def _normalize(name, *args, **kwargs):
+            result = MagicMock()
+            result.normalized = core_map.get(name, name)
+            result.transformations = []
+            return result
+
+        engine.normalize.side_effect = _normalize
+        engine.extract_core_name.side_effect = lambda n: core_map.get(n, n)
+        engine.extract_call_sign.return_value = None
+        return engine
+
+    def _build(self):
+        client = MagicMock()
+        client.update_channel = AsyncMock(return_value={})
+        # Existing channel "SKY Sport 4K" — its core/normalized form is
+        # "sky sport" ("4K" stripped as a quality suffix).
+        existing = [{"id": 50, "name": "SKY Sport 4K", "streams": [],
+                     "channel_group_id": 9}]
+        core_map = {
+            "SKY Sport 4K": "sky sport",
+            # Unrelated streams that share the "sky sport" leading prefix.
+            "Sky Sport Bundesliga": "sky sport bundesliga",
+            "SKY SPORT TENNIS": "sky sport tennis",
+            "SKY SPORT 251": "sky sport 251",
+            # A genuinely-matching stream whose core equals the channel core.
+            "SKY Sport 4K UHD": "sky sport",
+        }
+        engine = self._make_engine(core_map)
+        executor = ActionExecutor(client, existing_channels=existing,
+                                  normalization_engine=engine)
+        return client, executor
+
+    def _stream(self, sid, name):
+        return StreamContext(
+            stream_id=sid,
+            stream_name=name,
+            m3u_account_id=1,
+            m3u_account_name="Provider",
+            group_name="Sports",
+            tvg_id=None,
+        )
+
+    def _merge(self, executor, stream_ctx, loose=False):
+        action = {"type": "merge_streams", "target": "auto"}
+        if loose:
+            action["loose_name_match"] = True
+        return asyncio.get_event_loop().run_until_complete(
+            executor.execute(action, stream_ctx, ExecutionContext(),
+                             normalization_group_ids=[1])
+        )
+
+    def test_default_does_not_overmatch_via_word_prefix(self):
+        """DEFAULT (exact-only): a 'Sky Sport Bundesliga' stream must NOT merge
+        into 'SKY Sport 4K' — the word-prefix containment cascade is disabled.
+        """
+        client, executor = self._build()
+        result = self._merge(executor, self._stream(201, "Sky Sport Bundesliga"))
+        # Skipped — no exact-name channel for "sky sport bundesliga".
+        assert result.skipped is True
+        client.update_channel.assert_not_called()
+
+    def test_default_does_not_overmatch_multiple_unrelated_streams(self):
+        """DEFAULT: none of the unrelated 'SKY SPORT *' streams merge."""
+        client, executor = self._build()
+        for sid, name in [(301, "SKY SPORT TENNIS"), (302, "SKY SPORT 251")]:
+            result = self._merge(executor, self._stream(sid, name))
+            assert result.skipped is True, f"{name} should not merge by default"
+        client.update_channel.assert_not_called()
+
+    def test_loose_flag_restores_word_prefix_match(self):
+        """loose_name_match=True restores the legacy fuzzy cascade: the
+        'Sky Sport Bundesliga' stream merges into 'SKY Sport 4K' (id=50).
+        """
+        client, executor = self._build()
+        result = self._merge(executor, self._stream(201, "Sky Sport Bundesliga"),
+                             loose=True)
+        assert result.success is True
+        client.update_channel.assert_called()
+        assert client.update_channel.call_args[0][0] == 50
+
+    def test_exact_normalized_name_merges_by_default(self):
+        """DEFAULT: a stream whose normalized/core name EXACTLY equals the
+        channel's ('sky sport') DOES merge into 'SKY Sport 4K'.
+        """
+        client, executor = self._build()
+        result = self._merge(executor, self._stream(401, "SKY Sport 4K UHD"))
+        assert result.success is True
+        client.update_channel.assert_called()
+        assert client.update_channel.call_args[0][0] == 50
+
+
 class TestActionExecutorPropertyActions:
     """Tests for property assignment actions."""
 

--- a/backend/tests/unit/test_auto_creation_schema.py
+++ b/backend/tests/unit/test_auto_creation_schema.py
@@ -355,6 +355,32 @@ class TestActionValidation:
         assert len(errors) > 0
         assert "find_channel_by" in errors[0]
 
+    def test_merge_streams_loose_name_match_defaults_false(self):
+        """bd-0emgo.1: loose_name_match defaults to False when omitted."""
+        action = Action(type="merge_streams", params={"target": "auto"})
+        errors = action.validate()
+        assert len(errors) == 0
+        assert action.params["loose_name_match"] is False
+
+    def test_merge_streams_loose_name_match_accepts_bool(self):
+        """bd-0emgo.1: loose_name_match accepts an explicit boolean."""
+        action = Action(
+            type="merge_streams",
+            params={"target": "auto", "loose_name_match": True},
+        )
+        errors = action.validate()
+        assert len(errors) == 0
+        assert action.params["loose_name_match"] is True
+
+    def test_merge_streams_loose_name_match_rejects_non_bool(self):
+        """bd-0emgo.1: loose_name_match must be a boolean."""
+        action = Action(
+            type="merge_streams",
+            params={"target": "auto", "loose_name_match": "yes"},
+        )
+        errors = action.validate()
+        assert any("loose_name_match" in e for e in errors)
+
     def test_valid_assign_logo(self):
         """Validates assign_logo action."""
         action = Action(

--- a/frontend/src/components/autoCreation/ActionEditor.test.tsx
+++ b/frontend/src/components/autoCreation/ActionEditor.test.tsx
@@ -207,6 +207,50 @@ describe('ActionEditor', () => {
 
       expect(screen.getByLabelText(/find.*value/i)).toHaveValue('ESPN');
     });
+
+    it('renders the loose name matching checkbox, unchecked by default', () => {
+      render(
+        <ActionEditor
+          action={{ type: 'merge_streams', target: 'auto' }}
+          onChange={vi.fn()}
+          onRemove={vi.fn()}
+        />
+      );
+
+      const checkbox = screen.getByLabelText(/loose name matching/i);
+      expect(checkbox).toBeInTheDocument();
+      expect(checkbox).not.toBeChecked();
+    });
+
+    it('reflects loose_name_match=true as a checked checkbox', () => {
+      render(
+        <ActionEditor
+          action={{ type: 'merge_streams', target: 'auto', loose_name_match: true }}
+          onChange={vi.fn()}
+          onRemove={vi.fn()}
+        />
+      );
+
+      expect(screen.getByLabelText(/loose name matching/i)).toBeChecked();
+    });
+
+    it('includes loose_name_match in the payload when toggled on', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <ActionEditor
+          action={{ type: 'merge_streams', target: 'auto' }}
+          onChange={onChange}
+          onRemove={vi.fn()}
+        />
+      );
+
+      await user.click(screen.getByLabelText(/loose name matching/i));
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'merge_streams', loose_name_match: true })
+      );
+    });
   });
 
   describe('assign_logo action', () => {

--- a/frontend/src/components/autoCreation/ActionEditor.tsx
+++ b/frontend/src/components/autoCreation/ActionEditor.tsx
@@ -878,6 +878,22 @@ export function ActionEditor({
                 When enabled, the target channel is kept in sync: after this run, it will keep only the streams that were merged into that channel during this run (removing stale streams that no longer match).
               </span>
             </div>
+
+            <div className="action-field">
+              <label className="transform-toggle">
+                <input
+                  type="checkbox"
+                  checked={!!action.loose_name_match}
+                  onChange={e => onChange({ ...action, loose_name_match: e.target.checked })}
+                  disabled={readonly}
+                  aria-label="Loose name matching (legacy fuzzy)"
+                />
+                Loose name matching (legacy fuzzy)
+              </label>
+              <span className="field-hint">
+                Off (default): a stream merges into an existing channel only when its normalized name exactly matches. On: restores the older fuzzy matching (core-name, parentheses, word-prefix, call-sign) — this can over-match unrelated streams.
+              </span>
+            </div>
           </>
         )}
 

--- a/frontend/src/types/autoCreation.ts
+++ b/frontend/src/types/autoCreation.ts
@@ -120,6 +120,13 @@ export interface Action {
   max_streams_per_channel?: number;
   /** When true, remove streams from the target channel that no longer match this rule run. */
   remove_non_matching?: boolean;
+  /**
+   * merge_streams target=auto matching mode (bd-0emgo.1). When false/undefined
+   * (default), the stream merges into an existing channel only on EXACT
+   * normalized-name equality. When true, restores the legacy fuzzy cascade
+   * (core-name / deparen / word-prefix containment / call-sign).
+   */
+  loose_name_match?: boolean;
   message?: string;
   // Name transform (for create_channel and create_group)
   name_transform_pattern?: string;

--- a/mcp-server/tests/test_loose_name_match_passthrough.py
+++ b/mcp-server/tests/test_loose_name_match_passthrough.py
@@ -1,0 +1,120 @@
+"""TDD tests for bd-0emgo.1 — merge_streams loose_name_match pass-through (MCP).
+
+The ``loose_name_match`` flag is a per-action param that lives inside a
+merge_streams action dict. create_auto_creation_rule / update_auto_creation_rule
+forward the ``actions`` list verbatim to the backend, so the flag rides through
+untouched (like find_channel_by / remove_non_matching). These tests pin that
+behavior so a future refactor that strips/filters action params is caught.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+def _make_mock(return_value=None):
+    mock = AsyncMock()
+    mock.call_endpoint.return_value = return_value if return_value is not None else {}
+    return mock
+
+
+def _register_and_get_mcp():
+    from tools.auto_creation import register
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP("test")
+    register(mcp)
+    return mcp
+
+
+def _sent_payload(mock_client):
+    """Return the body dict passed to the (single) call_endpoint invocation."""
+    call = mock_client.call_endpoint.call_args
+    return call.kwargs.get("body")
+
+
+class TestLooseNameMatchPassthroughCreate:
+    """create_auto_creation_rule forwards loose_name_match inside the action."""
+
+    @pytest.mark.asyncio
+    async def test_loose_name_match_true_survives_to_payload(self):
+        mcp = _register_and_get_mcp()
+        mock_client = _make_mock(return_value={"rule": {"id": 7}})
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "loose_name_match": True,
+        }
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            await mcp.call_tool(
+                "create_auto_creation_rule",
+                {
+                    "name": "Sky Sport merge (loose)",
+                    "conditions": [{"type": "always"}],
+                    "actions": [action],
+                },
+            )
+
+        payload = _sent_payload(mock_client)
+        assert payload is not None
+        sent_action = payload["actions"][0]
+        assert sent_action["type"] == "merge_streams"
+        assert sent_action["loose_name_match"] is True
+
+    @pytest.mark.asyncio
+    async def test_loose_name_match_false_survives_to_payload(self):
+        mcp = _register_and_get_mcp()
+        mock_client = _make_mock(return_value={"rule": {"id": 8}})
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "loose_name_match": False,
+        }
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            await mcp.call_tool(
+                "create_auto_creation_rule",
+                {
+                    "name": "Sky Sport merge (exact)",
+                    "conditions": [{"type": "always"}],
+                    "actions": [action],
+                },
+            )
+
+        sent_action = _sent_payload(mock_client)["actions"][0]
+        assert sent_action["loose_name_match"] is False
+
+
+class TestLooseNameMatchPassthroughUpdate:
+    """update_auto_creation_rule forwards loose_name_match inside the action."""
+
+    @pytest.mark.asyncio
+    async def test_update_forwards_loose_name_match(self):
+        mcp = _register_and_get_mcp()
+        mock_client = _make_mock(return_value={"rule": {"id": 9}})
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "loose_name_match": True,
+        }
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            await mcp.call_tool(
+                "update_auto_creation_rule",
+                {"rule_id": 9, "actions": [action]},
+            )
+
+        payload = _sent_payload(mock_client)
+        assert payload is not None
+        sent_action = payload["actions"][0]
+        assert sent_action["loose_name_match"] is True
+
+
+class TestLooseNameMatchContract:
+    """The flag rides inside the top-level ``actions`` field, which IS in the
+    create/update contract — no per-action contract entry is required."""
+
+    def test_actions_is_in_create_contract(self):
+        from _endpoint_contracts import ENDPOINTS
+
+        assert "actions" in ENDPOINTS["ac_create_rule"].request_fields
+        assert "actions" in ENDPOINTS["ac_update_rule"].request_fields

--- a/mcp-server/tools/auto_creation.py
+++ b/mcp-server/tools/auto_creation.py
@@ -455,7 +455,15 @@ def register(mcp: FastMCP):
                   create_group — params: name_template, if_exists (skip/use_existing)
                   create_channel — params: name_template, if_exists (skip/merge/merge_only/update),
                                    channel_number (e.g. "800-99999" for range)
-                  merge_streams — params: name_template, match_by (tvg_id/normalized_name/stream_group)
+                  merge_streams — params: target (auto/existing_channel/new_channel),
+                                   find_channel_by (name_exact/name_regex/tvg_id) + find_channel_value,
+                                   max_streams_per_channel, remove_non_matching (bool),
+                                   loose_name_match (bool, default false). With target=auto the
+                                   stream merges into an existing channel only on EXACT normalized-
+                                   name equality; set loose_name_match=true to restore the legacy
+                                   fuzzy cascade (core-name/deparen/word-prefix/call-sign).
+                                   NOTE: match_by is a DEPRECATED no-op (validated but never
+                                   consumed at runtime) — use loose_name_match to control matching.
                   assign_logo — params: value (URL or empty for stream logo)
                   assign_tvg_id — params: value
                   assign_epg — params: epg_id, set_tvg_id (bool)


### PR DESCRIPTION
Closes **0emgo.1** (epic 0emgo, roadmap:v0.17.3). Fixes the primary cause of the production false-merge incident (1,341 merges / 726 channels).

## Root cause
`merge_streams target=auto` (merge a stream into an existing channel) ran a fixed fuzzy cascade whose **bidirectional word-prefix containment** step (`auto_creation_executor.py` ~1180) over-matched: "SKY Sport 4K" (core "sky sport") swallowed "Sky Sport Bundesliga", "SKY SPORT TENNIS", etc. Also: `match_by` was a silent **no-op**.

## Fix (PO-decided: default exact, with a loosen checkbox)
- **Default = exact normalized-name equality** for the auto merge-into-existing match (`_find_channel_by_name(..., exact_only=True)` — exact-key indices only; the core-name/deparen/word-prefix/call-sign fallbacks no longer run by default).
- **New `loose_name_match` flag** (per-action on `merge_streams`, default `False`) restores the legacy fuzzy cascade when checked.
- **GH-104 untouched:** the duplicate-channel-prevention fallbacks on channel *creation* keep their fuzzy behavior (`exact_only` defaults False; only the merge-into-existing target match changed).
- Threaded through **schema → executor**, **MCP** (`create/update_auto_creation_rule` accept the flag), and a **checkbox in the rule builder** (`ActionEditor.tsx`). `match_by` left as a documented no-op (separate cleanup).

## Verification
- **Tests:** new `TestMergeStreamsExactDefaultMatch` reproduces the SKY-Sport over-match — **proven to FAIL on unpatched code** (streams wrongly merged) and PASS after (default skips them; `loose_name_match=True` restores the merge). GH-104 dedup-on-create tests stay green. Backend auto-creation sweep **299 passed**; MCP **338 passed**; frontend `ActionEditor` **50 passed** + tsc clean.
- **Live (deployed to ecm-ecm-1 / ecm-ecm-mcp-1):** created a rule via MCP with `loose_name_match: true`; confirmed the deployed backend persists it end-to-end (raw rule JSON: `"loose_name_match": true`); cleaned up.

ECM-layer (matching) + MCP (param) + frontend (checkbox). No Dispatcharr change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)