### PR TITLE
v0.17.3-0009: Finish 0.17.3 line (bd-757hc, bd-4xxax, bd-d5z9u, bd-i5gfz)

### DIFF
--- a/backend/dispatcharr_client.py
+++ b/backend/dispatcharr_client.py
@@ -290,7 +290,7 @@ class DispatcharrClient:
         params = {"page": page, "page_size": page_size}
         if search:
             params["search"] = search
-        if channel_group:
+        if channel_group is not None:
             group_name = await self._channel_group_name_for_id(channel_group)
             if group_name is None:
                 logger.warning(

--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0008",
+    version="0.17.3-0009",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -550,8 +550,8 @@ def _lint_auto_creation_rule_request(
 
 
 @router.post("/rules")
-async def create_auto_creation_rule(request: CreateAutoCreationRuleRequest):
-    """Create a new auto-creation rule."""
+async def create_auto_creation_rule(request: CreateAutoCreationRuleRequest, _admin=RequireAdminIfEnabled):
+    """Create a new auto-creation rule. Admin only."""
     try:
         from models import AutoCreationRule
         from auto_creation_schema import validate_rule
@@ -639,8 +639,8 @@ async def create_auto_creation_rule(request: CreateAutoCreationRuleRequest):
 
 
 @router.put("/rules/{rule_id}")
-async def update_auto_creation_rule(rule_id: int, request: UpdateAutoCreationRuleRequest):
-    """Update an auto-creation rule."""
+async def update_auto_creation_rule(rule_id: int, request: UpdateAutoCreationRuleRequest, _admin=RequireAdminIfEnabled):
+    """Update an auto-creation rule. Admin only."""
     try:
         from models import AutoCreationRule
         from auto_creation_schema import validate_rule
@@ -717,8 +717,8 @@ async def update_auto_creation_rule(rule_id: int, request: UpdateAutoCreationRul
 
 
 @router.post("/rules/bulk-update")
-async def bulk_update_auto_creation_rules(request: BulkUpdateAutoCreationRulesRequest):
-    """Apply the same field changes to many rules. Omitted fields are left unchanged."""
+async def bulk_update_auto_creation_rules(request: BulkUpdateAutoCreationRulesRequest, _admin=RequireAdminIfEnabled):
+    """Apply the same field changes to many rules. Omitted fields are left unchanged. Admin only."""
     from models import AutoCreationRule
     from auto_creation_schema import validate_rule
 
@@ -872,8 +872,8 @@ async def bulk_update_auto_creation_rules(request: BulkUpdateAutoCreationRulesRe
 
 
 @router.delete("/rules/{rule_id}")
-async def delete_auto_creation_rule(rule_id: int):
-    """Delete an auto-creation rule."""
+async def delete_auto_creation_rule(rule_id: int, _admin=RequireAdminIfEnabled):
+    """Delete an auto-creation rule. Admin only."""
     logger.debug("[AUTO-CREATE] DELETE /rules/%s", rule_id)
     try:
         from models import AutoCreationRule
@@ -910,8 +910,8 @@ async def delete_auto_creation_rule(rule_id: int):
 
 
 @router.post("/rules/reorder")
-async def reorder_auto_creation_rules(rule_ids: List[int] = Body(...)):
-    """Reorder auto-creation rules by setting priorities based on array order."""
+async def reorder_auto_creation_rules(rule_ids: List[int] = Body(...), _admin=RequireAdminIfEnabled):
+    """Reorder auto-creation rules by setting priorities based on array order. Admin only."""
     logger.debug("[AUTO-CREATE] POST /rules/reorder - %d rules", len(rule_ids))
     try:
         from models import AutoCreationRule
@@ -933,8 +933,8 @@ async def reorder_auto_creation_rules(rule_ids: List[int] = Body(...)):
 
 
 @router.post("/rules/{rule_id}/toggle")
-async def toggle_auto_creation_rule(rule_id: int):
-    """Toggle the enabled state of an auto-creation rule."""
+async def toggle_auto_creation_rule(rule_id: int, _admin=RequireAdminIfEnabled):
+    """Toggle the enabled state of an auto-creation rule. Admin only."""
     logger.debug("[AUTO-CREATE] POST /rules/%s/toggle", rule_id)
     try:
         from models import AutoCreationRule
@@ -961,8 +961,8 @@ async def toggle_auto_creation_rule(rule_id: int):
 
 
 @router.post("/rules/{rule_id}/duplicate")
-async def duplicate_auto_creation_rule(rule_id: int):
-    """Duplicate an auto-creation rule."""
+async def duplicate_auto_creation_rule(rule_id: int, _admin=RequireAdminIfEnabled):
+    """Duplicate an auto-creation rule. Admin only."""
     logger.debug("[AUTO-CREATE] POST /rules/%s/duplicate", rule_id)
     try:
         from models import AutoCreationRule
@@ -1123,7 +1123,7 @@ def _supervise_background_pipeline(coro, *, execution_id: int, label: str) -> as
 
 
 @router.post("/run", status_code=202)
-async def run_auto_creation_pipeline(request: RunPipelineRequest):
+async def run_auto_creation_pipeline(request: RunPipelineRequest, _admin=RequireAdminIfEnabled):
     """Enqueue an auto-creation pipeline run and return immediately (bd-enfsy).
 
     Pipeline runs on large catalogs can take minutes — running them inside the
@@ -1168,7 +1168,7 @@ async def run_auto_creation_pipeline(request: RunPipelineRequest):
 
 
 @router.post("/rules/{rule_id}/run", status_code=202)
-async def run_auto_creation_rule(rule_id: int, dry_run: bool = False):
+async def run_auto_creation_rule(rule_id: int, dry_run: bool = False, _admin=RequireAdminIfEnabled):
     """Enqueue a single-rule auto-creation run and return immediately (bd-enfsy).
 
     See ``run_auto_creation_pipeline`` for the 202 + poll contract.
@@ -1296,8 +1296,8 @@ async def get_auto_creation_execution(execution_id: int, include_entities: bool 
 
 
 @router.post("/executions/{execution_id}/rollback")
-async def rollback_auto_creation_execution(execution_id: int):
-    """Rollback an auto-creation execution."""
+async def rollback_auto_creation_execution(execution_id: int, _admin=RequireAdminIfEnabled):
+    """Rollback an auto-creation execution. Admin only."""
     logger.debug("[AUTO-CREATE] POST /executions/%s/rollback", execution_id)
     try:
         from auto_creation_engine import get_auto_creation_engine, init_auto_creation_engine
@@ -1453,7 +1453,7 @@ async def export_auto_creation_rules_yaml():
 
 
 @router.post("/import/yaml")
-async def import_auto_creation_rules_yaml(request: ImportYAMLRequest):
+async def import_auto_creation_rules_yaml(request: ImportYAMLRequest, _admin=RequireAdminIfEnabled):
     """Import auto-creation rules from YAML.
 
     Supports portable name fields: if group_name/target_group_name/m3u_account_name

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0008"
+APP_VERSION = "0.17.3-0009"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/routers/channels.py
+++ b/backend/routers/channels.py
@@ -2576,7 +2576,28 @@ async def bulk_merge_channels(request: BulkMergeRequest):
 
     for item in request.merges:
         try:
-            target = await client.get_channel(item.target_channel_id)
+            # Pre-validate the target ID the same way source IDs are validated
+            # below: if the target no longer exists upstream (e.g., a stale
+            # reference after a previous merge), surface 422 with the same
+            # refresh hint instead of falling through to the per-item catch-all
+            # (which returns 200 + a failed count). Consistent with the
+            # source-ID path added in bd-ozhkf (bd-4xxax).
+            try:
+                target = await client.get_channel(item.target_channel_id)
+            except httpx.HTTPStatusError as fetch_err:
+                if fetch_err.response.status_code == 404:
+                    logger.warning(
+                        "[CHANNELS] bulk-merge: rejected — stale target ID %s no longer exists",
+                        item.target_channel_id,
+                    )
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            f"Target channel {item.target_channel_id} no longer exists — "
+                            "refresh the channels list and try again"
+                        ),
+                    )
+                raise
             target_name = target.get("name", f"Channel {item.target_channel_id}")
 
             # Collect all streams from target + sources (deduplicated, target first).
@@ -2606,6 +2627,13 @@ async def bulk_merge_channels(request: BulkMergeRequest):
                 except httpx.HTTPStatusError as fetch_err:
                     if fetch_err.response.status_code == 404:
                         missing_ids.append(src_id)
+                        # Keep source_names complete — one entry per requested
+                        # source ID, in order. Harmless today because the 422
+                        # branch below raises before the journal entry is
+                        # written, but prevents a silently misaligned audit
+                        # record if this ever becomes a partial-success batch
+                        # (bd-4xxax).
+                        source_names.append(f"Channel {src_id}")
                     else:
                         raise
 

--- a/backend/tests/integration/test_api_auto_creation.py
+++ b/backend/tests/integration/test_api_auto_creation.py
@@ -20,9 +20,29 @@ def mock_db_session():
 
 @pytest.fixture
 def test_client():
-    """Create test client."""
+    """Create test client.
+
+    The mutating auto-creation endpoints now carry RequireAdminIfEnabled
+    (bd-757hc). Its underlying dependency declares ``session=Depends(get_session)``,
+    which FastAPI resolves against the REAL database — these integration tests
+    only patch ``routers.auto_creation.get_session`` for the handler body, not
+    the auth subsystem's session, and they never call init_db(). Override the
+    admin dependency with an auth-disabled passthrough (returns None, exactly
+    what RequireAdminIfEnabled does when auth is off) so the gate doesn't touch
+    the uninitialized DB. Admin-enforcement itself is covered by
+    tests/routers/test_auto_creation.py::TestAutoCreationAdminGating.
+    """
     from main import app
-    return TestClient(app)
+    from auth import RequireAdminIfEnabled as _prebuilt
+
+    async def _allow_no_auth():
+        return None
+
+    app.dependency_overrides[_prebuilt.dependency] = _allow_no_auth
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(_prebuilt.dependency, None)
 
 
 class TestAutoCreationRulesAPI:

--- a/backend/tests/routers/test_auto_creation.py
+++ b/backend/tests/routers/test_auto_creation.py
@@ -2095,3 +2095,163 @@ rules:
             files={"file": ("debug.tar.gz", bundle, "application/gzip")},
         )
         assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Admin gating (bd-757hc) — destructive / mutating endpoints carry
+# RequireAdminIfEnabled, matching backup.py's create_backup / restore_backup.
+#
+# SECURITY FINDING: every mutating endpoint in this router was previously only
+# authenticated (via the global middleware) but NOT authorized to admin. Any
+# authenticated principal — including a narrowly-scoped MCP static-key session —
+# could invoke destructive bulk rollback / run / write ops. These tests prove
+# the gate is now in place.
+#
+# Pattern mirrors tests/routers/test_normalization.py::TestApplyToChannelsAdminGuard
+# and tests/routers/test_0hjrk_backup_save_restore.py: the default `async_client`
+# fixture runs with auth DISABLED (RequireAdminIfEnabled is a no-op → returns
+# None), so the existing happy-path tests above already prove behavior is
+# unchanged when auth is off. Here we override the prebuilt dependency to
+# simulate auth-enabled non-admin (403) and auth-enabled admin (pass-through).
+# ---------------------------------------------------------------------------
+
+# (path, http_method, request_kwargs) for every endpoint that must be admin-gated.
+# Bodies are intentionally well-formed enough to pass FastAPI request parsing —
+# the admin dependency raises BEFORE the handler runs, so the handler internals
+# are never reached when the gate rejects.
+_GATED_ENDPOINTS = [
+    ("/api/auto-creation/rules", "post", {"json": {"name": "X", "conditions": [], "actions": []}}),
+    ("/api/auto-creation/rules/1", "put", {"json": {"name": "X"}}),
+    ("/api/auto-creation/rules/bulk-update", "post", {"json": {"rule_ids": [1], "enabled": True}}),
+    ("/api/auto-creation/rules/1", "delete", {}),
+    ("/api/auto-creation/rules/reorder", "post", {"json": [1, 2, 3]}),
+    ("/api/auto-creation/rules/1/toggle", "post", {}),
+    ("/api/auto-creation/rules/1/duplicate", "post", {}),
+    ("/api/auto-creation/run", "post", {"json": {}}),
+    ("/api/auto-creation/rules/1/run", "post", {}),
+    ("/api/auto-creation/executions/1/rollback", "post", {}),
+    ("/api/auto-creation/import/yaml", "post", {"json": {"yaml_content": "rules: []"}}),
+]
+
+
+class TestAutoCreationAdminGating:
+    """Mutating/destructive auto-creation endpoints require admin when auth is
+    enabled; read endpoints stay open. Mirrors backup.py's admin guard."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("path, method, kwargs", _GATED_ENDPOINTS)
+    async def test_non_admin_is_forbidden_when_auth_enabled(
+        self, async_client, path, method, kwargs
+    ):
+        """Auth enabled + non-admin principal → 403 on every gated endpoint.
+
+        Overriding RequireAdminIfEnabled.dependency to raise 403 simulates an
+        authenticated-but-non-admin caller regardless of the test's auth state."""
+        from fastapi import HTTPException, status
+        from main import app
+        from auth import RequireAdminIfEnabled as _prebuilt
+
+        async def _reject() -> None:
+            # Parameterless so FastAPI's DI introspection doesn't pull query args.
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Admin access required",
+            )
+
+        app.dependency_overrides[_prebuilt.dependency] = _reject
+        try:
+            response = await getattr(async_client, method)(path, **kwargs)
+        finally:
+            app.dependency_overrides.pop(_prebuilt.dependency, None)
+
+        assert response.status_code == 403, (
+            f"{method.upper()} {path} should be admin-gated but returned "
+            f"{response.status_code}"
+        )
+        assert "admin" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_admin_principal_can_rollback_when_auth_enabled(self, async_client):
+        """Auth enabled + admin principal → the gate passes through and the
+        destructive rollback (the headline finding) executes normally."""
+        from main import app
+        from auth import RequireAdminIfEnabled as _prebuilt
+
+        async def _allow_admin():
+            # Stand in for an authenticated admin User; the handler ignores the
+            # returned value (param is the unused `_admin`).
+            return MagicMock(is_admin=True, username="admin")
+
+        mock_engine = AsyncMock()
+        mock_engine.rollback_execution.return_value = {
+            "success": True,
+            "rule_name": "Sports Rule",
+            "entities_removed": 3,
+            "entities_restored": 0,
+        }
+
+        app.dependency_overrides[_prebuilt.dependency] = _allow_admin
+        try:
+            with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine), \
+                 patch("routers.auto_creation.journal"):
+                response = await async_client.post(
+                    "/api/auto-creation/executions/1/rollback"
+                )
+        finally:
+            app.dependency_overrides.pop(_prebuilt.dependency, None)
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_rollback_allowed_when_auth_disabled(self, async_client):
+        """Auth disabled (default async_client) → RequireAdminIfEnabled is a
+        no-op and the endpoint behaves exactly as before the gate was added."""
+        mock_engine = AsyncMock()
+        mock_engine.rollback_execution.return_value = {
+            "success": True,
+            "rule_name": "Sports Rule",
+            "entities_removed": 1,
+            "entities_restored": 0,
+        }
+
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post(
+                "/api/auto-creation/executions/1/rollback"
+            )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_read_endpoints_not_admin_gated(self, async_client, test_session):
+        """Read-only endpoints stay reachable for a non-admin principal even
+        when auth is enabled — only mutating ops are gated. We override the admin
+        dependency to reject; the read endpoints don't depend on it, so they
+        must still return 200."""
+        from fastapi import HTTPException, status
+        from main import app
+        from auth import RequireAdminIfEnabled as _prebuilt
+
+        async def _reject() -> None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Admin access required",
+            )
+
+        _create_rule(test_session, name="Readable")
+
+        app.dependency_overrides[_prebuilt.dependency] = _reject
+        try:
+            list_resp = await async_client.get("/api/auto-creation/rules")
+            execs_resp = await async_client.get("/api/auto-creation/executions")
+            schema_resp = await async_client.get(
+                "/api/auto-creation/schema/conditions"
+            )
+        finally:
+            app.dependency_overrides.pop(_prebuilt.dependency, None)
+
+        assert list_resp.status_code == 200
+        assert execs_resp.status_code == 200
+        assert schema_resp.status_code == 200

--- a/backend/tests/routers/test_channels.py
+++ b/backend/tests/routers/test_channels.py
@@ -1384,3 +1384,120 @@ class TestBulkMergeChannelsStaleSourceIds:
         assert item["success"] is False
         # The upstream detail (not "HTTPStatusError") is surfaced.
         assert "does not exist" in item["error"]
+
+    @pytest.mark.asyncio
+    async def test_returns_422_when_target_id_no_longer_exists(self, async_client):
+        """Stale TARGET ID in bulk merge returns 422 with refresh hint, matching the
+        source-ID path — not a generic per-item failure (bd-4xxax)."""
+        mock_client = AsyncMock()
+        not_found_response = MagicMock(spec=httpx.Response)
+        not_found_response.status_code = 404
+        not_found_response.text = "Not found"
+        not_found_request = MagicMock(spec=httpx.Request)
+        stale_target = 777
+        mock_client.get_channel.side_effect = [
+            httpx.HTTPStatusError(  # target gone
+                "404 Not Found",
+                request=not_found_request,
+                response=not_found_response,
+            ),
+        ]
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.post(
+                "/api/channels/bulk-merge",
+                json={
+                    "merges": [
+                        {
+                            "target_channel_id": stale_target,
+                            "source_channel_ids": [2],
+                        }
+                    ]
+                },
+            )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert str(stale_target) in detail
+        assert "no longer exists" in detail
+        assert "refresh the channels list and try again" in detail
+        # Did not proceed to mutate or delete anything.
+        mock_client.update_channel.assert_not_called()
+        mock_client.delete_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_404_source_error_reraises_not_swallowed_as_422(self, async_client):
+        """A non-404 HTTPStatusError fetching a SOURCE (e.g. 410 Gone) must propagate
+        to the per-item catch-all, NOT be misclassified as a stale-ID 422 (bd-4xxax)."""
+        mock_client = AsyncMock()
+        gone_response = MagicMock(spec=httpx.Response)
+        gone_response.status_code = 410
+        gone_response.text = "Gone"
+        gone_request = MagicMock(spec=httpx.Request)
+        mock_client.get_channel.side_effect = [
+            {"id": 1, "name": "Target", "streams": [10]},  # target OK
+            httpx.HTTPStatusError(  # source 410 Gone — not a 404
+                "410 Gone",
+                request=gone_request,
+                response=gone_response,
+            ),
+        ]
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.post(
+                "/api/channels/bulk-merge",
+                json={
+                    "merges": [
+                        {"target_channel_id": 1, "source_channel_ids": [2]},
+                    ]
+                },
+            )
+
+        # Partial-success contract: HTTP 200 with the item marked failed.
+        assert response.status_code == 200
+        body = response.json()
+        assert body["failed"] == 1
+        item = body["results"][0]
+        assert item["success"] is False
+        # Crucially NOT a 422 stale-ID rejection.
+        assert response.status_code != 422
+        # Never reached the delete loop.
+        mock_client.delete_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_404_target_error_reraises_not_swallowed_as_422(self, async_client):
+        """A non-404 HTTPStatusError fetching the TARGET (e.g. 500) must propagate to
+        the per-item catch-all, NOT be misclassified as a stale-ID 422 (bd-4xxax)."""
+        mock_client = AsyncMock()
+        server_error_response = MagicMock(spec=httpx.Response)
+        server_error_response.status_code = 500
+        server_error_response.text = "Server error"
+        server_error_request = MagicMock(spec=httpx.Request)
+        mock_client.get_channel.side_effect = [
+            httpx.HTTPStatusError(  # target 500 — not a 404
+                "500 Server Error",
+                request=server_error_request,
+                response=server_error_response,
+            ),
+        ]
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.post(
+                "/api/channels/bulk-merge",
+                json={
+                    "merges": [
+                        {"target_channel_id": 1, "source_channel_ids": [2]},
+                    ]
+                },
+            )
+
+        # Partial-success contract: HTTP 200, item failed, NOT a 422.
+        assert response.status_code == 200
+        body = response.json()
+        assert body["failed"] == 1
+        item = body["results"][0]
+        assert item["success"] is False
+        mock_client.delete_channel.assert_not_called()

--- a/backend/tests/unit/test_dispatcharr_client_group_filter.py
+++ b/backend/tests/unit/test_dispatcharr_client_group_filter.py
@@ -113,3 +113,56 @@ async def test_unknown_group_id_does_not_silently_return_all():
         request_mock.assert_not_awaited()
     finally:
         await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_group_filter_zero_includes_channel_group_param():
+    """channel_group=0 must NOT be silently dropped (bd-d5z9u).
+
+    The original ``if channel_group:`` guard is falsy for 0, so
+    ``get_channels(channel_group=0)`` behaved identically to
+    ``get_channels()`` and fetched ALL groups. The fix uses
+    ``if channel_group is not None:`` so that 0 is a valid filter value."""
+    client = _make_client()
+    try:
+        request_mock = AsyncMock(
+            return_value=_response(200, {"results": [{"id": 10}], "count": 1})
+        )
+        groups_mock = AsyncMock(
+            return_value=[
+                {"id": 0, "name": "Uncategorized"},
+                {"id": 1, "name": "Sports"},
+            ]
+        )
+
+        with patch.object(client, "_request", request_mock), \
+             patch.object(client, "get_channel_groups", groups_mock):
+            result = await client.get_channels(channel_group=0)
+
+        params = request_mock.await_args.kwargs["params"]
+        assert params["channel_group"] == "Uncategorized"
+        assert result["count"] == 1
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_group_filter_none_omits_channel_group_param():
+    """channel_group=None (the default) must omit the channel_group param
+    entirely, matching the pre-existing no-filter behaviour (bd-d5z9u)."""
+    client = _make_client()
+    try:
+        request_mock = AsyncMock(
+            return_value=_response(200, {"results": [], "count": 0})
+        )
+        groups_mock = AsyncMock(return_value=[{"id": 0, "name": "Uncategorized"}])
+
+        with patch.object(client, "_request", request_mock), \
+             patch.object(client, "get_channel_groups", groups_mock):
+            await client.get_channels(channel_group=None)
+
+        groups_mock.assert_not_awaited()
+        params = request_mock.await_args.kwargs["params"]
+        assert "channel_group" not in params
+    finally:
+        await client._client.aclose()

--- a/docs/api.md
+++ b/docs/api.md
@@ -679,6 +679,83 @@ The frontend uses this to drive the "add alert method" form so new method types 
 | `POST /api/auto-creation/rules/analyze/from-bundle` | Run the analyzer over `rules.yaml` inside an uploaded debug-bundle `tar.gz`; never touches the DB, so it is safe for support diagnosis of any user's bundle. See `docs/auto_creation_rule_analyzer.md` |
 | `POST /api/auto-creation/debug-bundle` | Start a diagnostic-bundle build; returns `{job_id, status: "running"}` immediately and dispatches a supervised background task |
 | `GET /api/auto-creation/debug-bundle/{job_id}` | Poll a bundle build: JSON status while running, JSON `{status: "failed", error}` on failure, or the `tar.gz` (`application/gzip`) attachment when ready (obfuscated channels, rules, normalization rules, streams, probe stats, settings, task schedules, logs). Job is evicted on successful read; abandoned jobs pruned after 30 min |
+| `GET /api/auto-creation/fuzzy-preview` | Paginated, write-free scored fuzzy match preview across given channel groups (bead jnzst, v0.17.3-0006). Admin-gated. See notes below. |
+
+---
+
+### `GET /api/auto-creation/fuzzy-preview`
+
+Returns scored `(stream, channel)` pairs for the given channel groups using the same backend scoring core and admission policy used by `merge_streams` rules with `loose_name_match + min_score`. Zero writes — inspection only.
+
+**Authentication:** `RequireAdminIfEnabled` (admin token required when auth is enabled).
+
+**Query parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-|-|-|-|-|
+| `group_ids` | list of integers | Yes | — | Channel-group IDs to scope the preview to. Non-empty; no duplicates; no negatives; max 25 groups. An empty list is rejected (`400`). |
+| `min_score` | float [0.0–1.0] | Yes | — | Minimum score to include a triple. May be below the `CONFIDENCE_FLOOR` (0.60) — the preview deliberately exposes sub-floor scores for inspection. An M1 callsign `conflict` is never returned regardless of `min_score`. |
+| `allow_no_callsign` | boolean | No | `false` | Q1 opt-in. When `true`, a no-callsign (`"absent"`) pair is admissible at score ≥ 0.90 (`NO_CALLSIGN_FLOOR`). Default `false` requires a parseable callsign on both sides. |
+| `page` | integer ≥ 1 | No | `1` | Page number. |
+| `page_size` | integer 1–200 | No | `50` | Results per page. |
+
+**DoS ceilings:** the N×M scoring pass is bounded. The endpoint processes at most 2,000 streams and 2,000 channels total across all requested groups. When a ceiling is hit the response includes `"truncated": true`.
+
+**Response: `200 OK`**
+
+```json
+{
+  "triples": [
+    {
+      "stream_id": 1042,
+      "stream_name": "WI | WBAY CBS Green Bay HD",
+      "channel_id": "a1b2c3d4-e5f6-...",
+      "channel_name": "WBAY",
+      "score": 0.9412,
+      "callsign_verdict": "match",
+      "signal": "fuzzy-with-callsign"
+    }
+  ],
+  "total": 47,
+  "page": 1,
+  "page_size": 50,
+  "total_pages": 1,
+  "min_score": 0.7,
+  "truncated": false
+}
+```
+
+Each `triples` entry is a `ScoredTriple`:
+
+| Field | Type | Description |
+|-|-|-|
+| `stream_id` | integer | ECM stream ID |
+| `stream_name` | string | Raw stream name (not the LOCALS-cleaned form) |
+| `channel_id` | string | Dispatcharr channel UUID |
+| `channel_name` | string | Raw channel name (not the cleaned form) |
+| `score` | float | Normalized score in [0.0, 1.0], rounded to 4 decimal places |
+| `callsign_verdict` | string | `"match"` — both sides parsed a callsign and they agree; `"absent"` — at least one side had no parseable callsign |
+| `signal` | string | Which scoring rung produced the score: `"callsign-exact"`, `"tvg_id-override"`, `"fuzzy-with-callsign"`, or `"fuzzy-no-callsign-floor"` |
+
+Triples are sorted highest score first; ties break on `stream_id` then `channel_id` (deterministic).
+
+**Admission policy.** The endpoint applies the shared `is_admissible` policy from `services.dedup_matcher`:
+
+- `"conflict"` verdict (M1 callsign hard-reject) — never returned, even at `min_score == 0`.
+- `"absent"` verdict — returned only when `allow_no_callsign=true` and `score >= 0.90`.
+- `"match"` verdict — returned when `score >= min_score`.
+
+This is the same policy the `merge_streams` rule executor applies, so the preview shows exactly what a rule would do.
+
+**Example:**
+
+```bash
+curl -X GET \
+  "http://localhost:6100/api/auto-creation/fuzzy-preview?group_ids=14&group_ids=22&min_score=0.7&allow_no_callsign=false&page=1&page_size=50" \
+  -H "Authorization: Bearer TOKEN"
+```
+
+---
 
 `POST /api/auto-creation/rules/bulk-update` applies the same partial update to every rule in `rule_ids` in a single transaction. Send only the fields you want to change; omitted fields are left as-is per rule.
 

--- a/docs/auto_creation_rule_analyzer.md
+++ b/docs/auto_creation_rule_analyzer.md
@@ -319,6 +319,77 @@ existed, not whether the merge itself would land there.
 
 ---
 
+## Scored-fuzzy rule path (`loose_name_match` + `min_score`)
+
+Shipped in v0.17.3-0006 (bead jnzst). This path adds a callsign-aware, confidence-scored stream→channel matching mode on top of the existing `loose_name_match` boolean. It is opt-in — a `loose_name_match` rule without `min_score` keeps running the legacy fuzzy cascade exactly as before.
+
+### How to activate it
+
+Add `min_score` to a `merge_streams` action that already has `loose_name_match: true`:
+
+```json
+{
+  "type": "merge_streams",
+  "target": "auto",
+  "loose_name_match": true,
+  "min_score": 0.75,
+  "target_channel_in_group": [14, 22],
+  "allow_no_callsign": false
+}
+```
+
+When `min_score` is present, the executor delegates to the unified scoring core (`services.dedup_matcher.score_all`) instead of the legacy cascade. The score is a normalized float in [0.0, 1.0] produced by RapidFuzz `token_set_ratio` on LOCALS-cleaned names, with two override rungs (callsign exact match → 1.0, tvg_id callsign equality → 1.0) that take precedence.
+
+### Required fields and validation
+
+| Field | Type | Required | Notes |
+|-|-|-|-|
+| `loose_name_match` | boolean | Yes (`true`) | Must be `true`; `min_score` has no meaning on the exact path. |
+| `min_score` | float [0.0–1.0] | Yes (to activate scored path) | Floored at `CONFIDENCE_FLOOR` (0.60). A value below the floor is rejected at write time with a `400`. |
+| `target_channel_in_group` | list of integer group IDs | **Yes — non-empty** | A scored-fuzzy rule with no `target_channel_in_group` allowlist is rejected by the schema validator (`400`). This is an intentional safety constraint: an unscoped fuzzy rule was the root cause of a 1,341-false-positive merge incident. |
+| `allow_no_callsign` | boolean | No (default `false`) | Opt-in to matching pairs where at least one side has no parseable callsign. When `true`, such pairs are admitted only at score ≥ 0.90. |
+
+### Scoring precedence (shared core)
+
+The scoring core applies a hard precedence ladder — the same ladder the `fuzzy-preview` endpoint uses:
+
+1. **M1 callsign hard-reject.** If both the stream name and the channel name parse a callsign (e.g. `WBAY`/`WGBA`) and they differ, the pair is rejected unconditionally — score 0.0, verdict `"conflict"`. This fires before any threshold and cannot be overridden.
+2. **tvg_id callsign override.** If the stream's `tvg_id` (or its name) and the channel's `tvg_id` (or its name) parse the same callsign, the score is set to 1.0 (`tvg_id-override`). Only reached when M1 did not fire.
+3. **LOCALS-cleaned fuzzy.** RapidFuzz `token_set_ratio` on names cleaned with the LOCALS cleaner (strips `US |` / state-code / `CITY:` / `DIREC TV` prefixes, dotted sub-channel numbers, superscripts, quality tags like `RAW`/`HD`, and run-together market tokens like `GREENBAY → GREEN BAY`).
+
+### No-callsign opt-in (`allow_no_callsign`)
+
+The default policy requires a parseable FCC callsign on both sides of a match. This is the safe default — without a callsign cross-check, `WGBA 2 (NBC)` scored 0.889 against `WBAY` in the spike that motivated the callsign gate.
+
+Set `allow_no_callsign: true` to admit pairs where at least one side lacks a parseable callsign, subject to the 0.90 floor (`NO_CALLSIGN_FLOOR`). Even with the opt-in, an M1 conflict (different callsigns on both sides) is still never admitted.
+
+### Journal provenance
+
+For each stream matched via the scored-fuzzy path, the executor writes a journal entry with:
+
+- The match `score` (float)
+- `callsign_verdict` (`"match"` or `"absent"`)
+- `signal` — which scoring rung fired (`"callsign-exact"`, `"tvg_id-override"`, `"fuzzy-with-callsign"`, `"fuzzy-no-callsign-floor"`)
+- The stream and channel callsigns (when parsed)
+
+This lets you audit exactly why a merge fired — accessible in the ECM journal tab or via `GET /api/journal`.
+
+### Rollback
+
+Auto-creation executions are rollback-able via `POST /api/auto-creation/executions/{id}/rollback` regardless of whether the run used the scored-fuzzy path or the exact path.
+
+### What is unchanged
+
+- The global exact-match rule path is unchanged. Rules without `min_score` run as before.
+- `match_by` remains a validated no-op (see below).
+- `CONFIDENCE_FLOOR` (0.60) is the same floor used by the interactive stream deduplication (ADR-008 §D2). Both import the constant from `services.dedup_matcher` so they cannot drift.
+
+### Previewing before committing
+
+Use the `GET /api/auto-creation/fuzzy-preview` endpoint (or the `preview_fuzzy_matches` MCP tool) to inspect scored triples before enabling a rule. The preview applies the identical scoring core and admission policy, so it shows exactly what the rule would do. See [`docs/api.md`](api.md) for the endpoint reference.
+
+---
+
 ## Matching: `loose_name_match` vs the deprecated `match_by`
 
 ### `loose_name_match` (the real control)

--- a/docs/user_guide/auto-creation/fuzzy-locals-matching.md
+++ b/docs/user_guide/auto-creation/fuzzy-locals-matching.md
@@ -1,0 +1,213 @@
+# Fuzzy Matching for Local / OTA Channels
+
+> **Audience:** Operator managing OTA or affiliate local channels where stream
+> names vary across providers (state-code prefixes, quality tags, run-together
+> market names) and exact-name matching misses them.
+>
+> **Shipped:** v0.17.3-0006 (bead jnzst).
+
+## What it is
+
+ECM's auto-creation engine defaults to **exact normalized-name equality** when
+merging streams into existing channels. That default is intentional — it ended
+a 1,341-false-positive merge incident caused by over-broad word-prefix matching.
+
+Local and OTA streams are the one category where exact matching reliably fails.
+Different providers tag the same channel differently:
+
+| Provider A | Provider B | Provider C |
+|-|-|-|
+| `WI \| WBAY CBS Green Bay HD` | `US: WBAY-DT (CBS)` | `WBAY CBS 2.1` |
+
+All three point at the same station, but no two strings match exactly after
+normalization.
+
+**Fuzzy locals matching** adds a scored matching mode for these cases. It uses
+FCC callsigns as a hard correctness gate (WBAY ≠ WGBA, no matter how similar
+the names look), then applies a confidence-scored fuzzy match on cleaned names
+as a tiebreaker. You configure a minimum confidence score and scope it to the
+channel groups that hold your Local channels.
+
+## When to use it
+
+Use fuzzy locals matching when:
+
+- You have a "Local" or "OTA" channel group and streams are landing in M3U
+  under names like `WI | WBAY`, `US: WBAY-DT`, or `WBAY CBS Green Bay RAW`.
+- Streams are arriving but not merging into existing Local channels because
+  exact-name matching keeps missing them.
+- You have already checked the exact-match rule and confirmed it is not a
+  normalization gap that a normalization rule would fix first.
+
+Do **not** use it as a catch-all for non-local content. The callsign gate only
+protects pairs where both sides have a parseable callsign. For content without
+callsigns (sports networks, premium channels, international feeds) the gate
+cannot fire and the safety margin is narrower.
+
+## How it works
+
+When a `merge_streams` rule includes both `loose_name_match: true` and a
+`min_score` threshold, the engine uses a three-rung scoring ladder instead of
+the legacy fuzzy cascade:
+
+1. **Callsign hard-reject (M1).** If both the stream name and the channel name
+   contain a parseable FCC callsign and they differ, the pair is rejected
+   unconditionally — no score, no merge. `WGBA` against `WBAY` is always
+   rejected here regardless of how similar the surrounding words look.
+
+2. **Callsign equality override.** If the callsigns on both sides match (or the
+   `tvg_id` callsigns match), the score is set to 1.0 and the pair is admitted
+   immediately — no fuzzy scoring needed.
+
+3. **LOCALS fuzzy scoring.** Names are cleaned (state-code and market prefixes
+   stripped, superscripts converted, quality tags removed, `GREENBAY` split to
+   `Green Bay`) and scored with a token-based similarity algorithm. The result
+   is a float between 0.0 and 1.0; the pair is admitted when it reaches your
+   configured `min_score`.
+
+The minimum score is floored at 0.60. Values below 0.60 are rejected at save
+time.
+
+## Setting up a fuzzy locals rule
+
+### Step 1 — identify your Local channel groups
+
+Go to **Channel Groups** and note the ID(s) of the groups that hold your local
+channels (e.g., "Locals", "OTA"). You will need these group IDs for the
+`target_channel_in_group` allowlist.
+
+### Step 2 — preview before writing
+
+Use the preview tool to see what would match at your intended threshold before
+saving any rule.
+
+**Via MCP:**
+
+```
+preview_fuzzy_matches(group_ids=[14, 22], min_score=0.75)
+```
+
+**Via API:**
+
+```
+GET /api/auto-creation/fuzzy-preview
+  ?group_ids=14&group_ids=22&min_score=0.75
+```
+
+The preview returns scored `(stream, channel)` pairs in descending score order.
+Review the `callsign_verdict` column:
+
+- `match` — both sides have a callsign and they agree. These are the
+  high-confidence matches.
+- `absent` — at least one side has no parseable callsign. Admitted by default
+  only when `allow_no_callsign` is set (see below).
+
+Inspect any surprising pairs in the results. The preview never writes anything.
+
+### Step 3 — build the rule action
+
+Add a `merge_streams` action to your rule with these fields:
+
+```json
+{
+  "type": "merge_streams",
+  "target": "auto",
+  "loose_name_match": true,
+  "min_score": 0.75,
+  "target_channel_in_group": [14, 22]
+}
+```
+
+- `target_channel_in_group` is **required** for scored-fuzzy rules. The schema
+  rejects a scored-fuzzy rule without it. This is the scoping constraint that
+  keeps fuzzy matching from touching unintended channel groups.
+- `min_score` must be in [0.60, 1.0]. 0.75 is a reasonable starting point for
+  callsign-verified matches; lower values increase recall at the cost of
+  precision.
+
+### Step 4 — run dry-run first
+
+Run the pipeline in dry-run mode before enabling the rule:
+
+```
+POST /api/auto-creation/run
+{ "dry_run": true, "rule_ids": [<your rule id>] }
+```
+
+Or via MCP:
+
+```
+match_streams_to_channels(group_ids=[14, 22], min_score=0.75, apply=false)
+```
+
+The dry-run shows which streams would be matched and at what score, without
+writing anything.
+
+### Step 5 — enable and monitor
+
+Enable the rule and watch the journal (`GET /api/journal` or the Journal tab).
+Each scored-fuzzy merge writes a journal entry with the score, `callsign_verdict`,
+signal, and the callsigns that were parsed — so you can audit exactly why each
+merge fired.
+
+If a run produces unexpected matches, use
+`POST /api/auto-creation/executions/{id}/rollback` to undo it.
+
+## No-callsign opt-in
+
+The default policy requires a parseable FCC callsign on both sides of a match.
+For channels or streams where no callsign is present in the name or `tvg_id`,
+the pair is skipped by default.
+
+To admit no-callsign pairs, add `"allow_no_callsign": true` to the action. When
+set, pairs where at least one side has no callsign are admitted only when they
+score ≥ 0.90. The 0.90 bar is higher than the normal `min_score` floor to
+partially compensate for the absence of the callsign correctness gate.
+
+The M1 hard-reject still fires if both sides have parseable but different
+callsigns — `allow_no_callsign` does not affect that case.
+
+## Safety guarantees
+
+- **Dry-run by default.** Both `match_streams_to_channels` (MCP) and
+  `POST /api/auto-creation/run` support `dry_run: true`. The `preview_fuzzy_matches`
+  MCP tool and `GET /api/auto-creation/fuzzy-preview` endpoint never write under
+  any circumstances.
+- **Admin-gated.** The `fuzzy-preview` endpoint requires admin authentication
+  when auth is enabled.
+- **Rollback-able.** Auto-creation executions are recorded and reversible via
+  `POST /api/auto-creation/executions/{id}/rollback`.
+- **Scoping required.** The schema refuses to save a scored-fuzzy rule without
+  a non-empty `target_channel_in_group` allowlist.
+- **Callsign hard-reject.** Pairs with conflicting callsigns on both sides are
+  never admitted, regardless of `min_score` or `allow_no_callsign`.
+
+## MCP tools
+
+The MCP server exposes two tools for the fuzzy locals workflow:
+
+**`preview_fuzzy_matches(group_ids, min_score)`**
+
+Read-only. Returns ranked `(stream, channel, score)` triples for the given
+groups. Uses the same scoring core and admission policy as the rule executor.
+
+**`match_streams_to_channels(group_ids, min_score, apply=false, backfill=false)`**
+
+Defaults to dry-run (`apply=false`). Shows which channels would receive a stream.
+Set `apply=true` to actually assign the best-scoring stream per channel. The
+`backfill` flag extends matching to channels that already have streams (default
+is channels with zero streams only).
+
+Both tools call `GET /api/auto-creation/fuzzy-preview` under the hood and
+inherit M1/M2 admission from the shared policy — they cannot see or assign
+non-admissible pairs.
+
+## Deep reference
+
+| Topic | Where |
+|-|-|
+| Scoring core internals | `backend/services/dedup_matcher.py` — `score_one`, `score_all`, `is_admissible`, `_normalize(mode=LOCALS)` |
+| Rule schema validation | `backend/auto_creation_schema.py` — `min_score` / `target_channel_in_group` constraints |
+| Preview endpoint | [`docs/api.md`](../../api.md) — `GET /api/auto-creation/fuzzy-preview` |
+| Scored-fuzzy rule path (dev reference) | [`docs/auto_creation_rule_analyzer.md`](../../auto_creation_rule_analyzer.md) — "Scored-fuzzy rule path" section |
+| Confidence floor (ADR-008 §D2) | `CONFIDENCE_FLOOR = 0.60` in `services.dedup_matcher` — same constant used by interactive stream dedup |

--- a/docs/user_guide/auto-creation/index.md
+++ b/docs/user_guide/auto-creation/index.md
@@ -25,6 +25,7 @@ End users do not read this section.
 | `test-a-rule.md` | The dry-run / preview workflow. What's safe to test against production data and what isn't. |
 | `bulk-operations.md` | Running rules across an entire source, the cost of a large run, and the bulk-amplification cautions an operator should know about. |
 | [`debugging-rules.md`](debugging-rules.md) | "My rule didn't fire" — the diagnostic flow using the rule analyzer: the 7 finding codes in plain language with worked examples, how to run the analyzer (API direct call, debug-bundle upload, `/analyze-rules` agent command), and when to use the analyzer vs. the per-rule dry-run preview. |
+| [`fuzzy-locals-matching.md`](fuzzy-locals-matching.md) | Scored fuzzy matching for OTA / Local channels: when to use it, how to preview before writing, the callsign safety gate, and the dry-run / rollback guarantees (v0.17.3-0006). |
 | `clone-and-reuse.md` | Duplicating a rule as a starting point, sharing a normalization group across rules. |
 
 ## Going deeper (for now)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0008",
+  "version": "0.17.3-0009",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Combined PR finishing the 0.17.3 line. Four independent, non-overlapping beads, each implemented by a project-engineer agent in an isolated worktree and gate-verified independently.

## Changes
- **bd-757hc (P2, security):** Gate the 11 mutating/destructive endpoints in `routers/auto_creation.py` with `RequireAdminIfEnabled` (headline: `POST /executions/{id}/rollback`), matching `backup.py`'s pattern. Read-only endpoints left ungated. Also fixes an integration-test fixture gap. +`TestAutoCreationAdminGating` (non-admin→403, admin→works, auth-disabled→unchanged).
- **bd-4xxax (P2):** `bulk_merge_channels` — add 404 stale-guard on the target-ID fetch (mirrors the source-ID 422-with-refresh-hint path), add coverage for the non-404 HTTPStatusError re-raise path, and complete the `source_names` list in the 422 branch.
- **bd-d5z9u (P3):** `dispatcharr_client.get_channels` — `if channel_group is not None:` (was falsy-dropping `channel_group=0`, silently fetching all groups). +tests.
- **bd-i5gfz (P3, docs):** Operator + API-reference docs for the jnzst fuzzy-locals feature: `docs/api.md` (the `/api/auto-creation/fuzzy-preview` endpoint), `docs/auto_creation_rule_analyzer.md` (scored-fuzzy rule path), and a new `docs/user_guide/auto-creation/fuzzy-locals-matching.md` + index entry.

## Verification
- Version consistency: all 3 touchpoints at `0.17.3-0009`.
- Affected tests on the combined branch: 610 passed, 0 failed.

## Follow-up filed
- `clear-auto-created` in `channels.py` is the same class of ungated mutating op (different router, out of bd-757hc scope) — filed as a P2 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)