### PR TITLE
feat(auto-creation): target-channel group filter for merge_streams (0emgo.3)

### DIFF
--- a/backend/auto_creation_executor.py
+++ b/backend/auto_creation_executor.py
@@ -1175,6 +1175,17 @@ class ActionExecutor:
         # streams via the word-prefix step). Set loose_name_match=True on the
         # action to restore the legacy cascade.
         loose_name_match = params.get("loose_name_match", False) is True
+        # bd-0emgo.3: TARGET-CHANNEL group filter (post-resolution reject).
+        # Distinct from the stream-side normalized_name_[not_]in_group
+        # conditions (which only gate whether the rule FIRES). These constrain
+        # which existing channel the merge may land in, by the RESOLVED
+        # channel's channel_group_id. Absent/empty list = no filter (back-
+        # compat). target_channel_not_in_group = "merge anywhere EXCEPT these
+        # groups" (primary); target_channel_in_group = "only merge into these
+        # groups" (complement). Applied AFTER resolution, mirroring the GH #298
+        # scope reject below.
+        target_channel_not_in_group = params.get("target_channel_not_in_group") or []
+        target_channel_in_group = params.get("target_channel_in_group") or []
         # Effective scope group for merge lookups (GH #298). merge_streams has no
         # action group_id, so the explicit rule scope group is the only source.
         # None when scope is off or no explicit group is pinned — preserves the
@@ -1302,6 +1313,55 @@ class ActionExecutor:
                     channel.get('channel_group_id'), effective_scope_group_id
                 )
                 channel = None
+
+            # bd-0emgo.3: TARGET-CHANNEL group filter (post-resolution reject).
+            # Mirrors the GH #298 scope reject above, but instead of folding the
+            # rejected candidate into the generic "not found" path it returns an
+            # explicit skip with a clear reason so the operator sees WHY the
+            # merge was withheld. Whatever resolution path produced the
+            # candidate, if the resolved channel's group is excluded (or not in
+            # the allow-list), the merge is skipped — this is the guard the
+            # stream-side conditions could never provide.
+            if channel and (target_channel_not_in_group or target_channel_in_group):
+                resolved_group_id = channel.get("channel_group_id")
+                if target_channel_not_in_group and resolved_group_id in target_channel_not_in_group:
+                    logger.info(
+                        "[AUTO-CREATE-EXEC] Skipped stream '%s': resolved target "
+                        "channel '%s' (id=%s) is in excluded group %s "
+                        "(target_channel_not_in_group=%s)",
+                        stream_ctx.stream_name, channel.get('name'),
+                        channel.get('id'), resolved_group_id,
+                        target_channel_not_in_group
+                    )
+                    return ActionResult(
+                        success=True, action_type=action.type,
+                        description=(
+                            f"Skipped: target channel '{channel['name']}' is in "
+                            f"excluded group {resolved_group_id} "
+                            f"(target_channel_not_in_group)"
+                        ),
+                        entity_type="channel", entity_id=channel["id"],
+                        entity_name=channel["name"], skipped=True
+                    )
+                if target_channel_in_group and resolved_group_id not in target_channel_in_group:
+                    logger.info(
+                        "[AUTO-CREATE-EXEC] Skipped stream '%s': resolved target "
+                        "channel '%s' (id=%s) group %s is not in allowed groups "
+                        "%s (target_channel_in_group)",
+                        stream_ctx.stream_name, channel.get('name'),
+                        channel.get('id'), resolved_group_id,
+                        target_channel_in_group
+                    )
+                    return ActionResult(
+                        success=True, action_type=action.type,
+                        description=(
+                            f"Skipped: target channel '{channel['name']}' group "
+                            f"{resolved_group_id} is not in allowed groups "
+                            f"{target_channel_in_group} (target_channel_in_group)"
+                        ),
+                        entity_type="channel", entity_id=channel["id"],
+                        entity_name=channel["name"], skipped=True
+                    )
 
             if channel:
                 # Track merged stream IDs per channel for optional prune step.

--- a/backend/auto_creation_schema.py
+++ b/backend/auto_creation_schema.py
@@ -432,6 +432,26 @@ class Action:
             if "loose_name_match" not in self.params:
                 self.params["loose_name_match"] = False
 
