### PR TITLE
v0.17.3-0014: Admin-gate all remaining channels.py writes (operator-only, bd-v7n9f)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0013",
+    version="0.17.3-0014",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0013"
+APP_VERSION = "0.17.3-0014"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/routers/channels.py
+++ b/backend/routers/channels.py
@@ -356,8 +356,8 @@ async def get_channels(
 
 
 @router.post("")
-async def create_channel(request: CreateChannelRequest):
-    """Create a new channel."""
+async def create_channel(request: CreateChannelRequest, _admin=RequireAdminIfEnabled):
+    """Create a new channel. Admin only (operator-only write, bd-v7n9f)."""
     logger.debug("[CHANNELS] POST /channels - name=%s number=%s normalize=%s", request.name, request.channel_number, request.normalize)
     client = get_client()
     try:
@@ -484,8 +484,8 @@ async def get_logo(logo_id: int):
 
 
 @router.post("/logos")
-async def create_logo(request: CreateLogoRequest):
-    """Create a logo from a URL."""
+async def create_logo(request: CreateLogoRequest, _admin=RequireAdminIfEnabled):
+    """Create a logo from a URL. Admin only (operator-only write, bd-v7n9f)."""
     logger.debug("[CHANNELS-LOGO] POST /channels/logos - name=%s", request.name)
     client = get_client()
     try:
@@ -512,8 +512,8 @@ async def create_logo(request: CreateLogoRequest):
 
 
 @router.post("/logos/upload")
-async def upload_logo(request: Request, file: UploadFile = File(...)):
-    """Upload a logo image file directly to Dispatcharr."""
+async def upload_logo(request: Request, file: UploadFile = File(...), _admin=RequireAdminIfEnabled):
+    """Upload a logo image file directly to Dispatcharr. Admin only (operator-only write, bd-v7n9f)."""
     logger.debug("[CHANNELS-LOGO] POST /channels/logos/upload - filename=%s", file.filename)
     if not file.content_type or not file.content_type.startswith("image/"):
         raise HTTPException(status_code=400, detail="File must be an image")
@@ -538,8 +538,8 @@ async def upload_logo(request: Request, file: UploadFile = File(...)):
 
 
 @router.patch("/logos/{logo_id}")
-async def update_logo(logo_id: int, data: dict):
-    """Update a logo."""
+async def update_logo(logo_id: int, data: dict, _admin=RequireAdminIfEnabled):
+    """Update a logo. Admin only (operator-only write, bd-v7n9f)."""
     logger.debug("[CHANNELS-LOGO] PATCH /channels/logos/%s", logo_id)
     client = get_client()
     try:
@@ -554,8 +554,8 @@ async def update_logo(logo_id: int, data: dict):
 
 
 @router.delete("/logos/{logo_id}")
-async def delete_logo(logo_id: int):
-    """Delete a logo."""
+async def delete_logo(logo_id: int, _admin=RequireAdminIfEnabled):
+    """Delete a logo. Admin only (operator-only write, bd-v7n9f)."""
     logger.debug("[CHANNELS-LOGO] DELETE /channels/logos/%s", logo_id)
     client = get_client()
     try:
@@ -1981,8 +1981,8 @@ async def get_channel_streams(channel_id: int):
 
 
 @router.patch("/{channel_id}")
-async def update_channel(channel_id: int, data: dict):
-    """Update a channel."""
+async def update_channel(channel_id: int, data: dict, _admin=RequireAdminIfEnabled):
+    """Update a channel. Admin only (operator-only write, bd-v7n9f)."""
     logger.debug("[CHANNELS] PATCH /channels/%s - data=%s", channel_id, data)
     client = get_client()
     try:
@@ -2189,8 +2189,8 @@ async def merge_channels(request: "MergeChannelsRequest", _admin=RequireAdminIfE
 
 
 @router.delete("/{channel_id}")
-async def delete_channel(channel_id: int):
-    """Delete a channel."""
+async def delete_channel(channel_id: int, _admin=RequireAdminIfEnabled):
+    """Delete a channel. Admin only (operator-only write, bd-v7n9f)."""
     logger.debug("[CHANNELS] DELETE /channels/%s", channel_id)
     client = get_client()
     try:
@@ -2229,8 +2229,8 @@ async def delete_channel(channel_id: int):
 
 
 @router.post("/{channel_id}/add-stream")
-async def add_stream_to_channel(channel_id: int, request: AddStreamRequest):
-    """Add a stream to a channel."""
+async def add_stream_to_channel(channel_id: int, request: AddStreamRequest, _admin=RequireAdminIfEnabled):
+    """Add a stream to a channel. Admin only (operator-only write, bd-v7n9f)."""
     logger.debug("[CHANNELS] POST /channels/%s/add-stream - stream_id=%s", channel_id, request.stream_id)
     client = get_client()
     try:
@@ -2277,8 +2277,10 @@ async def add_stream_to_channel(channel_id: int, request: AddStreamRequest):
 
 
 @router.post("/{channel_id}/add-streams")
-async def add_streams_to_channel(channel_id: int, request: AddStreamsRequest):
+async def add_streams_to_channel(channel_id: int, request: AddStreamsRequest, _admin=RequireAdminIfEnabled):
     """Add multiple streams to a channel in a single Dispatcharr roundtrip.
+
+    Admin only (operator-only write, bd-v7n9f).
 
     Mirrors the single-add semantics (dedup against streams already on the
     channel, append in request order) but fetches the channel once and PUTs
@@ -2341,8 +2343,8 @@ async def add_streams_to_channel(channel_id: int, request: AddStreamsRequest):
 
 
 @router.post("/{channel_id}/remove-stream")
-async def remove_stream_from_channel(channel_id: int, request: RemoveStreamRequest):
-    """Remove a stream from a channel."""
+async def remove_stream_from_channel(channel_id: int, request: RemoveStreamRequest, _admin=RequireAdminIfEnabled):
+    """Remove a stream from a channel. Admin only (operator-only write, bd-v7n9f)."""
     logger.debug("[CHANNELS] POST /channels/%s/remove-stream - stream_id=%s", channel_id, request.stream_id)
     client = get_client()
     try:
@@ -2389,8 +2391,10 @@ async def remove_stream_from_channel(channel_id: int, request: RemoveStreamReque
 
 
 @router.post("/{channel_id}/reorder-streams")
-async def reorder_channel_streams(channel_id: int, request: ReorderStreamsRequest):
+async def reorder_channel_streams(channel_id: int, request: ReorderStreamsRequest, _admin=RequireAdminIfEnabled):
     """Reorder streams within a channel.
+
+    Admin only (operator-only write, bd-v7n9f).
 
     This endpoint REPLACES the channel's stream set with the supplied list, so
     the list must be a true reorder — a permutation of the channel's *current*

--- a/backend/tests/routers/test_channels.py
+++ b/backend/tests/routers/test_channels.py
@@ -1525,11 +1525,14 @@ class TestBulkMergeChannelsStaleSourceIds:
 # off). Here we override the prebuilt dependency to simulate auth-enabled
 # non-admin (403) and auth-enabled admin (pass-through).
 #
-# Single-resource CRUD (create/update/delete channel, add/remove/reorder a
-# single stream, logo CRUD) is intentionally NOT gated here — a non-admin
-# Dispatcharr principal may legitimately perform routine per-resource edits,
-# and over-gating those would regress normal flows. Only the destructive /
-# bulk operator-op class is gated, matching bd-757hc's scope.
+# bd-v7n9f overturns the original assumption: ECM is OPERATOR-ONLY (federated
+# Dispatcharr users default is_admin=False), so ALL channel-config writes now
+# require admin — single-resource CRUD (create/update/delete channel, add/
+# add-streams/remove/reorder a single channel's streams, logo CRUD incl. upload)
+# is gated alongside the destructive/bulk class um30y already covered. Only
+# read-only GETs and the preview/validation scan endpoints (preview-csv,
+# normalize-preview-batch, find-duplicates) stay ungated — the global auth
+# middleware already requires authentication for those.
 # ---------------------------------------------------------------------------
 
 # (path, http_method, request_kwargs) for every channels endpoint now admin-gated.
@@ -1547,6 +1550,20 @@ _GATED_CHANNEL_ENDPOINTS = [
      {"json": {"merges": [{"target_channel_id": 1, "source_channel_ids": [2]}]}}),
     ("/api/channels/import-csv", "post",
      {"files": {"file": ("channels.csv", b"name\nESPN\n", "text/csv")}}),
+    # bd-v7n9f: routine single-resource channel-config writes, now also gated.
+    ("/api/channels", "post", {"json": {"name": "ESPN"}}),
+    ("/api/channels/1", "patch", {"json": {"name": "ESPN HD"}}),
+    ("/api/channels/1", "delete", {}),
+    ("/api/channels/1/add-stream", "post", {"json": {"stream_id": 7}}),
+    ("/api/channels/1/add-streams", "post", {"json": {"stream_ids": [7, 8]}}),
+    ("/api/channels/1/remove-stream", "post", {"json": {"stream_id": 7}}),
+    ("/api/channels/1/reorder-streams", "post", {"json": {"stream_ids": [8, 7]}}),
+    ("/api/channels/logos", "post",
+     {"json": {"name": "ESPN", "url": "http://x/logo.png"}}),
+    ("/api/channels/logos/upload", "post",
+     {"files": {"file": ("logo.png", b"\x89PNG", "image/png")}}),
+    ("/api/channels/logos/1", "patch", {"json": {"name": "ESPN HD"}}),
+    ("/api/channels/logos/1", "delete", {}),
 ]
 
 
@@ -1651,12 +1668,71 @@ class TestChannelsAdminGating:
         mock_client.update_channel.assert_called()
 
     @pytest.mark.asyncio
-    async def test_routine_and_read_endpoints_not_admin_gated(self, async_client):
-        """Routine single-resource mutations and read-only endpoints stay
+    @pytest.mark.parametrize(
+        "path, method, kwargs",
+        [
+            ("/api/channels", "post", {"json": {"name": "ESPN"}}),
+            ("/api/channels/1", "delete", {}),
+            ("/api/channels/1/add-stream", "post", {"json": {"stream_id": 7}}),
+        ],
+    )
+    async def test_admin_principal_can_perform_routine_writes_when_auth_enabled(
+        self, async_client, path, method, kwargs
+    ):
+        """Auth enabled + admin principal → the bd-v7n9f gate passes through and
+        the newly-gated routine writes (create + delete + add-stream) execute
+        normally."""
+        from main import app
+        from auth import RequireAdminIfEnabled as _prebuilt
+
+        async def _allow_admin():
+            return MagicMock(is_admin=True, username="admin")
+
+        mock_client = AsyncMock()
+        mock_client.create_channel.return_value = {"id": 1, "name": "ESPN"}
+        mock_client.get_channel.return_value = {
+            "id": 1, "name": "ESPN", "channel_number": 5, "streams": [],
+        }
+        mock_client.delete_channel.return_value = None
+        mock_client.update_channel.return_value = {"id": 1, "streams": [7]}
+
+        app.dependency_overrides[_prebuilt.dependency] = _allow_admin
+        try:
+            with patch("routers.channels.get_client", return_value=mock_client), \
+                 patch("routers.channels.journal"):
+                response = await getattr(async_client, method)(path, **kwargs)
+        finally:
+            app.dependency_overrides.pop(_prebuilt.dependency, None)
+
+        assert response.status_code == 200, (
+            f"{method.upper()} {path} should succeed for admin but returned "
+            f"{response.status_code}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_channel_allowed_when_auth_disabled(self, async_client):
+        """Auth disabled (default async_client) → RequireAdminIfEnabled is a
+        no-op and a representative newly-gated write (create channel) behaves
+        exactly as before the bd-v7n9f gate was added."""
+        mock_client = AsyncMock()
+        mock_client.create_channel.return_value = {"id": 1, "name": "ESPN"}
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels.journal"):
+            response = await async_client.post(
+                "/api/channels", json={"name": "ESPN"}
+            )
+
+        assert response.status_code == 200
+        mock_client.create_channel.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_read_and_preview_endpoints_not_admin_gated(self, async_client):
+        """Read-only GETs and the preview/validation scan endpoints stay
         reachable for a non-admin principal even when auth is enabled — only
-        the destructive/bulk class is gated. We override the admin dependency
-        to reject; these endpoints don't depend on it, so they must still
-        succeed (not 403)."""
+        state-mutating writes are gated (bd-v7n9f). We override the admin
+        dependency to reject; these endpoints don't depend on it, so they must
+        still succeed (not 403)."""
         from fastapi import HTTPException, status
         from main import app
         from auth import RequireAdminIfEnabled as _prebuilt
@@ -1669,20 +1745,17 @@ class TestChannelsAdminGating:
 
         mock_client = AsyncMock()
         mock_client.get_channels.return_value = {"results": [], "count": 0}
-        mock_client.create_channel.return_value = {"id": 1, "name": "ESPN"}
 
         app.dependency_overrides[_prebuilt.dependency] = _reject
         try:
             with patch("routers.channels.get_client", return_value=mock_client), \
                  patch("routers.channels.journal"):
                 list_resp = await async_client.get("/api/channels")
-                create_resp = await async_client.post(
-                    "/api/channels", json={"name": "ESPN"}
-                )
+                dup_resp = await async_client.post("/api/channels/find-duplicates")
         finally:
             app.dependency_overrides.pop(_prebuilt.dependency, None)
 
-        # Read endpoint and routine single-resource create are NOT admin-gated,
+        # Read endpoint and the read-only duplicate scan are NOT admin-gated,
         # so the reject override must not turn them into 403s.
         assert list_resp.status_code == 200
-        assert create_resp.status_code != 403
+        assert dup_resp.status_code != 403

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0013",
+  "version": "0.17.3-0014",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Completes the channels.py admin-gating per the PO decision that **ECM is operator-only**. bd-um30y gated the destructive/bulk class; this gates the remaining channel-config **write** endpoints that were left open under the (now-overturned) assumption that non-admins edit channels.

Context: Dispatcharr-federated users default to `is_admin=False` (secure default; an admin can promote them), so "operator-only" means every channel-config write requires admin.

## Now admin-gated (added `_admin=RequireAdminIfEnabled`)
`create_channel`, `update_channel`, `delete_channel`, `add-stream`, `add-streams`, `remove-stream`, `reorder-streams`, `create_logo`, `upload_logo`, `update_logo`, `delete_logo` — on top of um30y's `clear-auto-created`/`merge`/`bulk-merge`/`bulk-commit`/`assign-numbers`/`import-csv`.

## Deliberately left open (non-mutating, behind global auth middleware)
`preview-csv`, `normalize-preview-batch`, `find-duplicates`, and all GETs.

## Verification (independent)
- Enumerated every `@router.(post|patch|put|delete)` in channels.py — **every mutating handler now carries `_admin=RequireAdminIfEnabled`**; only the 3 non-mutating preview/scan POSTs remain open.
- `test_channels.py` 90 passed (non-admin→403 across all 16 gated endpoints, admin→works, auth-disabled→unchanged).
- Version consistency: all 3 touchpoints at `0.17.3-0014`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)