### PR TITLE
v0.17.3-0017: Encode worktree/agent-isolation default in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,22 @@ The canonical pattern is documented in `~/.claude/skills/spike/SKILL.md` (Step 3
 
 For multi-persona workflows (team-plan, team-review, spike, grooming, standup, retro, onboard), invoke the orchestrating skill via the Skill tool — it handles the fan-out itself.
 
+## Worktree & Agent Isolation (this environment)
+
+The Claude Code worktree mechanism is unreliable here. Two harness-level bugs — NOT fixable in-repo (see bd-j8osn):
+
+- **cwd-trap:** a worktree-spawned agent's Bash cwd resets to the MAIN checkout between calls, while Read/Edit act on the literal absolute path given. An agent that doesn't make EVERY path worktree-absolute ends up editing `dev` directly — silently polluting the main checkout.
+- **Lock accumulation:** a finished agent's worktree stays locked and is never auto-cleaned; `git worktree remove` then needs `-f -f`.
+
+Standing defaults (these OVERRIDE the global "worktree-isolate every write agent" rule, which assumes a working mechanism):
+
+1. **Default: non-worktree, sequential engineers.** For typical small / single-domain changes, spawn the engineer WITHOUT `isolation: "worktree"` and brief it to work on a branch in the main checkout (do NOT create a worktree). No second tree ⇒ no cwd-trap, nothing left locked.
+2. **Worktrees only for genuinely parallel, independent write agents.** When used: brief the cwd-trap hard (every Read/Edit/Bash path worktree-absolute; verify `git -C <wt> branch --show-current` before any commit), and on return verify each agent's gates AND that the main checkout is clean (`git status` shows none of the agent's files).
+3. **Clean up on merge, every time.** `git worktree remove -f -f <path>` is part of the PR-merge step — never defer to a later sweep. Skip and flag any worktree with uncommitted tracked changes instead of force-removing it.
+4. **Trust nothing unverified.** Independently re-run the agent's claimed gates before merging — the agent's report is not the gate.
+
+Frontend tooling in a worktree (writable `.vite-temp`) is fixed in `scripts/worktree-bootstrap.sh`; full caveats in `docs/shipping.md` → "Worktree quirks".
+
 ## Sizing Vocabulary — No Calendar Estimates
 
 Size work as **Small / Medium / Large / Epic — needs decomposition** (per `~/.claude/skills/grooming/SKILL.md`). Do NOT give the PO calendar estimates in hours/days/weeks/months. Calendar estimates invite commitment theater and are almost always wrong.

--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0016",
+    version="0.17.3-0017",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0016"
+APP_VERSION = "0.17.3-0017"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0016",
+  "version": "0.17.3-0017",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Encodes the session learning from our repeated worktree struggles into the project `CLAUDE.md` so it sticks beyond this session.

## Why
The Claude Code worktree mechanism is unreliable in this environment — two harness-level bugs we can't fix in-repo: the **cwd-trap** (a worktree-spawned agent's Bash cwd resets to the main checkout, so edits land on `dev` and pollute it) and **lock accumulation** (finished worktrees stay locked, pile up, need `-f -f`). We kept re-triggering them by defaulting to worktree-isolated agents and cleaning up reactively.

## The new standing default (in `CLAUDE.md` → "Worktree & Agent Isolation")
1. **Default to non-worktree, sequential engineers** for typical small changes (branch in the main checkout, no worktree) — eliminates both bugs at the source.
2. **Worktrees only for genuinely parallel, independent agents**, with a hard cwd-trap briefing + post-run main-checkout cleanliness check.
3. **Force-clean the worktree on merge, every time** — not a later sweep.
4. **Independently re-run the agent's gates before merge** — the agent's report is not the gate.

These explicitly override the global "worktree-isolate every write agent" rule, which assumes a working mechanism. The in-repo `.vite-temp` part was already fixed in `scripts/worktree-bootstrap.sh` (bd-j8osn).

Docs-only change (`CLAUDE.md`) + version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)