### PR TITLE
v0.17.3-0004: get_streams_by_ids assignment status (opt-in, cached) (bd-0hjrk.6)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -130,7 +130,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0003",
+    version="0.17.3-0004",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0003"
+APP_VERSION = "0.17.3-0004"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/routers/streams.py
+++ b/backend/routers/streams.py
@@ -23,6 +23,16 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Streams"])
 
+# Cache key + TTL for the reverse stream_id -> [channel_id] assignment index.
+# Dispatcharr's stream payloads carry NO per-stream channel linkage, so
+# assignment must be derived by paginating get_channels() and inverting each
+# channel's `streams` list. That paginated fetch is expensive, so the inverted
+# index is cached under a stable key with a SHORT TTL: assignment changes when
+# streams are added/removed from channels, and a 45s window keeps repeated
+# opt-in (include_assignment) calls cheap without serving badly stale linkage.
+ASSIGNMENT_INDEX_CACHE_KEY = "stream_channel_assignment_index"
+ASSIGNMENT_INDEX_TTL_SECONDS = 45
+
 
 class StreamSortOrder(str, Enum):
     """Available server-side sort orders for streams."""
@@ -50,6 +60,68 @@ def _enrich_stream_results(streams: list[dict]) -> None:
         )
 
 
+async def _get_stream_channel_index() -> dict[int, list[int]]:
+    """Build (or reuse a cached) reverse stream_id -> [channel_id] index.
+
+    Dispatcharr stream payloads carry no channel linkage, so assignment is
+    derived by paginating get_channels() and inverting each channel's `streams`
+    ID list — the same cross-reference the struck-out-streams endpoint uses
+    (see backend/routers/stream_stats.py). The result is cached under
+    ASSIGNMENT_INDEX_CACHE_KEY with the short ASSIGNMENT_INDEX_TTL_SECONDS TTL so
+    repeated opt-in (include_assignment) calls don't re-fetch every channel.
+
+    Returns a dict mapping stream_id to the list of channel_ids it belongs to,
+    in channel-encounter order (first encountered channel first).
+    """
+    cache = get_cache()
+    cached = cache.get(ASSIGNMENT_INDEX_CACHE_KEY, ttl=ASSIGNMENT_INDEX_TTL_SECONDS)
+    if cached is not None:
+        return cached
+
+    client = get_client()
+    start = time.time()
+    all_channels: list[dict] = []
+    page = 1
+    while True:
+        result = await client.get_channels(page=page, page_size=100)
+        page_channels = result.get("results", [])
+        all_channels.extend(page_channels)
+        if len(all_channels) >= result.get("count", 0) or not page_channels:
+            break
+        page += 1
+
+    index: dict[int, list[int]] = {}
+    for ch in all_channels:
+        ch_id = ch.get("id")
+        if ch_id is None:
+            continue
+        for sid in ch.get("streams", []) or []:
+            index.setdefault(sid, []).append(ch_id)
+
+    elapsed_ms = (time.time() - start) * 1000
+    logger.debug(
+        "[STREAMS] Built stream->channel assignment index from %d channels "
+        "(%d assigned streams) in %.1fms",
+        len(all_channels), len(index), elapsed_ms,
+    )
+    cache.set(ASSIGNMENT_INDEX_CACHE_KEY, index)
+    return index
+
+
+def _apply_assignment(streams: list[dict], index: dict[int, list[int]]) -> None:
+    """Annotate each stream in-place with channel-assignment status.
+
+    Sets ``has_channel`` (bool), ``assigned_channel_id`` (first channel id or
+    None) and ``assigned_channel_ids`` (full list) from the reverse index.
+    """
+    for stream in streams:
+        sid = stream.get("id")
+        channel_ids = index.get(sid, [])
+        stream["assigned_channel_ids"] = list(channel_ids)
+        stream["assigned_channel_id"] = channel_ids[0] if channel_ids else None
+        stream["has_channel"] = bool(channel_ids)
+
+
 @router.get("/api/streams")
 async def get_streams(
     page: int = 1,
@@ -59,20 +131,29 @@ async def get_streams(
     m3u_account: Optional[int] = None,
     sort: Optional[StreamSortOrder] = None,
     enrich: bool = True,
+    include_assignment: bool = False,
     bypass_cache: bool = False,
 ):
-    """List streams with pagination, search, filtering, and enrichment."""
+    """List streams with pagination, search, filtering, and enrichment.
+
+    When ``include_assignment`` is True, each returned stream is annotated with
+    ``has_channel`` / ``assigned_channel_id`` / ``assigned_channel_ids`` derived
+    from a cached reverse stream->channel index (see
+    ``_get_stream_channel_index``). This costs an extra paginated channel fetch
+    (cached for ASSIGNMENT_INDEX_TTL_SECONDS), so it is opt-in; the default path
+    is unchanged.
+    """
     start_time = time.time()
     logger.debug(
         "[STREAMS] Fetching streams - page=%s, page_size=%s, "
-        "search=%s, group=%s, m3u=%s, bypass_cache=%s",
+        "search=%s, group=%s, m3u=%s, include_assignment=%s, bypass_cache=%s",
         page, page_size,
-        search, channel_group_name, m3u_account, bypass_cache
+        search, channel_group_name, m3u_account, include_assignment, bypass_cache
     )
 
     cache = get_cache()
     sort_str = sort.value if sort else ""
-    cache_key = f"streams:p{page}:ps{page_size}:s{search or ''}:g{channel_group_name or ''}:m{m3u_account or ''}:sort{sort_str}:e{enrich}"
+    cache_key = f"streams:p{page}:ps{page_size}:s{search or ''}:g{channel_group_name or ''}:m{m3u_account or ''}:sort{sort_str}:e{enrich}:a{include_assignment}"
 
     # Try cache first (unless bypassed)
     if not bypass_cache:
@@ -117,6 +198,11 @@ async def get_streams(
         # Enrich streams with normalization metadata
         if enrich:
             _enrich_stream_results(streams)
+
+        # Optionally annotate channel-assignment status (opt-in: extra cost).
+        if include_assignment and streams:
+            index = await _get_stream_channel_index()
+            _apply_assignment(streams, index)
 
         # Apply server-side sorting
         if sort and streams:
@@ -183,12 +269,27 @@ async def get_stream_groups(bypass_cache: bool = False, m3u_account_id: Optional
 
 class BulkStreamIdsRequest(BaseModel):
     stream_ids: list[int]
+    # Opt-in channel-assignment status. When True, each returned stream is
+    # annotated with has_channel / assigned_channel_id / assigned_channel_ids
+    # derived from a cached reverse stream->channel index (costs an extra
+    # paginated channel fetch, cached for ASSIGNMENT_INDEX_TTL_SECONDS). Default
+    # False keeps the proxy path cheap and behaviorally unchanged.
+    include_assignment: bool = False
 
 
 @router.post("/api/streams/by-ids")
 async def get_streams_by_ids(request: BulkStreamIdsRequest):
-    """Get multiple streams by their IDs (proxies to Dispatcharr)."""
-    logger.debug("[STREAMS] POST /api/streams/by-ids - %d streams", len(request.stream_ids))
+    """Get multiple streams by their IDs (proxies to Dispatcharr).
+
+    With ``include_assignment=True``, results carry channel-assignment status
+    (has_channel / assigned_channel_id / assigned_channel_ids). Dispatcharr's
+    payload has no channel linkage, so this is derived from a cached reverse
+    stream->channel index — hence opt-in.
+    """
+    logger.debug(
+        "[STREAMS] POST /api/streams/by-ids - %d streams include_assignment=%s",
+        len(request.stream_ids), request.include_assignment,
+    )
     try:
         client = get_client()
         start = time.time()
@@ -198,6 +299,10 @@ async def get_streams_by_ids(request: BulkStreamIdsRequest):
         # Enrich results
         if isinstance(result, list):
             _enrich_stream_results(result)
+            # Opt-in channel-assignment status (extra cost: cached channel fetch).
+            if request.include_assignment and result:
+                index = await _get_stream_channel_index()
+                _apply_assignment(result, index)
         return result
     except Exception as e:
         logger.exception("[STREAMS] Failed to get streams by IDs: %s", e)

--- a/backend/tests/routers/test_0hjrk_stream_assignment.py
+++ b/backend/tests/routers/test_0hjrk_stream_assignment.py
@@ -1,0 +1,294 @@
+"""
+TDD tests for enhancedchannelmanager-0hjrk.6 — stream assignment status.
+
+Dispatcharr's POST /api/channels/streams/by-ids/ and GET /api/streams responses
+carry NO per-stream channel linkage (channels/channel_id/channel are all None
+even for an assigned stream — verified live 2026-05-24). The authoritative
+source of assignment is each CHANNEL's `streams` ID list. So assignment is
+derived by paginating get_channels() and building a reverse
+stream_id -> [channel_id] index.
+
+These tests cover:
+  * POST /api/streams/by-ids with include_assignment=True derives
+    has_channel / assigned_channel_id / assigned_channel_ids correctly for
+    assigned AND unassigned streams.
+  * include_assignment=False (the default) does NOT fetch channels and adds
+    no assignment fields — the default path stays cheap.
+  * The reverse index is cached: a second include_assignment call within the
+    TTL does not re-paginate get_channels().
+  * GET /api/streams supports include_assignment for the list path enrichment.
+
+Mocks: get_client(), get_cache() at the router module level
+(per backend/CLAUDE.md).
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _channels_page(channels, count=None):
+    """Build a single-page get_channels() response envelope."""
+    return {"count": count if count is not None else len(channels), "results": channels}
+
+
+def _passthrough_cache():
+    """A MagicMock cache whose get() always misses (forces a fresh fetch)."""
+    cache = MagicMock()
+    cache.get.return_value = None
+    return cache
+
+
+class TestByIdsIncludeAssignment:
+    """POST /api/streams/by-ids with include_assignment=True."""
+
+    @pytest.mark.asyncio
+    async def test_assigned_and_unassigned_streams(self, async_client):
+        """Assigned streams get has_channel/assigned_channel_id(s); unassigned do not."""
+        mock_client = AsyncMock()
+        # Stream 1 is in channel 100; stream 2 is in channels 100 and 200;
+        # stream 3 is assigned to nothing.
+        mock_client.get_streams_by_ids.return_value = [
+            {"id": 1, "name": "Stream 1"},
+            {"id": 2, "name": "Stream 2"},
+            {"id": 3, "name": "Stream 3"},
+        ]
+        mock_client.get_channels.return_value = _channels_page([
+            {"id": 100, "name": "Channel A", "streams": [1, 2]},
+            {"id": 200, "name": "Channel B", "streams": [2]},
+        ])
+        mock_cache = _passthrough_cache()
+
+        with patch("routers.streams.get_client", return_value=mock_client), \
+             patch("routers.streams.get_cache", return_value=mock_cache):
+            response = await async_client.post(
+                "/api/streams/by-ids",
+                json={"stream_ids": [1, 2, 3], "include_assignment": True},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        by_id = {s["id"]: s for s in data}
+
+        # Stream 1: assigned to channel 100 only.
+        assert by_id[1]["has_channel"] is True
+        assert by_id[1]["assigned_channel_id"] == 100
+        assert by_id[1]["assigned_channel_ids"] == [100]
+
+        # Stream 2: assigned to two channels — first wins for assigned_channel_id.
+        assert by_id[2]["has_channel"] is True
+        assert by_id[2]["assigned_channel_id"] in (100, 200)
+        assert sorted(by_id[2]["assigned_channel_ids"]) == [100, 200]
+
+        # Stream 3: unassigned.
+        assert by_id[3]["has_channel"] is False
+        assert by_id[3]["assigned_channel_id"] is None
+        assert by_id[3]["assigned_channel_ids"] == []
+
+        # The channel reverse index was fetched once.
+        assert mock_client.get_channels.called
+
+    @pytest.mark.asyncio
+    async def test_default_does_not_fetch_channels(self, async_client):
+        """include_assignment defaults to False: no channel fetch, no assignment fields."""
+        mock_client = AsyncMock()
+        mock_client.get_streams_by_ids.return_value = [
+            {"id": 1, "name": "Stream 1"},
+        ]
+        mock_cache = _passthrough_cache()
+
+        with patch("routers.streams.get_client", return_value=mock_client), \
+             patch("routers.streams.get_cache", return_value=mock_cache):
+            response = await async_client.post(
+                "/api/streams/by-ids",
+                json={"stream_ids": [1]},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        # No channel fetch on the default path.
+        mock_client.get_channels.assert_not_called()
+        # No assignment fields added.
+        assert "has_channel" not in data[0]
+        assert "assigned_channel_id" not in data[0]
+        assert "assigned_channel_ids" not in data[0]
+
+    @pytest.mark.asyncio
+    async def test_explicit_false_does_not_fetch_channels(self, async_client):
+        """include_assignment=False explicitly: still no channel fetch."""
+        mock_client = AsyncMock()
+        mock_client.get_streams_by_ids.return_value = [{"id": 1, "name": "Stream 1"}]
+        mock_cache = _passthrough_cache()
+
+        with patch("routers.streams.get_client", return_value=mock_client), \
+             patch("routers.streams.get_cache", return_value=mock_cache):
+            response = await async_client.post(
+                "/api/streams/by-ids",
+                json={"stream_ids": [1], "include_assignment": False},
+            )
+
+        assert response.status_code == 200
+        mock_client.get_channels.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_paginates_all_channel_pages(self, async_client):
+        """The reverse index spans all channel pages, not just the first."""
+        mock_client = AsyncMock()
+        mock_client.get_streams_by_ids.return_value = [
+            {"id": 1, "name": "Stream 1"},
+            {"id": 2, "name": "Stream 2"},
+        ]
+        # Two pages: stream 1 in channel on page 1, stream 2 on page 2.
+        pages = [
+            _channels_page([{"id": 100, "name": "A", "streams": [1]}], count=2),
+            _channels_page([{"id": 200, "name": "B", "streams": [2]}], count=2),
+        ]
+        mock_client.get_channels.side_effect = pages
+        mock_cache = _passthrough_cache()
+
+        with patch("routers.streams.get_client", return_value=mock_client), \
+             patch("routers.streams.get_cache", return_value=mock_cache):
+            response = await async_client.post(
+                "/api/streams/by-ids",
+                json={"stream_ids": [1, 2], "include_assignment": True},
+            )
+
+        assert response.status_code == 200
+        by_id = {s["id"]: s for s in response.json()}
+        assert by_id[1]["assigned_channel_ids"] == [100]
+        assert by_id[2]["assigned_channel_ids"] == [200]
+        assert mock_client.get_channels.call_count == 2
+
+
+class TestReverseIndexCache:
+    """The reverse stream->channel index is cached with a short TTL."""
+
+    @pytest.mark.asyncio
+    async def test_second_call_within_ttl_does_not_refetch(self, async_client):
+        """Two include_assignment calls share one channel fetch via the cache."""
+        mock_client = AsyncMock()
+        mock_client.get_streams_by_ids.return_value = [{"id": 1, "name": "Stream 1"}]
+        mock_client.get_channels.return_value = _channels_page([
+            {"id": 100, "name": "A", "streams": [1]},
+        ])
+
+        # A real-ish cache: stores on set, returns the stored value on get.
+        store = {}
+
+        def cache_get(key, ttl=None):
+            return store.get(key)
+
+        def cache_set(key, value):
+            store[key] = value
+
+        mock_cache = MagicMock()
+        mock_cache.get.side_effect = cache_get
+        mock_cache.set.side_effect = cache_set
+
+        with patch("routers.streams.get_client", return_value=mock_client), \
+             patch("routers.streams.get_cache", return_value=mock_cache):
+            r1 = await async_client.post(
+                "/api/streams/by-ids",
+                json={"stream_ids": [1], "include_assignment": True},
+            )
+            r2 = await async_client.post(
+                "/api/streams/by-ids",
+                json={"stream_ids": [1], "include_assignment": True},
+            )
+
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        # Channels fetched exactly once across two assignment calls.
+        assert mock_client.get_channels.call_count == 1
+        # Both responses still correctly assigned.
+        assert r1.json()[0]["assigned_channel_ids"] == [100]
+        assert r2.json()[0]["assigned_channel_ids"] == [100]
+
+    @pytest.mark.asyncio
+    async def test_index_read_uses_short_ttl(self, async_client):
+        """The index is read from cache with the documented short TTL, not the default."""
+        from routers.streams import ASSIGNMENT_INDEX_TTL_SECONDS
+
+        mock_client = AsyncMock()
+        mock_client.get_streams_by_ids.return_value = [{"id": 1, "name": "Stream 1"}]
+        mock_client.get_channels.return_value = _channels_page([
+            {"id": 100, "name": "A", "streams": [1]},
+        ])
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None  # force a fetch
+
+        with patch("routers.streams.get_client", return_value=mock_client), \
+             patch("routers.streams.get_cache", return_value=mock_cache):
+            await async_client.post(
+                "/api/streams/by-ids",
+                json={"stream_ids": [1], "include_assignment": True},
+            )
+
+        # The index cache read must pass the short TTL.
+        ttl_calls = [
+            c for c in mock_cache.get.call_args_list
+            if c.kwargs.get("ttl") == ASSIGNMENT_INDEX_TTL_SECONDS
+            or (len(c.args) > 1 and c.args[1] == ASSIGNMENT_INDEX_TTL_SECONDS)
+        ]
+        assert ttl_calls, (
+            "Reverse index should be read from cache with the short "
+            f"ASSIGNMENT_INDEX_TTL_SECONDS={ASSIGNMENT_INDEX_TTL_SECONDS}s TTL"
+        )
+        # TTL is in the documented short range (30-60s).
+        assert 30 <= ASSIGNMENT_INDEX_TTL_SECONDS <= 60
+
+
+class TestListIncludeAssignment:
+    """GET /api/streams supports include_assignment enrichment."""
+
+    @pytest.mark.asyncio
+    async def test_list_enriches_with_assignment(self, async_client):
+        """include_assignment=True adds has_channel/assigned_channel_ids to list results."""
+        mock_client = AsyncMock()
+        mock_client.get_streams.return_value = {
+            "count": 2,
+            "results": [
+                {"id": 1, "name": "Stream 1", "channel_group": 10},
+                {"id": 2, "name": "Stream 2", "channel_group": 10},
+            ],
+        }
+        mock_client.get_channel_groups.return_value = [{"id": 10, "name": "Sports"}]
+        mock_client.get_channels.return_value = _channels_page([
+            {"id": 100, "name": "A", "streams": [1]},
+        ])
+        mock_cache = _passthrough_cache()
+
+        with patch("routers.streams.get_client", return_value=mock_client), \
+             patch("routers.streams.get_cache", return_value=mock_cache):
+            response = await async_client.get(
+                "/api/streams",
+                params={"include_assignment": True, "bypass_cache": True},
+            )
+
+        assert response.status_code == 200
+        by_id = {s["id"]: s for s in response.json()["results"]}
+        assert by_id[1]["has_channel"] is True
+        assert by_id[1]["assigned_channel_ids"] == [100]
+        assert by_id[2]["has_channel"] is False
+        assert by_id[2]["assigned_channel_ids"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_default_no_channel_fetch(self, async_client):
+        """Default list path does not fetch channels and adds no assignment fields."""
+        mock_client = AsyncMock()
+        mock_client.get_streams.return_value = {
+            "count": 1,
+            "results": [{"id": 1, "name": "Stream 1", "channel_group": 10}],
+        }
+        mock_client.get_channel_groups.return_value = [{"id": 10, "name": "Sports"}]
+        mock_cache = _passthrough_cache()
+
+        with patch("routers.streams.get_client", return_value=mock_client), \
+             patch("routers.streams.get_cache", return_value=mock_cache):
+            response = await async_client.get(
+                "/api/streams",
+                params={"bypass_cache": True},
+            )
+
+        assert response.status_code == 200
+        mock_client.get_channels.assert_not_called()
+        result = response.json()["results"][0]
+        assert "has_channel" not in result

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0003",
+  "version": "0.17.3-0004",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mcp-server/_endpoint_contracts.py
+++ b/mcp-server/_endpoint_contracts.py
@@ -713,14 +713,15 @@ ENDPOINTS: dict[str, Endpoint] = {
         method="GET",
         path="/api/streams",
         query_params=frozenset(
-            {"page", "page_size", "search", "channel_group_name", "m3u_account", "sort", "enrich", "bypass_cache"}
+            {"page", "page_size", "search", "channel_group_name", "m3u_account",
+             "sort", "enrich", "include_assignment", "bypass_cache"}
         ),
     ),
     "streams_by_ids": Endpoint(
         name="streams_by_ids",
         method="POST",
         path="/api/streams/by-ids",
-        request_fields=frozenset({"stream_ids"}),  # BulkStreamIdsRequest
+        request_fields=frozenset({"stream_ids", "include_assignment"}),  # BulkStreamIdsRequest
     ),
     "stream_stats_summary": Endpoint(
         name="stream_stats_summary",

--- a/mcp-server/tests/test_0hjrk_stream_assignment.py
+++ b/mcp-server/tests/test_0hjrk_stream_assignment.py
@@ -1,0 +1,244 @@
+"""TDD tests for enhancedchannelmanager-0hjrk.6 — stream assignment status (MCP).
+
+The backend derives channel-assignment status (has_channel /
+assigned_channel_id / assigned_channel_ids) from a cached reverse
+stream->channel index. These tests verify the MCP layer:
+
+  * get_streams_by_ids(include_assignment=True) renders "-> channel N" for
+    assigned streams and "[unassigned]" for unassigned ones, and passes the
+    flag through to the backend.
+  * get_streams_by_ids default (include_assignment=False) is unchanged — no
+    assignment markers, no include_assignment in the request body.
+  * list_streams / search_streams `assigned` filter selects assigned-only
+    (True) or unassigned-only (False), requesting assignment from the backend
+    and filtering client-side. Default (None) does no lookup.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+def _make_mcp_and_register():
+    """Register streams tools on a fresh FastMCP and return the mcp instance."""
+    from mcp.server.fastmcp import FastMCP
+    from tools.streams import register
+
+    mcp = FastMCP("test")
+    register(mcp)
+    return mcp
+
+
+# ---------------------------------------------------------------------------
+# get_streams_by_ids with include_assignment
+# ---------------------------------------------------------------------------
+
+class TestGetStreamsByIdsAssignment:
+    @pytest.mark.asyncio
+    async def test_include_assignment_renders_channel_and_unassigned(self):
+        """Assigned -> '-> channel N'; unassigned -> '[unassigned]'."""
+        mcp = _make_mcp_and_register()
+
+        by_ids_payload = [
+            {"id": 1, "name": "Stream 1", "has_channel": True,
+             "assigned_channel_id": 100, "assigned_channel_ids": [100]},
+            {"id": 2, "name": "Stream 2", "has_channel": True,
+             "assigned_channel_id": 100, "assigned_channel_ids": [100, 200]},
+            {"id": 3, "name": "Stream 3", "has_channel": False,
+             "assigned_channel_id": None, "assigned_channel_ids": []},
+        ]
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            name = endpoint.name
+            if name == "streams_by_ids":
+                return by_ids_payload
+            if name == "m3u_list_providers":
+                return []
+            if name == "groups_list":
+                return []
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.streams.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "get_streams_by_ids",
+                {"stream_ids": [1, 2, 3], "include_assignment": True},
+            )
+
+        text = result[0][0].text
+        # Single-channel assignment.
+        assert "channel 100" in text
+        # Multi-channel assignment rendered with the full list.
+        assert "channels" in text and "200" in text
+        # Unassigned marker.
+        assert "[unassigned]" in text
+
+        # include_assignment was forwarded to the backend body.
+        by_ids_calls = [
+            c for c in client.call_endpoint.call_args_list
+            if c.args and c.args[0].name == "streams_by_ids"
+        ]
+        assert by_ids_calls, "streams_by_ids endpoint was not called"
+        body = by_ids_calls[0].kwargs.get("body", {})
+        assert body.get("include_assignment") is True
+
+    @pytest.mark.asyncio
+    async def test_default_unchanged_no_assignment(self):
+        """Default (no include_assignment): no markers, no include_assignment body field."""
+        mcp = _make_mcp_and_register()
+
+        by_ids_payload = [{"id": 1, "name": "Stream 1"}]
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            name = endpoint.name
+            if name == "streams_by_ids":
+                return by_ids_payload
+            if name == "m3u_list_providers":
+                return []
+            if name == "groups_list":
+                return []
+            return {}
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+
+        with patch("tools.streams.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("get_streams_by_ids", {"stream_ids": [1]})
+
+        text = result[0][0].text
+        assert "[unassigned]" not in text
+        assert "-> channel" not in text and "→ channel" not in text
+
+        by_ids_calls = [
+            c for c in client.call_endpoint.call_args_list
+            if c.args and c.args[0].name == "streams_by_ids"
+        ]
+        body = by_ids_calls[0].kwargs.get("body", {})
+        # Default must not send include_assignment (keeps backend on cheap path).
+        assert "include_assignment" not in body or body["include_assignment"] is False
+
+
+# ---------------------------------------------------------------------------
+# list_streams / search_streams `assigned` filter
+# ---------------------------------------------------------------------------
+
+def _list_payload():
+    return {
+        "count": 3,
+        "results": [
+            {"id": 1, "name": "Assigned A", "has_channel": True,
+             "assigned_channel_id": 100, "assigned_channel_ids": [100]},
+            {"id": 2, "name": "Unassigned B", "has_channel": False,
+             "assigned_channel_id": None, "assigned_channel_ids": []},
+            {"id": 3, "name": "Assigned C", "has_channel": True,
+             "assigned_channel_id": 200, "assigned_channel_ids": [200]},
+        ],
+    }
+
+
+class TestListStreamsAssignedFilter:
+    @pytest.mark.asyncio
+    async def test_assigned_true_selects_only_assigned(self):
+        mcp = _make_mcp_and_register()
+        client = AsyncMock()
+        client.call_endpoint.return_value = _list_payload()
+
+        with patch("tools.streams.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("list_streams", {"assigned": True})
+
+        text = result[0][0].text
+        assert "Assigned A" in text
+        assert "Assigned C" in text
+        assert "Unassigned B" not in text
+
+        # The backend was asked to include assignment data.
+        call = client.call_endpoint.call_args
+        query = call.kwargs.get("query", {})
+        assert query.get("include_assignment") is True
+
+    @pytest.mark.asyncio
+    async def test_assigned_false_selects_only_unassigned(self):
+        mcp = _make_mcp_and_register()
+        client = AsyncMock()
+        client.call_endpoint.return_value = _list_payload()
+
+        with patch("tools.streams.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("list_streams", {"assigned": False})
+
+        text = result[0][0].text
+        assert "Unassigned B" in text
+        assert "Assigned A" not in text
+        assert "Assigned C" not in text
+
+        call = client.call_endpoint.call_args
+        query = call.kwargs.get("query", {})
+        assert query.get("include_assignment") is True
+
+    @pytest.mark.asyncio
+    async def test_default_none_no_lookup(self):
+        mcp = _make_mcp_and_register()
+        client = AsyncMock()
+        client.call_endpoint.return_value = {
+            "count": 1,
+            "results": [{"id": 1, "name": "Stream 1"}],
+        }
+
+        with patch("tools.streams.get_ecm_client", return_value=client):
+            result = await mcp.call_tool("list_streams", {})
+
+        text = result[0][0].text
+        assert "Stream 1" in text
+        # Default must not request assignment (no added cost).
+        call = client.call_endpoint.call_args
+        query = call.kwargs.get("query", {})
+        assert "include_assignment" not in query
+
+
+class TestSearchStreamsAssignedFilter:
+    @pytest.mark.asyncio
+    async def test_assigned_true_selects_only_assigned(self):
+        mcp = _make_mcp_and_register()
+        client = AsyncMock()
+        client.call_endpoint.return_value = _list_payload()
+
+        with patch("tools.streams.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "search_streams", {"query": "x", "assigned": True}
+            )
+
+        text = result[0][0].text
+        assert "Assigned A" in text
+        assert "Assigned C" in text
+        assert "Unassigned B" not in text
+
+        call = client.call_endpoint.call_args
+        query = call.kwargs.get("query", {})
+        assert query.get("include_assignment") is True
+
+    @pytest.mark.asyncio
+    async def test_assigned_false_selects_only_unassigned(self):
+        mcp = _make_mcp_and_register()
+        client = AsyncMock()
+        client.call_endpoint.return_value = _list_payload()
+
+        with patch("tools.streams.get_ecm_client", return_value=client):
+            result = await mcp.call_tool(
+                "search_streams", {"query": "x", "assigned": False}
+            )
+
+        text = result[0][0].text
+        assert "Unassigned B" in text
+        assert "Assigned A" not in text
+
+    @pytest.mark.asyncio
+    async def test_default_none_no_lookup(self):
+        mcp = _make_mcp_and_register()
+        client = AsyncMock()
+        client.call_endpoint.return_value = _list_payload()
+
+        with patch("tools.streams.get_ecm_client", return_value=client):
+            await mcp.call_tool("search_streams", {"query": "x"})
+
+        call = client.call_endpoint.call_args
+        query = call.kwargs.get("query", {})
+        assert "include_assignment" not in query

--- a/mcp-server/tools/streams.py
+++ b/mcp-server/tools/streams.py
@@ -267,12 +267,18 @@ _fuzzy_helpers = {
 }
 
 
-def _stream_query(*, search=None, m3u_account=None, channel_group_name=None, page=None, page_size=None):
+def _stream_query(*, search=None, m3u_account=None, channel_group_name=None,
+                  page=None, page_size=None, include_assignment=None):
     """Build a query dict for ENDPOINTS["streams_list"], dropping None values.
 
     Note the param names match the backend (``m3u_account``, ``channel_group_name``)
     — the MCP tools used to send ``provider_id`` / ``group`` here, which the
     backend silently ignored (drift fixed in bd-vtghg Phase 2).
+
+    ``include_assignment`` asks the backend to annotate each stream with
+    channel-assignment status (has_channel / assigned_channel_ids). It is only
+    sent when truthy so the default list path keeps the backend on its cheap
+    no-channel-fetch path.
     """
     q = {
         "search": search,
@@ -280,8 +286,41 @@ def _stream_query(*, search=None, m3u_account=None, channel_group_name=None, pag
         "channel_group_name": channel_group_name,
         "page": page,
         "page_size": page_size,
+        "include_assignment": True if include_assignment else None,
     }
     return {k: v for k, v in q.items() if v is not None}
+
+
+def _filter_by_assigned(streams: list[dict], assigned: bool | None) -> list[dict]:
+    """Filter streams by channel-assignment status.
+
+    assigned=True  -> only streams in at least one channel (has_channel)
+    assigned=False -> only unassigned streams
+    assigned=None  -> no filtering (returned unchanged)
+    """
+    if assigned is None:
+        return streams
+    return [s for s in streams if bool(s.get("has_channel")) is assigned]
+
+
+def _stream_assignment_suffix(s: dict) -> str:
+    """Render the `` -> channel N`` / `` [unassigned]`` assignment suffix.
+
+    Only emitted when the stream dict carries assignment fields (i.e. the
+    backend was called with include_assignment). Returns "" otherwise so the
+    default rendering is unchanged.
+    """
+    if "has_channel" not in s:
+        return ""
+    if not s.get("has_channel"):
+        return " [unassigned]"
+    channel_ids = s.get("assigned_channel_ids") or []
+    if len(channel_ids) > 1:
+        return " -> channels " + ", ".join(str(c) for c in channel_ids)
+    cid = s.get("assigned_channel_id")
+    if cid is None and channel_ids:
+        cid = channel_ids[0]
+    return f" -> channel {cid}"
 
 
 async def _build_id_name_maps(client) -> tuple[dict, dict]:
@@ -349,6 +388,7 @@ def register(mcp: FastMCP):
         search: str | None = None,
         page: int = 1,
         page_size: int = 50,
+        assigned: bool | None = None,
     ) -> str:
         """List streams with optional filtering.
 
@@ -358,6 +398,11 @@ def register(mcp: FastMCP):
             search: Search streams by name
             page: Page number (default 1)
             page_size: Results per page (default 50, max 100)
+            assigned: Filter by channel-assignment status. True -> only streams
+                assigned to a channel; False -> only unassigned streams; None
+                (default) -> no filtering. When set, the backend is asked to
+                include assignment status (costs an extra cached channel fetch),
+                so leave it None unless you need it.
         """
         try:
             client = get_ecm_client()
@@ -366,6 +411,7 @@ def register(mcp: FastMCP):
                 query=_stream_query(
                     search=search, m3u_account=provider_id, channel_group_name=group,
                     page=page, page_size=min(page_size, 100),
+                    include_assignment=assigned is not None,
                 ),
             )
 
@@ -375,6 +421,8 @@ def register(mcp: FastMCP):
             else:
                 streams = result
                 total = len(streams)
+
+            streams = _filter_by_assigned(streams, assigned)
 
             if not streams:
                 return "No streams found."
@@ -387,6 +435,7 @@ def register(mcp: FastMCP):
                 provider = s.get("provider_name", "")
                 info = f" [{group_name}]" if group_name else ""
                 info += f" from {provider}" if provider else ""
+                info += _stream_assignment_suffix(s)
                 lines.append(f"  {name} (id={sid}){info}")
 
             return "\n".join(lines)
@@ -755,6 +804,7 @@ def register(mcp: FastMCP):
         query: str,
         provider_id: int | None = None,
         limit: int = 25,
+        assigned: bool | None = None,
     ) -> str:
         """Search for streams by name across all providers.
 
@@ -762,12 +812,19 @@ def register(mcp: FastMCP):
             query: Search term to match against stream names
             provider_id: Optional M3U provider ID to narrow the search
             limit: Maximum results to return (default 25)
+            assigned: Filter by channel-assignment status. True -> only assigned
+                streams; False -> only unassigned; None (default) -> no filter.
+                When set, the backend includes assignment status (extra cached
+                channel fetch), and filtering is applied client-side.
         """
         try:
             client = get_ecm_client()
             result = await client.call_endpoint(
                 ENDPOINTS["streams_list"],
-                query=_stream_query(search=query, m3u_account=provider_id, page_size=min(limit, 100)),
+                query=_stream_query(
+                    search=query, m3u_account=provider_id, page_size=min(limit, 100),
+                    include_assignment=assigned is not None,
+                ),
             )
 
             if isinstance(result, dict):
@@ -775,6 +832,12 @@ def register(mcp: FastMCP):
                 total = result.get("count", len(streams))
             else:
                 streams = result
+                total = len(streams)
+
+            streams = _filter_by_assigned(streams, assigned)
+            # When an assignment filter narrows results client-side, the backend
+            # total no longer reflects what's shown; report the filtered count.
+            if assigned is not None:
                 total = len(streams)
 
             if not streams:
@@ -788,6 +851,7 @@ def register(mcp: FastMCP):
                 provider = s.get("provider_name", "")
                 info = f" [{group}]" if group else ""
                 info += f" from {provider}" if provider else ""
+                info += _stream_assignment_suffix(s)
                 lines.append(f"  {name} (id={sid}){info}")
 
             if total > limit:
@@ -799,15 +863,28 @@ def register(mcp: FastMCP):
             return f"Error searching streams: {e}"
 
     @mcp.tool()
-    async def get_streams_by_ids(stream_ids: list[int]) -> str:
+    async def get_streams_by_ids(stream_ids: list[int], include_assignment: bool = False) -> str:
         """Fetch detailed stream information for specific stream IDs.
+
+        Dispatcharr's stream payload carries no channel linkage, so assignment
+        status is derived backend-side from a reverse stream->channel index that
+        costs an extra (cached, ~45s TTL) channel fetch. It is therefore opt-in:
+        only set include_assignment=True when you need to know whether streams
+        are attached to a channel.
 
         Args:
             stream_ids: List of stream IDs to look up
+            include_assignment: When True, annotate each stream with its channel
+                assignment and render " -> channel N" (or " -> channels N, M" for
+                several) when assigned, or " [unassigned]" when not. Default
+                False leaves output unchanged and skips the channel fetch.
         """
         try:
             client = get_ecm_client()
-            result = await client.call_endpoint(ENDPOINTS["streams_by_ids"], body={"stream_ids": stream_ids})
+            body = {"stream_ids": stream_ids}
+            if include_assignment:
+                body["include_assignment"] = True
+            result = await client.call_endpoint(ENDPOINTS["streams_by_ids"], body=body)
 
             streams = result if isinstance(result, list) else result.get("streams", result.get("results", []))
 
@@ -821,6 +898,7 @@ def register(mcp: FastMCP):
                 name = s.get("name", "Unknown")
                 sid = s.get("id", "?")
                 info = _stream_group_provider_suffix(s, provider_map, group_map)
+                info += _stream_assignment_suffix(s)
                 lines.append(f"  {name} (id={sid}){info}")
 
             return "\n".join(lines)


### PR DESCRIPTION
## bd-0hjrk.6 — parent bd-0hjrk

**Confirmed (live probe):** Dispatcharr's POST /api/channels/streams/by-ids/ and GET /api/streams carry NO per-stream channel linkage (channels/channel_id/channel all None even for an assigned stream). Assignment's source of truth is each CHANNEL's `streams` ID list. (The original 'enrich from the stream payload' plan was impossible — verified before coding.)

**Fix (opt-in + cached cross-reference, no default-path regression):**
- Backend: `_get_stream_channel_index()` paginates get_channels() and inverts each channel's streams list into stream_id→[channel_id], cached via get_cache() (TTL 45s). `include_assignment` added to BulkStreamIdsRequest and to GET /api/streams; when set, enriches each stream with `has_channel`, `assigned_channel_id`, `assigned_channel_ids`. Default off → no channel fetch.
- MCP: get_streams_by_ids gains `include_assignment=False`; renders ` → channel N` / ` [unassigned]`. list_streams/search_streams gain `assigned: bool|None` filter (triggers the backend lookup, filters client-side; None = no cost). Docstrings note the opt-in cost.

Tests: backend/tests/routers/test_0hjrk_stream_assignment.py (assigned/unassigned/default-no-fetch/pagination/cache-no-refetch), mcp-server/tests/test_0hjrk_stream_assignment.py (render + filters). Gates: backend 5022, MCP 378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)