### PR TITLE
v0.17.3-0002: rollback no-restore-data refusal + run-summary regression guards (bd-0hjrk.2/.7/.8)

### DIFF
--- a/backend/auto_creation_engine.py
+++ b/backend/auto_creation_engine.py
@@ -289,8 +289,36 @@ class AutoCreationEngine:
 
             logger.info("[AUTO-CREATE-ENGINE] Rolling back execution %s", execution_id)
 
-            # Rollback created entities (in reverse order)
             created = execution.get_created_entities()
+            modified = execution.get_modified_entities()
+
+            # Refuse (rather than silently no-op) when there is nothing to undo.
+            # An execution with ZERO created AND ZERO modified entities has no
+            # recorded restore data — either it predates entity tracking (a
+            # legacy run) or it genuinely changed nothing. Marking such a run
+            # "rolled_back" with entities_removed=0/entities_restored=0 LOOKS
+            # like a clean rollback but guarantees nothing. Leave status
+            # untouched and tell the caller why. Runs that created OR modified
+            # anything fall through and roll back normally (only the both-empty
+            # case refuses); the already-rolled-back and dry-run guards above
+            # still take precedence.
+            if not created and not modified:
+                logger.warning(
+                    "[AUTO-CREATE-ENGINE] Refusing rollback of execution %s: "
+                    "no recorded created or modified entities",
+                    execution_id,
+                )
+                return {
+                    "success": False,
+                    "error": (
+                        f"No recorded created or modified entities for execution "
+                        f"{execution_id}; cannot guarantee a rollback (the run "
+                        f"predates entity tracking or made no changes). Refusing "
+                        f"to mark it rolled_back."
+                    ),
+                }
+
+            # Rollback created entities (in reverse order)
             for entity in reversed(created):
                 await self._rollback_created_entity(entity)
 
@@ -303,7 +331,6 @@ class AutoCreationEngine:
             # snapshot win, leaving all-but-the-last merged stream behind.
             # Reversing makes the earliest snapshot win — restoring the original
             # — exactly as created-entity teardown is reversed above.
-            modified = execution.get_modified_entities()
             for entity in reversed(modified):
                 await self._rollback_modified_entity(entity)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -130,7 +130,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0001",
