### PR TITLE
v0.17.3-0015: Fix e2e test-isolation flake (orphaned create_task coroutines, bd-gqtyf)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0014",
+    version="0.17.3-0015",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0014"
+APP_VERSION = "0.17.3-0015"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,9 +1,11 @@
 """
 Pytest configuration and shared fixtures for backend tests.
 """
+import inspect
 import os
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import create_engine
@@ -28,6 +30,43 @@ import export_models  # noqa: F401 — registers export tables with SQLAlchemy B
 from ffmpeg_builder import persistence  # noqa: F401 — registers table
 # Reference side-effect imports so static analysis sees them as used
 assert models and persistence and export_models
+
+
+def closing_create_task_mock() -> MagicMock:
+    """Return a MagicMock drop-in for ``asyncio.create_task`` that does not leak.
+
+    Endpoints that fire-and-forget background work call
+    ``asyncio.create_task(some_coro())``. Python evaluates ``some_coro()`` —
+    creating a coroutine object — *before* the (patched-out) ``create_task`` ever
+    sees it. A bare ``MagicMock`` discards that coroutine without awaiting or
+    closing it, so it survives until garbage collection and then emits
+    ``RuntimeWarning: coroutine '...' was never awaited``.
+
+    That warning fires at ``gc.collect()`` time, which is non-deterministic and
+    can be attributed by pytest's unraisable-exception plugin to whatever test
+    happens to be running when GC fires — causing order-dependent, flaky
+    failures in *unrelated* later tests (bead enhancedchannelmanager-gqtyf).
+
+    This mock closes the coroutine it receives (``coro.close()``), which is the
+    correct way to dispose of a coroutine that will never be awaited. The mock
+    still records the call, so ``assert_called_once()`` / ``assert_not_called()``
+    assertions on the returned mock keep working unchanged.
+
+    Usage::
+
+        with patch("asyncio.create_task", new=closing_create_task_mock()) as m:
+            ...
+        m.assert_called_once()
+    """
+    mock = MagicMock(name="create_task")
+
+    def _close_coro(coro=None, *args, **kwargs):
+        if inspect.iscoroutine(coro):
+            coro.close()
+        return MagicMock(name="task")
+
+    mock.side_effect = _close_coro
+    return mock
 
 
 @pytest.fixture(scope="function")

--- a/backend/tests/routers/test_m3u.py
+++ b/backend/tests/routers/test_m3u.py
@@ -9,6 +9,8 @@ import httpx
 import pytest
 from unittest.mock import AsyncMock, patch
 
+from tests.conftest import closing_create_task_mock
+
 
 def _upstream_404(method="GET", path="http://disp/api/m3u/accounts/999/"):
     """Build an httpx.HTTPStatusError mirroring a Dispatcharr 404 (raise_for_status)."""
@@ -326,7 +328,7 @@ class TestRefreshSingle:
         mock_client.refresh_m3u_account.return_value = {"status": "refreshing"}
 
         with patch("routers.m3u.get_client", return_value=mock_client), \
-             patch("asyncio.create_task"):
+             patch("asyncio.create_task", new=closing_create_task_mock()):
             response = await async_client.post("/api/m3u/refresh/1")
 
         assert response.status_code == 200

--- a/backend/tests/routers/test_stream_stats.py
+++ b/backend/tests/routers/test_stream_stats.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from models import StreamStats
+from tests.conftest import closing_create_task_mock
 
 
 def _create_stream_stats(session, stream_id, **overrides):
@@ -278,7 +279,7 @@ class TestProbeBulkStreams:
         mock_prober._probing_in_progress = False
 
         with patch("routers.stream_stats.ensure_prober", return_value=mock_prober), \
-             patch("asyncio.create_task") as mock_create_task:
+             patch("asyncio.create_task", new=closing_create_task_mock()) as mock_create_task:
             response = await async_client.post(
                 "/api/stream-stats/probe/bulk",
                 json={"stream_ids": [10, 11, 12]},
@@ -364,7 +365,7 @@ class TestProbeAllStreams:
         mock_prober._probing_in_progress = False
 
         with patch("routers.stream_stats.ensure_prober", return_value=mock_prober), \
-             patch("asyncio.create_task"):
+             patch("asyncio.create_task", new=closing_create_task_mock()):
             response = await async_client.post("/api/stream-stats/probe/all")
 
         assert response.status_code == 200
@@ -377,7 +378,7 @@ class TestProbeAllStreams:
         mock_prober._probing_in_progress = True
 
         with patch("routers.stream_stats.ensure_prober", return_value=mock_prober), \
-             patch("asyncio.create_task"):
+             patch("asyncio.create_task", new=closing_create_task_mock()):
             response = await async_client.post("/api/stream-stats/probe/all")
 
         assert response.status_code == 200

--- a/backend/tests/services/test_notification_service.py
+++ b/backend/tests/services/test_notification_service.py
@@ -10,6 +10,8 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from tests.conftest import closing_create_task_mock
+
 
 class TestCreateNotificationInternal:
     """Tests for create_notification_internal()."""
@@ -110,7 +112,7 @@ class TestCreateNotificationInternal:
         """When send_alerts=True (default), dispatches to alert channels."""
         with patch("services.notification_service.get_session", return_value=test_session), \
              patch("services.notification_service._dispatch_to_alert_channels", new_callable=AsyncMock) as mock_dispatch, \
-             patch("asyncio.create_task") as mock_create_task:
+             patch("asyncio.create_task", new=closing_create_task_mock()) as mock_create_task:
             from services.notification_service import create_notification_internal
 
             await create_notification_internal(

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0014",
+  "version": "0.17.3-0015",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Fixes the order-dependent e2e flake where 5 `TestStreamStats` tests failed under `pytest tests/ -k "stream_stats or probe" -q` but passed in isolation.

## Root cause
Router/service tests for fire-and-forget endpoints patched `asyncio.create_task` with a **bare `MagicMock`**. Python evaluates the coroutine argument (`some_coro()`) *before* the mock receives it, and the bare mock discards it without awaiting or **closing** it. The orphaned coroutine survives to `gc.collect()`, which emits `RuntimeWarning: coroutine '...' was never awaited` — and because GC timing is non-deterministic, pytest's unraisable-exception plugin attributes it to whatever (unrelated) test is running, failing it by collection order. The prober-singleton theory from triage was a red herring.

## Fix (test-only)
New `closing_create_task_mock()` helper in `backend/tests/conftest.py` — a `create_task` drop-in whose `side_effect` calls `coro.close()` (the correct disposal for a never-awaited coroutine), so no orphan reaches GC. It still records the call, so existing `assert_called_once()`/`assert_not_called()` assertions are unchanged. Applied at all 4 leak sites (`test_stream_stats.py`, `test_m3u.py`, `test_notification_service.py`). No production code touched; no `-p no:warnings`, no reorder, no skip/xfail.

## Verification (independent)
- The exact repro `-k "stream_stats or probe" -q` (no warning suppression): **green deterministically across 3 of my runs** (+5 by the implementing engineer); the "never awaited" warning is eliminated at source.
- Full non-e2e suite 5040 passed; full e2e 57 passed.
- Version consistency: all 3 touchpoints at `0.17.3-0015`.

Note: a separate, pre-existing **environmental** e2e flake exists — the live `ecm-ecm-1` login rate limit (5/min → 429 → 401) trips when the full e2e dir is re-run rapidly. Unrelated to this fix; worth a follow-up if we want the e2e fixture to handle login rate-limiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)