### PR TITLE
v0.17.3-0019: Auto-creation snapshot MVP — schema + capture + read API (bd-uc51o.2)

### DIFF
--- a/backend/alembic/versions/20260525_1200_0022_auto_creation_snapshots.py
+++ b/backend/alembic/versions/20260525_1200_0022_auto_creation_snapshots.py
@@ -1,0 +1,197 @@
+"""auto_creation_snapshots: pre-run channel<->stream snapshot table (ADR-010 §D6)
+
+Revision ID: 0022
+Revises: 0021
+Create Date: 2026-05-25 12:00:00.000000
+
+Creates ``auto_creation_snapshots`` — the point-in-time, pre-run snapshot of
+the manual (non-Dispatcharr-auto-created) channel<->stream state captured
+BEFORE an auto-creation execution mutates anything, to enable a full
+whole-run revert (ADR-010, Phase 2 / bead enhancedchannelmanager-uc51o.2).
+
+Schema (ADR-010 §D6):
+
+  auto_creation_snapshots:
+    id            INTEGER PK AUTOINCREMENT
+    execution_id  INTEGER NOT NULL FK -> auto_creation_executions.id
+                  ON DELETE CASCADE, UNIQUE (1:1 to the execution)
+    snapshot_time DATETIME NOT NULL (Python default datetime.utcnow)
+    channel_count INTEGER  NOT NULL (Python default=0; denormalized for cheap
+                  size reporting without parsing the BLOB; feeds the §D7 metric)
+    channels_data TEXT NULL (JSON: {"channels": [{id, name, channel_group_id,
+                  epg_data_id, tvg_id, stream_ids:[int]}, ...]} — STREAM IDS
+                  ONLY per §D1; never URLs, which embed XC credentials)
+    created_at    DATETIME NOT NULL
+
+Indexes (ADR-010 §D6):
+    uq_auto_snapshot_execution  UNIQUE (execution_id)
+        — the 1:1 invariant AND the O(1) has_snapshot existence lookup.
+    idx_auto_snapshot_time      (snapshot_time DESC)
+        — the §D7 age-window prune scan.
+
+CASCADE rationale (§D6): a pruned/deleted execution row takes its snapshot
+with it. The snapshot is a recoverable convenience artifact (Dispatcharr is
+the source of truth — §D8), so the FK delete-cascade and the downgrade DROP
+are both acceptable losses.
+
+Why a new table, not a reuse of ``m3u_snapshots`` (PO decision (f), §D6):
+``M3USnapshot`` is a per-M3U-account playlist-change-detection artifact with
+entirely different semantics, lifecycle, and FK. Reusing it would be a
+naming/semantic collision. ``M3USnapshot`` is the structural precedent for
+the retention-index pattern (§D7), NOT the table to overload.
+
+Named UNIQUE constraint (``uq_auto_snapshot_execution``) per the SQLite
+gotchas in ``docs/database_migrations.md`` — auto-generated UNIQUE/CHECK
+constraint names are unstable across SQLite versions.
+
+bd-5w6jz idempotency:
+
+The CREATE TABLE and both CREATE INDEX statements are guarded against a
+pre-existing artifact via per-statement ``has_table`` / ``get_indexes``
+inspection. The migration is safe to re-run in any of these states:
+
+* Fully drifted forward: the table already exists (e.g. ``create_all()``
+  materialised the post-0022 ORM shape on a long-running install while
+  ``alembic_version`` was still at 0021). Skip the CREATE TABLE and check
+  each index independently.
+* Index drift: table present, an index missing (an aborted prior run that
+  created the table but crashed before an index landed). Add only the
+  absent index.
+
+This matches the smart-bootstrap fast-path (``_schema_matches_head`` in
+``database.py``) which stamps ``alembic_version`` forward when the ORM shape
+is already fully materialised — a forced re-run after that stamp must be a
+no-op rather than raising ``OperationalError: table already exists``.
+
+downgrade() drops the table (and its indexes); the data is a recoverable
+convenience artifact, not source-of-truth (Dispatcharr is, §D8), so the drop
+is acceptable. Defensive: skip drops on artifacts that are not present so a
+half-applied prior state still cleans up rather than raising.
+
+Pre-merge gate: ``backend/tests/integration/test_auto_creation_snapshot_migration.py``
+covers fresh up, fresh down, full drift (table pre-created), and index drift.
+``tests/unit/test_alembic_baseline.py`` locks ORM/migration parity (the new
+table is picked up automatically by the metadata-drift comparison).
+
+Bead: ``enhancedchannelmanager-uc51o.2`` (Phase 2 of epic
+``enhancedchannelmanager-uc51o``; ADR-010 §D6).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0022"
+down_revision: Union[str, Sequence[str], None] = "0021"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+_TABLE = "auto_creation_snapshots"
+_UQ_EXECUTION = "uq_auto_snapshot_execution"
+_IDX_TIME = "idx_auto_snapshot_time"
+
+
+def _table_exists(connection, table_name: str) -> bool:
+    return inspect(connection).has_table(table_name)
+
+
+def _index_names(connection, table_name: str) -> set[str]:
+    """Return the set of index names currently on *table_name*.
+
+    Returns the empty set if the table is missing — the upgrade path creates
+    the table first then layers indexes on top, but a drifted DB may have one
+    without the other. Treating "table missing" as "no indexes" keeps the
+    per-index guard branch-free.
+    """
+    if not _table_exists(connection, table_name):
+        return set()
+    return {idx["name"] for idx in inspect(connection).get_indexes(table_name)}
+
+
+def _create_table_if_absent(conn) -> None:
+    """Create ``auto_creation_snapshots`` only if it does not already exist.
+
+    bd-5w6jz: ``create_all()`` may have materialised the table from the
+    post-0022 ORM model in ``models.py`` while ``alembic_version`` was still
+    at 0021. The named UNIQUE constraint keeps its identifier stable across
+    SQLite versions (``docs/database_migrations.md`` SQLite gotchas).
+    """
+    if _table_exists(conn, _TABLE):
+        return
+
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        # 1:1 to the execution whose pre-run state this captures. CASCADE so
+        # a pruned/deleted execution row takes its snapshot with it (§D6).
+        sa.Column("execution_id", sa.Integer(), nullable=False),
+        sa.Column("snapshot_time", sa.DateTime(), nullable=False),
+        # Denormalized channel count for cheap size reporting without parsing
+        # the BLOB. NOT NULL with the Python-side default=0 declared on the
+        # ORM column. No server_default: this is a brand-new table created in
+        # one statement, so there are no pre-existing rows that a NOT NULL add
+        # would orphan — a server_default would buy nothing and would show as
+        # modify_default drift against the ORM (which mirrors the
+        # M3USnapshot.total_streams precedent: default=0, no server_default).
+        sa.Column("channel_count", sa.Integer(), nullable=False),
+        # JSON TEXT payload — STREAM IDS ONLY (§D1).
+        sa.Column("channels_data", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["execution_id"],
+            ["auto_creation_executions.id"],
+            name="fk_auto_snapshot_execution",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_auto_creation_snapshots"),
+        sa.UniqueConstraint("execution_id", name=_UQ_EXECUTION),
+    )
+
+
+def upgrade() -> None:
+    """Create ``auto_creation_snapshots`` and its time index.
+
+    The UNIQUE(execution_id) constraint is declared inline in the CREATE
+    TABLE (it doubles as the FK-lookup index). The DESC time index is created
+    separately. Both the table CREATE and the index CREATE are guarded
+    (bd-5w6jz) so a drifted DB passes through as a no-op rather than raising
+    ``OperationalError: ... already exists``.
+    """
+    conn = op.get_bind()
+
+    _create_table_if_absent(conn)
+
+    existing = _index_names(conn, _TABLE)
+    if _IDX_TIME not in existing:
+        # snapshot_time DESC — the age-window prune scan (§D7).
+        op.create_index(
+            _IDX_TIME,
+            _TABLE,
+            [sa.text("snapshot_time DESC")],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Drop ``auto_creation_snapshots`` (and its indexes).
+
+    The snapshot data is a recoverable convenience artifact, not
+    source-of-truth (Dispatcharr is — §D8), so the drop is acceptable.
+    Defensive (bd-5w6jz): skip drops on artifacts that are not present so a
+    half-applied prior state still cleans up rather than raising. SQLite
+    cascades index drops on DROP TABLE, but the explicit index drop keeps the
+    migration symmetric with upgrade() and a partial-state rollback clean.
+    """
+    conn = op.get_bind()
+
+    existing = _index_names(conn, _TABLE)
+    if _IDX_TIME in existing:
+        op.drop_index(_IDX_TIME, table_name=_TABLE)
+
+    if _table_exists(conn, _TABLE):
+        op.drop_table(_TABLE)