+            # bd-0emgo.3: TARGET-CHANNEL group filter (post-resolution reject).
+            # These constrain which existing channel the merge may land in, by
+            # the RESOLVED channel's group — distinct from the stream-side
+            # normalized_name_[not_]in_group *conditions* (which only gate
+            # whether the rule FIRES). Absent = no filter (back-compat); the
+            # keys are NOT auto-injected so a no-filter rule stays unchanged.
+            # An empty list is valid and means "no exclusion / no restriction".
+            for key in ("target_channel_not_in_group", "target_channel_in_group"):
+                if key not in self.params:
+                    continue
+                value = self.params[key]
+                if not isinstance(value, list):
+                    errors.append(f"merge_streams.{key} must be a list of group IDs")
+                    continue
+                # bool is a subclass of int — reject it explicitly so True/False
+                # cannot masquerade as a group ID.
+                if any(not isinstance(item, int) or isinstance(item, bool)
+                       for item in value):
+                    errors.append(f"merge_streams.{key} must contain only integer group IDs")
+
         # Validate assign_logo
         elif action_type == ActionType.ASSIGN_LOGO:
             value = self.params.get("value")

--- a/backend/tests/unit/test_auto_creation_executor.py
+++ b/backend/tests/unit/test_auto_creation_executor.py
@@ -2258,6 +2258,172 @@ class TestMatchScopeGroupId:
         self.client.update_channel.assert_called()
 
 
