### PR TITLE
feat(auto-creation): per-merge journal audit for run recoverability (0emgo.5)

### DIFF
--- a/backend/auto_creation_engine.py
+++ b/backend/auto_creation_engine.py
@@ -1007,6 +1007,11 @@ class AutoCreationEngine:
             # the bulk-M3U dedup hook in _execute_create_channel only
             # fires for the M3U-refresh path per ADR-008 §D1.
             triggered_by=triggered_by,
+            # bd-0emgo.5: thread the execution_id so each LIVE merge writes
+            # a journal entry tagged batch_id=str(execution_id), giving an
+            # operator a queryable (channel_id, stream_id) audit trail to
+            # recover from a bad run via get_journal(batch_id=...).
+            execution_id=execution.id,
         )
 
         # Results tracking

--- a/backend/auto_creation_executor.py
+++ b/backend/auto_creation_executor.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 import re
 
 import safe_regex
+import journal
 from auto_creation_schema import Action, ActionType, TemplateVariables
 from auto_creation_evaluator import StreamContext
 
@@ -132,7 +133,7 @@ class ActionExecutor:
     def __init__(self, client, existing_channels: list = None, existing_groups: list = None,
                  normalization_engine=None, settings=None, all_profile_ids: list = None,
                  epg_data: list = None, epg_sources: list = None,
-                 triggered_by: str = "manual"):
+                 triggered_by: str = "manual", execution_id: int | None = None):
         """
         Initialize the executor.
 
@@ -152,6 +153,14 @@ class ActionExecutor:
                 per ADR-008 §D1. Defaults to "manual" so non-engine
                 callers (and existing tests that construct executors
                 directly) keep their pre-BD-F behaviour.
+            execution_id: The ``AutoCreationExecution.id`` for this run,
+                threaded from the engine. Used as the journal ``batch_id``
+                so an operator can list every ``(channel_id, stream_id)``
+                pair a run touched via ``get_journal(batch_id=...)`` and
+                recover from a bad merge (bd-0emgo.5). ``None`` (the default
+                for direct-construct callers/tests) disables the per-merge
+                journal write — entries without an execution_id would be
+                unrecoverable noise.
         """
         self.client = client
         self.existing_channels = existing_channels or []
@@ -160,6 +169,7 @@ class ActionExecutor:
         self._settings = settings
         self._all_profile_ids = all_profile_ids or []
         self._triggered_by = triggered_by
+        self._execution_id = execution_id
 
         # Build EPG data lookup: epg_source_id -> list of data entries
         self._epg_data_by_source: dict[int, list[dict]] = {}
@@ -919,6 +929,20 @@ class ActionExecutor:
             _track_m3u_count()
             exec_ctx.current_channel_id = channel_id
 
