### PR TITLE
v0.17.3-0001: get_journal honors limit via pagination + surfaces channel_id/stream_id (bd-0hjrk.1)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -130,7 +130,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0000",
+    version="0.17.3-0001",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0000"
+APP_VERSION = "0.17.3-0001"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0000",
+  "version": "0.17.3-0001",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mcp-server/tests/test_0hjrk_get_journal.py
+++ b/mcp-server/tests/test_0hjrk_get_journal.py
@@ -1,0 +1,357 @@
+"""Regression tests for bd-0hjrk.1 — get_journal pagination + compact recovery
+rendering.
+
+Root cause (MCP layer only — the backend data is already complete): the MCP
+``get_journal`` tool sent ``query={"page_size": limit}`` and the backend clamps
+``page_size`` to 200. The tool fetched ONE page and never looped, so a run with
+752 merges was truncated to at most 200 rows — 552 (channel_id, stream_id) pairs
+were unreachable for the journal -> bulk_remove_streams recovery path. The
+formatter also never surfaced ``entity_id`` (the channel_id) or the
+before/after stream-id lists.
+
+This module proves the fixed behaviour:
+  (a) a >200-row batch is fully returned by client-side pagination,
+  (b) merge_stream rows render channel_id AND the added stream_id,
+  (c) ``offset`` skips the first N rows,
+  (d) ``include_stream_ids=True`` appends the full before/after lists.
+
+Test patterns mirror tests/test_lq38l_journal_and_nits.py (FastMCP register +
+AsyncMock ecm_client patched at tools.system.get_ecm_client).
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from mcp.server.fastmcp import FastMCP
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _register_system() -> FastMCP:
+    mcp = FastMCP("test")
+    from tools.system import register
+
+    register(mcp)
+    return mcp
+
+
+def _merge_row(idx: int, channel_id: int, before_ids: list[int], after_ids: list[int]):
+    """Build a merge_stream JournalEntry.to_dict()-shaped row. The added stream
+    id is ``set(after) - set(before)``; the description embeds it for the parse
+    fallback."""
+    added = sorted(set(after_ids) - set(before_ids))
+    added_id = added[0] if added else "?"
+    return {
+        "id": idx,
+        "timestamp": "2026-05-22T10:%02d:00Z" % (idx % 60),
+        "category": "auto_creation",
+        "action_type": "merge_stream",
+        "entity_id": channel_id,
+        "entity_name": "Channel %s" % channel_id,
+        "description": "Merged stream %s into channel 'Channel %s'" % (added_id, channel_id),
+        "before_value": {"stream_ids": list(before_ids)},
+        "after_value": {"stream_ids": list(after_ids)},
+        "batch_id": "19",
+    }
+
+
+def _paginated_backend(total_rows: list[dict], cap: int = 200):
+    """Return a ``side_effect`` callable that serves ``total_rows`` as the
+    backend GET /api/journal would: newest-first envelopes paginated by the
+    requested ``page`` / ``page_size`` (clamped to ``cap``), reporting the true
+    total ``count`` / ``total_pages``. Used to verify the client loops pages."""
+    count = len(total_rows)
+
+    def _serve(ep, *, query=None, **_kw):
+        query = query or {}
+        page = int(query.get("page", 1))
+        page_size = min(int(query.get("page_size", 50)), cap)
+        page_size = max(page_size, 1)
+        start = (page - 1) * page_size
+        end = start + page_size
+        total_pages = (count + page_size - 1) // page_size if count > 0 else 1
+        return {
+            "count": count,
+            "page": page,
+            "page_size": page_size,
+            "total_pages": total_pages,
+            "results": total_rows[start:end],
+        }
+
+    return _serve
+
+
+def _text(result) -> str:
+    return result[0][0].text
+
+
+def _row_lines(text: str) -> list[str]:
+    """The rendered rows (lines that begin with the two-space indent), excluding
+    the header line."""
+    return [ln for ln in text.splitlines() if ln.startswith("  [")]
+
+
+# ===========================================================================
+# (a) A >200-row batch is fully returned — the client loops pages
+# ===========================================================================
+
+class TestPaginationOverCap:
+    @pytest.mark.asyncio
+    async def test_returns_all_752_rows_across_pages(self):
+        """752-row batch, limit=1000 → all 752 rendered (the backend cap is 200
+        per page, so this REQUIRES looping multiple pages)."""
+        rows = [
+            _merge_row(i, channel_id=1000 + i, before_ids=[i], after_ids=[i, 5000 + i])
+            for i in range(752)
+        ]
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = _paginated_backend(rows, cap=200)
+        mcp = _register_system()
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "get_journal", {"batch_id": "19", "limit": 1000}
+            )
+        text = _text(result)
+        # All 752 rows rendered — none truncated at the 200-row backend cap.
+        assert len(_row_lines(text)) == 752
+        # Header reports M from the envelope count.
+        assert "showing 752 of 752 total" in text
+        # It actually paginated: 752 / 200 = 4 page calls (200,200,200,152).
+        assert mock_client.call_endpoint.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_limit_below_cap_stops_early(self):
+        """limit smaller than the total stops once limit rows are collected and
+        does not fetch every page."""
+        rows = [
+            _merge_row(i, channel_id=1000 + i, before_ids=[i], after_ids=[i, 5000 + i])
+            for i in range(752)
+        ]
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = _paginated_backend(rows, cap=200)
+        mcp = _register_system()
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "get_journal", {"batch_id": "19", "limit": 50}
+            )
+        text = _text(result)
+        assert len(_row_lines(text)) == 50
+        # M (envelope count) is still the true total.
+        assert "showing 50 of 752 total" in text
+        # Only one page needed (50 <= 200).
+        assert mock_client.call_endpoint.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_page_size_query_never_exceeds_cap(self):
+        """Even with a huge limit, each backend call requests page_size <= 200."""
+        rows = [
+            _merge_row(i, channel_id=1000 + i, before_ids=[i], after_ids=[i, 5000 + i])
+            for i in range(500)
+        ]
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = _paginated_backend(rows, cap=200)
+        mcp = _register_system()
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            await mcp.call_tool("get_journal", {"batch_id": "19", "limit": 5000})
+        for call in mock_client.call_endpoint.call_args_list:
+            assert call.kwargs["query"]["page_size"] <= 200
+
+    @pytest.mark.asyncio
+    async def test_category_and_batch_id_passed_on_every_page(self):
+        """Filters must be threaded through every paginated request, not just
+        the first."""
+        rows = [
+            _merge_row(i, channel_id=1000 + i, before_ids=[i], after_ids=[i, 5000 + i])
+            for i in range(450)
+        ]
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = _paginated_backend(rows, cap=200)
+        mcp = _register_system()
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            await mcp.call_tool(
+                "get_journal",
+                {"batch_id": "19", "category": "auto_creation", "limit": 1000},
+            )
+        assert mock_client.call_endpoint.call_count >= 3
+        for call in mock_client.call_endpoint.call_args_list:
+            q = call.kwargs["query"]
+            assert q["batch_id"] == "19"
+            assert q["category"] == "auto_creation"
+
+
+# ===========================================================================
+# (b) merge_stream rows render channel_id AND the added stream_id
+# ===========================================================================
+
+class TestMergeRowRendering:
+    @pytest.mark.asyncio
+    async def test_renders_channel_id_and_added_stream_id(self):
+        """For a merge_stream row, channel_id=entity_id and stream_id=added id
+        (after - before) are surfaced, plus the before->after stream counts."""
+        rows = [_merge_row(1, channel_id=42, before_ids=[100, 101], after_ids=[100, 101, 201])]
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = _paginated_backend(rows)
+        mcp = _register_system()
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("get_journal", {"batch_id": "19", "limit": 20})
+        text = _text(result)
+        assert "channel_id=42" in text
+        assert "stream_id=201" in text
+        # before/after counts (2 -> 3) so an operator sees the merge delta.
+        assert "streams: 2" in text and "3" in text
+        # The category/action and entity_name still render.
+        assert "auto_creation/merge_stream" in text
+        assert "Channel 42" in text
+
+    @pytest.mark.asyncio
+    async def test_added_stream_id_parsed_from_description_when_values_absent(self):
+        """Fallback path: no before/after values, but the description embeds the
+        merged stream id → parse it out."""
+        row = {
+            "id": 7,
+            "timestamp": "2026-05-22T12:00:00Z",
+            "category": "auto_creation",
+            "action_type": "merge_stream",
+            "entity_id": 55,
+            "entity_name": "ESPN",
+            "description": "Merged stream 909 into channel 'ESPN'",
+            "before_value": None,
+            "after_value": None,
+            "batch_id": "19",
+        }
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = _paginated_backend([row])
+        mcp = _register_system()
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("get_journal", {"batch_id": "19"})
+        text = _text(result)
+        assert "channel_id=55" in text
+        assert "stream_id=909" in text
+
+    @pytest.mark.asyncio
+    async def test_non_merge_row_with_entity_id_shows_channel_id_only(self):
+        """A non-merge row that has entity_id renders channel_id but no
+        stream_id/streams delta."""
+        row = {
+            "id": 3,
+            "timestamp": "2026-05-22T09:00:00Z",
+            "category": "channel",
+            "action_type": "create",
+            "entity_id": 88,
+            "entity_name": "CNN",
+            "description": "Created channel CNN",
+        }
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = _paginated_backend([row])
+        mcp = _register_system()
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("get_journal", {})
+        text = _text(result)
+        assert "channel_id=88" in text
+        assert "stream_id=" not in text
+        assert "channel/create" in text
+
+
+# ===========================================================================
+# (c) offset skips the first N rows
+# ===========================================================================
+
+class TestOffset:
+    @pytest.mark.asyncio
+    async def test_offset_skips_leading_rows(self):
+        """offset=5 with a 20-row batch returns rows 5..19 (the first 5 skipped),
+        newest-first ordering preserved by the backend."""
+        rows = [
+            _merge_row(i, channel_id=1000 + i, before_ids=[i], after_ids=[i, 5000 + i])
+            for i in range(20)
+        ]
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = _paginated_backend(rows, cap=200)
+        mcp = _register_system()
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "get_journal", {"batch_id": "19", "limit": 100, "offset": 5}
+            )
+        text = _text(result)
+        # 15 rows remain after skipping the first 5.
+        assert len(_row_lines(text)) == 15
+        # Row 0..4 skipped → channel_id 1000..1004 not present; 1005 is.
+        assert "channel_id=1004" not in text
+        assert "channel_id=1005" in text
+        assert "channel_id=1019" in text
+
+    @pytest.mark.asyncio
+    async def test_offset_spanning_page_boundary(self):
+        """offset that lands inside a later page still drops exactly that many
+        rows when looping across the 200-row backend cap."""
+        rows = [
+            _merge_row(i, channel_id=1000 + i, before_ids=[i], after_ids=[i, 5000 + i])
+            for i in range(450)
+        ]
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = _paginated_backend(rows, cap=200)
+        mcp = _register_system()
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "get_journal", {"batch_id": "19", "limit": 1000, "offset": 250}
+            )
+        text = _text(result)
+        # 450 - 250 = 200 rows remain.
+        assert len(_row_lines(text)) == 200
+        # Row 249 skipped, row 250 is the first kept.
+        assert "channel_id=1249" not in text
+        assert "channel_id=1250" in text
+        assert "channel_id=1449" in text
+
+
+# ===========================================================================
+# (d) include_stream_ids=True appends the full before/after lists
+# ===========================================================================
+
+class TestIncludeStreamIds:
+    @pytest.mark.asyncio
+    async def test_full_lists_appended_when_requested(self):
+        rows = [_merge_row(1, channel_id=42, before_ids=[100, 101], after_ids=[100, 101, 201])]
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = _paginated_backend(rows)
+        mcp = _register_system()
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "get_journal",
+                {"batch_id": "19", "limit": 20, "include_stream_ids": True},
+            )
+        text = _text(result)
+        # Full before/after stream-id lists present for deep audit.
+        assert "[100, 101]" in text
+        assert "[100, 101, 201]" in text
+
+    @pytest.mark.asyncio
+    async def test_full_lists_absent_by_default(self):
+        """Default (include_stream_ids=False) must NOT dump the full lists — the
+        752-row token-budget guard."""
+        rows = [_merge_row(1, channel_id=42, before_ids=[100, 101], after_ids=[100, 101, 201])]
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = _paginated_backend(rows)
+        mcp = _register_system()
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("get_journal", {"batch_id": "19", "limit": 20})
+        text = _text(result)
+        # Compact: counts/added id shown, but not the verbose full before-list.
+        assert "[100, 101]" not in text
+        assert "stream_id=201" in text
+
+
+# ===========================================================================
+# Empty / no-results path is preserved
+# ===========================================================================
+
+class TestEmpty:
+    @pytest.mark.asyncio
+    async def test_empty_results_reports_no_entries(self):
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = _paginated_backend([])
+        mcp = _register_system()
+        with patch("tools.system.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("get_journal", {"batch_id": "nope"})
+        assert "No journal entries found." in _text(result)

--- a/mcp-server/tests/test_lq38l_journal_and_nits.py
+++ b/mcp-server/tests/test_lq38l_journal_and_nits.py
@@ -100,7 +100,11 @@ class TestJournalEnvelope:
 
         text = result[0][0].text
         assert "No journal entries found." not in text
-        assert "Recent journal entries (2)" in text
+        # bd-0hjrk.1 reworded the header to "Journal entries (showing N of M
+        # total):" (M = envelope count) when pagination landed. The behaviour
+        # this test guards (results unwrapped, rows + names + descriptions
+        # rendered, None-safe) is unchanged.
+        assert "Journal entries (showing 2 of 2 total)" in text
         assert "ESPN" in text
         assert "Created channel ESPN" in text
         # entity_name is appended for usefulness

--- a/mcp-server/tests/test_tools.py
+++ b/mcp-server/tests/test_tools.py
@@ -709,7 +709,13 @@ class TestPhase2Migration:
 
     @pytest.mark.asyncio
     async def test_get_journal_sends_page_size_not_limit(self):
-        """Backend /api/journal paginates via page_size (drift fixed in bd-vtghg)."""
+        """Backend /api/journal paginates via page_size (drift fixed in bd-vtghg).
+
+        bd-0hjrk.1: ``limit`` is now honored by CLIENT-SIDE pagination, so the
+        query carries the page cap (page_size=200) plus a ``page`` cursor rather
+        than the raw ``limit``. The contract this test guards — the backend gets
+        ``page_size``/``category`` and NEVER a bare ``limit`` key — still holds.
+        """
         from tools.system import register
         from mcp.server.fastmcp import FastMCP
         from _endpoint_contracts import ENDPOINTS
@@ -722,7 +728,7 @@ class TestPhase2Migration:
         call = mock_client.call_endpoint.call_args
         assert call.args[0] is ENDPOINTS["journal_list"]
         q = call.kwargs["query"]
-        assert q == {"page_size": 5, "category": "channels"}
+        assert q == {"page_size": 200, "category": "channels", "page": 1}
         assert "limit" not in q
 
 

--- a/mcp-server/tools/system.py
+++ b/mcp-server/tools/system.py
@@ -1,5 +1,6 @@
 """System management tools (settings, backup, journal)."""
 import logging
+import re
 
 import httpx
 from mcp.server.fastmcp import FastMCP
@@ -9,6 +10,76 @@ from config import ECM_URL, get_mcp_api_key
 from ecm_client import get_ecm_client
 
 logger = logging.getLogger(__name__)
+
+# Backend GET /api/journal clamps page_size to [1, 200]. The MCP tool honors an
+# arbitrary ``limit`` by paginating CLIENT-SIDE at this page size — never bump
+# the backend cap (bd-0hjrk.1).
+_JOURNAL_PAGE_SIZE = 200
+
+# Fallback parse of the merged stream id out of the per-merge journal
+# description ("Merged stream <id> into channel '<name>'") when the
+# before/after stream-id values are absent (bd-0emgo.5 / bd-0hjrk.1).
+_MERGED_STREAM_RE = re.compile(r"Merged stream (\d+) into channel")
+
+
+def _stream_ids(value) -> list | None:
+    """Pull the ``stream_ids`` list out of a journal before/after value, which is
+    shaped ``{"stream_ids": [...]}`` (see auto_creation_executor._journal_merge).
+    Returns None when absent so callers can detect the fallback path."""
+    if isinstance(value, dict):
+        ids = value.get("stream_ids")
+        if isinstance(ids, list):
+            return ids
+    return None
+
+
+def _format_journal_row(e: dict, include_stream_ids: bool) -> str:
+    """Render ONE journal entry as a compact single line (bd-0hjrk.1).
+
+    Always: ``[ts] category/action: entity_name`` and, when present,
+    ``channel_id=<entity_id>``. For ``merge_stream`` rows also the added
+    ``stream_id`` (after - before, falling back to the description) and the
+    ``streams: <before>→<after>`` count delta. ``include_stream_ids`` appends
+    the full before/after lists for a deep audit.
+    """
+    ts = e.get("timestamp", "?")
+    cat = e.get("category", "?")
+    action = e.get("action_type", e.get("action", "?"))
+    name = e.get("entity_name")
+
+    head = f"  [{ts}] {cat}/{action}:"
+    if name:
+        head += f" {name}"
+
+    extras: list[str] = []
+    entity_id = e.get("entity_id")
+    if entity_id is not None:
+        extras.append(f"channel_id={entity_id}")
+
+    if action == "merge_stream":
+        before = _stream_ids(e.get("before_value")) or []
+        after = _stream_ids(e.get("after_value")) or []
+        added = sorted(set(after) - set(before))
+        if added:
+            extras.append(f"stream_id={added[0]}")
+        else:
+            # Fallback: parse the merged stream id from the description.
+            m = _MERGED_STREAM_RE.search(e.get("description") or "")
+            if m:
+                extras.append(f"stream_id={m.group(1)}")
+        if before or after:
+            extras.append(f"streams: {len(before)}→{len(after)}")
+        if include_stream_ids:
+            extras.append(f"before={before} after={after}")
+    else:
+        # Non-merge rows: keep the short description for context (None-safe).
+        detail = (e.get("description") or e.get("detail") or "")[:80]
+        if detail:
+            extras.append(detail)
+
+    if extras:
+        return f"{head} — {' '.join(extras)}"
+    return head
 
 
 def register(mcp: FastMCP):
@@ -128,57 +199,118 @@ def register(mcp: FastMCP):
         limit: int = 20,
         category: str | None = None,
         batch_id: str | None = None,
+        offset: int = 0,
+        include_stream_ids: bool = False,
     ) -> str:
-        """Get recent entries from the ECM activity journal/audit log.
+        """Get entries from the ECM activity journal/audit log.
+
+        ``limit`` is now honored in full via CLIENT-SIDE pagination: the backend
+        GET /api/journal clamps ``page_size`` to 200, so this tool loops pages
+        (200 rows each, filters threaded through every request) until it has
+        ``limit`` rows or the results are exhausted. The old 200-row cap is gone
+        — a 752-merge auto-creation run is fully reachable (bd-0hjrk.1).
+
+        Output is COMPACT — one line per row — so a large response does not blow
+        the MCP token budget. Each row shows the timestamp, ``category/action``,
+        and entity_name; ``channel_id=<entity_id>`` is always included when
+        present. For ``merge_stream`` rows (auto-creation merges) it also
+        surfaces the added ``stream_id`` (= after.stream_ids - before.stream_ids,
+        falling back to parsing the description) plus the ``streams: <before>→
+        <after>`` count delta, so an operator can drive the journal →
+        bulk_remove_streams recovery path without a second lookup.
 
         Args:
-            limit: Number of entries to return (default 20)
-            category: Filter by category (e.g., 'channels', 'm3u', 'epg', 'settings')
+            limit: Total number of entries to return. Honored via pagination —
+                no longer capped at the backend's 200-row page size (default 20).
+            category: Filter by category (e.g., 'channels', 'm3u', 'epg',
+                'settings', 'auto_creation').
             batch_id: Filter to a single batched operation's rows. For an
                 auto-creation run this is the run's execution_id (as a string),
                 so an operator recovering from a bad merge can list every
                 (channel_id, stream_id) pair the run touched (bd-0emgo.5).
                 Also matches the 8-char batch_id from bulk handlers.
+            offset: Number of leading (newest-first) rows to skip before
+                collecting ``limit`` rows. Lets an operator page through a large
+                batch (default 0).
+            include_stream_ids: When True, append the full before/after
+                stream-id lists per row for a deep audit. Default False keeps the
+                output compact (counts only) to protect the token budget.
         """
         try:
             client = get_ecm_client()
