### PR TITLE
fix(auto-creation): reverse modified-entity restore so rollback un-merges fully (a7okb)

### DIFF
--- a/backend/auto_creation_engine.py
+++ b/backend/auto_creation_engine.py
@@ -294,9 +294,17 @@ class AutoCreationEngine:
             for entity in reversed(created):
                 await self._rollback_created_entity(entity)
 
-            # Restore modified entities
+            # Restore modified entities in REVERSE order (bd-a7okb). Restore is
+            # last-write-wins: _rollback_modified_entity overwrites the channel
+            # from each entry's pre-change `previous` snapshot. When a run merged
+            # several streams into the SAME pre-existing channel, the snapshots
+            # are cumulative ([A] before B, [A,B] before C, ...). Forward order
+            # would apply the earliest (true original) first and let a later
+            # snapshot win, leaving all-but-the-last merged stream behind.
+            # Reversing makes the earliest snapshot win — restoring the original
+            # — exactly as created-entity teardown is reversed above.
             modified = execution.get_modified_entities()
-            for entity in modified:
+            for entity in reversed(modified):
                 await self._rollback_modified_entity(entity)
 
             # Mark execution as rolled back

--- a/backend/tests/unit/test_auto_creation_engine.py
+++ b/backend/tests/unit/test_auto_creation_engine.py
@@ -479,6 +479,49 @@ class TestAutoCreationEngineRollback:
         # Should still succeed (errors are logged but don't fail rollback)
         assert result["success"] is True
 
+    @patch("auto_creation_engine.get_session")
+    def test_rollback_unmerge_multiple_into_same_channel_restores_original(self, mock_get_session):
+        """bd-a7okb: multiple merges into ONE pre-existing channel restore to the
+        true original stream list, not the second-to-last snapshot.
+
+        A run that merges streams 11, 12, 13 into a channel that already held
+        [10] records cumulative `previous` snapshots, one per merge:
+            before 11 -> [10]
+            before 12 -> [10, 11]
+            before 13 -> [10, 11, 12]
+        Restore is overwrite/last-write-wins. Applied FORWARD, the final state
+        would be [10, 11, 12] (only the last merge removed). Applied REVERSED,
+        the earliest snapshot [10] wins — the correct original. This asserts the
+        LAST update_channel call restores [10].
+        """
+        mock_session = MagicMock()
+        mock_get_session.return_value = mock_session
+
+        mock_execution = MagicMock()
+        mock_execution.status = "completed"
+        mock_execution.mode = "execute"
+        mock_execution.get_created_entities.return_value = []
+        mock_execution.get_modified_entities.return_value = [
+            {"type": "channel", "id": 3, "name": "ESPN", "previous": {"streams": [10]}},
+            {"type": "channel", "id": 3, "name": "ESPN", "previous": {"streams": [10, 11]}},
+            {"type": "channel", "id": 3, "name": "ESPN", "previous": {"streams": [10, 11, 12]}},
+        ]
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+
+        result = asyncio.get_event_loop().run_until_complete(
+            self.engine.rollback_execution(1)
+        )
+
+        assert result["success"] is True
+        assert result["entities_restored"] == 3
+        assert self.client.update_channel.call_count == 3
+        # The decisive assertion: the final write must restore the ORIGINAL list.
+        last_call = self.client.update_channel.call_args_list[-1]
+        assert last_call.args == (3, {"streams": [10]}), (
+            "rollback must end by restoring the pre-run streams [10]; "
+            f"last update_channel was {last_call.args} (forward-order bug leaves extra streams)"
+        )
+
 
 class TestAutoCreationEngineProcessStreams:
     """Tests for stream processing logic."""


### PR DESCRIPTION
## What & why

bd-a7okb (found while documenting the rollback feature): `rollback_execution()` restored `modified_entities` in **forward** order, while created entities used `reversed()`. Restore is overwrite / last-write-wins, and merging several streams into one **pre-existing** channel records cumulative `previous` snapshots:

```
before merge B -> {streams: [A]}
before merge C -> {streams: [A, B]}
before merge D -> {streams: [A, B, C]}
```

Forward order let the **last** snapshot win, so rolling back ended at `[A, B, C]` — it removed only the final merge and **left the rest behind**. This bites exactly the "backfill existing channels" use case the rollback feature exists to protect. (Run-*created* channels are unaffected — they're deleted wholesale in the reversed `created` phase; single-merge-per-channel is unaffected.)

## Fix

Iterate `reversed(modified)` so the **earliest** snapshot (the true original) wins, mirroring the created-entity teardown. One line.

## Verification

- New regression test merges 3 streams into one pre-existing channel, rolls back, asserts the final `update_channel` restores the original `[10]`.
- **Proven guard:** temporarily reverting to forward order makes the test fail with `[10, 11, 12]` (the bug); reversed makes it pass.
- Engine + router auto-creation suites: 156 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)