--- a/backend/auto_creation_engine.py
+++ b/backend/auto_creation_engine.py
@@ -25,6 +25,7 @@ from models import (
     AutoCreationRule,
     AutoCreationExecution,
     AutoCreationConflict,
+    AutoCreationSnapshot,
     StreamStats
 )
 from auto_creation_schema import (
@@ -172,6 +173,17 @@ class AutoCreationEngine:
                 mode="dry_run" if dry_run else "execute",
                 triggered_by=triggered_by
             )
+
+        # ADR-010 §D2: capture a pre-run snapshot of the manual
+        # (non-Dispatcharr-auto-created) channel<->stream state BEFORE any
+        # mutation, so a full whole-run revert is possible. Gated on
+        # ``not dry_run`` (mode=="execute") — a dry run mutates nothing, so
+        # there is nothing to revert and a snapshot would only consume
+        # storage. This runs AFTER _load_existing_data (the in-memory channel
+        # list is already populated — no N+1) and BEFORE _process_streams
+        # (the single call that performs all mutation).
+        if not dry_run:
+            await self._capture_snapshot(execution.id)
 
         # Process streams through rules
         results = await self._process_streams(
@@ -2392,6 +2404,78 @@ class AutoCreationEngine:
             session.commit()
         finally:
             session.close()
+
+    async def _capture_snapshot(self, execution_id: int) -> None:
+        """Persist a pre-run AutoCreationSnapshot for ``execution_id`` (ADR-010).
+
+        Serializes the manual (non-Dispatcharr-auto-created) channel<->stream
+        state from the already-loaded in-memory ``self._existing_channels`` —
+        no per-channel API call, no N+1 (ADR-010 §D2). One row per execution,
+        linked 1:1 via FK.
+
+        Per-channel payload (STREAM IDS ONLY — never URLs, §D1):
+        ``{id, name, channel_group_id, epg_data_id, tvg_id, stream_ids:[int]}``
+
+        Channels where ``auto_created`` is truthy are EXCLUDED (§D3) — they are
+        Dispatcharr-owned, regenerable state that Dispatcharr re-derives on
+        every refresh; restoring them would fight Dispatcharr's own sync and
+        bloat the snapshot. The filter mirrors ``channels.py:614``'s
+        ``not ch.get("auto_created", False)``.
+
+        Capture-failure policy (ADR-010 §D2, uc51o.2 v1 default):
+        LOG-AND-PROCEED. A capture failure must NOT abort the mutating run —
+        it logs a WARNING and the run continues with NO snapshot (the run is
+        still revertible via the legacy entity-rollback). It does NOT raise.
+        """
+        try:
+            channels = []
+            for ch in (self._existing_channels or []):
+                # §D3: exclude Dispatcharr-auto-created-from-groups channels.
+                if ch.get("auto_created", False):
+                    continue
+                # §D1: stream IDs only. Match the executor's own coercion
+                # (executor.py:918) — Dispatcharr embeds streams as a list of
+                # IDs (or, defensively, dicts carrying an "id").
+                stream_ids = [
+                    s["id"] if isinstance(s, dict) else s
+                    for s in ch.get("streams", [])
+                ]
+                channels.append({
+                    "id": ch.get("id"),
+                    "name": ch.get("name"),
+                    "channel_group_id": ch.get("channel_group_id"),
+                    "epg_data_id": ch.get("epg_data_id"),
+                    "tvg_id": ch.get("tvg_id"),
+                    "stream_ids": stream_ids,
+                })
+
+            session = get_session()
+            try:
+                snapshot = AutoCreationSnapshot(
+                    execution_id=execution_id,
+                    snapshot_time=datetime.utcnow(),
+                    channel_count=len(channels),
+                )
+                snapshot.set_channels_data({"channels": channels})
+                session.add(snapshot)
+                session.commit()
+                logger.info(
+                    "[AUTO-CREATE-ENGINE] Captured pre-run snapshot for "
+                    "execution_id=%s (%s manual channels)",
+                    execution_id, len(channels),
+                )
+            finally:
+                session.close()
+        except Exception as e:
+            # Log-and-proceed: never abort the mutating run on a capture
+            # failure. The run remains revertible via the legacy
+            # entity-rollback; the execution simply has no snapshot.
+            logger.warning(
+                "[AUTO-CREATE-ENGINE] Failed to capture pre-run snapshot for "
+                "execution_id=%s; run proceeds WITHOUT a snapshot (legacy "
+                "rollback still available): %s",
+                execution_id, e,
+            )
 
     async def _record_conflict(
         self,

--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0018",
+    version="0.17.3-0019",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/models.py
+++ b/backend/models.py
@@ -2249,6 +2249,74 @@ class AutoCreationExecution(Base):
         return f"<AutoCreationExecution(id={self.id}, rule_id={self.rule_id}, status={self.status}, mode={self.mode})>"
 
 
+class AutoCreationSnapshot(Base):
+    """Point-in-time snapshot of the manual (non-Dispatcharr-auto-created)
+    channel<->stream state captured BEFORE an auto-creation execution mutated
+    anything, to enable a full whole-run revert (ADR-010).
+
+    Stores STREAM IDs ONLY — never stream URLs (ADR-010 §D1: XC URLs embed
+    live credentials and the backup ZIP scrubber covers only
+    ``alert_methods``, so storing URLs here would be unscrubbed
+    credential-at-rest). One row per ``mode="execute"`` execution (1:1 FK,
+    UNIQUE on ``execution_id``); dry-run executions get no snapshot.
+    """
+    __tablename__ = "auto_creation_snapshots"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    # 1:1 to the execution whose pre-run state this captures. CASCADE so a
+    # pruned/deleted execution row takes its snapshot with it.
+    execution_id = Column(
+        Integer,
+        ForeignKey("auto_creation_executions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    snapshot_time = Column(DateTime, default=datetime.utcnow, nullable=False)
+    # Number of channels captured (denormalized for cheap list/size reporting
+    # without parsing the BLOB; feeds the retention metric in ADR-010 §D7).
+    channel_count = Column(Integer, default=0, nullable=False)
+    # Serialized per-channel payload. JSON TEXT (the project convention for
+    # snapshot/entity BLOBs — cf. AutoCreationExecution.created_entities and
+    # M3USnapshot.groups_data). Shape: {"channels": [{id, name,
+    # channel_group_id, epg_data_id, tvg_id, stream_ids: [int]}, ...]}.
+    channels_data = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        # Unique 1:1 — one snapshot per execution. Also the FK lookup index
+        # that makes the has_snapshot existence check O(1) (ADR-010 §D6).
+        UniqueConstraint("execution_id", name="uq_auto_snapshot_execution"),
+        # Age-window prune scan (ADR-010 §D7).
+        Index("idx_auto_snapshot_time", snapshot_time.desc()),
+    )
+
+    def get_channels_data(self) -> dict:
+        """Parse channels_data JSON into a dict ({"channels": [...]})."""
+        if not self.channels_data:
+            return {"channels": []}
+        try:
+            return json.loads(self.channels_data)
+        except (ValueError, TypeError):
+            return {"channels": []}
+
+    def set_channels_data(self, data: dict) -> None:
+        """Set channels_data from a dict."""
+        self.channels_data = json.dumps(data) if data else None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for API responses."""
+        return {
+            "id": self.id,
+            "execution_id": self.execution_id,
+            "snapshot_time": self.snapshot_time.isoformat() + "Z" if self.snapshot_time else None,
+            "channel_count": self.channel_count,
+            "channels": self.get_channels_data().get("channels", []),
+            "created_at": self.created_at.isoformat() + "Z" if self.created_at else None,
+        }
+
+    def __repr__(self):
+        return f"<AutoCreationSnapshot(id={self.id}, execution_id={self.execution_id}, channel_count={self.channel_count})>"
+
+
 class AutoCreationConflict(Base):
     """
     Tracks conflicts detected during pipeline execution.

--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -1295,6 +1295,46 @@ async def get_auto_creation_execution(execution_id: int, include_entities: bool 
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+@router.get("/executions/{execution_id}/snapshot")
+async def get_auto_creation_execution_snapshot(execution_id: int):
+    """Get the pre-run channel<->stream snapshot for an execution (ADR-010).
+
+    Returns the snapshot payload — the manual (non-Dispatcharr-auto-created)
+    channels captured BEFORE this execution mutated anything, with
+    ``stream_ids`` (IDs only — never URLs, §D1), plus ``snapshot_time`` and
+    ``channel_count``. Read-only — no admin guard (consistent with the
+    router's other GETs; the global auth middleware already covers it). The
+    WRITE restore endpoint (Phase 3, uc51o.4) WILL be admin-gated.
+
+    Returns 404 when the execution has no snapshot (e.g. a dry-run, a legacy
+    run, or a run whose capture failed and logged-and-proceeded — §D2).
+    """
+    logger.debug("[AUTO-CREATE] GET /executions/%s/snapshot", execution_id)
+    try:
+        from models import AutoCreationSnapshot
+        session = get_session()
+        try:
+            snapshot = session.query(AutoCreationSnapshot).filter(
+                AutoCreationSnapshot.execution_id == execution_id
+            ).first()
+            if not snapshot:
+                raise HTTPException(
+                    status_code=404,
+                    detail="No snapshot for this execution",
+                )
+            return snapshot.to_dict()
+        finally:
+            session.close()
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(
+            "[AUTO-CREATE] Failed to get snapshot for execution %s: %s",
+            execution_id, e,
+        )
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
 @router.post("/executions/{execution_id}/rollback")
 async def rollback_auto_creation_execution(execution_id: int, _admin=RequireAdminIfEnabled):
     """Rollback an auto-creation execution. Admin only."""

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0018"
+APP_VERSION = "0.17.3-0019"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/tests/integration/test_auto_creation_snapshot_migration.py
+++ b/backend/tests/integration/test_auto_creation_snapshot_migration.py
@@ -1,0 +1,293 @@
+"""Migration tests for ``auto_creation_snapshots`` (revision 0022, ADR-010 §D6).
+
+Bead: ``enhancedchannelmanager-uc51o.2`` (Phase 2 of epic
+``enhancedchannelmanager-uc51o``).
+
+Covers:
+
+* Fresh up from 0021 → the table exists with the ADR-010 §D6 column set, the
+  named UNIQUE constraint on ``execution_id`` (1:1), the ``snapshot_time``
+  index, and the FK to ``auto_creation_executions.id`` with ON DELETE CASCADE.
+* Fresh down from 0022 → the table and its indexes are gone.
+* bd-5w6jz idempotency:
+  - Full drift: the table is already materialised (e.g. ``create_all()`` from
+    the post-0022 ORM model on a long-running install where
+    ``alembic_version`` is still at 0021). Re-running the migration must skip
+    the CREATE TABLE without raising ``table ... already exists``.
+  - Index drift: the table is present but the time index is missing. The
+    migration adds only the absent index.
+
+All fixtures use synthetic ids — no production-derived data.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+
+import database
+
+
+TABLE = "auto_creation_snapshots"
+UQ_EXECUTION = "uq_auto_snapshot_execution"
+IDX_TIME = "idx_auto_snapshot_time"
+
+EXPECTED_COLUMNS = {
+    "id", "execution_id", "snapshot_time", "channel_count",
+    "channels_data", "created_at",
+}
+
+
+def _make_alembic_config(db_url: str):
+    """Build an Alembic Config pinned to *db_url*.
+
+    Mirrors the helper in the other migration test files so each file is
+    self-contained (``docs/database_migrations.md`` test-isolation convention).
+    """
+    from alembic.config import Config
+
+    ini_path = Path(database.ALEMBIC_INI_PATH)
+    assert ini_path.exists(), f"alembic.ini missing at {ini_path}"
+    cfg = Config(str(ini_path))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    return cfg
+
+
+def _table_names(engine) -> set[str]:
+    return set(inspect(engine).get_table_names())
+
+
+def _index_names(engine, table: str) -> set[str]:
+    return {idx["name"] for idx in inspect(engine).get_indexes(table)}
+
+
+def _unique_constraint_names(engine, table: str) -> set[str]:
+    return {
+        uc["name"]
+        for uc in inspect(engine).get_unique_constraints(table)
+        if uc.get("name")
+    }
+
+
+def _foreign_keys(engine, table: str) -> list[dict]:
+    return list(inspect(engine).get_foreign_keys(table))
+
+
+@pytest.mark.integration
+class TestMigration0022Fresh:
+    """Revision 0022 — fresh upgrade creates the table + index + constraints."""
+
+    def test_migration_0022_creates_table_fresh_install(self, tmp_path):
+        """Empty DB → ``alembic upgrade head`` lands the table intact."""
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'mig0022_fresh.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "head")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            assert TABLE in _table_names(engine), (
+                f"{TABLE} not created by upgrade head"
+            )
+
+            cols = {c["name"]: c for c in inspect(engine).get_columns(TABLE)}
+            assert set(cols) == EXPECTED_COLUMNS, (
+                f"column set differs from ADR-010 §D6: {sorted(cols)}"
+            )
+            assert cols["execution_id"]["nullable"] is False
+            assert cols["snapshot_time"]["nullable"] is False
+            assert cols["channel_count"]["nullable"] is False
+            assert cols["created_at"]["nullable"] is False
+            assert cols["channels_data"]["nullable"] is True
+
+            # Named UNIQUE constraint on execution_id (1:1, §D6).
+            assert UQ_EXECUTION in _unique_constraint_names(engine, TABLE), (
+                f"{UQ_EXECUTION} missing — the 1:1 invariant is unenforced"
+            )
+
+            # snapshot_time index (the §D7 age-window prune scan).
+            assert IDX_TIME in _index_names(engine, TABLE), (
+                f"{IDX_TIME} missing: have {sorted(_index_names(engine, TABLE))}"
+            )
+
+            # FK → auto_creation_executions.id with ON DELETE CASCADE (§D6).
+            fks = _foreign_keys(engine, TABLE)
+            assert len(fks) == 1, f"expected exactly one FK, got {fks!r}"
+            fk = fks[0]
+            assert fk["constrained_columns"] == ["execution_id"]
+            assert fk["referred_table"] == "auto_creation_executions"
+            assert fk["referred_columns"] == ["id"]
+            assert fk.get("options", {}).get("ondelete", "").upper() == "CASCADE", (
+                f"FK must use ON DELETE CASCADE per §D6: options={fk.get('options')}"
+            )
+        finally:
+            engine.dispose()
+
+    def test_migration_0022_downgrade_drops_table(self, tmp_path):
+        """Downgrade 0022 → 0021 removes the table and its indexes."""
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'mig0022_down.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "0022")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            assert TABLE in _table_names(engine)
+        finally:
+            engine.dispose()
+
+        command.downgrade(cfg, "0021")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            assert TABLE not in _table_names(engine), (
+                f"{TABLE} still present after downgrade to 0021"
+            )
+            with engine.connect() as conn:
+                rows = conn.execute(text(
+                    "SELECT name FROM sqlite_master WHERE type='index' "
+                    "AND name LIKE '%auto_snapshot%'"
+                )).fetchall()
+            assert rows == [], f"orphan snapshot indexes survive downgrade: {rows}"
+        finally:
+            engine.dispose()
+
+    def test_migration_0022_cascade_deletes_snapshot(self, tmp_path):
+        """Deleting the parent execution cascades to its snapshot (§D6)."""
+        from datetime import datetime
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'mig0022_cascade.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "head")
+
+        # FK enforcement requires PRAGMA foreign_keys=ON. The app connect
+        # listener sets it; here we set it explicitly on the test connection.
+        engine = create_engine(db_url, future=True)
+        try:
+            with engine.begin() as conn:
+                conn.execute(text("PRAGMA foreign_keys=ON"))
+                conn.execute(text(
+                    "INSERT INTO auto_creation_executions "
+                    "(id, mode, triggered_by, started_at, status, "
+                    " streams_evaluated, streams_matched, channels_created, "
+                    " channels_updated, groups_created, streams_merged, "
+                    " channels_touched, streams_skipped, streams_excluded, "
+                    " created_at) "
+                    "VALUES (1, 'execute', 'manual', :now, 'completed', "
+                    " 0,0,0,0,0,0,0,0,0, :now)"
+                ), {"now": datetime.utcnow().isoformat()})
+                conn.execute(text(
+                    "INSERT INTO auto_creation_snapshots "
+                    "(execution_id, snapshot_time, channel_count, "
+                    " channels_data, created_at) "
+                    "VALUES (1, :now, 0, '{\"channels\": []}', :now)"
+                ), {"now": datetime.utcnow().isoformat()})
+
+            with engine.begin() as conn:
+                conn.execute(text("PRAGMA foreign_keys=ON"))
+                conn.execute(text("DELETE FROM auto_creation_executions WHERE id=1"))
+
+            with engine.connect() as conn:
+                remaining = conn.execute(text(
+                    "SELECT COUNT(*) FROM auto_creation_snapshots WHERE execution_id=1"
+                )).scalar()
+            assert remaining == 0, "ON DELETE CASCADE did not remove the snapshot"
+        finally:
+            engine.dispose()
+
+
+@pytest.mark.integration
+class TestMigration0022Idempotent:
+    """bd-5w6jz idempotency for migration 0022."""
+
+    def test_migration_0022_idempotent_table_pre_created(self, tmp_path):
+        """Table already materialised pre-migration (create_all drift case).
+
+        Re-running the migration must skip the CREATE TABLE without raising
+        ``OperationalError: table auto_creation_snapshots already exists`` and
+        still produce a schema with the time index present.
+        """
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'mig0022_drift.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "0021")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            assert TABLE not in _table_names(engine)
+            # Inject the table via raw SQL — mimics create_all() materialising
+            # the post-0022 ORM shape while alembic_version is still 0021.
+            with engine.begin() as conn:
+                conn.execute(text(
+                    "CREATE TABLE auto_creation_snapshots ("
+                    "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                    "  execution_id INTEGER NOT NULL,"
+                    "  snapshot_time DATETIME NOT NULL,"
+                    "  channel_count INTEGER NOT NULL DEFAULT 0,"
+                    "  channels_data TEXT,"
+                    "  created_at DATETIME NOT NULL,"
+                    "  CONSTRAINT uq_auto_snapshot_execution UNIQUE (execution_id),"
+                    "  FOREIGN KEY(execution_id) "
+                    "    REFERENCES auto_creation_executions (id) ON DELETE CASCADE"
+                    ")"
+                ))
+            assert TABLE in _table_names(engine)
+        finally:
+            engine.dispose()
+
+        # Pre-fix this would raise: table already exists.
+        command.upgrade(cfg, "head")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            assert TABLE in _table_names(engine)
+            assert IDX_TIME in _index_names(engine, TABLE), (
+                "time index must be created even though the table pre-existed"
+            )
+            assert UQ_EXECUTION in _unique_constraint_names(engine, TABLE)
+        finally:
+            engine.dispose()
+
+    def test_migration_0022_idempotent_index_missing(self, tmp_path):
+        """Table present, time index absent → migration adds only the index."""
+        from alembic import command
+
+        db_url = f"sqlite:///{tmp_path / 'mig0022_idxdrift.db'}"
+        cfg = _make_alembic_config(db_url)
+        command.upgrade(cfg, "0021")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            with engine.begin() as conn:
+                conn.execute(text(
+                    "CREATE TABLE auto_creation_snapshots ("
+                    "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                    "  execution_id INTEGER NOT NULL,"
+                    "  snapshot_time DATETIME NOT NULL,"
+                    "  channel_count INTEGER NOT NULL DEFAULT 0,"
+                    "  channels_data TEXT,"
+                    "  created_at DATETIME NOT NULL,"
+                    "  CONSTRAINT uq_auto_snapshot_execution UNIQUE (execution_id),"
+                    "  FOREIGN KEY(execution_id) "
+                    "    REFERENCES auto_creation_executions (id) ON DELETE CASCADE"
+                    ")"
+                ))
+            # Table present but NO idx_auto_snapshot_time yet.
+            assert IDX_TIME not in _index_names(engine, TABLE)
+        finally:
+            engine.dispose()
+
+        command.upgrade(cfg, "head")
+
+        engine = create_engine(db_url, future=True)
+        try:
+            assert IDX_TIME in _index_names(engine, TABLE), (
+                "migration must add the absent time index"
+            )
+        finally:
+            engine.dispose()

--- a/backend/tests/routers/test_auto_creation.py
+++ b/backend/tests/routers/test_auto_creation.py
@@ -1350,6 +1350,65 @@ class TestGetExecution:
         assert response.status_code == 404
 
 
+class TestGetExecutionSnapshot:
+    """Tests for GET /api/auto-creation/executions/{execution_id}/snapshot (ADR-010)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_snapshot(self, async_client, test_session):
+        """Returns the pre-run snapshot payload for an execution that has one."""
+        from models import AutoCreationSnapshot
+
+        execution = _create_execution(test_session)
+        snapshot = AutoCreationSnapshot(
+            execution_id=execution.id,
+            snapshot_time=datetime.utcnow(),
+            channel_count=2,
+        )
+        snapshot.set_channels_data({"channels": [
+            {"id": 10, "name": "ESPN", "channel_group_id": 1,
+             "epg_data_id": 99, "tvg_id": "espn.us", "stream_ids": [501, 502]},
+            {"id": 11, "name": "CNN", "channel_group_id": 2,
+             "epg_data_id": None, "tvg_id": "cnn.us", "stream_ids": [601]},
+        ]})
+        test_session.add(snapshot)
+        test_session.commit()
+
+        response = await async_client.get(
+            f"/api/auto-creation/executions/{execution.id}/snapshot"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["execution_id"] == execution.id
+        assert data["channel_count"] == 2
+        assert data["snapshot_time"] is not None
+        assert len(data["channels"]) == 2
+        espn = next(c for c in data["channels"] if c["id"] == 10)
+        assert espn["stream_ids"] == [501, 502]
+        assert espn["tvg_id"] == "espn.us"
+        # IDs only — no URL leakage anywhere in the payload.
+        assert "url" not in espn
+        assert "streams" not in espn
+
+    @pytest.mark.asyncio
+    async def test_returns_404_when_no_snapshot(self, async_client, test_session):
+        """Returns 404 when the execution exists but has no snapshot (dry-run,
+        legacy, or capture-failure run)."""
+        execution = _create_execution(test_session, mode="dry_run")
+
+        response = await async_client.get(
+            f"/api/auto-creation/executions/{execution.id}/snapshot"
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_nonexistent_execution(self, async_client):
+        """Returns 404 for an execution id with no snapshot row at all."""
+        response = await async_client.get(
+            "/api/auto-creation/executions/99999/snapshot"
+        )
+        assert response.status_code == 404
+
+
 class TestRollbackExecution:
     """Tests for POST /api/auto-creation/executions/{execution_id}/rollback."""
 

--- a/backend/tests/unit/test_auto_creation_snapshot_capture.py
+++ b/backend/tests/unit/test_auto_creation_snapshot_capture.py
@@ -1,0 +1,306 @@
+"""Unit tests for the auto-creation pre-run snapshot CAPTURE (ADR-010 §D2/§D3).
+
+Bead: ``enhancedchannelmanager-uc51o.2`` (Phase 2 of epic
+``enhancedchannelmanager-uc51o``).
+
+Pins the capture-hook contract:
+
+* ``_capture_snapshot`` serializes the manual (non-Dispatcharr-auto-created)
+  channel<->stream state from the in-memory ``self._existing_channels`` —
+  STREAM IDs ONLY (§D1), one snapshot row per execution.
+* Channels where ``auto_created`` is truthy are EXCLUDED (§D3); manual
+  channels (``auto_created`` falsy / absent) are INCLUDED with their
+  ``stream_ids`` (coercing dict-or-int stream entries).
+* Capture failure LOGS a warning and the run PROCEEDS with no snapshot — the
+  helper does NOT raise (§D2 v1 log-and-proceed policy).
+* ``run_pipeline`` invokes capture only when ``mode=="execute"`` (``not
+  dry_run``); a dry run writes NO snapshot.
+
+Capture tests use a real in-memory SQLite session (so the persisted row is
+read back and asserted), bound by patching ``auto_creation_engine.get_session``.
+The dry-run gating test stubs the pipeline helpers and spies on
+``_capture_snapshot`` so the gate is asserted without exercising the full
+mutation path.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import database
+from auto_creation_engine import AutoCreationEngine
+from models import AutoCreationExecution, AutoCreationSnapshot
+
+
+@pytest.fixture()
+def db_session_factory():
+    """A real in-memory SQLite session factory with the ECM schema created.
+
+    Yields a callable that returns a fresh session bound to the same in-memory
+    engine (StaticPool keeps the single connection alive across sessions, so
+    rows committed in one session are visible in the next).
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+    database.Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(
+        autocommit=False, autoflush=False, bind=engine, expire_on_commit=False
+    )
+    try:
+        yield SessionLocal
+    finally:
+        database.Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+def _make_execution(session_factory, mode: str = "execute") -> int:
+    """Create an AutoCreationExecution row and return its id (FK target)."""
+    from datetime import datetime
+
+    session = session_factory()
+    try:
+        execution = AutoCreationExecution(
+            mode=mode,
+            triggered_by="manual",
+            started_at=datetime.utcnow(),
+            status="running",
+        )
+        session.add(execution)
+        session.commit()
+        session.refresh(execution)
+        return execution.id
+    finally:
+        session.close()
+
+
+class TestCaptureSerialization:
+    """_capture_snapshot writes one row with the §D1/§D3 payload."""
+
+    def test_captures_manual_channels_with_stream_ids(self, db_session_factory):
+        """A snapshot row is written with manual channels and their stream IDs.
+
+        Stream entries arrive as either bare ints or ``{"id": ...}`` dicts
+        (Dispatcharr embeds IDs; the coercion mirrors executor.py:918). Only
+        IDs are persisted — never URLs.
+        """
+        execution_id = _make_execution(db_session_factory)
+
+        client = MagicMock()
+        engine = AutoCreationEngine(client)
+        engine._existing_channels = [
+            {
+                "id": 10, "name": "ESPN", "channel_group_id": 1,
+                "epg_data_id": 99, "tvg_id": "espn.us",
+                # Mixed: dict-form and int-form stream entries.
+                "streams": [{"id": 501, "url": "http://leak/501.ts"}, 502],
+            },
+            {
+                "id": 11, "name": "CNN", "channel_group_id": 2,
+                "epg_data_id": None, "tvg_id": "cnn.us",
+                "streams": [601],
+            },
+        ]
+
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            asyncio.get_event_loop().run_until_complete(
+                engine._capture_snapshot(execution_id)
+            )
+
+        session = db_session_factory()
+        try:
+            row = session.query(AutoCreationSnapshot).filter(
+                AutoCreationSnapshot.execution_id == execution_id
+            ).first()
+            assert row is not None, "no snapshot row was written"
+            assert row.channel_count == 2
+            channels = row.get_channels_data()["channels"]
+            assert {c["id"] for c in channels} == {10, 11}
+
+            espn = next(c for c in channels if c["id"] == 10)
+            assert espn["stream_ids"] == [501, 502]
+            assert espn["name"] == "ESPN"
+            assert espn["channel_group_id"] == 1
+            assert espn["epg_data_id"] == 99
+            assert espn["tvg_id"] == "espn.us"
+
+            # §D1: no URL leaks into the serialized payload anywhere.
+            serialized = row.channels_data
+            assert "leak" not in serialized
+            assert "url" not in serialized
+            assert ".ts" not in serialized
+        finally:
+            session.close()
+
+    def test_excludes_auto_created_channels(self, db_session_factory):
+        """Channels with truthy ``auto_created`` are excluded (§D3); manual
+        ones are kept with the correct stream_ids."""
+        execution_id = _make_execution(db_session_factory)
+
+        client = MagicMock()
+        engine = AutoCreationEngine(client)
+        engine._existing_channels = [
+            # Manual — kept.
+            {"id": 1, "name": "Manual A", "streams": [100, 101]},
+            # Dispatcharr-auto-created-from-groups — excluded.
+            {"id": 2, "name": "Auto B", "auto_created": True, "streams": [200]},
+            # auto_created falsy — kept (a "claimed"/cleared channel).
+            {"id": 3, "name": "Manual C", "auto_created": False, "streams": [300]},
+            # auto_created absent — kept (defaults to manual).
+            {"id": 4, "name": "Manual D", "streams": [400]},
+        ]
+
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            asyncio.get_event_loop().run_until_complete(
+                engine._capture_snapshot(execution_id)
+            )
+
+        session = db_session_factory()
+        try:
+            row = session.query(AutoCreationSnapshot).filter(
+                AutoCreationSnapshot.execution_id == execution_id
+            ).first()
+            channels = row.get_channels_data()["channels"]
+            ids = {c["id"] for c in channels}
+            assert ids == {1, 3, 4}, "auto_created channel (id=2) must be excluded"
+            assert row.channel_count == 3
+            kept = {c["id"]: c["stream_ids"] for c in channels}
+            assert kept[1] == [100, 101]
+            assert kept[3] == [300]
+            assert kept[4] == [400]
+        finally:
+            session.close()
+
+    def test_no_channels_writes_empty_snapshot(self, db_session_factory):
+        """An instance with no manual channels still writes a (zero-count) row
+        — the run had nothing manual to capture, not a capture failure."""
+        execution_id = _make_execution(db_session_factory)
+
+        client = MagicMock()
+        engine = AutoCreationEngine(client)
+        engine._existing_channels = [
+            {"id": 2, "name": "Auto", "auto_created": True, "streams": [200]},
+        ]
+
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            asyncio.get_event_loop().run_until_complete(
+                engine._capture_snapshot(execution_id)
+            )
+
+        session = db_session_factory()
+        try:
+            row = session.query(AutoCreationSnapshot).filter(
+                AutoCreationSnapshot.execution_id == execution_id
+            ).first()
+            assert row is not None
+            assert row.channel_count == 0
+            assert row.get_channels_data()["channels"] == []
+        finally:
+            session.close()
+
+
+class TestCaptureFailureLogsAndProceeds:
+    """A capture failure logs a warning and does NOT raise (§D2)."""
+
+    def test_failure_logs_warning_and_does_not_raise(self, db_session_factory, caplog):
+        """When the DB write fails, _capture_snapshot swallows the error,
+        logs at WARNING, and returns normally so the mutating run proceeds."""
+        execution_id = _make_execution(db_session_factory)
+
+        client = MagicMock()
+        engine = AutoCreationEngine(client)
+        engine._existing_channels = [
+            {"id": 1, "name": "Manual A", "streams": [100]},
+        ]
+
+        # Force the persistence to blow up: get_session returns a session whose
+        # commit raises. The helper must catch it, log, and NOT re-raise.
+        failing_session = MagicMock()
+        failing_session.commit.side_effect = RuntimeError("disk full")
+
+        with patch("auto_creation_engine.get_session", return_value=failing_session), \
+             caplog.at_level(logging.WARNING, logger="auto_creation_engine"):
+            # Must NOT raise.
+            asyncio.get_event_loop().run_until_complete(
+                engine._capture_snapshot(execution_id)
+            )
+
+        # Warning logged, mentions the execution id, and no snapshot persisted.
+        assert any(
+            "Failed to capture pre-run snapshot" in rec.message
+            for rec in caplog.records
+        ), f"expected a capture-failure WARNING; got {[r.message for r in caplog.records]}"
+
+        session = db_session_factory()
+        try:
+            row = session.query(AutoCreationSnapshot).filter(
+                AutoCreationSnapshot.execution_id == execution_id
+            ).first()
+            assert row is None, "no snapshot should exist after a capture failure"
+        finally:
+            session.close()
+
+
+class TestRunPipelineDryRunGate:
+    """run_pipeline captures only on mode=='execute' (not dry-run) — §D2."""
+
+    def _stub_engine(self):
+        """An engine with the pipeline helpers stubbed so run_pipeline reaches
+        (or skips) the capture call without touching Dispatcharr or the DB."""
+        client = MagicMock()
+        engine = AutoCreationEngine(client)
+
+        engine._load_existing_data = AsyncMock()
+        engine._load_rules = AsyncMock(return_value=[MagicMock(id=1)])
+        engine._fetch_streams = AsyncMock(return_value=[])
+        engine._apply_global_filters = AsyncMock(return_value=([], []))
+        engine._capture_snapshot = AsyncMock()
+        engine._update_rule_stats = AsyncMock()
+        engine._save_execution = AsyncMock()
+
+        execution = MagicMock()
+        execution.id = 4242
+        engine._create_execution = AsyncMock(return_value=execution)
+
+        # Minimal valid results dict for the finalize block.
+        engine._process_streams = AsyncMock(return_value={
+            "streams_evaluated": 0, "streams_matched": 0,
+            "channels_created": 0, "channels_updated": 0,
+            "groups_created": 0, "streams_merged": 0,
+            "channels_touched": 0, "streams_skipped": 0,
+            "streams_excluded": 0, "created_entities": [],
+            "modified_entities": [], "execution_log": [],
+            "dry_run_results": [],
+        })
+        return engine
+
+    def test_execute_run_captures_snapshot(self):
+        """mode=='execute' (dry_run=False) → _capture_snapshot is called with
+        the execution id, before _process_streams."""
+        engine = self._stub_engine()
+
+        asyncio.get_event_loop().run_until_complete(
+            engine.run_pipeline(dry_run=False, triggered_by="manual")
+        )
+
+        engine._capture_snapshot.assert_awaited_once_with(4242)
+
+    def test_dry_run_skips_snapshot(self):
+        """dry_run=True → _capture_snapshot is NEVER called (no snapshot for a
+        run that mutates nothing)."""
+        engine = self._stub_engine()
+
+        asyncio.get_event_loop().run_until_complete(
+            engine.run_pipeline(dry_run=True, triggered_by="manual")
+        )
+
+        engine._capture_snapshot.assert_not_called()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0018",
+  "version": "0.17.3-0019",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Phase 2 of 4 of the **uc51o epic**, per ADR-010. Lays the foundation: capture a pre-run snapshot of channel→stream state so a run can later be fully reverted (Phase 3).

## What's in this PR
- **`AutoCreationSnapshot` table** (migration `0022` on `0021`): 1:1 FK→`AutoCreationExecution` (UNIQUE, ON DELETE CASCADE), `snapshot_time`, denormalized `channel_count`, `channels_data` JSON, `created_at`, + retention index. New table, not a M3USnapshot reuse. `server_default` deliberately omitted to avoid migration drift (matches the M3USnapshot precedent).
- **Pre-run capture hook** in `auto_creation_engine.run_pipeline`: fires after the execution row exists and before any mutation, **execute-mode only** (skips dry-run). Serializes each channel from the already-loaded in-memory list (no N+1) as `{id,name,channel_group_id,epg_data_id,tvg_id,stream_ids:[int]}` — **stream-IDs only, no URLs** (credential safety). **Excludes** Dispatcharr-auto-created channels (`auto_created`). Capture failure **logs-and-proceeds** (never aborts the run; `has_snapshot=False`).
- **Read-only** `GET /api/auto-creation/executions/{id}/snapshot` (404 if none). Not admin-gated — read-only, behind the global auth middleware; the Phase-3 restore *write* endpoint will carry `RequireAdminIfEnabled`.

## Verification (independent)
- Migration chain confirmed `0022 → 0021`; up/down/re-up round-trip clean in-container; UNIQUE + FK CASCADE + time index verified.
- Gate (`-k "snapshot or migration or alembic"`): **268 passed, 0 failed**. 14 new tests (capture on execute / skip on dry-run / excludes auto_created / IDs-only / capture-failure-proceeds / GET 200+404 / migration up-down).
- Version consistency: all 3 touchpoints at `0.17.3-0019`.

Next: Phase 3 (`uc51o.4` restore algorithm + endpoint, admin-gated; + `uc51o.3` retention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)