+class TestMergeStreamsTargetChannelGroupFilter:
+    """bd-0emgo.3: target-channel group filter on the merge_streams action.
+
+    The ``*_in_group`` / ``normalized_name_not_in_group`` *conditions* are
+    stream-side — they only gate whether a rule FIRES, never which existing
+    channel merge_streams target=auto resolves to. This new action-level
+    filter is a post-resolution reject (mirroring the GH #298 scope-reject at
+    auto_creation_executor.py): after the target channel is resolved, the merge
+    is skipped if the resolved channel's ``channel_group_id`` is in
+    ``target_channel_not_in_group`` (or, for ``target_channel_in_group``, NOT
+    in the allow-list). Resolution itself is unchanged.
+
+    Two existing channels named "ESPN": one in group 1 (allowed), one in
+    group 567 (the excluded group from the production report). The filter is
+    applied AFTER resolution, so we vary which channel resolution returns by
+    pointing find_channel_value at the right name.
+    """
+
+    def setup_method(self):
+        self.client = MagicMock()
+        self.client.create_channel = AsyncMock()
+        self.client.update_channel = AsyncMock()
+
+        # "Keep" lives in group 1; "Excluded" lives in group 567.
+        self.channels = [
+            {"id": 10, "name": "Keep", "channel_number": 100,
+             "channel_group_id": 1, "streams": [101]},
+            {"id": 20, "name": "Excluded", "channel_number": 200,
+             "channel_group_id": 567, "streams": [201]},
+        ]
+        self.groups = [
+            {"id": 1, "name": "ALLOWED"},
+            {"id": 567, "name": "EXCLUDED"},
+        ]
+        self.executor = ActionExecutor(
+            self.client,
+            existing_channels=self.channels,
+            existing_groups=self.groups,
+        )
+
+    def _stream(self, name):
+        return StreamContext(
+            stream_id=999,
+            stream_name=name,
+            m3u_account_id=1,
+            m3u_account_name="Provider A",
+            group_name="whatever",
+        )
+
+    def _run(self, action, stream_name, **kwargs):
+        exec_ctx = ExecutionContext()
+        return asyncio.get_event_loop().run_until_complete(
+            self.executor.execute(action, self._stream(stream_name), exec_ctx, **kwargs)
+        )
+
+    # --- target_channel_not_in_group (primary: "merge anywhere EXCEPT X") ---
+
+    def test_not_in_group_skips_merge_into_excluded_group(self):
+        """Bug-1 reproduction: the resolved target is in the excluded group →
+        the merge is SKIPPED and the channel in that group receives nothing.
+        """
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "Excluded",  # resolves to channel 20 (group 567)
+            "target_channel_not_in_group": [567],
+        }
+        result = self._run(action, "Excluded")
+        assert result.success is True
+        assert result.skipped is True
+        # The channel in the excluded group did NOT receive the merge.
+        self.client.update_channel.assert_not_called()
+
+    def test_not_in_group_merges_when_target_outside_excluded_group(self):
+        """A stream whose resolved target is NOT in the excluded group merges."""
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "Keep",  # resolves to channel 10 (group 1)
+            "target_channel_not_in_group": [567],
+        }
+        result = self._run(action, "Keep")
+        assert result.success is True
+        assert result.skipped is not True
+        self.client.update_channel.assert_called()
+
+    # --- target_channel_in_group (complement: "only merge into X") ---
+
+    def test_in_group_merges_when_target_in_allowed_group(self):
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "Keep",  # group 1 — in allow-list
+            "target_channel_in_group": [1],
+        }
+        result = self._run(action, "Keep")
+        assert result.success is True
+        assert result.skipped is not True
+        self.client.update_channel.assert_called()
+
+    def test_in_group_skips_when_target_outside_allowed_group(self):
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "Excluded",  # group 567 — NOT in allow-list
+            "target_channel_in_group": [1],
+        }
+        result = self._run(action, "Excluded")
+        assert result.success is True
+        assert result.skipped is True
+        self.client.update_channel.assert_not_called()
+
+    # --- back-compat: no filter → unchanged ---
+
+    def test_no_filter_merges_into_any_group(self):
+        """No filter set → behavior unchanged; merges into group 567 freely."""
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "Excluded",
+        }
+        result = self._run(action, "Excluded")
+        assert result.success is True
+        assert result.skipped is not True
+        self.client.update_channel.assert_called()
+
+    def test_empty_not_in_group_list_is_noop(self):
+        """An empty exclusion list excludes nothing — merge proceeds."""
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "Excluded",
+            "target_channel_not_in_group": [],
+        }
+        result = self._run(action, "Excluded")
+        assert result.success is True
+        assert result.skipped is not True
+        self.client.update_channel.assert_called()
+
+    def test_not_in_group_composes_with_match_scope(self):
+        """The new filter is independent of GH #298 match_scope: with scope on
+        and pinned to group 567, the candidate is in scope, but the new
+        exclusion still rejects it.
+        """
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "find_channel_by": "name_exact",
+            "find_channel_value": "Excluded",
+            "target_channel_not_in_group": [567],
+        }
+        result = self._run(
+            action, "Excluded",
+            match_scope_target_group=True,
+            rule_scope_group_id=567,
+        )
+        assert result.success is True
+        assert result.skipped is True
+        self.client.update_channel.assert_not_called()
+
 
 class TestCreateChannelSuperscriptStripping:
     """

--- a/backend/tests/unit/test_auto_creation_schema.py
+++ b/backend/tests/unit/test_auto_creation_schema.py
@@ -381,6 +381,78 @@ class TestActionValidation:
         errors = action.validate()
         assert any("loose_name_match" in e for e in errors)
 
+    # --- bd-0emgo.3: target-channel group filter -------------------------
+
+    def test_merge_streams_target_channel_filters_absent_by_default(self):
+        """bd-0emgo.3: with no filter set the keys are NOT auto-injected.
+
+        Absent = no filter (back-compat). Unlike loose_name_match (which the
+        schema defaults to False), the group-filter lists are left absent so
+        a stored rule with no filter stays byte-identical.
+        """
+        action = Action(type="merge_streams", params={"target": "auto"})
+        errors = action.validate()
+        assert len(errors) == 0
+        assert "target_channel_not_in_group" not in action.params
+        assert "target_channel_in_group" not in action.params
+
+    def test_merge_streams_target_channel_not_in_group_accepts_int_list(self):
+        """bd-0emgo.3: target_channel_not_in_group accepts a list of group IDs."""
+        action = Action(
+            type="merge_streams",
+            params={"target": "auto", "target_channel_not_in_group": [567, 12]},
+        )
+        errors = action.validate()
+        assert len(errors) == 0
+        assert action.params["target_channel_not_in_group"] == [567, 12]
+
+    def test_merge_streams_target_channel_in_group_accepts_int_list(self):
+        """bd-0emgo.3: target_channel_in_group accepts a list of group IDs."""
+        action = Action(
+            type="merge_streams",
+            params={"target": "auto", "target_channel_in_group": [42]},
+        )
+        errors = action.validate()
+        assert len(errors) == 0
+        assert action.params["target_channel_in_group"] == [42]
+
+    def test_merge_streams_target_channel_not_in_group_rejects_non_list(self):
+        """bd-0emgo.3: target_channel_not_in_group must be a list."""
+        action = Action(
+            type="merge_streams",
+            params={"target": "auto", "target_channel_not_in_group": 567},
+        )
+        errors = action.validate()
+        assert any("target_channel_not_in_group" in e for e in errors)
+
+    def test_merge_streams_target_channel_not_in_group_rejects_non_int_items(self):
+        """bd-0emgo.3: target_channel_not_in_group items must be integers."""
+        action = Action(
+            type="merge_streams",
+            params={"target": "auto", "target_channel_not_in_group": ["sports"]},
+        )
+        errors = action.validate()
+        assert any("target_channel_not_in_group" in e for e in errors)
+
+    def test_merge_streams_target_channel_in_group_rejects_non_int_items(self):
+        """bd-0emgo.3: target_channel_in_group items must be integers."""
+        action = Action(
+            type="merge_streams",
+            params={"target": "auto", "target_channel_in_group": [1.5]},
+        )
+        errors = action.validate()
+        assert any("target_channel_in_group" in e for e in errors)
+
+    def test_merge_streams_target_channel_empty_list_is_valid(self):
+        """bd-0emgo.3: an empty list is valid (no exclusions) and preserved."""
+        action = Action(
+            type="merge_streams",
+            params={"target": "auto", "target_channel_not_in_group": []},
+        )
+        errors = action.validate()
+        assert len(errors) == 0
+        assert action.params["target_channel_not_in_group"] == []
+
     def test_valid_assign_logo(self):
         """Validates assign_logo action."""
         action = Action(

--- a/frontend/src/components/autoCreation/ActionEditor.test.tsx
+++ b/frontend/src/components/autoCreation/ActionEditor.test.tsx
@@ -251,6 +251,114 @@ describe('ActionEditor', () => {
         expect.objectContaining({ type: 'merge_streams', loose_name_match: true })
       );
     });
+
+    // bd-0emgo.3: target-channel group filter
+    it('renders the exclude-target-groups control with a checkbox per group', async () => {
+      mockDataStore.channelGroups.push(
+        createMockChannelGroup({ id: 1, name: 'Sports' }),
+        createMockChannelGroup({ id: 567, name: 'Excluded' })
+      );
+
+      render(
+        <ActionEditor
+          action={{ type: 'merge_streams', target: 'auto' }}
+          onChange={vi.fn()}
+          onRemove={vi.fn()}
+        />
+      );
+
+      expect(screen.getByText(/exclude target groups/i)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('Excluded')).toBeInTheDocument();
+      });
+    });
+
+    it('reflects an existing target_channel_not_in_group selection as checked', async () => {
+      mockDataStore.channelGroups.push(
+        createMockChannelGroup({ id: 1, name: 'Sports' }),
+        createMockChannelGroup({ id: 567, name: 'Excluded' })
+      );
+
+      render(
+        <ActionEditor
+          action={{ type: 'merge_streams', target: 'auto', target_channel_not_in_group: [567] }}
+          onChange={vi.fn()}
+          onRemove={vi.fn()}
+        />
+      );
+
+      const excludeGroupBox = await screen.findByRole('group', { name: /exclude target groups/i });
+      await waitFor(() => {
+        const checkboxes = excludeGroupBox.querySelectorAll('input[type="checkbox"]');
+        expect(checkboxes.length).toBe(2);
+      });
+      const checkboxes = excludeGroupBox.querySelectorAll('input[type="checkbox"]');
+      // Order matches channelGroups: [Sports(1), Excluded(567)]
+      expect(checkboxes[0]).not.toBeChecked(); // Sports (1) not excluded
+      expect(checkboxes[1]).toBeChecked();     // Excluded (567) is excluded
+    });
+
+    it('adds a group to target_channel_not_in_group when its checkbox is toggled on', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      mockDataStore.channelGroups.push(
+        createMockChannelGroup({ id: 567, name: 'Excluded' })
+      );
+
+      render(
+        <ActionEditor
+          action={{ type: 'merge_streams', target: 'auto' }}
+          onChange={onChange}
+          onRemove={vi.fn()}
+        />
+      );
+
+      const excludeGroupBox = await screen.findByRole('group', { name: /exclude target groups/i });
+      const checkbox = await waitFor(() => {
+        const cb = excludeGroupBox.querySelector('input[type="checkbox"]') as HTMLElement;
+        expect(cb).toBeTruthy();
+        return cb;
+      });
+      await user.click(checkbox);
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'merge_streams',
+          target_channel_not_in_group: [567],
+        })
+      );
+    });
+
+    it('clears target_channel_not_in_group to undefined when last group is unchecked', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      mockDataStore.channelGroups.push(
+        createMockChannelGroup({ id: 567, name: 'Excluded' })
+      );
+
+      render(
+        <ActionEditor
+          action={{ type: 'merge_streams', target: 'auto', target_channel_not_in_group: [567] }}
+          onChange={onChange}
+          onRemove={vi.fn()}
+        />
+      );
+
+      const excludeGroupBox = await screen.findByRole('group', { name: /exclude target groups/i });
+      const checkbox = await waitFor(() => {
+        const cb = excludeGroupBox.querySelector('input[type="checkbox"]') as HTMLElement;
+        expect(cb).toBeTruthy();
+        return cb;
+      });
+      await user.click(checkbox); // uncheck the only excluded group
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'merge_streams',
+          target_channel_not_in_group: undefined,
+        })
+      );
+    });
   });
 
   describe('assign_logo action', () => {

--- a/frontend/src/components/autoCreation/ActionEditor.tsx
+++ b/frontend/src/components/autoCreation/ActionEditor.tsx
@@ -229,7 +229,8 @@ export function ActionEditor({
 
   // Fetch channel groups for group selector
   useEffect(() => {
-    if (action.type === 'create_channel' || action.type === 'create_group') {
+    if (action.type === 'create_channel' || action.type === 'create_group'
+        || action.type === 'merge_streams') {
       getChannelGroups().then(groups => {
         setChannelGroups(groups.map(g => ({ id: g.id, name: g.name })));
       }).catch(() => {
@@ -893,6 +894,40 @@ export function ActionEditor({
               <span className="field-hint">
                 Off (default): a stream merges into an existing channel only when its normalized name exactly matches. On: restores the older fuzzy matching (core-name, parentheses, word-prefix, call-sign) — this can over-match unrelated streams.
               </span>
+            </div>
+
+            {/* Target-channel group filter (bd-0emgo.3) */}
+            <div className="action-field">
+              <label>Exclude target groups</label>
+              <span className="field-hint">
+                After the merge target channel is resolved, skip the merge if that channel is in any selected group. Keeps merges OUT of these groups. This is a real target-channel guard — the stream-side &ldquo;not in group&rdquo; condition only decides whether the rule fires, not where it merges. Leave empty for no filter.
+              </span>
+              {channelGroups.length === 0 ? (
+                <span className="field-hint">No channel groups available.</span>
+              ) : (
+                <div className="checkbox-group vertical" role="group" aria-label="Exclude target groups">
+                  {channelGroups.map(group => (
+                    <label key={group.id} className="checkbox-item">
+                      <input
+                        type="checkbox"
+                        checked={(action.target_channel_not_in_group ?? []).includes(group.id)}
+                        onChange={e => {
+                          const current = action.target_channel_not_in_group ?? [];
+                          const next = e.target.checked
+                            ? [...current, group.id]
+                            : current.filter(gid => gid !== group.id);
+                          onChange({
+                            ...action,
+                            target_channel_not_in_group: next.length > 0 ? next : undefined,
+                          });
+                        }}
+                        disabled={readonly}
+                      />
+                      <span>{group.name}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
             </div>
           </>
         )}

--- a/frontend/src/types/autoCreation.ts
+++ b/frontend/src/types/autoCreation.ts
@@ -127,6 +127,20 @@ export interface Action {
    * (core-name / deparen / word-prefix containment / call-sign).
    */
   loose_name_match?: boolean;
+  /**
+   * merge_streams TARGET-channel group filter (bd-0emgo.3). After the merge
+   * target is resolved, the merge is SKIPPED if the resolved channel's group
+   * is in this list. This is the "keep merges OUT of group N" guard — distinct
+   * from the stream-side normalized_name_not_in_group *condition* (which only
+   * gates whether the rule fires). Absent/empty = no filter (back-compat).
+   */
+  target_channel_not_in_group?: number[];
+  /**
+   * merge_streams TARGET-channel group filter complement (bd-0emgo.3). When
+   * non-empty, only merges when the resolved channel's group IS in this list
+   * ("only merge into group N"). Absent/empty = no restriction.
+   */
+  target_channel_in_group?: number[];
   message?: string;
   // Name transform (for create_channel and create_group)
   name_transform_pattern?: string;

--- a/mcp-server/tests/test_target_channel_group_filter_passthrough.py
+++ b/mcp-server/tests/test_target_channel_group_filter_passthrough.py
@@ -1,0 +1,121 @@
+"""TDD tests for bd-0emgo.3 — merge_streams target-channel group filter (MCP).
+
+``target_channel_not_in_group`` / ``target_channel_in_group`` are per-action
+params that live inside a merge_streams action dict. create_auto_creation_rule /
+update_auto_creation_rule forward the ``actions`` list verbatim to the backend,
+so these lists ride through untouched (like loose_name_match / find_channel_by).
+These tests pin that behavior so a future refactor that strips/filters action
+params is caught.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+def _make_mock(return_value=None):
+    mock = AsyncMock()
+    mock.call_endpoint.return_value = return_value if return_value is not None else {}
+    return mock
+
+
+def _register_and_get_mcp():
+    from tools.auto_creation import register
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP("test")
+    register(mcp)
+    return mcp
+
+
+def _sent_payload(mock_client):
+    """Return the body dict passed to the (single) call_endpoint invocation."""
+    call = mock_client.call_endpoint.call_args
+    return call.kwargs.get("body")
+
+
+class TestTargetChannelGroupFilterCreate:
+    """create_auto_creation_rule forwards the group filter inside the action."""
+
+    @pytest.mark.asyncio
+    async def test_not_in_group_survives_to_payload(self):
+        mcp = _register_and_get_mcp()
+        mock_client = _make_mock(return_value={"rule": {"id": 11}})
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "target_channel_not_in_group": [567],
+        }
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            await mcp.call_tool(
+                "create_auto_creation_rule",
+                {
+                    "name": "Keep merges out of 567",
+                    "conditions": [{"type": "always"}],
+                    "actions": [action],
+                },
+            )
+
+        payload = _sent_payload(mock_client)
+        assert payload is not None
+        sent_action = payload["actions"][0]
+        assert sent_action["type"] == "merge_streams"
+        assert sent_action["target_channel_not_in_group"] == [567]
+
+    @pytest.mark.asyncio
+    async def test_in_group_survives_to_payload(self):
+        mcp = _register_and_get_mcp()
+        mock_client = _make_mock(return_value={"rule": {"id": 12}})
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "target_channel_in_group": [42, 43],
+        }
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            await mcp.call_tool(
+                "create_auto_creation_rule",
+                {
+                    "name": "Only merge into 42/43",
+                    "conditions": [{"type": "always"}],
+                    "actions": [action],
+                },
+            )
+
+        sent_action = _sent_payload(mock_client)["actions"][0]
+        assert sent_action["target_channel_in_group"] == [42, 43]
+
+
+class TestTargetChannelGroupFilterUpdate:
+    """update_auto_creation_rule forwards the group filter inside the action."""
+
+    @pytest.mark.asyncio
+    async def test_update_forwards_not_in_group(self):
+        mcp = _register_and_get_mcp()
+        mock_client = _make_mock(return_value={"rule": {"id": 13}})
+        action = {
+            "type": "merge_streams",
+            "target": "auto",
+            "target_channel_not_in_group": [567],
+        }
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            await mcp.call_tool(
+                "update_auto_creation_rule",
+                {"rule_id": 13, "actions": [action]},
+            )
+
+        payload = _sent_payload(mock_client)
+        assert payload is not None
+        sent_action = payload["actions"][0]
+        assert sent_action["target_channel_not_in_group"] == [567]
+
+
+class TestTargetChannelGroupFilterContract:
+    """The filter rides inside the top-level ``actions`` field, which IS in the
+    create/update contract — no per-action contract entry is required."""
+
+    def test_actions_is_in_create_contract(self):
+        from _endpoint_contracts import ENDPOINTS
+
+        assert "actions" in ENDPOINTS["ac_create_rule"].request_fields
+        assert "actions" in ENDPOINTS["ac_update_rule"].request_fields