+    version="0.17.3-0002",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0001"
+APP_VERSION = "0.17.3-0002"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/tests/unit/test_0hjrk_rollback.py
+++ b/backend/tests/unit/test_0hjrk_rollback.py
@@ -1,0 +1,175 @@
+"""bd-0hjrk.2 — rollback_auto_creation guarantees.
+
+Two behaviors are pinned here:
+
+1. UN-MERGE of merge-only runs (modified entities, 0 created): after rollback
+   the touched channel is restored to its pre-run stream list. The decisive
+   reversed-restore assertion already lives in
+   ``test_auto_creation_engine.py::TestAutoCreationEngineRollback
+   .test_rollback_unmerge_multiple_into_same_channel_restores_original``
+   (bd-a7okb). We add a focused single-channel un-merge assertion here so the
+   guarantee has a home alongside the new refusal test; the cumulative-snapshot
+   reversed-order case is NOT duplicated.
+
+2. REFUSAL on no restore data: an execution with ZERO created AND ZERO modified
+   entities must NOT be silently marked ``rolled_back``. It is a no-op that
+   *looks* like a clean rollback (entities_removed=0 / entities_restored=0).
+   The engine now refuses: returns ``success=False`` with an explanatory error
+   and leaves ``status`` unchanged. Runs that DID create or modify anything are
+   unaffected.
+"""
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from auto_creation_engine import AutoCreationEngine
+
+
+class TestRollbackUnmergeMergeOnlyRun:
+    """A merge-only run (0 created, modified present) un-merges on rollback."""
+
+    def setup_method(self):
+        self.client = MagicMock()
+        self.client.delete_channel = AsyncMock()
+        self.client.delete_channel_group = AsyncMock()
+        self.client.update_channel = AsyncMock()
+        self.engine = AutoCreationEngine(self.client)
+
+    @patch("auto_creation_engine.get_session")
+    def test_merge_only_run_restores_pre_run_stream_set(self, mock_get_session):
+        """A run that ONLY merged a stream into a pre-existing channel (no
+        channels created) restores that channel's pre-run stream list.
+
+        The reversed-order cumulative-snapshot edge case is covered by the
+        a7okb test cited in the module docstring; here we assert the simple
+        un-merge guarantee for a single-merge merge-only run.
+        """
+        mock_session = MagicMock()
+        mock_get_session.return_value = mock_session
+
+        mock_execution = MagicMock()
+        mock_execution.status = "completed"
+        mock_execution.mode = "execute"
+        # Zero created — this is a merge-only run.
+        mock_execution.get_created_entities.return_value = []
+        # Pre-run the channel held streams [10]; the run merged 11 in.
+        mock_execution.get_modified_entities.return_value = [
+            {"type": "channel", "id": 3, "name": "ESPN", "previous": {"streams": [10]}},
+        ]
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+
+        result = asyncio.get_event_loop().run_until_complete(
+            self.engine.rollback_execution(1)
+        )
+
+        assert result["success"] is True
+        assert result["entities_removed"] == 0
+        assert result["entities_restored"] == 1
+        # The channel is restored to its pre-run stream set — the merged stream
+        # is un-merged.
+        self.client.update_channel.assert_called_once_with(3, {"streams": [10]})
+        assert mock_execution.status == "rolled_back"
+
+
+class TestRollbackRefusesWhenNoRestoreData:
+    """0 created + 0 modified → refuse, do not mark rolled_back."""
+
+    def setup_method(self):
+        self.client = MagicMock()
+        self.client.delete_channel = AsyncMock()
+        self.client.delete_channel_group = AsyncMock()
+        self.client.update_channel = AsyncMock()
+        self.engine = AutoCreationEngine(self.client)
+
+    @patch("auto_creation_engine.get_session")
+    def test_refuses_and_does_not_mark_rolled_back(self, mock_get_session):
+        """An execution with no recorded created/modified entities cannot be
+        guaranteed rolled back — refuse rather than silently no-op."""
+        mock_session = MagicMock()
+        mock_get_session.return_value = mock_session
+
+        mock_execution = MagicMock()
+        mock_execution.status = "completed"
+        mock_execution.mode = "execute"
+        mock_execution.get_created_entities.return_value = []
+        mock_execution.get_modified_entities.return_value = []
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+
+        result = asyncio.get_event_loop().run_until_complete(
+            self.engine.rollback_execution(42)
+        )
+
+        assert result["success"] is False
+        assert "error" in result
+        # Message must name the execution and explain why it refuses.
+        assert "42" in result["error"]
+        assert "cannot guarantee" in result["error"].lower()
+        # The decisive guard: status is NOT flipped to rolled_back, and no
+        # commit-style mutation of the status happened.
+        assert mock_execution.status != "rolled_back"
+        # Nothing was deleted or restored.
+        self.client.delete_channel.assert_not_called()
+        self.client.update_channel.assert_not_called()
+
+    @patch("auto_creation_engine.get_session")
+    def test_run_with_created_entities_is_unaffected(self, mock_get_session):
+        """A run that created entities still rolls back (only the both-empty
+        case refuses)."""
+        mock_session = MagicMock()
+        mock_get_session.return_value = mock_session
+
+        mock_execution = MagicMock()
+        mock_execution.status = "completed"
+        mock_execution.mode = "execute"
+        mock_execution.get_created_entities.return_value = [
+            {"type": "channel", "id": 1, "name": "ESPN"},
+        ]
+        mock_execution.get_modified_entities.return_value = []
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+
+        result = asyncio.get_event_loop().run_until_complete(
+            self.engine.rollback_execution(7)
+        )
+
+        assert result["success"] is True
+        assert mock_execution.status == "rolled_back"
+        self.client.delete_channel.assert_called_once_with(1)
+
+    @patch("auto_creation_engine.get_session")
+    def test_run_with_only_modified_entities_is_unaffected(self, mock_get_session):
+        """A merge-only run (0 created, modified present) still rolls back."""
+        mock_session = MagicMock()
+        mock_get_session.return_value = mock_session
+
+        mock_execution = MagicMock()
+        mock_execution.status = "completed"
+        mock_execution.mode = "execute"
+        mock_execution.get_created_entities.return_value = []
+        mock_execution.get_modified_entities.return_value = [
+            {"type": "channel", "id": 3, "name": "ESPN", "previous": {"streams": [10]}},
+        ]
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+
+        result = asyncio.get_event_loop().run_until_complete(
+            self.engine.rollback_execution(9)
+        )
+
+        assert result["success"] is True
+        assert mock_execution.status == "rolled_back"
+        self.client.update_channel.assert_called_once_with(3, {"streams": [10]})
+
+    @patch("auto_creation_engine.get_session")
+    def test_refusal_preserves_already_rolled_back_guard(self, mock_get_session):
+        """The already-rolled-back guard still fires before the no-data check."""
+        mock_session = MagicMock()
+        mock_get_session.return_value = mock_session
+
+        mock_execution = MagicMock()
+        mock_execution.status = "rolled_back"
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+
+        result = asyncio.get_event_loop().run_until_complete(
+            self.engine.rollback_execution(1)
+        )
+
+        assert result["success"] is False
+        assert "already rolled back" in result["error"].lower()

