### PR TITLE
v0.17.3-0013: Admin-gate destructive/bulk channels endpoints (bd-um30y)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0012",
+    version="0.17.3-0013",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0012"
+APP_VERSION = "0.17.3-0013"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/routers/channels.py
+++ b/backend/routers/channels.py
@@ -16,6 +16,7 @@ import httpx
 from fastapi import APIRouter, HTTPException, Request, UploadFile, File, Response
 from pydantic import BaseModel
 
+from auth import RequireAdminIfEnabled
 from concurrency import run_cpu_bound
 from config import get_settings
 from csv_handler import parse_csv, generate_csv, generate_template, CSVParseError
@@ -672,8 +673,8 @@ async def export_channels_csv():
 
 
 @router.post("/import-csv")
-async def import_channels_csv(file: UploadFile = File(...)):
-    """Import channels from CSV file."""
+async def import_channels_csv(file: UploadFile = File(...), _admin=RequireAdminIfEnabled):
+    """Import channels from CSV file. Admin only (bulk operator op, bd-um30y)."""
     logger.debug("[CHANNELS-CSV] POST /channels/import-csv - filename=%s", file.filename)
     client = get_client()
 
@@ -927,8 +928,8 @@ async def preview_csv(data: dict):
 # ---------------------------------------------------------------------------
 
 @router.post("/assign-numbers")
-async def assign_channel_numbers(request: AssignNumbersRequest):
-    """Bulk assign channel numbers."""
+async def assign_channel_numbers(request: AssignNumbersRequest, _admin=RequireAdminIfEnabled):
+    """Bulk assign channel numbers. Admin only (bulk operator op, bd-um30y)."""
     logger.debug("[CHANNELS] POST /channels/assign-numbers - %s channels starting_number=%s", len(request.channel_ids), request.starting_number)
     client = get_client()
     settings = get_settings()