--- a/mcp-server/tools/auto_creation.py
+++ b/mcp-server/tools/auto_creation.py
@@ -446,7 +446,13 @@ def register(mcp: FastMCP):
                   has_channel — stream already assigned to a channel
                   channel_exists_with_name — exact channel name exists
                   channel_exists_matching — regex match on existing channels
-                  normalized_name_in_group / normalized_name_not_in_group
+                  normalized_name_in_group / normalized_name_not_in_group —
+                    STREAM-side: fire only when the triggering stream's
+                    normalized name IS (or is NOT) already present in group N.
+                    These gate whether the rule FIRES; they do NOT constrain
+                    which existing channel a merge_streams action targets. To
+                    keep merges OUT of a group, use the merge_streams action's
+                    target_channel_not_in_group param (see actions below).
                   normalized_name_exists / normalized_name_not_exists
                   always / never — always or never matches
                 Example: [{"type": "stream_group_contains", "value": "USA | Entertainment", "connector": "and"}]
@@ -464,6 +470,14 @@ def register(mcp: FastMCP):
                                    fuzzy cascade (core-name/deparen/word-prefix/call-sign).
                                    NOTE: match_by is a DEPRECATED no-op (validated but never
                                    consumed at runtime) — use loose_name_match to control matching.
+                                   target_channel_not_in_group (list[int], default absent) — TARGET-
+                                   channel group filter: after the merge target is resolved, SKIP
+                                   the merge if the resolved channel's group is in this list. This
+                                   is the "keep merges OUT of group N" guard (the stream-side
+                                   normalized_name_not_in_group condition cannot do this). Optional
+                                   complement target_channel_in_group (list[int]) only merges when
+                                   the resolved channel's group IS in the list. Both default to
+                                   absent (no filter); they ride inside the action dict.
                   assign_logo — params: value (URL or empty for stream logo)
                   assign_tvg_id — params: value
                   assign_epg — params: epg_id, set_tvg_id (bool)


