### PR TITLE
v0.17.3-0003: channel-group count fix + list_channel_groups compact/pagination (bd-0hjrk.3/.4)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -130,7 +130,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0002",
+    version="0.17.3-0003",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0002"
+APP_VERSION = "0.17.3-0003"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/routers/channel_groups.py
+++ b/backend/routers/channel_groups.py
@@ -661,6 +661,12 @@ async def get_groups_with_auto_created_channels():
             groups_with_auto_created.append({
                 "id": group_id,
                 "name": group_info.get("name", f"Unknown Group {group_id}"),
+                # Total membership of the group, straight from the Dispatcharr
+                # group object (same ``channel_count`` field that the plain
+                # /channel-groups list surfaces). This is NOT the auto-created
+                # subset — a group can have 170 channels of which only 12 were
+                # auto-created (bd-0hjrk.3).
+                "channel_count": group_info.get("channel_count", 0),
                 "auto_created_count": len(channels),
                 "sample_channels": channels[:5],  # First 5 as samples
             })

--- a/backend/tests/routers/test_0hjrk_auto_created_groups.py
+++ b/backend/tests/routers/test_0hjrk_auto_created_groups.py
@@ -1,0 +1,92 @@
+"""TDD tests for bd-0hjrk.3 — auto-created groups must report total membership.
+
+ROOT CAUSE: GET /api/channel-groups/auto-created returned each group as
+``{id, name, auto_created_count, sample_channels}``. ``auto_created_count``
+counts ONLY channels with ``auto_created=True`` in the group — it is NOT the
+group's total membership. The MCP tool read a non-existent ``channel_count``
+key (always 0). The fix surfaces the Dispatcharr group object's ``channel_count``
+(total membership) alongside ``auto_created_count`` so the operator sees both
+the full group size and the auto-created subset.
+
+Mocks: get_client() at router module level (per backend/CLAUDE.md).
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+class TestAutoCreatedGroupsTotalMembership:
+    """GET /api/channel-groups/auto-created reports both counts."""
+
+    @pytest.mark.asyncio
+    async def test_includes_total_channel_count_and_auto_created_count(self, async_client):
+        """A group with 170 total channels but 12 auto-created reports BOTH.
+
+        The Dispatcharr group object carries ``channel_count`` (total
+        membership = 170). Only 12 of those channels are ``auto_created=True``.
+        The endpoint entry must report ``channel_count == 170`` AND
+        ``auto_created_count == 12``.
+        """
+        mock_client = AsyncMock()
+        # Dispatcharr group object: total membership is 170 (channel_count),
+        # which is NOT equal to the auto-created subset.
+        mock_client.get_channel_groups.return_value = [
+            {"id": 1, "name": "Sports", "channel_count": 170},
+        ]
+        # 12 auto-created channels in group 1 (a subset of the 170 total).
+        auto_created_channels = [
+            {
+                "id": 100 + i,
+                "name": f"Auto Channel {i}",
+                "channel_group_id": 1,
+                "auto_created": True,
+                "channel_number": 100 + i,
+                "auto_created_by": 1,
+                "auto_created_by_name": "Rule 1",
+            }
+            for i in range(12)
+        ]
+        mock_client.get_channels.return_value = {
+            "results": auto_created_channels,
+            "next": None,
+        }
+
+        with patch("routers.channel_groups.get_client", return_value=mock_client):
+            response = await async_client.get("/api/channel-groups/auto-created")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["groups"]) == 1
+        group = data["groups"][0]
+        assert group["channel_count"] == 170, (
+            f"Expected total membership channel_count=170, got: {group!r}"
+        )
+        assert group["auto_created_count"] == 12, (
+            f"Expected auto_created_count=12 (the subset), got: {group!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_channel_count_defaults_to_zero_when_missing(self, async_client):
+        """If the Dispatcharr group object lacks channel_count, default to 0.
+
+        Guards against a KeyError when the upstream group object is missing the
+        field — the entry must still surface auto_created_count.
+        """
+        mock_client = AsyncMock()
+        mock_client.get_channel_groups.return_value = [
+            {"id": 1, "name": "Sports"},  # no channel_count key
+        ]
+        mock_client.get_channels.return_value = {
+            "results": [
+                {"id": 10, "name": "ESPN", "channel_group_id": 1, "auto_created": True,
+                 "channel_number": 100, "auto_created_by": 1, "auto_created_by_name": "Rule 1"},
+            ],
+            "next": None,
+        }
+
+        with patch("routers.channel_groups.get_client", return_value=mock_client):
+            response = await async_client.get("/api/channel-groups/auto-created")
+
+        assert response.status_code == 200
+        group = response.json()["groups"][0]
+        assert group["channel_count"] == 0
+        assert group["auto_created_count"] == 1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0002",
+  "version": "0.17.3-0003",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mcp-server/tests/test_0hjrk_channel_groups.py
+++ b/mcp-server/tests/test_0hjrk_channel_groups.py
@@ -1,0 +1,232 @@
+"""TDD tests for bd-0hjrk.3 and bd-0hjrk.4 — channel_groups MCP tools.
+
+bd-0hjrk.3: get_auto_created_groups must render BOTH the total membership count
+  and the auto-created subset. The backend returns ``channel_count`` (total)
+  and ``auto_created_count`` (subset); the tool previously read a key that did
+  not exist and always printed 0.
+
+bd-0hjrk.4: list_channel_groups dumped ALL groups (~1115 live) with no compact
+  mode and no pagination, blowing the MCP token limit. It must mirror
+  list_channels: ``compact=True`` (pipe-delimited, ignores pagination, shows
+  all) plus ``page``/``page_size`` so the default human call is bounded.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+def _make_mcp_and_register():
+    from mcp.server.fastmcp import FastMCP
+    from tools.channel_groups import register
+
+    mcp = FastMCP("test")
+    register(mcp)
+    return mcp
+
+
+class TestGetAutoCreatedGroupsRendersBothCounts:
+    """get_auto_created_groups shows total membership AND auto-created subset."""
+
+    @pytest.mark.asyncio
+    async def test_renders_membership_and_auto_created_counts(self):
+        """Render must read channel_count (170) and auto_created_count (12)."""
+        mcp = _make_mcp_and_register()
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            if endpoint.name == "groups_auto_created":
+                return {
+                    "groups": [
+                        {
+                            "id": 1,
+                            "name": "Sports",
+                            "channel_count": 170,
+                            "auto_created_count": 12,
+                            "sample_channels": [],
+                        }
+                    ],
+                    "total_auto_created_channels": 12,
+                }
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.channel_groups.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("get_auto_created_groups", {})
+
+        text = result[0][0].text
+        assert "170 channels" in text, (
+            f"Expected total membership '170 channels' in output, got: {text!r}"
+        )
+        assert "12 auto-created" in text, (
+            f"Expected '12 auto-created' subset in output, got: {text!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_does_not_print_zero_for_populated_group(self):
+        """Regression: tool must NOT print 0 channels for a populated group."""
+        mcp = _make_mcp_and_register()
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            if endpoint.name == "groups_auto_created":
+                return {
+                    "groups": [
+                        {"id": 5, "name": "Movies", "channel_count": 88,
+                         "auto_created_count": 3, "sample_channels": []}
+                    ],
+                    "total_auto_created_channels": 3,
+                }
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.channel_groups.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("get_auto_created_groups", {})
+
+        text = result[0][0].text
+        assert "Movies" in text
+        # Must not render the broken "0 channels" for a group with 88 members.
+        assert "0 channels" not in text, (
+            f"Tool printed '0 channels' for a populated group: {text!r}"
+        )
+
+
+def _make_groups(n):
+    """Build n fake group dicts for pagination tests."""
+    return [
+        {"id": i, "name": f"Group {i}", "channel_count": i}
+        for i in range(1, n + 1)
+    ]
+
+
+class TestListChannelGroupsCompact:
+    """list_channel_groups compact mode: pipe-delimited, all rows, header."""
+
+    @pytest.mark.asyncio
+    async def test_compact_returns_header_and_pipe_rows(self):
+        """compact=True returns 'id|name|channel_count' header + pipe rows."""
+        mcp = _make_mcp_and_register()
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            if endpoint.name == "groups_list":
+                return [
+                    {"id": 1, "name": "Sports", "channel_count": 170},
+                    {"id": 2, "name": "Movies", "channel_count": 88},
+                ]
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.channel_groups.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("list_channel_groups", {"compact": True})
+
+        text = result[0][0].text
+        lines = text.splitlines()
+        assert lines[0] == "id|name|channel_count", (
+            f"Expected pipe header first, got: {lines[0]!r}"
+        )
+        assert "1|Sports|170" in lines
+        assert "2|Movies|88" in lines
+
+    @pytest.mark.asyncio
+    async def test_compact_shows_all_rows_ignoring_pagination(self):
+        """compact=True shows ALL groups, ignoring page/page_size (like list_channels)."""
+        mcp = _make_mcp_and_register()
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            if endpoint.name == "groups_list":
+                return _make_groups(250)
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.channel_groups.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "list_channel_groups", {"compact": True, "page": 1, "page_size": 100}
+            )
+
+        text = result[0][0].text
+        data_rows = [ln for ln in text.splitlines() if "|" in ln and not ln.startswith("id|")]
+        assert len(data_rows) == 250, (
+            f"compact must show all 250 rows ignoring page_size, got {len(data_rows)}"
+        )
+
+
+class TestListChannelGroupsPagination:
+    """list_channel_groups human mode: paginate so the default call is bounded."""
+
+    @pytest.mark.asyncio
+    async def test_default_call_does_not_dump_everything(self):
+        """Default (non-compact) call must NOT dump all 1115 groups."""
+        mcp = _make_mcp_and_register()
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            if endpoint.name == "groups_list":
+                return _make_groups(1115)
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.channel_groups.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("list_channel_groups", {})
+
+        text = result[0][0].text
+        rendered_groups = [ln for ln in text.splitlines() if "(id=" in ln]
+        # Default page_size is 100 — far fewer than 1115.
+        assert len(rendered_groups) <= 100, (
+            f"Default call dumped {len(rendered_groups)} groups — must be bounded by page_size"
+        )
+
+    @pytest.mark.asyncio
+    async def test_paged_call_returns_only_page_size_rows(self):
+        """A paged call returns only page_size rows and notes the page."""
+        mcp = _make_mcp_and_register()
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            if endpoint.name == "groups_list":
+                return _make_groups(250)
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.channel_groups.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "list_channel_groups", {"page": 2, "page_size": 50}
+            )
+
+        text = result[0][0].text
+        rendered_groups = [ln for ln in text.splitlines() if "(id=" in ln]
+        assert len(rendered_groups) == 50, (
+            f"Expected exactly 50 rows on page 2, got {len(rendered_groups)}: {text!r}"
+        )
+        # Page 2 of page_size 50 → ids 51..100
+        assert "(id=51)" in text, f"Expected page-2 first row id=51, got: {text!r}"
+        assert "(id=100)" in text, f"Expected page-2 last row id=100, got: {text!r}"
+        assert "(id=50)" not in text, "Page 2 must not include page-1 rows"
+        # Output should note pagination context (page number / total).
+        assert "page 2" in text.lower() or "page=2" in text.lower(), (
+            f"Expected page context in output: {text!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_groups_message(self):
+        """No groups still returns a friendly message (no crash)."""
+        mcp = _make_mcp_and_register()
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            if endpoint.name == "groups_list":
+                return []
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.channel_groups.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("list_channel_groups", {})
+
+        text = result[0][0].text
+        assert "No channel groups" in text

--- a/mcp-server/tests/test_tools.py
+++ b/mcp-server/tests/test_tools.py
@@ -1191,10 +1191,14 @@ class TestGetAutoCreatedGroupsEnvelopeUnwrap:
             result = await mcp.call_tool("get_auto_created_groups", {})
 
         text = result[0][0].text
-        assert "2 auto-created" in text
+        # Both groups in the envelope are rendered (unwrap worked).
+        assert "Found 2 groups" in text
         assert "Sports AC" in text
         assert "News AC" in text
         assert "id=20" in text
+        # Per-group auto-created subset counts are rendered (bd-0hjrk.3).
+        assert "5 auto-created" in text
+        assert "3 auto-created" in text
         assert "has no attribute" not in text
 
     @pytest.mark.asyncio

--- a/mcp-server/tools/channel_groups.py
+++ b/mcp-server/tools/channel_groups.py
@@ -11,21 +11,73 @@ logger = logging.getLogger(__name__)
 
 def register(mcp: FastMCP):
     @mcp.tool()
-    async def list_channel_groups() -> str:
-        """List all channel groups with their channel counts."""
+    async def list_channel_groups(
+        compact: bool = False,
+        page: int = 1,
+        page_size: int = 100,
+    ) -> str:
+        """List all channel groups with their channel counts.
+
+        The live system can hold ~1000+ groups, so the default human-readable
+        call is PAGINATED to stay within the MCP token limit (bd-0hjrk.4).
+
+        Args:
+            compact: If True, output pipe-delimited format optimized for agent
+                consumption — ``id|name|channel_count`` with a header line.
+                Ignores pagination and shows ALL groups (mirrors list_channels).
+            page: 1-based page number for the human-readable format (default 1).
+            page_size: Rows per page for the human-readable format (default 100).
+        """
         try:
             client = get_ecm_client()
             groups = await client.call_endpoint(ENDPOINTS["groups_list"])
+            # Backend groups_list returns a flat list with no server-side
+            # pagination, so we slice client-side.
+            groups = groups or []
 
             if not groups:
                 return "No channel groups found."
 
-            lines = [f"Found {len(groups)} channel groups:"]
-            for g in groups:
+            if compact:
+                # Pipe-delimited, all rows, no pagination — same idiom as
+                # list_channels' compact mode.
+                lines = ["id|name|channel_count"]
+                for g in groups:
+                    gid = g.get("id", "?")
+                    name = g.get("name", "Unknown")
+                    channel_count = g.get("channel_count", 0)
+                    lines.append(f"{gid}|{name}|{channel_count}")
+                return "\n".join(lines)
+
+            total = len(groups)
+            page = max(page, 1)
+            page_size = max(page_size, 1)
+            start = (page - 1) * page_size
+            end = start + page_size
+            shown = groups[start:end]
+            total_pages = (total + page_size - 1) // page_size
+
+            if not shown:
+                return (
+                    f"No channel groups on page {page} "
+                    f"(total {total} groups across {total_pages} pages)."
+                )
+
+            lines = [
+                f"Found {total} channel groups "
+                f"(page {page}/{total_pages}, showing {len(shown)}):"
+            ]
+            for g in shown:
                 name = g.get("name", "Unknown")
                 gid = g.get("id", "?")
                 channel_count = g.get("channel_count", 0)
                 lines.append(f"  {name} (id={gid}) — {channel_count} channels")
+
+            if page < total_pages:
+                lines.append(
+                    f"  ... {total - end} more — request page {page + 1} "
+                    f"(or use compact=True for all groups in one call)"
+                )
 
             return "\n".join(lines)
         except Exception as e:
@@ -182,7 +234,17 @@ def register(mcp: FastMCP):
 
     @mcp.tool()
     async def get_auto_created_groups() -> str:
-        """List channel groups that were created by the auto-creation pipeline."""
+        """List channel groups that contain auto-created channels.
+
+        Each group shows two distinct counts:
+          - **channels**: total group membership (every channel in the group,
+            regardless of how it was created).
+          - **auto-created**: the subset of that membership whose channels were
+            produced by the auto-creation pipeline (auto_created=True).
+
+        A group can show e.g. "170 channels (12 auto-created)" — most of the
+        group was created manually or by M3U sync; only 12 came from a rule.
+        """
         try:
             client = get_ecm_client()
             resp = await client.call_endpoint(ENDPOINTS["groups_auto_created"])
@@ -193,12 +255,20 @@ def register(mcp: FastMCP):
             if not groups:
                 return "No auto-created channel groups."
 
-            lines = [f"Found {len(groups)} auto-created groups:"]
+            lines = [f"Found {len(groups)} groups with auto-created channels:"]
             for g in groups:
                 name = g.get("name", "Unknown")
                 gid = g.get("id", "?")
+                # channel_count = total membership; auto_created_count = subset.
+                # bd-0hjrk.3: the tool used to read a non-existent
+                # "channel_count" off the old payload and always printed 0;
+                # the backend now supplies both, so render both explicitly.
                 channel_count = g.get("channel_count", 0)
-                lines.append(f"  {name} (id={gid}) — {channel_count} channels")
+                auto_created_count = g.get("auto_created_count", 0)
+                lines.append(
+                    f"  {name} (id={gid}) — {channel_count} channels "
+                    f"({auto_created_count} auto-created)"
+                )
 
             return "\n".join(lines)
         except Exception as e:


### PR DESCRIPTION
## bd-0hjrk.3 + .4 — parent bd-0hjrk

### .3 get_auto_created_groups reported 0 channels for populated groups
**Root cause:** MCP tool read `g.get('channel_count')` but the backend GET /api/channel-groups/auto-created returned only `auto_created_count` (the auto_created=True subset) → always 0; and that count isn't total membership anyway. **Fix:** backend now also returns the group's total `channel_count` (from the Dispatcharr group object — verified live: Radio=427, Entertainment=135); MCP renders `NAME (id=X) — N channels (M auto-created)`. Docstring defines both counts.

### .4 list_channel_groups exceeded the MCP token limit
**Root cause:** dumped all ~1115 groups (~126KB), no compact/pagination → 'result exceeds maximum allowed tokens'. **Fix:** mirror list_channels — `compact=True` (pipe-delimited `id|name|channel_count`, shows all) + `page`/`page_size` (default 100, client-side slice over the backend's flat list). Docstring updated.

Tests: backend/tests/routers/test_0hjrk_auto_created_groups.py (channel_count + auto_created_count), mcp-server/tests/test_0hjrk_channel_groups.py (membership+auto-created render, compact, pagination). Gates: backend 5014, MCP 370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)