-            # Backend GET /api/journal paginates via ``page_size`` (a bare
-            # ``limit`` query param was silently ignored: drift fixed in
-            # bd-vtghg Phase 2).
-            query = {"page_size": limit}
+            offset = max(offset, 0)
+            limit = max(limit, 0)
+
+            # ----------------------------------------------------------------
+            # Paginate client-side. The backend serves newest-first and clamps
+            # page_size to [1, 200]; we request _JOURNAL_PAGE_SIZE per call,
+            # starting at the page that covers ``offset``, and accumulate rows
+            # until we have ``limit`` of them or the envelope says we are done.
+            # Filters (category/batch_id) ride on EVERY page.
+            # ----------------------------------------------------------------
+            base_query: dict = {"page_size": _JOURNAL_PAGE_SIZE}
             if category:
-                query["category"] = category
+                base_query["category"] = category
             if batch_id:
                 # Indexed filter (idx_journal_batch_id) — passed through to the
                 # backend journal_list endpoint's batch_id query param.
-                query["batch_id"] = batch_id
-            entries = await client.call_endpoint(ENDPOINTS["journal_list"], query=query)
+                base_query["batch_id"] = batch_id
 
-            # Backend GET /api/journal returns a paginated envelope
-            # {"count","page","page_size","total_pages","results":[...]}
-            # (see backend/journal.py get_entries). Older drafts used "entries";
-            # fall back to that, then to [].
-            if isinstance(entries, list):
-                items = entries
-            else:
-                items = entries.get("results", entries.get("entries", []))
+            start_page = (offset // _JOURNAL_PAGE_SIZE) + 1
+            skip_in_first_page = offset % _JOURNAL_PAGE_SIZE
+
+            items: list = []
+            total = 0
+            page = start_page
+            first = True
+            while limit == 0 or len(items) < limit:
+                query = dict(base_query, page=page)
+                envelope = await client.call_endpoint(
+                    ENDPOINTS["journal_list"], query=query
+                )
+
+                # Backend returns {"count","page","page_size","total_pages",
+                # "results":[...]} (backend/journal.py get_entries). Older drafts
+                # used "entries"; a bare list is also tolerated.
+                if isinstance(envelope, list):
+                    results = envelope
+                    total = max(total, len(results))
+                else:
+                    results = envelope.get(
+                        "results", envelope.get("entries", [])
+                    )
+                    total = envelope.get("count", total)
+
+                # Page fullness must be judged BEFORE the offset slice — slicing
+                # off the first ``skip_in_first_page`` rows would otherwise make
+                # a full page look exhausted and stop the loop early.
+                page_was_full = len(results) >= _JOURNAL_PAGE_SIZE
+
+                if first and skip_in_first_page:
+                    results = results[skip_in_first_page:]
+                first = False
+
+                items.extend(results)
+
+                # Stop when the backend page was not full (results exhausted) or
+                # we've already collected enough rows.
+                if not page_was_full:
+                    break
+                if limit and len(items) >= limit:
+                    break
+                page += 1
+
+            if limit:
+                items = items[:limit]
 
             if not items:
                 return "No journal entries found."
 
-            lines = [f"Recent journal entries ({len(items)}):"]
-            for e in items[:limit]:
-                ts = e.get("timestamp", "?")
-                cat = e.get("category", "?")
-                action = e.get("action_type", e.get("action", "?"))
-                # description may be null (Text column is non-null in the DB but
-                # be defensive); coerce to "" before slicing.
-                detail = (e.get("description") or e.get("detail") or "")[:80]
-                name = e.get("entity_name")
-                if name:
-                    lines.append(f"  [{ts}] {cat}/{action}: {name} — {detail}")
-                else:
-                    lines.append(f"  [{ts}] {cat}/{action}: {detail}")
+            shown = len(items)
+            header_total = total if total else shown
+            lines = [f"Journal entries (showing {shown} of {header_total} total):"]
+            for e in items:
+                lines.append(_format_journal_row(e, include_stream_ids))
 
             return "\n".join(lines)
         except Exception as e:


### PR DESCRIPTION
## bd-0hjrk.1 (parent bd-0hjrk — MCP audit cluster from run #19)

**Root cause (MCP layer only — data was already complete):** `get_journal` sent `page_size=limit` to GET /api/journal, which clamps page_size to [1,200], and never looped pages → max 200 rows regardless of `limit`. A 752-merge run lost 552 (channel_id, stream_id) pairs needed for the journal→bulk_remove_streams recovery path. The formatter also never surfaced `entity_id` (=channel_id) or the before/after stream-id lists, though `_journal_merge` stores them.

**Fix:** client-side pagination loop (200/page, filters threaded on every page) honoring arbitrary `limit`; new `offset` param for paging; compact one-line rows now show `channel_id=<entity_id>` and, for `merge_stream` rows, the added `stream_id` (= after−before, fallback parse) + `streams: before→after` counts; new `include_stream_ids` appends full before/after lists. Backend 200/page cap left intact (looped client-side). Docstring updated.

**Tests:** new mcp-server/tests/test_0hjrk_get_journal.py (12 tests) incl. a >200-row (752) batch returning all rows across pages, channel_id+stream_id rendering, offset, include_stream_ids. MCP suite: 359 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)