### PR DESCRIPTION
Closes **0emgo.3** (epic 0emgo, roadmap:v0.17.3). Your Bug 1: the `*_in_group` conditions are stream-side and can't keep merges *out of* a group.

## Problem
`normalized_name_not_in_group` (and the other `*_in_group` conditions) are evaluated against the triggering STREAM and only gate whether the rule FIRES — they never constrain which existing channel `merge_streams target=auto` picks. So `normalized_name_not_in_group: 567` couldn't stop merges INTO channels in group 567.

## Fix
- New `merge_streams` action params: **`target_channel_not_in_group`** (primary — "merge anywhere EXCEPT these groups") and **`target_channel_in_group`** (complement), `list[int]` of group IDs; absent/empty = no filter (back-compat).
- Applied as a **post-resolution reject** right after the GH#298 match-scope reject in `_execute_merge_streams` (same `channel.channel_group_id` source) — but with an explicit `skipped` reason naming the group, for execution-log visibility.
- Plumbed schema → executor; **MCP** `create/update_auto_creation_rule` accept it (rides in `actions`); **frontend** adds an "Exclude target groups" selector for `target_channel_not_in_group` in the rule builder.
- **Clarified the misleading condition:** `normalized_name_not_in_group` is now documented (MCP docstring + UI help) as STREAM-side, pointing operators to `target_channel_not_in_group` for excluding merge targets.
- `target_channel_in_group` is schema/executor/MCP-supported but not given its own UI control (overlaps the existing GH#298 "only into group X" match-scope) — easy to surface later.

## Verification
- **Tests:** Bug-1 reproduction (`test_not_in_group_skips_merge_into_excluded_group` — a channel in the excluded group receives nothing; `update_channel` never called) + the in-group complement + back-compat. 458 backend auto-creation passing; full backend 4983; MCP 344; frontend ActionEditor 54.
- **Live (deployed):** created a rule via MCP with `target_channel_not_in_group: [567]`; confirmed it persists end-to-end (raw rule JSON); cleaned up.

ECM (executor/schema) + MCP (param) + frontend (selector). No Dispatcharr change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)