@@ -1118,9 +1119,10 @@ def _consolidate_operations(operations: list[BulkOperation]) -> list[BulkOperati
 
 
 @router.post("/bulk-commit")
-async def bulk_commit_operations(request: BulkCommitRequest):
+async def bulk_commit_operations(request: BulkCommitRequest, _admin=RequireAdminIfEnabled):
     """
-    Process multiple channel operations in a single request.
+    Process multiple channel operations in a single request. Admin only
+    (bulk operator op, bd-um30y).
 
     This endpoint is optimized for bulk changes (1000+ operations) by:
     - Processing all operations in a single HTTP request
@@ -1779,11 +1781,13 @@ async def normalize_preview_batch(request: NormalizePreviewBatchRequest):
 
 
 @router.post("/clear-auto-created")
-async def clear_auto_created_flag(request: ClearAutoCreatedRequest):
+async def clear_auto_created_flag(request: ClearAutoCreatedRequest, _admin=RequireAdminIfEnabled):
     """Clear the auto_created flag from all channels in the specified groups.
 
     This converts auto_created channels to manual channels by setting
     auto_created=False and auto_created_by=None.
+
+    Admin only (destructive bulk operator op, bd-um30y).
     """
     logger.debug("[CHANNELS] POST /channels/clear-auto-created - group_ids=%s", request.group_ids)
     client = get_client()
@@ -2054,12 +2058,14 @@ async def update_channel(channel_id: int, data: dict):
 
 
 @router.post("/merge")
-async def merge_channels(request: "MergeChannelsRequest"):
+async def merge_channels(request: "MergeChannelsRequest", _admin=RequireAdminIfEnabled):
     """Merge multiple channels into a single new channel.
 
     Creates a new channel with the specified metadata, moves all streams
     from the source channels into it (preserving order, deduplicating),
     then deletes the source channels.
+
+    Admin only (destructive operator op — deletes channels, bd-um30y).
     """
     logger.debug("[CHANNELS] POST /channels/merge - sources=%s target_name=%s",
                  request.source_channel_ids, request.target_name)
@@ -2561,11 +2567,13 @@ async def find_duplicate_channels():
 
 
 @router.post("/bulk-merge")
-async def bulk_merge_channels(request: BulkMergeRequest):
+async def bulk_merge_channels(request: BulkMergeRequest, _admin=RequireAdminIfEnabled):
     """Merge multiple groups of duplicate channels.
 
     For each merge item, keeps the target channel and moves all streams
     from source channels into it, then deletes the sources.
+
+    Admin only (destructive bulk operator op — deletes channels, bd-um30y).
     """
     logger.debug("[CHANNELS] POST /channels/bulk-merge - %d merge groups", len(request.merges))
 

--- a/backend/tests/routers/test_channels.py
+++ b/backend/tests/routers/test_channels.py
@@ -1501,3 +1501,188 @@ class TestBulkMergeChannelsStaleSourceIds:
         item = body["results"][0]
         assert item["success"] is False
         mock_client.delete_channel.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Admin gating (bd-um30y) — destructive / bulk operator-level channel
+# endpoints carry RequireAdminIfEnabled, matching the bd-757hc gate on
+# auto_creation.py and backup.py's create_backup / restore_backup.
+#
+# SECURITY FINDING: POST /api/channels/clear-auto-created (and its
+# destructive/bulk siblings) were only authenticated via the global
+# middleware but NOT authorized to admin. ECM has a real non-admin
+# authenticated role (Dispatcharr-federated users are created with
+# is_admin=False — auth/routes.py), so an authenticated NON-admin principal
+# (or a narrowly-scoped MCP static-key session) could invoke destructive
+# bulk ops (clear-auto-created, merge/bulk-merge that delete channels,
+# bulk-commit, assign-numbers, import-csv). These tests prove the gate is
+# now in place.
+#
+# Pattern mirrors test_auto_creation.py::TestAutoCreationAdminGating: the
+# default `async_client` fixture runs with auth DISABLED (so
+# RequireAdminIfEnabled is a no-op → returns None, and the existing
+# happy-path tests above already prove behavior is unchanged when auth is
+# off). Here we override the prebuilt dependency to simulate auth-enabled
+# non-admin (403) and auth-enabled admin (pass-through).
+#
+# Single-resource CRUD (create/update/delete channel, add/remove/reorder a
+# single stream, logo CRUD) is intentionally NOT gated here — a non-admin
+# Dispatcharr principal may legitimately perform routine per-resource edits,
+# and over-gating those would regress normal flows. Only the destructive /
+# bulk operator-op class is gated, matching bd-757hc's scope.
+# ---------------------------------------------------------------------------
+
+# (path, http_method, request_kwargs) for every channels endpoint now admin-gated.
+# Bodies are well-formed enough to pass FastAPI request parsing — the admin
+# dependency raises BEFORE the handler runs, so handler internals are never
+# reached when the gate rejects.
+_GATED_CHANNEL_ENDPOINTS = [
+    ("/api/channels/clear-auto-created", "post", {"json": {"group_ids": [1]}}),
+    ("/api/channels/assign-numbers", "post",
+     {"json": {"channel_ids": [1, 2], "starting_number": 100}}),
+    ("/api/channels/bulk-commit", "post", {"json": {"operations": []}}),
+    ("/api/channels/merge", "post",
+     {"json": {"source_channel_ids": [1, 2], "target_name": "Merged"}}),
+    ("/api/channels/bulk-merge", "post",
+     {"json": {"merges": [{"target_channel_id": 1, "source_channel_ids": [2]}]}}),
+    ("/api/channels/import-csv", "post",
+     {"files": {"file": ("channels.csv", b"name\nESPN\n", "text/csv")}}),
+]
+
+
+class TestChannelsAdminGating:
+    """Destructive / bulk channel endpoints require admin when auth is enabled;
+    read endpoints and routine single-resource mutations stay reachable.
+    Mirrors test_auto_creation.py::TestAutoCreationAdminGating."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("path, method, kwargs", _GATED_CHANNEL_ENDPOINTS)
+    async def test_non_admin_is_forbidden_when_auth_enabled(
+        self, async_client, path, method, kwargs
+    ):
+        """Auth enabled + non-admin principal → 403 on every gated endpoint.
+
+        Overriding RequireAdminIfEnabled.dependency to raise 403 simulates an
+        authenticated-but-non-admin caller regardless of the test's auth state."""
+        from fastapi import HTTPException, status
+        from main import app
+        from auth import RequireAdminIfEnabled as _prebuilt
+
+        async def _reject() -> None:
+            # Parameterless so FastAPI's DI introspection doesn't pull query args.
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Admin access required",
+            )
+
+        app.dependency_overrides[_prebuilt.dependency] = _reject
+        try:
+            response = await getattr(async_client, method)(path, **kwargs)
+        finally:
+            app.dependency_overrides.pop(_prebuilt.dependency, None)
+
+        assert response.status_code == 403, (
+            f"{method.upper()} {path} should be admin-gated but returned "
+            f"{response.status_code}"
+        )
+        assert "admin" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_admin_principal_can_clear_auto_created_when_auth_enabled(
+        self, async_client
+    ):
+        """Auth enabled + admin principal → the gate passes through and the
+        destructive clear-auto-created (the headline finding) executes
+        normally."""
+        from main import app
+        from auth import RequireAdminIfEnabled as _prebuilt
+
+        async def _allow_admin():
+            # Stand in for an authenticated admin User; the handler ignores the
+            # returned value (param is the unused `_admin`).
+            return MagicMock(is_admin=True, username="admin")
+
+        mock_client = AsyncMock()
+        mock_client.get_channels.return_value = {
+            "results": [
+                {"id": 5, "name": "Auto ESPN", "channel_number": 5,
+                 "channel_group_id": 1, "auto_created": True},
+            ],
+            "next": None,
+        }
+        mock_client.update_channel.return_value = {"id": 5, "auto_created": False}
+
+        app.dependency_overrides[_prebuilt.dependency] = _allow_admin
+        try:
+            with patch("routers.channels.get_client", return_value=mock_client), \
+                 patch("routers.channels.journal"):
+                response = await async_client.post(
+                    "/api/channels/clear-auto-created",
+                    json={"group_ids": [1]},
+                )
+        finally:
+            app.dependency_overrides.pop(_prebuilt.dependency, None)
+
+        assert response.status_code == 200
+        mock_client.update_channel.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_clear_auto_created_allowed_when_auth_disabled(self, async_client):
+        """Auth disabled (default async_client) → RequireAdminIfEnabled is a
+        no-op and the endpoint behaves exactly as before the gate was added."""
+        mock_client = AsyncMock()
+        mock_client.get_channels.return_value = {
+            "results": [
+                {"id": 5, "name": "Auto ESPN", "channel_number": 5,
+                 "channel_group_id": 1, "auto_created": True},
+            ],
+            "next": None,
+        }
+        mock_client.update_channel.return_value = {"id": 5, "auto_created": False}
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.post(
+                "/api/channels/clear-auto-created",
+                json={"group_ids": [1]},
+            )
+
+        assert response.status_code == 200
+        mock_client.update_channel.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_routine_and_read_endpoints_not_admin_gated(self, async_client):
+        """Routine single-resource mutations and read-only endpoints stay
+        reachable for a non-admin principal even when auth is enabled — only
+        the destructive/bulk class is gated. We override the admin dependency
+        to reject; these endpoints don't depend on it, so they must still
+        succeed (not 403)."""
+        from fastapi import HTTPException, status
+        from main import app
+        from auth import RequireAdminIfEnabled as _prebuilt
+
+        async def _reject() -> None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Admin access required",
+            )
+
+        mock_client = AsyncMock()
+        mock_client.get_channels.return_value = {"results": [], "count": 0}
+        mock_client.create_channel.return_value = {"id": 1, "name": "ESPN"}
+
+        app.dependency_overrides[_prebuilt.dependency] = _reject
+        try:
+            with patch("routers.channels.get_client", return_value=mock_client), \
+                 patch("routers.channels.journal"):
+                list_resp = await async_client.get("/api/channels")
+                create_resp = await async_client.post(
+                    "/api/channels", json={"name": "ESPN"}
+                )
+        finally:
+            app.dependency_overrides.pop(_prebuilt.dependency, None)
+
+        # Read endpoint and routine single-resource create are NOT admin-gated,
+        # so the reject override must not turn them into 403s.
+        assert list_resp.status_code == 200
+        assert create_resp.status_code != 403

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0012",
+  "version": "0.17.3-0013",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Security follow-up to bd-757hc (which gated the auto-creation router). Surfaced by that engineer: `POST /api/channels/clear-auto-created` and sibling destructive/bulk endpoints in `channels.py` lacked admin-level authorization, so a narrowly-scoped/non-admin authenticated principal (e.g. an MCP token) could invoke them.