+            # bd-0emgo.5: per-merge journal entry for lightweight
+            # recoverability. Tagging each LIVE merge with
+            # batch_id=str(execution_id) lets an operator list every
+            # (channel_id, stream_id) pair a run touched via
+            # get_journal(batch_id=...) and revert a bad run. STREAM IDs
+            # ONLY in before/after — never URLs/objects (they embed
+            # provider credentials). Skipped when no execution_id was
+            # threaded in (direct-construct callers): such entries would
+            # be uncorrelatable noise. Dry-run never reaches here.
+            self._journal_merge(
+                channel_id, channel_name, stream_ctx.stream_id,
+                current_streams, new_streams,
+            )
+
             return ActionResult(
                 success=True,
                 action_type="merge_stream",
@@ -937,6 +961,40 @@ class ActionExecutor:
                 action_type="merge_stream",
                 description=f"Failed to add stream to channel",
                 error=str(e)
+            )
+
+    def _journal_merge(self, channel_id: int, channel_name: str, stream_id: int,
+                       before_ids: list, after_ids: list) -> None:
+        """Write a per-merge journal entry for an executed LIVE merge (bd-0emgo.5).
+
+        Tags the entry with ``batch_id=str(execution_id)`` so an operator can
+        list every ``(channel_id, stream_id)`` pair a run touched and recover
+        from a bad merge. ``before_value``/``after_value`` carry STREAM IDs
+        ONLY — never URLs/objects, which embed provider credentials. A failed
+        journal write must never break the merge, so failures are logged and
+        swallowed (``journal.log_entry`` already does this internally; this is
+        defense-in-depth).
+        """
+        if self._execution_id is None:
+            # No execution_id threaded in (direct-construct callers): an
+            # uncorrelatable entry would be recovery noise, so skip.
+            return
+        try:
+            journal.log_entry(
+                category="auto_creation",
+                action_type="merge_stream",
+                entity_id=channel_id,
+                entity_name=channel_name,
+                description="Merged stream %s into channel '%s'" % (stream_id, channel_name),
+                before_value={"stream_ids": list(before_ids)},
+                after_value={"stream_ids": list(after_ids)},
+                user_initiated=False,
+                batch_id=str(self._execution_id),
+            )
+        except Exception as e:
+            logger.warning(
+                "[AUTO-CREATE-EXEC] Failed to journal merge of stream %s into channel '%s': %s",
+                stream_id, channel_name, e,
             )
 
     async def _update_channel(self, channel: dict, stream_ctx: StreamContext,

--- a/backend/routers/journal.py
+++ b/backend/routers/journal.py
@@ -27,7 +27,7 @@ async def get_journal_entries(
     user_initiated: Optional[bool] = None,
     batch_id: Optional[str] = Query(
         None,
-        description="Filter to a single bulk operation's journal rows (8-char batch_id from bulk handlers, e.g. POST /api/auto-creation/rules/bulk-update). Indexed lookup via idx_journal_batch_id.",
+        description="Filter to a single batched operation's journal rows. Either an 8-char batch_id from bulk handlers (e.g. POST /api/auto-creation/rules/bulk-update) or an auto-creation run's execution_id (as a string) for per-merge audit rows written by the executor (bd-0emgo.5). Indexed lookup via idx_journal_batch_id.",
     ),
 ):
     """Query journal entries with filtering and pagination."""

--- a/backend/tests/unit/test_auto_creation_executor.py
+++ b/backend/tests/unit/test_auto_creation_executor.py
@@ -4,7 +4,7 @@ Unit tests for the auto-creation executor service.
 Tests the ActionExecutor class which executes actions against channels, groups,
 and streams with proper rollback tracking.
 """
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock, AsyncMock, patch
 import asyncio
 
 from auto_creation_executor import (
@@ -2391,3 +2391,209 @@ class TestCreateChannelSuperscriptStripping:
         posted = client.create_channel.call_args[0][0]
         assert "²" not in posted["name"]  # ² stripped/converted
         assert posted["name"] == "ESPN2"
+
+
+class TestMergeJournalEntry:
+    """bd-0emgo.5: per-merge journal entry for lightweight recoverability.
+
+    Each LIVE merge in ``_add_stream_to_channel`` must write one
+    ``auto_creation``/``merge_stream`` journal entry tagged with
+    ``batch_id=str(execution_id)`` so an operator can later list every
+    ``(channel_id, stream_id)`` pair a run touched via
+    ``get_journal(batch_id=...)``. STREAM IDs ONLY in before/after — never
+    stream URLs/objects (they embed provider credentials). Dry-run writes
+    nothing.
+    """
+
+    def setup_method(self):
+        self.client = MagicMock()
+        self.client.update_channel = AsyncMock()
+        self.channels = [
+            {"id": 1, "name": "ESPN", "tvg_id": "ESPN.US",
+             "channel_number": 100, "streams": [101]},
+        ]
+        self.stream_ctx = StreamContext(
+            stream_id=201,
+            stream_name="ESPN HD Backup",
+            stream_url="http://provider.example/secret-token/201.ts",
+            m3u_account_id=1,
+            m3u_account_name="Provider A",
+            tvg_id="ESPN.US",
+        )
+
+    def _run_live_merge(self, execution_id):
+        executor = ActionExecutor(
+            self.client,
+            existing_channels=self.channels,
+            execution_id=execution_id,
+        )
+        action = {
+            "type": "merge_streams",
+            "target": "existing_channel",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "ESPN",
+        }
+        exec_ctx = ExecutionContext()  # dry_run defaults to False (live)
+        return asyncio.get_event_loop().run_until_complete(
+            executor.execute(action, self.stream_ctx, exec_ctx)
+        )
+
+    def test_live_merge_writes_one_journal_entry(self):
+        """A live merge writes exactly one auto_creation/merge_stream entry."""
+        with patch("auto_creation_executor.journal.log_entry") as mock_log:
+            result = self._run_live_merge(execution_id=42)
+
+        assert result.success is True
+        assert result.modified is True
+        mock_log.assert_called_once()
+        kwargs = mock_log.call_args.kwargs
+        assert kwargs["category"] == "auto_creation"
+        assert kwargs["action_type"] == "merge_stream"
+        assert kwargs["entity_id"] == 1  # channel_id
+        assert kwargs["entity_name"] == "ESPN"
+        assert kwargs["user_initiated"] is False
+
+    def test_journal_batch_id_is_execution_id(self):
+        """batch_id carries the run's execution_id (as a string)."""
+        with patch("auto_creation_executor.journal.log_entry") as mock_log:
+            self._run_live_merge(execution_id=42)
+
+        kwargs = mock_log.call_args.kwargs
+        assert kwargs["batch_id"] == "42"
+
+    def test_journal_before_after_carry_stream_ids_only(self):
+        """before/after hold stream IDs only — never URLs/objects (creds)."""
+        with patch("auto_creation_executor.journal.log_entry") as mock_log:
+            self._run_live_merge(execution_id=42)
+
+        kwargs = mock_log.call_args.kwargs
+        before = kwargs["before_value"]
+        after = kwargs["after_value"]
+        assert before == {"stream_ids": [101]}
+        assert after == {"stream_ids": [101, 201]}
+        # Credential safety: the provider token must not leak anywhere.
+        serialized = repr(kwargs)
+        assert "secret-token" not in serialized
+        assert "http" not in serialized
+
+    def test_journal_round_trip_recovers_channel_stream_pair(self):
+        """The (channel_id, stream_id) pair is recoverable from the entry."""
+        with patch("auto_creation_executor.journal.log_entry") as mock_log:
+            self._run_live_merge(execution_id=42)
+
+        kwargs = mock_log.call_args.kwargs
+        channel_id = kwargs["entity_id"]
+        before_ids = set(kwargs["before_value"]["stream_ids"])
+        after_ids = set(kwargs["after_value"]["stream_ids"])
+        merged_stream_ids = after_ids - before_ids
+        assert channel_id == 1
+        assert merged_stream_ids == {201}
+
+    def test_dry_run_writes_no_journal_entry(self):
+        """A dry-run merge writes NOTHING to the journal."""
+        executor = ActionExecutor(
+            self.client,
+            existing_channels=self.channels,
+            execution_id=42,
+        )
+        action = {
+            "type": "merge_streams",
+            "target": "existing_channel",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "ESPN",
+        }
+        exec_ctx = ExecutionContext(dry_run=True)
+        with patch("auto_creation_executor.journal.log_entry") as mock_log:
+            result = asyncio.get_event_loop().run_until_complete(
+                executor.execute(action, self.stream_ctx, exec_ctx)
+            )
+
+        assert result.success is True
+        assert "Would add" in result.description
+        self.client.update_channel.assert_not_called()
+        mock_log.assert_not_called()
+
+    def test_multi_merge_run_writes_one_entry_per_merge(self):
+        """A run merging N streams writes N entries, all sharing batch_id."""
+        executor = ActionExecutor(
+            self.client,
+            existing_channels=self.channels,
+            execution_id=7,
+        )
+        action = {
+            "type": "merge_streams",
+            "target": "existing_channel",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "ESPN",
+        }
+        exec_ctx = ExecutionContext()
+        stream_ctxs = [
+            StreamContext(stream_id=sid, stream_name=f"S{sid}",
+                          m3u_account_id=1, tvg_id="ESPN.US")
+            for sid in (301, 302, 303)
+        ]
+        with patch("auto_creation_executor.journal.log_entry") as mock_log:
+            for sc in stream_ctxs:
+                asyncio.get_event_loop().run_until_complete(
+                    executor.execute(action, sc, exec_ctx)
+                )
+
+        assert mock_log.call_count == 3
+        batch_ids = {c.kwargs["batch_id"] for c in mock_log.call_args_list}
+        assert batch_ids == {"7"}
+
+    def test_no_execution_id_skips_journal(self):
+        """Without an execution_id (direct-construct callers) no entry is written.
+
+        execution_id is the audit-correlation primitive; entries without it
+        would be unrecoverable noise, so the executor skips the journal write
+        when no execution_id was threaded in (default None).
+        """
+        executor = ActionExecutor(
+            self.client,
+            existing_channels=self.channels,
+        )  # no execution_id
+        action = {
+            "type": "merge_streams",
+            "target": "existing_channel",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "ESPN",
+        }
+        exec_ctx = ExecutionContext()
+        with patch("auto_creation_executor.journal.log_entry") as mock_log:
+            result = asyncio.get_event_loop().run_until_complete(
+                executor.execute(action, self.stream_ctx, exec_ctx)
+            )
+
+        assert result.success is True
+        mock_log.assert_not_called()
+
+    def test_already_present_stream_writes_no_journal_entry(self):
+        """Re-merging an already-present stream is a skip — no journal entry."""
+        executor = ActionExecutor(
+            self.client,
+            existing_channels=self.channels,
+            execution_id=42,
+        )
+        stream_ctx = StreamContext(
+            stream_id=101,  # already in channel 1
+            stream_name="ESPN",
+            m3u_account_id=1,
+            tvg_id="ESPN.US",
+        )
+        action = {
+            "type": "merge_streams",
+            "target": "existing_channel",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "ESPN",
+        }
+        exec_ctx = ExecutionContext()
+        with patch("auto_creation_executor.journal.log_entry") as mock_log:
+            result = asyncio.get_event_loop().run_until_complete(
+                executor.execute(action, stream_ctx, exec_ctx)
+            )
+
+        assert result.success is True
+        assert result.skipped is True
+        self.client.update_channel.assert_not_called()
+        mock_log.assert_not_called()

--- a/backend/tests/unit/test_journal.py
+++ b/backend/tests/unit/test_journal.py
@@ -296,6 +296,97 @@ class TestGetEntries:
             assert page1["total_pages"] == 2
 
 
+class TestAutoCreationMergeJournalRoundTrip:
+    """bd-0emgo.5: end-to-end round-trip — a LIVE auto-creation merge writes a
+    real journal entry recoverable via get_entries(batch_id=...).
+
+    Unlike the executor unit tests (which mock journal.log_entry), this drives
+    the executor against the real journal module + a test DB session, then
+    queries by batch_id to confirm the (channel_id, stream_id) audit trail an
+    operator would use to recover from a bad run.
+    """
+
+    def _run_live_merge(self, execution_id, stream_id, channel):
+        import asyncio
+        from unittest.mock import MagicMock, AsyncMock
+        from auto_creation_executor import ActionExecutor, ExecutionContext
+        from auto_creation_evaluator import StreamContext
+
+        client = MagicMock()
+        client.update_channel = AsyncMock()
+        executor = ActionExecutor(
+            client,
+            existing_channels=[channel],
+            execution_id=execution_id,
+        )
+        stream_ctx = StreamContext(
+            stream_id=stream_id,
+            stream_name=f"Stream {stream_id}",
+            stream_url=f"http://provider.example/secret-token/{stream_id}.ts",
+            m3u_account_id=1,
+            tvg_id="ESPN.US",
+        )
+        action = {
+            "type": "merge_streams",
+            "target": "existing_channel",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "ESPN",
+        }
+        return asyncio.get_event_loop().run_until_complete(
+            executor.execute(action, stream_ctx, ExecutionContext())
+        )
+
+    def test_live_merge_round_trips_through_journal_by_batch_id(self, test_session):
+        """A live merge entry is queryable by its execution_id batch_id."""
+        from journal import get_entries
+
+        channel = {"id": 1, "name": "ESPN", "tvg_id": "ESPN.US",
+                   "channel_number": 100, "streams": [101]}
+
+        with patch("journal.get_session", return_value=test_session):
+            result = self._run_live_merge(execution_id=555, stream_id=201,
+                                          channel=channel)
+            assert result.success is True
+
+            entries = get_entries(batch_id="555")
+
+        assert entries["count"] == 1
+        row = entries["results"][0]
+        assert row["category"] == "auto_creation"
+        assert row["action_type"] == "merge_stream"
+        assert row["entity_id"] == 1  # channel_id
+        assert row["batch_id"] == "555"
+        assert row["user_initiated"] is False
+        # Stream IDs recoverable from before/after (to_dict parses the JSON);
+        # no credentials leaked.
+        assert row["before_value"] == {"stream_ids": [101]}
+        assert row["after_value"] == {"stream_ids": [101, 201]}
+        assert "secret-token" not in json.dumps(row)
+
+    def test_multi_merge_run_groups_all_pairs_under_one_batch_id(self, test_session):
+        """All pairs a run touched are recoverable under the shared batch_id."""
+        from journal import get_entries
+
+        # Two channels, two live merges in the same run (execution_id=777).
+        ch_a = {"id": 10, "name": "ESPN", "tvg_id": "ESPN.US",
+                "channel_number": 100, "streams": [1001]}
+        ch_b = {"id": 20, "name": "ESPN", "tvg_id": "ESPN.US",
+                "channel_number": 101, "streams": []}
+
+        with patch("journal.get_session", return_value=test_session):
+            self._run_live_merge(execution_id=777, stream_id=2001, channel=ch_a)
+            self._run_live_merge(execution_id=777, stream_id=2002, channel=ch_b)
+
+            entries = get_entries(batch_id="777")
+
+        assert entries["count"] == 2
+        pairs = {
+            (r["entity_id"], r["after_value"]["stream_ids"][-1])
+            for r in entries["results"]
+        }
+        assert pairs == {(10, 2001), (20, 2002)}
+
+
 class TestGetStats:
     """Tests for get_stats() function."""
 

--- a/mcp-server/tests/test_lq38l_journal_and_nits.py
+++ b/mcp-server/tests/test_lq38l_journal_and_nits.py
@@ -129,6 +129,53 @@ class TestJournalEnvelope:
             result = await mcp.call_tool("get_journal", {})
         assert "m3u/refresh: Prov" in result[0][0].text
 
+    @pytest.mark.asyncio
+    async def test_batch_id_passed_through_to_backend_query(self):
+        """bd-0emgo.5: get_journal(batch_id=...) filters by the run's
+        execution_id so an operator can recover a bad auto-creation merge."""
+        mcp = _register("system")
+        envelope = {
+            "count": 1,
+            "page": 1,
+            "page_size": 20,
+            "total_pages": 1,
+            "results": [
+                {
+                    "id": 9,
+                    "timestamp": "2026-05-22T12:00:00Z",
+                    "category": "auto_creation",
+                    "action_type": "merge_stream",
+                    "entity_id": 1,
+                    "entity_name": "ESPN",
+                    "description": "Merged stream 201 into channel 'ESPN'",
+                    "batch_id": "555",
+                },
+            ],
+        }
+        mock_client = _client(return_value=envelope)
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "get_journal", {"limit": 20, "batch_id": "555"}
+            )
+
+        # The batch_id must reach the backend journal_list query.
+        _, call_kwargs = mock_client.call_endpoint.call_args
+        assert call_kwargs["query"]["batch_id"] == "555"
+        # And the merge row renders.
+        text = result[0][0].text
+        assert "auto_creation/merge_stream: ESPN" in text
+
+    @pytest.mark.asyncio
+    async def test_batch_id_omitted_when_not_provided(self):
+        """No batch_id arg means no batch_id key in the backend query."""
+        mcp = _register("system")
+        mock_client = _client(return_value={"count": 0, "results": []})
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            await mcp.call_tool("get_journal", {"limit": 5})
+
+        _, call_kwargs = mock_client.call_endpoint.call_args
+        assert "batch_id" not in call_kwargs["query"]
+
 
 # ===========================================================================
 # lq38l.13 #1 — channel numbers render as ints (no trailing .0)