--- a/backend/tests/unit/test_0hjrk_run_summary_invariants.py
+++ b/backend/tests/unit/test_0hjrk_run_summary_invariants.py
@@ -1,0 +1,392 @@
+"""bd-0hjrk.7 + bd-0hjrk.8 — consolidated run-summary regression guard.
+
+These pin field semantics that bd-0emgo.4 established (merge -> streams_merged,
+channels_touched persisted, MCP formatter) plus the two NEW invariants the bead
+calls out, and the bd-0hjrk.8 match_by no-op guard.
+
+Part B (bd-0hjrk.7) — run-summary field semantics:
+  (a) merge_stream results count as streams_merged, NEVER channels_updated.
+  (b) INVARIANT: channels_touched <= streams_merged after a run merging N
+      streams into M (M<=N) distinct channels — the explicit inequality is the
+      new value over 0emgo.4's equality-on-a-fixed-scenario tests.
+  (c) a property-only update (logo/tvg/epg/number) increments channels_updated,
+      NOT streams_merged.
+  (d) execution_id is present in BOTH a dry_run and a real run result.
+
+Part C (bd-0hjrk.8, test-only slice) — match_by no-op:
+  Two merge_streams actions identical except for match_by ("tvg_id" vs
+  "normalized_name") resolve to the SAME target; loose_name_match is the toggle
+  that actually changes matching.
+
+Fixtures mirror the existing 0emgo.4 tests in
+``test_auto_creation_executor.py`` (ExecutionContext.add_result) and
+``test_auto_creation_engine.py::TestRunPipelineCreateChannelMergeChannelsTouched``
+(real-pipeline create+merge dry-run/live driver) so engine scaffolding is not
+rebuilt from scratch.
+"""
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from auto_creation_executor import ActionResult, ExecutionContext, ActionExecutor
+from auto_creation_evaluator import StreamContext
+from auto_creation_engine import AutoCreationEngine
+
+
+def _merge_result(entity_id, name="ESPN"):
+    return ActionResult(
+        success=True,
+        action_type="merge_stream",
+        description=f"Added stream to {name}",
+        entity_type="channel",
+        entity_id=entity_id,
+        entity_name=name,
+        modified=True,
+    )
+
+
+def _property_result(action_type, entity_id=1, name="ESPN"):
+    return ActionResult(
+        success=True,
+        action_type=action_type,
+        description=f"Updated {name} via {action_type}",
+        entity_type="channel",
+        entity_id=entity_id,
+        entity_name=name,
+        modified=True,
+    )
+
+
+class TestRunSummaryFieldSemantics:
+    """Part B (a), (c): merge vs property-only attribution at the chokepoint."""
+
+    def test_merge_counts_as_streams_merged_never_channels_updated(self):
+        """(a) merge_stream -> streams_merged, and channels_updated stays 0."""
+        ctx = ExecutionContext()
+        for i in range(25):
+            ctx.add_result(_merge_result(entity_id=(i % 5) + 1))
+
+        assert ctx.streams_merged == 25
+        assert ctx.channels_updated == 0, (
+            "merge_stream results must NEVER be counted as channels_updated"
+        )
+
+    def test_property_only_update_counts_as_channels_updated_not_streams_merged(self):
+        """(c) logo/tvg/epg/number updates -> channels_updated, not streams_merged."""
+        ctx = ExecutionContext()
+        for action_type in ("assign_logo", "assign_tvg_id", "assign_epg",
+                            "set_channel_number"):
+            ctx.add_result(_property_result(action_type))
+
+        assert ctx.channels_updated == 4
+        assert ctx.streams_merged == 0, (
+            "property-only updates must NOT inflate streams_merged"
+        )
+
+    def test_mixed_run_attributes_each_kind_separately(self):
+        """A run with both merges and property updates keeps the buckets distinct."""
+        ctx = ExecutionContext()
+        # 3 merges into 2 distinct channels.
+        ctx.add_result(_merge_result(entity_id=1))
+        ctx.add_result(_merge_result(entity_id=1))
+        ctx.add_result(_merge_result(entity_id=2))
+        # 2 property-only updates.
+        ctx.add_result(_property_result("assign_logo", entity_id=3))
+        ctx.add_result(_property_result("assign_epg", entity_id=4))
+
+        assert ctx.streams_merged == 3
+        assert ctx.channels_updated == 2
+        # channels_touched is derived from this set (engine unions across streams).
+        assert len(ctx.merged_channel_ids) == 2
+
+
+class TestChannelsTouchedInvariant:
+    """Part B (b): channels_touched <= streams_merged after a real merge run."""
+
+    def setup_method(self):
+        self.client = MagicMock()
+        self.client.get_channels = AsyncMock(return_value={"count": 0, "results": []})
+        self.client.get_channel_groups = AsyncMock(return_value=[])
+        self.client.update_channel = AsyncMock()
+        self.engine = AutoCreationEngine(self.client)
+
+    def _make_rule(self):
+        from models import AutoCreationRule
+
+        rule = AutoCreationRule()
+        rule.id = 1
+        rule.name = "Create+Merge Rule"
+        rule.priority = 0
+        rule.enabled = True
+        rule.m3u_account_id = None
+        rule.target_group_id = None
+        rule.stop_on_first_match = True
+        rule.match_scope_target_group = False
+        rule.match_scope_group_id = None
+        rule.skip_struck_streams = False
+        rule.set_conditions([{"type": "always"}])
+        rule.set_actions([{
+            "type": "create_channel",
+            "name_template": "{stream_name}",
+            "if_exists": "merge",
+        }])
+        return rule
+
+    def _make_streams(self, names_to_ids):
+        return [
+            StreamContext(stream_id=sid, stream_name=name, m3u_account_id=1)
+            for name, sid in names_to_ids
+        ]
+
+    def _run(self, rule, streams, dry_run):
+        self.engine._load_rules = AsyncMock(return_value=[rule])
+        self.engine._fetch_streams = AsyncMock(return_value=streams)
+        self.engine._create_execution = AsyncMock(return_value=MagicMock(id=1, mode=None))
+        self.engine._save_execution = AsyncMock()
+        self.engine._update_rule_stats = AsyncMock()
+
+        with patch("auto_creation_engine.get_session") as mock_get_session:
+            mock_get_session.return_value = MagicMock()
+            return asyncio.get_event_loop().run_until_complete(
+                self.engine.run_pipeline(dry_run=dry_run)
+            )
+
+    def test_channels_touched_le_streams_merged_dry_run(self):
+        """N streams merged into M<=N distinct channels => channels_touched <= streams_merged.
+
+        ESPN x3 -> 2 merged; CNN x2 -> 1 merged; FOX x1 -> 0 merged.
+        => streams_merged == 3 across M == 2 distinct channels (ESPN, CNN).
+        """
+        rule = self._make_rule()
+        streams = self._make_streams([
+            ("ESPN", 601), ("ESPN", 602), ("ESPN", 603),
+            ("CNN", 701), ("CNN", 702),
+            ("FOX", 801),
+        ])
+
+        result = self._run(rule, streams, dry_run=True)
+
+        merged = result["streams_merged"]
+        touched = result["channels_touched"]
+        assert merged == 3
+        assert touched == 2
+        assert touched <= merged, (
+            f"INVARIANT VIOLATED: channels_touched ({touched}) must be "
+            f"<= streams_merged ({merged}) — a channel cannot be 'touched by a "
+            f"merge' more times than there were merges"
+        )
+
+    def test_channels_touched_le_streams_merged_live(self):
+        """Same invariant holds on the live create+merge path."""
+        self._next_live_id = iter(range(3000, 4000))
+        self.client.create_channel = AsyncMock(
+            side_effect=lambda data: {
+                "id": next(self._next_live_id),
+                "name": data["name"],
+                "channel_number": data.get("channel_number"),
+                "channel_group_id": data.get("channel_group_id"),
+                "streams": data.get("streams", []),
+            }
+        )
+        rule = self._make_rule()
+        streams = self._make_streams([
+            ("ESPN", 901), ("ESPN", 902), ("ESPN", 903),
+            ("CNN", 911), ("CNN", 912),
+            ("FOX", 921),
+        ])
+
+        with patch("auto_creation_executor.journal.log_entry"):
+            result = self._run(rule, streams, dry_run=False)
+
+        merged = result["streams_merged"]
+        touched = result["channels_touched"]
+        assert merged == 3
+        assert touched == 2
+        assert touched <= merged, (
+            f"INVARIANT VIOLATED (live): channels_touched ({touched}) "
+            f"must be <= streams_merged ({merged})"
+        )
+
+
+class TestExecutionIdPresentBothModes:
+    """Part B (d): execution_id is returned for BOTH dry_run and real runs.
+
+    FINDING (run_pipeline, backend/auto_creation_engine.py): whenever there is
+    at least one enabled rule to process, the engine creates an
+    AutoCreationExecution row (mode="dry_run"/"execute") and returns
+    ``execution_id=execution.id`` for both modes (lines ~169-172, ~230). The
+    only path that returns NO execution_id is the no-enabled-rules early return
+    (no row is created there) — an expected no-op, not a dry_run gap. So
+    execution_id is genuinely present in both real-work modes; nothing is faked.
+    """
+
+    def setup_method(self):
+        self.client = MagicMock()
+        self.client.get_channels = AsyncMock(return_value={"count": 0, "results": []})
+        self.client.get_channel_groups = AsyncMock(return_value=[])
+        self.client.update_channel = AsyncMock()
+        self.engine = AutoCreationEngine(self.client)
+
+    def _make_rule(self):
+        from models import AutoCreationRule
+
+        rule = AutoCreationRule()
+        rule.id = 1
+        rule.name = "Create+Merge Rule"
+        rule.priority = 0
+        rule.enabled = True
+        rule.m3u_account_id = None
+        rule.target_group_id = None
+        rule.stop_on_first_match = True
+        rule.match_scope_target_group = False
+        rule.match_scope_group_id = None
+        rule.skip_struck_streams = False
+        rule.set_conditions([{"type": "always"}])
+        rule.set_actions([{
+            "type": "create_channel",
+            "name_template": "{stream_name}",
+            "if_exists": "merge",
+        }])
+        return rule
+
+    def _run(self, dry_run):
+        rule = self._make_rule()
+        streams = [StreamContext(stream_id=601, stream_name="ESPN", m3u_account_id=1)]
+        # The real execution id the row would carry — assert it is threaded out.
+        self.engine._load_rules = AsyncMock(return_value=[rule])
+        self.engine._fetch_streams = AsyncMock(return_value=streams)
+        self.engine._create_execution = AsyncMock(
+            return_value=MagicMock(id=4242, mode="dry_run" if dry_run else "execute")
+        )
+        self.engine._save_execution = AsyncMock()
+        self.engine._update_rule_stats = AsyncMock()
+
+        with patch("auto_creation_engine.get_session") as mock_get_session, \
+                patch("auto_creation_executor.journal.log_entry"):
+            mock_get_session.return_value = MagicMock()
+            return asyncio.get_event_loop().run_until_complete(
+                self.engine.run_pipeline(dry_run=dry_run)
+            )
+
+    def test_execution_id_present_dry_run(self):
+        result = self._run(dry_run=True)
+        assert "execution_id" in result
+        assert result["execution_id"] == 4242
+
+    def test_execution_id_present_real_run(self):
+        result = self._run(dry_run=False)
+        assert "execution_id" in result
+        assert result["execution_id"] == 4242
+
+
+class TestMatchByIsNoOp:
+    """Part C (bd-0hjrk.8): match_by is a documented no-op; loose_name_match is
+    the real matching toggle.
+
+    Two merge_streams actions identical except for match_by ("tvg_id" vs
+    "normalized_name") must resolve to the SAME target channel — match_by never
+    changes the resolved target. Then loose_name_match flipped on shows it IS
+    the toggle that changes matching (restores the fuzzy cascade).
+
+    (There is no exact_match/match_strict param — those do not exist.)
+    """
+
+    def _make_engine(self, core_map):
+        engine = MagicMock()
+
+        def _normalize(name, *args, **kwargs):
+            result = MagicMock()
+            result.normalized = core_map.get(name, name)
+            result.transformations = []
+            return result
+
+        engine.normalize.side_effect = _normalize
+        engine.extract_core_name.side_effect = lambda n: core_map.get(n, n)
+        engine.extract_call_sign.return_value = None
+        return engine
+
+    def _build(self):
+        client = MagicMock()
+        client.update_channel = AsyncMock(return_value={})
+        existing = [{"id": 50, "name": "SKY Sport 4K", "streams": [],
+                     "channel_group_id": 9}]
+        core_map = {
+            "SKY Sport 4K": "sky sport",
+            "Sky Sport Bundesliga": "sky sport bundesliga",
+        }
+        engine = self._make_engine(core_map)
+        executor = ActionExecutor(client, existing_channels=existing,
+                                  normalization_engine=engine)
+        return client, executor
+
+    def _stream(self, sid, name):
+        return StreamContext(
+            stream_id=sid,
+            stream_name=name,
+            m3u_account_id=1,
+            m3u_account_name="Provider",
+            group_name="Sports",
+            tvg_id=None,
+        )
+
+    def _merge(self, executor, stream_ctx, match_by, loose=False):
+        action = {"type": "merge_streams", "target": "auto", "match_by": match_by}
+        if loose:
+            action["loose_name_match"] = True
+        return asyncio.get_event_loop().run_until_complete(
+            executor.execute(action, stream_ctx, ExecutionContext(),
+                             normalization_group_ids=[1])
+        )
+
+    def test_match_by_does_not_change_resolved_target_exact_case(self):
+        """An EXACT-name match resolves the SAME way under both match_by values."""
+        # Stream whose normalized/core name equals the channel core ("sky sport").
+        client_a, executor_a = self._build()
+        result_tvg = self._merge(executor_a, self._stream(401, "SKY Sport 4K"),
+                                 match_by="tvg_id")
+
+        client_b, executor_b = self._build()
+        result_norm = self._merge(executor_b, self._stream(401, "SKY Sport 4K"),
+                                  match_by="normalized_name")
+
+        # Both succeed and resolve to the SAME channel (id=50) — match_by inert.
+        assert result_tvg.success is True
+        assert result_norm.success is True
+        assert client_a.update_channel.call_args[0][0] == 50
+        assert client_b.update_channel.call_args[0][0] == 50
+        assert (client_a.update_channel.call_args[0][0]
+                == client_b.update_channel.call_args[0][0]), (
+            "match_by must NOT change the resolved merge target"
+        )
+
+    def test_match_by_does_not_change_resolved_target_no_match_case(self):
+        """A non-exact stream is SKIPPED under both match_by values (no fuzzy)."""
+        client_a, executor_a = self._build()
+        result_tvg = self._merge(executor_a, self._stream(501, "Sky Sport Bundesliga"),
+                                 match_by="tvg_id")
+
+        client_b, executor_b = self._build()
+        result_norm = self._merge(executor_b, self._stream(501, "Sky Sport Bundesliga"),
+                                  match_by="normalized_name")
+
+        assert result_tvg.skipped is True
+        assert result_norm.skipped is True
+        client_a.update_channel.assert_not_called()
+        client_b.update_channel.assert_not_called()
+
+    def test_loose_name_match_is_the_real_toggle(self):
+        """loose_name_match=True (NOT match_by) is what changes matching: the
+        'Sky Sport Bundesliga' stream that was skipped now merges into id=50."""
+        # Default (loose off): skipped — proven above.
+        client_off, executor_off = self._build()
+        result_off = self._merge(executor_off, self._stream(601, "Sky Sport Bundesliga"),
+                                 match_by="tvg_id", loose=False)
+        assert result_off.skipped is True
+        client_off.update_channel.assert_not_called()
+
+        # loose on: same stream, same match_by, now merges (fuzzy cascade).
+        client_on, executor_on = self._build()
+        result_on = self._merge(executor_on, self._stream(601, "Sky Sport Bundesliga"),
+                                match_by="tvg_id", loose=True)
+        assert result_on.success is True
+        client_on.update_channel.assert_called()
+        assert client_on.update_channel.call_args[0][0] == 50

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0001",
+  "version": "0.17.3-0002",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mcp-server/tests/test_0hjrk_rollback.py
+++ b/mcp-server/tests/test_0hjrk_rollback.py
@@ -1,0 +1,135 @@
+"""bd-0hjrk.2 — MCP rollback_auto_creation: refusal surfacing + success wording.
+
+The engine refuses to roll back an execution with no recorded created/modified
+entities (returns ``success=False`` + an error). The backend router turns that
+into an HTTP 400 whose ``detail`` is the refusal message, so the MCP client's
+``call_endpoint`` raises with that text. The tool must surface it clearly rather
+than report a phantom clean rollback.
+
+On success the tool clarifies the wording: it reports channels deleted AND
+channels restored to their pre-run stream sets (streams un-merged).
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+def _make_ecm_client_mock(**method_returns):
+    mock = AsyncMock()
+    for method, return_value in method_returns.items():
+        getattr(mock, method).return_value = return_value
+    return mock
+
+
+class TestRollbackRefusalSurfaced:
+    """The refusal message reaches the user clearly."""
+
+    @pytest.mark.asyncio
+    async def test_refusal_via_http_error_is_surfaced(self):
+        """Backend 400 (engine refusal) -> call_endpoint raises -> tool returns
+        the refusal text, not a phantom 'rolled back' success line."""
+        from tools.auto_creation import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        refusal = (
+            "No recorded created or modified entities for execution 5; cannot "
+            "guarantee a rollback (the run predates entity tracking or made no "
+            "changes). Refusing to mark it rolled_back."
+        )
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = RuntimeError(
+            f"POST /api/auto-creation/executions/5/rollback failed (400): {refusal}"
+        )
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("rollback_auto_creation", {"execution_id": 5})
+
+        text = result[0][0].text
+        assert "cannot guarantee a rollback" in text.lower()
+        assert "5" in text
+        # Must NOT claim a clean rollback happened.
+        assert "rolled back. 0 channel" not in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_refusal_via_success_false_dict_is_surfaced(self):
+        """Defensive: if the engine refusal reaches the tool as a dict
+        (success False / error) instead of an exception, surface it too."""
+        from tools.auto_creation import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        refusal = (
+            "No recorded created or modified entities for execution 9; cannot "
+            "guarantee a rollback. Refusing to mark it rolled_back."
+        )
+        mock_client = _make_ecm_client_mock(call_endpoint={
+            "success": False,
+            "error": refusal,
+        })
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("rollback_auto_creation", {"execution_id": 9})
+
+        text = result[0][0].text
+        assert "cannot guarantee a rollback" in text.lower()
+        assert "rolled back" not in text.lower() or "refus" in text.lower()
+
+
+class TestRollbackSuccessWording:
+    """On success the tool clarifies deleted vs un-merged channels."""
+
+    @pytest.mark.asyncio
+    async def test_success_reports_deleted_and_unmerged(self):
+        """N deleted + M restored renders both counts and explains un-merge."""
+        from tools.auto_creation import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = _make_ecm_client_mock(call_endpoint={
+            "success": True,
+            "execution_id": 7,
+            "rule_name": "Sports Rule",
+            "entities_removed": 45,
+            "entities_restored": 3,
+        })
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("rollback_auto_creation", {"execution_id": 7})
+
+        text = result[0][0].text
+        assert "45" in text
+        assert "3" in text
+        assert "delet" in text.lower()
+        # Clarified wording: restored channels had their pre-run stream sets put
+        # back (streams un-merged).
+        assert "un-merg" in text.lower() or "pre-run stream" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_success_with_only_deletions(self):
+        """A create-only run rollback reports deletions and 0 restored."""
+        from tools.auto_creation import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = _make_ecm_client_mock(call_endpoint={
+            "success": True,
+            "execution_id": 8,
+            "rule_name": "News Rule",
+            "entities_removed": 10,
+            "entities_restored": 0,
+        })
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool("rollback_auto_creation", {"execution_id": 8})
+
+        text = result[0][0].text
+        assert "10" in text
+        assert "delet" in text.lower()

--- a/mcp-server/tools/auto_creation.py
+++ b/mcp-server/tools/auto_creation.py
@@ -672,7 +672,25 @@ def register(mcp: FastMCP):
 
     @mcp.tool()
     async def rollback_auto_creation(execution_id: int) -> str:
-        """Rollback an auto-creation execution, deleting all channels it created.
+        """Rollback an auto-creation execution.
+
+        Undoes everything the run did:
+          - DELETES every channel (and group) the run created.
+          - UN-MERGES streams the run added to PRE-EXISTING channels — each
+            touched channel is restored to its exact pre-run stream set. If the
+            run merged several streams into the same channel, the cumulative
+            snapshots are replayed in reverse so the ORIGINAL stream list wins
+            (bd-a7okb), not an intermediate state.
+
+        Guarantee: a successful rollback returns the affected channels to their
+        pre-run state — created channels gone, merged streams removed.
+
+        Caveat — no restore data: an execution that recorded NEITHER created NOR
+        modified entities (a legacy run from before entity tracking, or a run
+        that changed nothing) cannot be guaranteed reversible. Rather than mark
+        it rolled_back and report a phantom clean rollback, the engine REFUSES
+        and this tool surfaces the refusal. The execution's status is left
+        unchanged.
 
         Args:
             execution_id: The execution ID to rollback
@@ -682,18 +700,35 @@ def register(mcp: FastMCP):
             result = await client.call_endpoint(
                 ENDPOINTS["ac_rollback"], path_args={"execution_id": execution_id}, timeout=300.0,
             )
+            # Defensive: if the engine refusal (or any failure) reaches us as a
+            # dict (success False / error) instead of an HTTP error, surface it
+            # rather than printing a phantom clean-rollback line. (The live
+            # backend turns engine refusals into HTTP 400, which arrives via the
+            # except branch below — this guards direct/changed call paths.)
+            if isinstance(result, dict) and (result.get("success") is False or result.get("error")):
+                return (
+                    f"Cannot roll back execution {execution_id}: "
+                    f"{result.get('error', 'rollback refused')}"
+                )
             # Engine returns entities_removed (channels deleted) and
-            # entities_restored (streams/entities un-merged). Neither
-            # "deleted" nor "channels_deleted" exists in the response shape
-            # — reading those keys always produced 0 (bd-1wq7z.5).
-            removed = result.get("entities_removed", 0)
-            restored = result.get("entities_restored", 0)
+            # entities_restored (channels whose pre-run stream set was put back,
+            # i.e. streams un-merged). Neither "deleted" nor "channels_deleted"
+            # exists in the response shape — reading those keys always produced
+            # 0 (bd-1wq7z.5).
+            removed = result.get("entities_removed", 0) if isinstance(result, dict) else 0
+            restored = result.get("entities_restored", 0) if isinstance(result, dict) else 0
             msg = f"Execution {execution_id} rolled back. {removed} channel(s) deleted"
             if restored:
-                msg += f", {restored} entit{'y' if restored == 1 else 'ies'} restored"
+                msg += (
+                    f", {restored} channel(s) restored to their pre-run stream "
+                    f"sets (streams un-merged)"
+                )
             msg += "."
             return msg
         except Exception as e:
+            # The backend converts the engine's no-restore-data refusal into an
+            # HTTP 400 whose detail is the refusal message; call_endpoint raises
+            # it here. Surface it clearly so the user sees WHY nothing changed.
             logger.error("[MCP] rollback_auto_creation failed: %s", e)
             return f"Error rolling back execution {execution_id}: {e}"
 


### PR DESCRIPTION
## bd-0hjrk.2 + .7 (+ .8 test slice) — parent bd-0hjrk

### .2 rollback_auto_creation guarantees
bd-a7okb already made the engine un-merge merge-only runs (reversed modified-entity restore). Remaining gaps closed here:
- **MCP docstring** rewritten: documents that rollback DELETES created channels AND un-merges streams added to pre-existing channels (restores each touched channel's pre-run stream set), plus the no-restore-data caveat.
- **Engine refusal**: an execution with ZERO created AND ZERO modified entities (legacy run / no snapshot) no longer silently reports a phantom clean rollback — `rollback_execution` refuses (`success:false`, status left unchanged). Runs that created/modified anything are unaffected.
- **MCP** surfaces the refusal (HTTP 400 path + defensive dict path) and clarifies success wording ('N channel(s) restored to pre-run stream sets — streams un-merged').

### .7 run-summary field-semantics regression guard
bd-0emgo.4 already made merges increment `streams_merged` (not `channels_updated`) + persist `channels_touched`. This adds a consolidated guard test: (a) merges→Stream merges never Channels updated, (b) invariant **channels_touched ≤ streams_merged**, (c) channels_updated = property-only, (d) execution_id present in BOTH dry-run and real runs. Finding: run_pipeline returns execution_id for dry_run + real whenever ≥1 enabled rule exists (only the no-rules early return has none — expected).

### .8 (test slice) match_by no-op guard
Asserts `match_by` ('tvg_id' vs 'normalized_name') does NOT change merge matching; `loose_name_match` is the real toggle. (`exact_match`/`match_strict` don't exist.) Docs slice of .8 ships separately.

Gates: backend 5012 passed, MCP 363 passed (post-merge with dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)