### PR TITLE
v0.17.3-0012: Fix Stats-tab footer-hover scrolling the whole UI off-page (bd-tkcmu)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0011",
+    version="0.17.3-0012",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0011"
+APP_VERSION = "0.17.3-0012"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0011",
+  "version": "0.17.3-0012",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/tabs/StatsTab.css
+++ b/frontend/src/components/tabs/StatsTab.css
@@ -8,6 +8,10 @@
   padding: 1rem 1.5rem;
   overflow: hidden;
   box-sizing: border-box;
+  /* Prevent scroll events from leaking out when stats-content is at its
+   * scroll boundary — belt-and-suspenders alongside index.css overflow:hidden
+   * (bd-tkcmu). */
+  overscroll-behavior: contain;
 }
 
 .stats-header {
@@ -120,6 +124,9 @@
   flex: 1;
   overflow-y: auto;
   min-height: 0;
+  /* Prevent wheel events from chaining to the document when the stats
+   * list is scrolled to its top/bottom boundary (bd-tkcmu). */
+  overscroll-behavior: contain;
 }
 
 /* No Streams State */

--- a/frontend/src/components/tabs/StatsTab.test.tsx
+++ b/frontend/src/components/tabs/StatsTab.test.tsx
@@ -1488,3 +1488,60 @@ describe('StatsTab — real client device IP field (bd-7ncci)', () => {
     );
   });
 });
+
+// bd-tkcmu: scroll-containment regression lock.
+//
+// Scrolling over the footer while on the Stats tab used to scroll the
+// ENTIRE page off the viewport.  The fix is two-part:
+//   1. index.css sets overflow:hidden on html/body/#root so the document
+//      can never be a scroll container (app-shell defence, not testable
+//      here — JSDOM doesn't honour CSS files).
+//   2. .stats-tab sets overscroll-behavior:contain so wheel events don't
+//      chain out of the component even when the inner .stats-content is
+//      at a scroll boundary (belt-and-suspenders).
+//
+// This test is a structural assertion: it verifies that
+//   • .stats-tab is the component root (the element that carries the CSS)
+//   • .stats-content is its scroll-container child (the element with the
+//     scroll containment rule)
+// If either class is removed or renamed the test will fail, surfacing a
+// regression at the layout level before a browser is involved.
+//
+// Manual repro (without the fix): open the Stats tab in any browser,
+// scroll the page so the footer is visible, hover the mouse over the
+// footer "API: Healthy" bar, then wheel-scroll — the entire UI scrolls
+// off the page.  With the fix the page stays locked; only the
+// .stats-content area scrolls.
+
+describe('StatsTab — scroll-containment DOM structure (bd-tkcmu)', () => {
+  beforeEach(() => {
+    vi.mocked(api.getChannelStats).mockResolvedValue({
+      count: 0,
+      channels: [],
+    } as unknown as ChannelStatsResponse);
+  });
+
+  it('renders .stats-tab as the root element and .stats-content as a descendant once loaded', async () => {
+    const { container } = render(<StatsTab />);
+
+    // Wait for the loading state to clear (all API calls must resolve).
+    // The component shows .tab-loading while loading; once done it
+    // renders .stats-content inside .stats-tab.
+    await waitFor(() => {
+      expect(container.querySelector('.stats-content')).toBeInTheDocument();
+    });
+
+    // The component root must carry the .stats-tab class (which owns
+    // overflow:hidden + overscroll-behavior:contain in the CSS).
+    const statsTab = container.querySelector('.stats-tab');
+    expect(statsTab).toBeInTheDocument();
+
+    // .stats-content must be inside .stats-tab (not at the same level or
+    // outside) so the CSS containment chain is intact.
+    const statsContent = statsTab?.querySelector('.stats-content');
+    expect(statsContent).not.toBeNull();
+
+    // Sanity-check: .stats-content must not be the stats-tab root itself.
+    expect(statsTab).not.toBe(statsContent);
+  });
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -297,6 +297,12 @@
 html, body, #root {
   height: 100%;
   width: 100%;
+  /* Prevent the document itself from becoming a scroll container.
+   * This is an SPA — all scrolling happens inside the app shell.
+   * Without overflow:hidden the page can scroll if any content path
+   * lets a flex/block child overflow its constrained ancestor (e.g.
+   * the Stats tab footer-hover scroll bug, bd-tkcmu). */
+  overflow: hidden;
 }
 
 /* Search input with clear button */


### PR DESCRIPTION
Fixes a user-reported bug: on the **Stats tab**, hovering the bottom status bar ("API: Healthy …") and scrolling moved the **entire UI** off the page.

## Root cause / fix
`html, body, #root` had `height: 100%` but no `overflow: hidden`, so the document itself could become a scroll container. A wheel event over the non-scrollable `.footer` (a sibling of `.main`, outside any tab's scroll container) then scrolled the document, dragging the whole UI. Adding `overflow: hidden` to the app root makes the document non-scrollable — all scrolling stays inside the app shell — so this can't happen on any tab. `.stats-content` keeps its own `overflow-y: auto`, so no Stats content becomes unreachable. Added `overscroll-behavior: contain` on the Stats scroll containers as a scroll-chain guard.

Why other tabs don't regress: every tab scrolls **inside** `.main` (which is `overflow: hidden`); none relied on document scroll.

## Verification
- Independently ran: `tsc` clean, `eslint --max-warnings 0` clean, vitest 43/43 (incl. a new structural assertion).
- **Deployed to the running container and confirmed by the reporter** that the scroll bug is gone and other scrolling is unaffected.
- Version consistency: all 3 touchpoints at `0.17.3-0012`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)