--- a/mcp-server/tools/system.py
+++ b/mcp-server/tools/system.py
@@ -127,12 +127,18 @@ def register(mcp: FastMCP):
     async def get_journal(
         limit: int = 20,
         category: str | None = None,
+        batch_id: str | None = None,
     ) -> str:
         """Get recent entries from the ECM activity journal/audit log.
 
         Args:
             limit: Number of entries to return (default 20)
             category: Filter by category (e.g., 'channels', 'm3u', 'epg', 'settings')
+            batch_id: Filter to a single batched operation's rows. For an
+                auto-creation run this is the run's execution_id (as a string),
+                so an operator recovering from a bad merge can list every
+                (channel_id, stream_id) pair the run touched (bd-0emgo.5).
+                Also matches the 8-char batch_id from bulk handlers.
         """
         try:
             client = get_ecm_client()
@@ -142,6 +148,10 @@ def register(mcp: FastMCP):
             query = {"page_size": limit}
             if category:
                 query["category"] = category
+            if batch_id:
+                # Indexed filter (idx_journal_batch_id) — passed through to the
+                # backend journal_list endpoint's batch_id query param.
+                query["batch_id"] = batch_id
             entries = await client.call_endpoint(ENDPOINTS["journal_list"], query=query)
 
             # Backend GET /api/journal returns a paginated envelope