## Auth model finding
ECM has a **real non-admin authenticated role** (Dispatcharr-federated users are created `is_admin=False`); the global middleware authenticates all `/api/*`. So the meaningful per-endpoint control is `RequireAdminIfEnabled` (no-op when auth disabled; requires admin when enabled). Because non-admins exist, routine per-resource CRUD was **deliberately not** blanket-gated — only the destructive/bulk operator class, matching how `channel_merges.py` / `normalization.py` / `auto_creation.py` already gate.

## Gated (added `_admin=RequireAdminIfEnabled`)
`clear-auto-created` (primary), `merge`, `bulk-merge`, `bulk-commit`, `assign-numbers`, `import-csv`.

## Left ungated (with reason)
- Read-only GETs and preview/validation scans.
- Routine single-resource mutations (create/update/delete one channel, add/remove one stream, reorder, logo CRUD) — a non-admin principal may legitimately perform these; gating would regress normal flows.

## Flagged for a possible follow-up policy decision (NOT gated here)
`DELETE /{channel_id}` and `POST /{channel_id}/add-streams` — if the intent is "all channel-config writes are operator-only," these (and the routine CRUD set) could be promoted to admin-gated later. Left open to avoid over-gating non-admin flows; out of this bead's destructive/bulk scope.

## Verification
- Independently ran the channels admin-gating suite: green (non-admin→403 on all 6 gated endpoints, admin→works, auth-disabled→unchanged; create/read endpoints proven NOT gated). Full `test_channels.py` passes.
- Version consistency: all 3 touchpoints at `0.17.3-0013`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)