### PR TITLE
fix(mcp): disambiguate channel #number from API id in list_channels (0emgo.6)

### DIFF
--- a/mcp-server/tests/test_lq38l_journal_and_nits.py
+++ b/mcp-server/tests/test_lq38l_journal_and_nits.py
@@ -192,7 +192,10 @@ class TestChannelNumberFormatting:
         with patch("tools.channels.get_ecm_client", return_value=mock_client):
             result = await mcp.call_tool("list_channels", {})
         text = result[0][0].text
-        assert "#10440:" in text
+        # bd-0emgo.6: non-compact line now reads "#<num> (id=<cid>): <name>" so
+        # the channel number isn't mistaken for the API id. The float-suffix
+        # check (the point of this test) still holds on the channel number.
+        assert "#10440 (id=5):" in text
         assert "10440.0" not in text
 
     @pytest.mark.asyncio

--- a/mcp-server/tools/channels.py
+++ b/mcp-server/tools/channels.py
@@ -118,7 +118,10 @@ def register(mcp: FastMCP):
                 name = c.get("name", "Unknown")
                 cid = c.get("id", "?")
                 stream_count = len(c.get("streams", []))
-                lines.append(f"  #{num}: {name} (id={cid}) — {stream_count} streams")
+                # bd-0emgo.6: lead with both identifiers, explicitly labelled,
+                # so callers don't mistake the channel #number for the API id
+                # (mutate/lookup tools need id=<cid>, not the channel number).
+                lines.append(f"  #{num} (id={cid}): {name} — {stream_count} streams")
 
             if total > len(shown):
                 lines.append(f"  ... and {total - len(shown)} more")


### PR DESCRIPTION
## What & why

bd-0emgo.6: non-compact `list_channels` rendered `#<num>: <name> (id=<cid>)`. The leading `#number` reads like an id and trips callers — mutate/lookup tools (`get_channel`, `update_channel`, etc.) need `id=<cid>`, not the channel number, so the id was easy to miss buried at the end of the line.

## Change

Lead with both identifiers, explicitly labelled:

```
  #10440 (id=12319): Radio: Yacht Rock Radio — 1 streams
```

- Compact format (`number|id|name|streams`) is unchanged.
- `create_channel`'s own `#<num>:` line is a separate format, out of this bead's scope.
- Updated the float-suffix nit test to the new shape (its channel-number int-rendering check still holds).

## Verification

- MCP tests: 134 passed (`test_tools.py` + `test_lq38l_journal_and_nits.py`).
- Live (`ecm-ecm-mcp-1`): `#10440 (id=12319): Radio: Yacht Rock Radio — 1 streams`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)