### PR DESCRIPTION
Closes **0emgo.5** (epic 0emgo, roadmap:v0.17.3). The lightweight standalone recoverability win from the production false-merge incident.

## Problem
Auto-creation runs wrote **no per-merge audit** — after a bad merge run, an operator couldn't recover which `(channel_id, stream_id)` pairs to revert (journal only logged rule lifecycle; logs are an in-memory ring buffer that rotates fast).

## Fix
- On each **live** merge in `auto_creation_executor._add_stream_to_channel`, write a journal entry: `category="auto_creation"`, `action_type="merge_stream"`, `entity_id=channel_id`, `before_value`/`after_value` = **stream IDs only** (never URLs — credential safety), `user_initiated=False`, **`batch_id=str(execution_id)`**.
- `execution_id` is threaded from the engine (the `AutoCreationExecution` row) into the executor → the merge site.
- So `get_journal(batch_id="<execution_id>")` returns every `(channel_id, stream_id)` a run touched — the revert trail.
- **Dry-run writes nothing** (no changes). Both `merge_stream` and `merge_streams` paths route through the same site, so both are journaled.
- **MCP** `get_journal` gains an optional `batch_id` filter (passthrough to the backend, which already indexed `batch_id`).
- Out of scope (→ epic `uc51o`): unwind-on-rollback and a per-pair table. This is the journal slice only.

## Verification
- **Tests:** real-journal round-trip (`test_journal.py::TestAutoCreationMergeJournalRoundTrip`) — executor merge → actual `journal.log_entry` → `get_entries(batch_id)` returns the run's pairs; `TestMergeJournalEntry` (entry shape, stream-IDs-only + no-credential-leak, dry-run-writes-nothing, multi-merge shares batch_id). 148 backend + 340 MCP passing.
- **Live (deployed):** MCP `get_journal(batch_id=…)` passthrough confirmed against the backend (filters; tool unaffected otherwise). Full live-merge-on-data is operator-side (production is where merges occur).

ECM (journal/executor) + MCP (filter). No Dispatcharr change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)