### PR TITLE
v0.17.3-0020: Auto-creation snapshot restore + retention (bd-uc51o.4, bd-uc51o.3)

### DIFF
--- a/backend/auto_creation_engine.py
+++ b/backend/auto_creation_engine.py
@@ -383,6 +383,191 @@ class AutoCreationEngine:
         finally:
             session.close()
 
+    async def restore_snapshot(self, execution_id: int, restored_by: str = "manual") -> dict:
+        """Whole-run revert via the pre-run AutoCreationSnapshot (ADR-010 §D8).
+
+        SAFETY-CRITICAL: this mutates live Dispatcharr channels. It performs an
+        OPTIMISTIC OVERWRITE (ADR-010 §D5) — it unconditionally writes the
+        snapshot's stream-set + key metadata back to each channel, clobbering
+        ANY changes made (manual edits, Dispatcharr drift) AFTER the run but
+        BEFORE this revert. The caller MUST surface the §D5 pre-revert warning;
+        the endpoint requires an explicit ``confirm=true`` so a raw API call
+        cannot skip the acknowledgement.
+
+        Algorithm (ADR-010 §D8):
+          1. Load the snapshot for ``execution_id`` (404-equivalent — returns
+             ``{"success": False, "error": ...}`` with a ``no_snapshot`` flag so
+             the router can map to 404 and tell the caller to use /rollback).
+             Refuse a dry-run execution or one already in a terminal revert
+             state, mirroring the rollback guards.
+          2. Delete run-CREATED channels/groups first (via the existing
+             ``_rollback_created_entity`` path) so channels that did not exist
+             at snapshot time do not survive as orphans.
+          3. For each snapshot channel, full-REPLACE its stream set
+             (``update_channel(streams=[ids])`` — the §D1 IDs-only primitive)
+             and restore key metadata (name, channel_group_id, epg_data_id,
+             tvg_id) in one PATCH.
+          4. Idempotent: re-running re-issues the same PATCHes / deletes →
+             same end state. A second call after a clean first call finds the
+             created channels already gone (delete 404 swallowed by
+             ``_rollback_created_entity``) and re-writes the same stream-sets.
+          5. Partial failures are COLLECTED and SURFACED, never silent and
+             never fatal mid-run: a snapshot channel that 404s in Dispatcharr
+             (deleted since the run) or a metadata/stream write that fails is
+             recorded in ``failed_channels`` and the loop CONTINUES. The result
+             reports ``restored_channels`` / ``removed_channels`` counts plus
+             the per-item ``failed_channels`` list. ``success`` is True only
+             when nothing failed; a run that failed on some items returns
+             ``success=False`` (success-with-warnings) carrying the failures —
+             NEVER a blanket success that hides them.
+
+        Args:
+            execution_id: ID of the execution whose pre-run state to restore.
+            restored_by: Who/what initiated the restore (recorded on the row).
+
+        Returns:
+            On no-snapshot / guard failure: ``{"success": False, "error": ...,
+            "no_snapshot": bool}``. On a restore attempt: ``{"success": bool,
+            "execution_id", "rule_name", "removed_channels", "restored_channels",
+            "failed_channels": [{"id", "name", "error"}]}``.
+        """
+        session = get_session()
+        try:
+            execution = session.query(AutoCreationExecution).filter(
+                AutoCreationExecution.id == execution_id
+            ).first()
+
+            if not execution:
+                return {"success": False, "error": "Execution not found"}
+
+            if execution.mode == "dry_run":
+                # A dry run mutates nothing and has no snapshot anyway.
+                return {
+                    "success": False,
+                    "error": "Cannot restore a dry-run execution",
+                }
+
+            if execution.status == "rolled_back":
+                return {
+                    "success": False,
+                    "error": "Execution already reverted",
+                }
+
+            snapshot = session.query(AutoCreationSnapshot).filter(
+                AutoCreationSnapshot.execution_id == execution_id
+            ).first()
+
+            if not snapshot:
+                # No snapshot to restore from — the caller should use the legacy
+                # /rollback path (delete-created-only) instead. Flagged so the
+                # router can map to 404 with that guidance.
+                return {
+                    "success": False,
+                    "no_snapshot": True,
+                    "error": (
+                        f"No snapshot for execution {execution_id}; use "
+                        f"/rollback instead (this run predates snapshotting, "
+                        f"was a dry-run, or its capture failed)."
+                    ),
+                }
+
+            logger.info(
+                "[AUTO-CREATE-ENGINE] Restoring snapshot for execution %s "
+                "(OPTIMISTIC OVERWRITE — post-run edits will be lost)",
+                execution_id,
+            )
+
+            # --- Step 2: delete run-created channels/groups first -------------
+            # Reuse the rollback's created-entity teardown verbatim so a
+            # channel that did NOT exist at snapshot time (and therefore is not
+            # in the snapshot) is removed rather than left as an orphan. Deletes
+            # in reverse order, mirroring rollback. _rollback_created_entity
+            # swallows a 404 (already-deleted) so a SECOND restore is safe.
+            created = execution.get_created_entities()
+            removed_channels = 0
+            for entity in reversed(created):
+                await self._rollback_created_entity(entity)
+                if entity.get("type") == "channel":
+                    removed_channels += 1
+
+            # --- Step 3-5: full-replace each snapshot channel -----------------
+            channels = snapshot.get_channels_data().get("channels", [])
+            restored_channels = 0
+            failed_channels: list[dict] = []
+
+            for ch in channels:
+                channel_id = ch.get("id")
+                channel_name = ch.get("name")
+                try:
+                    # Full-REPLACE primitive (§D1 IDs-only) + key metadata in
+                    # one PATCH. Including ``streams`` makes update_channel
+                    # overwrite the entire stream set to the snapshot order;
+                    # the metadata keys restore drift on name / group / epg /
+                    # tvg.
+                    payload = {
+                        "streams": list(ch.get("stream_ids") or []),
+                        "name": channel_name,
+                        "channel_group_id": ch.get("channel_group_id"),
+                        "epg_data_id": ch.get("epg_data_id"),
+                        "tvg_id": ch.get("tvg_id"),
+                    }
+                    await self.client.update_channel(channel_id, payload)
+                    restored_channels += 1
+                except Exception as e:
+                    # Collect-and-continue: a deleted channel (404), a
+                    # vanished referenced stream id (IDs-only can't recreate a
+                    # deleted stream — ADR-010 negative consequence #2), or any
+                    # write error is recorded and the loop proceeds. NEVER
+                    # abort on the first failure; NEVER report blanket success.
+                    logger.warning(
+                        "[AUTO-CREATE-ENGINE] Restore failed for channel %s (%s): %s",
+                        channel_id, channel_name, e,
+                    )
+                    failed_channels.append({
+                        "id": channel_id,
+                        "name": channel_name,
+                        "error": str(e),
+                    })
+
+            # --- Step 7: mark terminal state + return -------------------------
+            # Share the ``rolled_back`` terminal state with the legacy rollback
+            # (ADR-010 §D8 step 7 leaves the exact name to this bead; reusing
+            # the existing state keeps the idempotency guard — already-reverted
+            # → refuse — consistent across both revert surfaces). Only mark
+            # terminal when NOTHING failed, so a partial restore stays
+            # re-runnable (idempotent retry after a partial failure, §D5).
+            if not failed_channels:
+                execution.status = "rolled_back"
+                execution.rolled_back_at = datetime.utcnow()
+                execution.rolled_back_by = restored_by
+            session.commit()
+
+            logger.info(
+                "[AUTO-CREATE-ENGINE] Restore complete for execution %s: "
+                "%s created channel(s) removed, %s channel(s) restored, "
+                "%s failed",
+                execution_id, removed_channels, restored_channels,
+                len(failed_channels),
+            )
+
+            return {
+                # success-with-warnings: False when any item failed so the
+                # caller never mistakes a partial restore for a clean one.
+                "success": not failed_channels,
+                "execution_id": execution_id,
+                "rule_name": execution.rule_name or f"Execution {execution_id}",
+                "removed_channels": removed_channels,
+                "restored_channels": restored_channels,
+                "failed_channels": failed_channels,
+            }
+
+        except Exception as e:
+            session.rollback()
+            logger.error("[AUTO-CREATE-ENGINE] Restore failed: %s", e)
+            return {"success": False, "error": str(e)}
+        finally:
+            session.close()
+
     # =========================================================================
     # Data Loading
     # =========================================================================

--- a/backend/config.py
+++ b/backend/config.py
@@ -196,6 +196,15 @@ class DispatcharrSettings(BaseModel):
     auto_creation_excluded_terms: list[str] = []  # Terms that exclude streams by name (case-insensitive substring)
     auto_creation_excluded_groups: list[str] = []  # M3U group names to exclude (case-insensitive exact match)
     auto_creation_exclude_auto_sync_groups: bool = False  # Exclude streams in Dispatcharr auto-sync groups
+    # Auto-creation pre-run snapshot retention (ADR-010 §D7 / uc51o.3). Two
+    # bounds, whichever fires first, pruned by CleanupTask BEFORE the VACUUM
+    # step. Without these, a per-run ~570-channel snapshot captured on every
+    # execute (incl. hourly run_on_refresh) is an unbounded SQLite-growth bomb.
+    # Naming + 30-day default match the auto_creation_blob_days retention
+    # cadence already in tasks/cleanup.py; the count cap is modeled on the
+    # M3USnapshot newest-N precedent (ADR-010 §D7).
+    auto_creation_snapshot_days: int = 30  # Age window — prune snapshots older than this many days (by snapshot_time).
+    auto_creation_snapshot_max: int = 50  # Count cap — keep at most this many newest snapshots; older ones pruned regardless of age.
     # MCP server API key for Claude integration (empty = not configured)
     mcp_api_key: str = ""
     # Frontend error telemetry toggle (ADR-006 §10, bd-i6a1m).

--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0019",
+    version="0.17.3-0020",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -749,6 +749,43 @@ def _build_metrics(registry: CollectorRegistry) -> Dict[str, Any]:
             registry=registry,
         ),
         # ----------------------------------------------------------------
+        # Auto-creation pre-run snapshot growth (ADR-010 §D7, uc51o.3).
+        #
+        # A per-run snapshot of ~570 channels serializes to roughly
+        # 50 KB–3 MB, captured on every execute (incl. hourly
+        # run_on_refresh). Retention (CleanupTask age window + count cap)
+        # bounds it by construction; these two gauges make the current
+        # state observable so an operator (and any future alert rule) can
+        # see whether the cap is doing its job. Both are label-free —
+        # single-file, single-tenant — matching the database-size gauges.
+        #
+        # ``snapshot_count`` is the live row count of auto_creation_snapshots;
+        # the count cap (auto_creation_snapshot_max, default 50) is the
+        # ceiling, so a value pinned at the cap means the prune is the
+        # binding constraint (healthy). ``snapshot_bytes`` sums the
+        # serialized channels_data payload (LENGTH(channels_data)) — the
+        # storage cost — computed cheaply at prune time. Updated by
+        # CleanupTask.execute after the snapshot prune. No established
+        # alert rule yet; SRE owns the threshold (note in ADR-010 §D7).
+        # ----------------------------------------------------------------
+        "auto_creation_snapshot_count": Gauge(
+            "ecm_auto_creation_snapshot_count",
+            "Current number of auto_creation_snapshots rows retained. Bounded "
+            "by the auto_creation_snapshot_max count cap (default 50) and the "
+            "auto_creation_snapshot_days age window (default 30) enforced by "
+            "CleanupTask. Updated after the snapshot prune. No labels.",
+            registry=registry,
+        ),
+        "auto_creation_snapshot_bytes": Gauge(
+            "ecm_auto_creation_snapshot_bytes",
+            "Total size in bytes of the serialized channels_data payloads "
+            "across all retained auto_creation_snapshots (SUM(LENGTH("
+            "channels_data))). The storage cost of the snapshot table; the "
+            "count cap holds this to a bounded ceiling. Updated after the "
+            "snapshot prune. No labels.",
+            registry=registry,
+        ),
+        # ----------------------------------------------------------------
         # Task scheduler health (bd-qxi02, bd-p5b8i SRE recommendation).
         #
         # Two gauges expose the operational health of the task scheduler
@@ -1193,6 +1230,57 @@ def update_database_size_metrics(db_path: Optional[str] = None) -> None:
         logging.getLogger(__name__).debug(
             "[OBSERVABILITY] update_database_size_metrics failed", exc_info=True
         )
+
+
+def update_auto_creation_snapshot_metrics(session=None) -> None:
+    """Sample the auto_creation_snapshots count + size onto the gauges (ADR-010 §D7).
+
+    Publishes ``ecm_auto_creation_snapshot_count`` (live row count) and
+    ``ecm_auto_creation_snapshot_bytes`` (SUM(LENGTH(channels_data)) — the
+    serialized payload size, computed without parsing the BLOB) so the
+    growth of the pre-run snapshot table is observable and the count cap's
+    effectiveness is visible.
+
+    Called from ``tasks.cleanup.CleanupTask.execute`` immediately after the
+    snapshot prune step, so the gauges reflect the post-prune state.
+
+    Defensive: never raises. Observability instrumentation must not break the
+    cleanup task it's wrapping. A failure to publish is logged at DEBUG.
+
+    Parameters
+    ----------
+    session:
+        An active SQLAlchemy ``Session`` already connected to the journal DB
+        (the cleanup task passes its own). When ``None``, opens a fresh
+        session via ``database.get_session`` (the import is local so tests
+        that haven't initialized the DB module don't pay an import-time cost).
+    """
+    own_session = False
+    try:
+        from sqlalchemy import func
+
+        from models import AutoCreationSnapshot
+
+        if session is None:
+            from database import get_session  # local — avoid import cycle
+            session = get_session()
+            own_session = True
+
+        count = session.query(func.count(AutoCreationSnapshot.id)).scalar() or 0
+        total_bytes = session.query(
+            func.coalesce(func.sum(func.length(AutoCreationSnapshot.channels_data)), 0)
+        ).scalar() or 0
+
+        get_metric("auto_creation_snapshot_count").set(float(count))
+        get_metric("auto_creation_snapshot_bytes").set(float(total_bytes))
+    except Exception:  # pragma: no cover — never break the caller
+        logging.getLogger(__name__).debug(
+            "[OBSERVABILITY] update_auto_creation_snapshot_metrics failed",
+            exc_info=True,
+        )
+    finally:
+        if own_session and session is not None:
+            session.close()
 
 
 def record_task_success(task_id: str, timestamp: Optional[float] = None) -> None:

--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -1377,6 +1377,117 @@ async def rollback_auto_creation_execution(execution_id: int, _admin=RequireAdmi
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+@router.post("/executions/{execution_id}/restore-snapshot")
+async def restore_auto_creation_snapshot(
+    execution_id: int,
+    confirm: bool = Query(
+        False,
+        description=(
+            "Required acknowledgement of the optimistic-overwrite warning "
+            "(ADR-010 §D5). Must be true. Reverting OVERWRITES the current "
+            "stream assignments of every snapshot channel with the state "
+            "captured before this run — ANY changes made after the run "
+            "(manual edits, Dispatcharr drift) WILL BE LOST. This cannot be "
+            "undone."
+        ),
+    ),
+    _admin=RequireAdminIfEnabled,
+):
+    """Whole-run revert from the pre-run snapshot (ADR-010 §D8). Admin only.
+
+    SAFETY-CRITICAL DESTRUCTIVE WRITE. This overwrites live Dispatcharr channels
+    with the snapshot's pre-run stream-set + metadata (OPTIMISTIC OVERWRITE,
+    §D5) — it intentionally clobbers any changes made since the snapshot was
+    captured. The caller MUST have surfaced the §D5 pre-revert warning; the
+    ``confirm=true`` parameter is the API-level acknowledgement so a raw call
+    cannot skip it.
+
+    Returns a structured result — ``removed_channels`` / ``restored_channels``
+    counts plus a per-item ``failed_channels`` list. Partial failures are
+    SURFACED (a snapshot channel deleted since the run, a vanished stream id):
+    the operation does NOT abort on the first failure and does NOT report
+    blanket success if any item failed.
+
+    Status codes:
+      * 400 — ``confirm`` not set (warning unacknowledged), or the execution is
+        a dry-run / already reverted.
+      * 404 — no snapshot for this execution (use ``/rollback`` instead).
+      * 200 — restore attempted. ``success`` is False (with the failures
+        listed) when any channel failed; True when all succeeded.
+    """
+    logger.debug(
+        "[AUTO-CREATE] POST /executions/%s/restore-snapshot (confirm=%s)",
+        execution_id, confirm,
+    )
+
+    if not confirm:
+        # The §D5 warning is mandatory and the ONLY mitigation for the
+        # overwrite risk in v1 — refuse to act without explicit acknowledgement.
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Restore requires confirm=true. Reverting overwrites the "
+                "current stream assignments of every snapshot channel with the "
+                "pre-run state; any changes made after the run will be lost. "
+                "This cannot be undone."
+            ),
+        )
+
+    try:
+        from auto_creation_engine import get_auto_creation_engine, init_auto_creation_engine
+
+        engine = get_auto_creation_engine()
+        if not engine:
+            client = get_client()
+            engine = await init_auto_creation_engine(client)
+
+        result = await engine.restore_snapshot(execution_id, restored_by="api")
+
+        # No snapshot → 404 with guidance to use /rollback (ADR-010 §D8 step 1).
+        if result.get("no_snapshot"):
+            raise HTTPException(status_code=404, detail=result.get("error"))
+
+        # Guard failures (dry-run, already reverted, not found) → 400.
+        # A restore that was ATTEMPTED returns success/failure with counts;
+        # only the pre-attempt guards carry no count keys.
+        if not result.get("success") and "restored_channels" not in result:
+            error = result.get("error", "Restore failed")
+            status = 404 if "not found" in error.lower() else 400
+            raise HTTPException(status_code=status, detail=error)
+
+        # Journal the restore (mirrors the rollback endpoint's journaling).
+        rule_name = result.get("rule_name", f"Execution {execution_id}")
+        removed = result.get("removed_channels", 0)
+        restored = result.get("restored_channels", 0)
+        failed = len(result.get("failed_channels", []))
+        session = get_session()
+        try:
+            journal.log_entry(
+                category="auto_creation",
+                action_type="restore_snapshot",
+                entity_id=execution_id,
+                entity_name=rule_name,
+                description=(
+                    f"Restored snapshot for '{rule_name}': "
+                    f"removed {removed} created channel(s), "
+                    f"restored {restored} channel(s)"
+                    + (f", {failed} failed" if failed else "")
+                ),
+            )
+        finally:
+            session.close()
+
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(
+            "[AUTO-CREATE] Failed to restore snapshot for execution %s: %s",
+            execution_id, e,
+        )
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
 # =============================================================================
 # YAML Import/Export Endpoints
 # =============================================================================

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0019"
+APP_VERSION = "0.17.3-0020"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/tasks/cleanup.py
+++ b/backend/tasks/cleanup.py
@@ -8,6 +8,7 @@ Scheduled task to clean up old data:
 - AutoCreationExecution BLOB columns (bd-ia28g)
 - health_checks rows (bd-ia28g)
 - Notifications (bd-ia28g)
+- AutoCreationSnapshot rows (ADR-010 §D7 / uc51o.3)
 - Orphaned data
 """
 import logging
@@ -19,6 +20,7 @@ from sqlalchemy import inspect, text, update
 from database import get_session
 from models import (
     AutoCreationExecution,
+    AutoCreationSnapshot,
     JournalEntry,
     Notification,
     StreamStats,
@@ -46,6 +48,21 @@ class CleanupTask(TaskScheduler):
     - notifications_days: Delete notifications older than this many days
       (default: 30) — see bd-ia28g; uses ``expires_at`` if set, else ``created_at``
     - vacuum_db: Run VACUUM after cleanup (default: True)
+
+    AutoCreationSnapshot retention (ADR-010 §D7, uc51o.3) is bounded by TWO
+    config knobs read from the global Settings (config.py), whichever fires
+    first — NOT from this task's own config, so they sit alongside the other
+    ``auto_creation_*`` settings and are operator-configurable there:
+    - auto_creation_snapshot_days (default 30): age window — prune snapshots
+      older than this many days by ``snapshot_time``.
+    - auto_creation_snapshot_max (default 50): count cap — keep at most this
+      many newest snapshots; older ones pruned regardless of age. This bounds
+      the hourly-refresh worst case (50 x up-to-3 MB ~= 150 MB ceiling)
+      independent of the age window.
+    The prune runs BEFORE the VACUUM step so the freed pages are reclaimed in
+    the same maintenance pass. Snapshot counts are bounded (tens, not millions)
+    by the count cap, so a single DELETE is fine (no batched-delete-to-dodge-
+    the-write-lock concern — ADR-010 §D7).
 
     Retention rationale (bd-dmu8w): the journal default is 90 days because
     bulk auto-creation now produces per-entity rows (bd-91mcq), amplifying
@@ -141,15 +158,17 @@ class CleanupTask(TaskScheduler):
         deleted_counts = {}
         errors = []
 
-        # 7 prune operations total:
+        # 8 prune operations total:
         # 1. stream_stats failed/pending probes
         # 2. task_executions
         # 3. journal_entries
         # 4. auto_creation_executions BLOB null-out (bd-ia28g)
         # 5. health_checks (bd-ia28g)
         # 6. notifications (bd-ia28g)
-        # 7. VACUUM
-        total_steps = 7
+        # 7. auto_creation_snapshots age + count prune (ADR-010 §D7, uc51o.3)
+        # 8. VACUUM (must remain LAST — runs after the snapshot prune so the
+        #    freed pages are reclaimed in the same pass)
+        total_steps = 8
 
         self._set_progress(
             total=total_steps,
@@ -386,8 +405,101 @@ class CleanupTask(TaskScheduler):
                     session.close()
                     return self._cancelled_result(started_at, deleted_counts)
 
-                # 7. VACUUM the database
-                self._set_progress(current=7, current_item="Vacuuming database")
+                # 7. ADR-010 §D7 (uc51o.3): prune AutoCreationSnapshot rows by
+                # BOTH an age window and a count cap (whichever fires first),
+                # BEFORE the VACUUM step below so the freed pages are reclaimed
+                # in this pass. Without retention, a per-run ~570-channel
+                # snapshot captured on every execute (incl. hourly
+                # run_on_refresh) grows SQLite unbounded — the same growth-bomb
+                # class the bd-ia28g blocks above exist to defuse.
+                #
+                # Knobs come from the global Settings (config.py), NOT this
+                # task's own config, so they live alongside the other
+                # auto_creation_* settings: auto_creation_snapshot_days (age,
+                # default 30) and auto_creation_snapshot_max (count cap,
+                # default 50). The age delete and the count-cap delete are
+                # separate statements: the age pass removes anything past the
+                # window; the count-cap pass then keeps only the newest N of
+                # whatever remains. A single DELETE per pass is fine — the cap
+                # bounds the table to tens of rows, so the ADR-007 batched-
+                # delete-to-dodge-the-write-lock concern does not apply.
+                self._set_progress(
+                    current=7,
+                    current_item="Pruning auto_creation_snapshots",
+                )
+
+                try:
+                    from config import get_settings
+                    settings = get_settings()
+                    snapshot_days = getattr(settings, "auto_creation_snapshot_days", 30)
+                    snapshot_max = getattr(settings, "auto_creation_snapshot_max", 50)
+
+                    snapshots_pruned = 0
+
+                    # 7a. Age window — prune snapshots older than the window by
+                    # snapshot_time (the idx_auto_snapshot_time index covers
+                    # this scan).
+                    snapshot_cutoff = datetime.utcnow() - timedelta(days=snapshot_days)
+                    aged = session.query(AutoCreationSnapshot).filter(
+                        AutoCreationSnapshot.snapshot_time < snapshot_cutoff,
+                    ).delete(synchronize_session=False)
+                    snapshots_pruned += aged
+
+                    # 7b. Count cap — of whatever survived the age pass, keep
+                    # only the newest ``snapshot_max``; delete the rest. Find
+                    # the cutoff ids by ordering newest-first, skipping the cap,
+                    # and deleting the remainder by id.
+                    surplus_ids = [
+                        row.id
+                        for row in session.query(AutoCreationSnapshot.id)
+                        .order_by(AutoCreationSnapshot.snapshot_time.desc())
+                        .offset(snapshot_max)
+                        .all()
+                    ]
+                    if surplus_ids:
+                        capped = session.query(AutoCreationSnapshot).filter(
+                            AutoCreationSnapshot.id.in_(surplus_ids),
+                        ).delete(synchronize_session=False)
+                        snapshots_pruned += capped
+
+                    deleted_counts["auto_creation_snapshots"] = snapshots_pruned
+                    session.commit()
+
+                    # Metric: publish the current retained snapshot count + size
+                    # so growth is observable (ADR-010 §D7). Best-effort —
+                    # never breaks the prune.
+                    try:
+                        from observability import update_auto_creation_snapshot_metrics
+                        update_auto_creation_snapshot_metrics(session=session)
+                    except Exception as exc:  # pragma: no cover — observability is best-effort
+                        logger.debug(
+                            "[%s] Snapshot metric publish failed: %s",
+                            self.task_id, exc,
+                        )
+
+                    logger.info(
+                        "[%s] Pruned %s auto_creation_snapshots (older than %s days "
+                        "or beyond newest %s)",
+                        self.task_id,
+                        snapshots_pruned,
+                        snapshot_days,
+                        snapshot_max,
+                    )
+                except Exception as e:
+                    logger.error(
+                        "[%s] Failed to prune auto_creation_snapshots: %s",
+                        self.task_id,
+                        e,
+                    )
+                    errors.append(f"AutoCreation snapshot prune: {str(e)}")
+                    session.rollback()
+
+                if self._cancel_requested:
+                    session.close()
+                    return self._cancelled_result(started_at, deleted_counts)
+
+                # 8. VACUUM the database
+                self._set_progress(current=8, current_item="Vacuuming database")
 
                 if self.vacuum_db:
                     try:

--- a/backend/tests/routers/test_auto_creation.py
+++ b/backend/tests/routers/test_auto_creation.py
@@ -1445,6 +1445,105 @@ class TestRollbackExecution:
         assert response.status_code == 400
 
 
+class TestRestoreSnapshot:
+    """Tests for POST /api/auto-creation/executions/{id}/restore-snapshot (ADR-010 §D8).
+
+    SAFETY-CRITICAL destructive write — admin-gated, confirm-gated, surfaces
+    partial failures.
+    """
+
+    @pytest.mark.asyncio
+    async def test_requires_confirm(self, async_client):
+        """Without confirm=true → 400 (the §D5 warning is unacknowledged); the
+        engine is never invoked."""
+        mock_engine = AsyncMock()
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine):
+            response = await async_client.post(
+                "/api/auto-creation/executions/1/restore-snapshot"
+            )
+        assert response.status_code == 400
+        assert "confirm" in response.json()["detail"].lower()
+        mock_engine.restore_snapshot.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_restores_with_confirm(self, async_client):
+        """confirm=true → engine.restore_snapshot runs and the result is returned."""
+        mock_engine = AsyncMock()
+        mock_engine.restore_snapshot.return_value = {
+            "success": True,
+            "execution_id": 1,
+            "rule_name": "Sports Rule",
+            "removed_channels": 2,
+            "restored_channels": 5,
+            "failed_channels": [],
+        }
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post(
+                "/api/auto-creation/executions/1/restore-snapshot?confirm=true"
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["restored_channels"] == 5
+        mock_engine.restore_snapshot.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_snapshot_returns_404(self, async_client):
+        """An execution with no snapshot → 404 (use /rollback instead)."""
+        mock_engine = AsyncMock()
+        mock_engine.restore_snapshot.return_value = {
+            "success": False,
+            "no_snapshot": True,
+            "error": "No snapshot for execution 1; use /rollback instead.",
+        }
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine):
+            response = await async_client.post(
+                "/api/auto-creation/executions/1/restore-snapshot?confirm=true"
+            )
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_dry_run_guard_returns_400(self, async_client):
+        """A dry-run / already-reverted guard failure → 400."""
+        mock_engine = AsyncMock()
+        mock_engine.restore_snapshot.return_value = {
+            "success": False,
+            "error": "Cannot restore a dry-run execution",
+        }
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine):
+            response = await async_client.post(
+                "/api/auto-creation/executions/1/restore-snapshot?confirm=true"
+            )
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_is_200_with_failures_surfaced(self, async_client):
+        """A restore that failed on some channels returns 200 with success=False
+        and the per-item failures — success-with-warnings, never a blanket 200
+        that hides them, never a blanket 500."""
+        mock_engine = AsyncMock()
+        mock_engine.restore_snapshot.return_value = {
+            "success": False,
+            "execution_id": 1,
+            "rule_name": "Sports Rule",
+            "removed_channels": 0,
+            "restored_channels": 4,
+            "failed_channels": [{"id": 11, "name": "GONE", "error": "404"}],
+        }
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post(
+                "/api/auto-creation/executions/1/restore-snapshot?confirm=true"
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["restored_channels"] == 4
+        assert len(data["failed_channels"]) == 1
+        assert data["failed_channels"][0]["id"] == 11
+
+
 class TestExportYAML:
     """Tests for GET /api/auto-creation/export/yaml."""
 
@@ -2189,6 +2288,10 @@ _GATED_ENDPOINTS = [
     ("/api/auto-creation/run", "post", {"json": {}}),
     ("/api/auto-creation/rules/1/run", "post", {}),
     ("/api/auto-creation/executions/1/rollback", "post", {}),
+    # restore-snapshot: the admin dependency raises BEFORE the confirm check
+    # and BEFORE the handler, so a non-admin caller is rejected even without
+    # confirm=true (proving the gate, not the confirm gate).
+    ("/api/auto-creation/executions/1/restore-snapshot", "post", {}),
     ("/api/auto-creation/import/yaml", "post", {"json": {"yaml_content": "rules: []"}}),
 ]
 
@@ -2278,6 +2381,62 @@ class TestAutoCreationAdminGating:
              patch("routers.auto_creation.journal"):
             response = await async_client.post(
                 "/api/auto-creation/executions/1/rollback"
+            )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_admin_principal_can_restore_when_auth_enabled(self, async_client):
+        """Auth enabled + admin principal → the gate passes and the destructive
+        snapshot restore (with confirm) executes normally."""
+        from main import app
+        from auth import RequireAdminIfEnabled as _prebuilt
+
+        async def _allow_admin():
+            return MagicMock(is_admin=True, username="admin")
+
+        mock_engine = AsyncMock()
+        mock_engine.restore_snapshot.return_value = {
+            "success": True,
+            "execution_id": 1,
+            "rule_name": "Sports Rule",
+            "removed_channels": 1,
+            "restored_channels": 3,
+            "failed_channels": [],
+        }
+
+        app.dependency_overrides[_prebuilt.dependency] = _allow_admin
+        try:
+            with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine), \
+                 patch("routers.auto_creation.journal"):
+                response = await async_client.post(
+                    "/api/auto-creation/executions/1/restore-snapshot?confirm=true"
+                )
+        finally:
+            app.dependency_overrides.pop(_prebuilt.dependency, None)
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_restore_allowed_when_auth_disabled(self, async_client):
+        """Auth disabled (default async_client) → RequireAdminIfEnabled is a
+        no-op; the restore endpoint behaves normally (confirm still required)."""
+        mock_engine = AsyncMock()
+        mock_engine.restore_snapshot.return_value = {
+            "success": True,
+            "execution_id": 1,
+            "rule_name": "Sports Rule",
+            "removed_channels": 0,
+            "restored_channels": 2,
+            "failed_channels": [],
+        }
+
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post(
+                "/api/auto-creation/executions/1/restore-snapshot?confirm=true"
             )
 
         assert response.status_code == 200

--- a/backend/tests/unit/test_auto_creation_snapshot_metrics.py
+++ b/backend/tests/unit/test_auto_creation_snapshot_metrics.py
@@ -1,0 +1,99 @@
+"""Unit tests for ``observability.update_auto_creation_snapshot_metrics``
+(ADR-010 §D7 / bead ``enhancedchannelmanager-uc51o.3``).
+
+The snapshot count/size gauges are emitted from ``CleanupTask.execute`` after
+the snapshot prune. These tests exercise the helper directly against a real
+in-memory SQLite session so the count + SUM(LENGTH(channels_data)) contract
+stays locked.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from prometheus_client import generate_latest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import database
+import observability
+from models import AutoCreationExecution, AutoCreationSnapshot
+
+
+@pytest.fixture(autouse=True)
+def _reset_observability_state():
+    observability.reset_for_tests()
+    yield
+    observability.reset_for_tests()
+
+
+@pytest.fixture()
+def session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+    database.Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    s = SessionLocal()
+    try:
+        yield s
+    finally:
+        s.close()
+        database.Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+def _add_snapshot(session, channels):
+    execution = AutoCreationExecution(
+        mode="execute", triggered_by="manual",
+        started_at=datetime.utcnow(), status="completed",
+    )
+    session.add(execution)
+    session.commit()
+    snap = AutoCreationSnapshot(
+        execution_id=execution.id,
+        snapshot_time=datetime.utcnow(),
+        channel_count=len(channels),
+    )
+    snap.set_channels_data({"channels": channels})
+    session.add(snap)
+    session.commit()
+    return snap
+
+
+class TestUpdateAutoCreationSnapshotMetrics:
+    def test_publishes_count_and_bytes(self, session):
+        observability.install_metrics()
+        snap1 = _add_snapshot(session, [{"id": 1, "stream_ids": [1, 2]}])
+        snap2 = _add_snapshot(session, [{"id": 2, "stream_ids": [3]}])
+        expected_bytes = float(len(snap1.channels_data) + len(snap2.channels_data))
+
+        observability.update_auto_creation_snapshot_metrics(session=session)
+
+        assert observability.get_metric("auto_creation_snapshot_count")._value.get() == 2.0
+        assert observability.get_metric("auto_creation_snapshot_bytes")._value.get() == expected_bytes
+
+    def test_zero_when_no_snapshots(self, session):
+        observability.install_metrics()
+        observability.update_auto_creation_snapshot_metrics(session=session)
+        assert observability.get_metric("auto_creation_snapshot_count")._value.get() == 0.0
+        assert observability.get_metric("auto_creation_snapshot_bytes")._value.get() == 0.0
+
+    def test_does_not_raise_when_metrics_uninitialized(self, session):
+        """Cold start: get_metric lazily installs; helper must never raise."""
+        observability.reset_for_tests()
+        _add_snapshot(session, [{"id": 1, "stream_ids": [1]}])
+        # Must not raise.
+        observability.update_auto_creation_snapshot_metrics(session=session)
+
+    def test_metrics_render_with_expected_names(self, session):
+        observability.install_metrics()
+        _add_snapshot(session, [{"id": 1, "stream_ids": [1]}])
+        observability.update_auto_creation_snapshot_metrics(session=session)
+        rendered = generate_latest(observability.REGISTRY).decode("utf-8")
+        assert "ecm_auto_creation_snapshot_count" in rendered
+        assert "ecm_auto_creation_snapshot_bytes" in rendered

--- a/backend/tests/unit/test_auto_creation_snapshot_restore.py
+++ b/backend/tests/unit/test_auto_creation_snapshot_restore.py
@@ -1,0 +1,341 @@
+"""Unit tests for the auto-creation snapshot RESTORE algorithm (ADR-010 §D8).
+
+Bead: ``enhancedchannelmanager-uc51o.4`` (Phase 3 of epic
+``enhancedchannelmanager-uc51o``).
+
+SAFETY-CRITICAL: ``AutoCreationEngine.restore_snapshot`` mutates live
+Dispatcharr channels. These tests pin the restore contract:
+
+* Happy path — run-CREATED channels are deleted; every snapshot channel's
+  stream set is full-REPLACED (``update_channel(streams=[ids])``) and key
+  metadata restored.
+* Idempotency — calling restore twice yields the same end state; the second
+  call is clean (no double-delete crash, re-issues the same PATCHes).
+* Partial failure — a missing channel / vanished stream is COLLECTED into
+  ``failed_channels`` and the loop CONTINUES; the result reports it and is NOT
+  a blanket success.
+* 404-equivalent — an execution with no snapshot returns ``no_snapshot=True``.
+* Guards — dry-run / already-reverted executions are refused.
+
+Tests use a real in-memory SQLite session (so the persisted snapshot/execution
+rows are read back) bound by patching ``auto_creation_engine.get_session``.
+The Dispatcharr client is a mock with async methods.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import database
+from auto_creation_engine import AutoCreationEngine
+from models import AutoCreationExecution, AutoCreationSnapshot
+
+
+@pytest.fixture()
+def db_session_factory():
+    """In-memory SQLite session factory with the ECM schema (StaticPool keeps
+    the single connection alive across sessions)."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+    database.Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(
+        autocommit=False, autoflush=False, bind=engine, expire_on_commit=False
+    )
+    try:
+        yield SessionLocal
+    finally:
+        database.Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+def _seed_execution_and_snapshot(
+    session_factory,
+    *,
+    mode: str = "execute",
+    status: str = "completed",
+    created_entities: list | None = None,
+    channels: list | None = None,
+    with_snapshot: bool = True,
+) -> int:
+    """Create an execution (+ optional snapshot) and return the execution id."""
+    session = session_factory()
+    try:
+        execution = AutoCreationExecution(
+            mode=mode,
+            triggered_by="manual",
+            started_at=datetime.utcnow(),
+            status=status,
+            rule_name="Test Rule",
+        )
+        if created_entities is not None:
+            execution.set_created_entities(created_entities)
+        session.add(execution)
+        session.commit()
+        session.refresh(execution)
+        execution_id = execution.id
+
+        if with_snapshot:
+            snapshot = AutoCreationSnapshot(
+                execution_id=execution_id,
+                snapshot_time=datetime.utcnow(),
+                channel_count=len(channels or []),
+            )
+            snapshot.set_channels_data({"channels": channels or []})
+            session.add(snapshot)
+            session.commit()
+        return execution_id
+    finally:
+        session.close()
+
+
+def _make_engine_with_client():
+    client = MagicMock()
+    client.update_channel = AsyncMock()
+    client.delete_channel = AsyncMock()
+    client.delete_channel_group = AsyncMock()
+    return AutoCreationEngine(client), client
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestRestoreHappyPath:
+    """Created channels deleted + snapshot channels' streams/metadata restored."""
+
+    def test_full_restore_deletes_created_and_replaces_streams(self, db_session_factory):
+        channels = [
+            {"id": 10, "name": "ESPN", "channel_group_id": 1,
+             "epg_data_id": 99, "tvg_id": "espn.us", "stream_ids": [501, 502]},
+            {"id": 11, "name": "CNN", "channel_group_id": 2,
+             "epg_data_id": None, "tvg_id": "cnn.us", "stream_ids": [601]},
+        ]
+        created = [
+            {"type": "channel", "id": 500, "name": "New Sports"},
+            {"type": "group", "id": 77, "name": "New Group"},
+        ]
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, created_entities=created, channels=channels,
+        )
+
+        engine, client = _make_engine_with_client()
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            result = _run(engine.restore_snapshot(execution_id))
+
+        assert result["success"] is True
+        assert result["removed_channels"] == 1  # one created CHANNEL (group not counted)
+        assert result["restored_channels"] == 2
+        assert result["failed_channels"] == []
+
+        # Created channel + group were deleted.
+        client.delete_channel.assert_awaited_once_with(500)
+        client.delete_channel_group.assert_awaited_once_with(77)
+
+        # Both snapshot channels got a full-replace PATCH with IDs-only streams
+        # and the restored metadata.
+        assert client.update_channel.await_count == 2
+        calls = {c.args[0]: c.args[1] for c in client.update_channel.await_args_list}
+        assert calls[10]["streams"] == [501, 502]
+        assert calls[10]["name"] == "ESPN"
+        assert calls[10]["channel_group_id"] == 1
+        assert calls[10]["epg_data_id"] == 99
+        assert calls[10]["tvg_id"] == "espn.us"
+        assert calls[11]["streams"] == [601]
+
+        # Execution marked terminal (shared rolled_back state).
+        session = db_session_factory()
+        try:
+            ex = session.query(AutoCreationExecution).filter(
+                AutoCreationExecution.id == execution_id
+            ).first()
+            assert ex.status == "rolled_back"
+            assert ex.rolled_back_at is not None
+            assert ex.rolled_back_by == "manual"
+        finally:
+            session.close()
+
+    def test_streams_are_ids_only_never_urls(self, db_session_factory):
+        """The PATCH body carries integer stream IDs only — never URLs (§D1)."""
+        channels = [{"id": 10, "name": "ESPN", "stream_ids": [501, 502]}]
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, channels=channels,
+        )
+        engine, client = _make_engine_with_client()
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            _run(engine.restore_snapshot(execution_id))
+
+        body = client.update_channel.await_args_list[0].args[1]
+        assert body["streams"] == [501, 502]
+        assert all(isinstance(s, int) for s in body["streams"])
+
+
+class TestRestoreIdempotency:
+    """Calling restore twice yields the same end state; the second call is clean
+    (no double-delete crash, end state unchanged)."""
+
+    def test_second_restore_after_full_success_is_clean_noop(self, db_session_factory):
+        """After a clean restore the execution is terminal (rolled_back). A
+        second call is a safe no-op refused as already-reverted — it does NOT
+        crash and does NOT re-mutate, so the end state is unchanged. This is the
+        terminal-state guard shared with the legacy rollback."""
+        channels = [
+            {"id": 10, "name": "ESPN", "channel_group_id": 1,
+             "epg_data_id": 99, "tvg_id": "espn.us", "stream_ids": [501]},
+        ]
+        created = [{"type": "channel", "id": 500, "name": "New Sports"}]
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, created_entities=created, channels=channels,
+        )
+
+        engine, client = _make_engine_with_client()
+
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            first = _run(engine.restore_snapshot(execution_id))
+            patches_after_first = client.update_channel.await_count
+            second = _run(engine.restore_snapshot(execution_id))
+
+        assert first["success"] is True
+        # Second call is a clean no-op (already-reverted guard) — no crash, no
+        # re-mutation.
+        assert second["success"] is False
+        assert "already reverted" in second["error"].lower()
+        assert client.update_channel.await_count == patches_after_first
+
+    def test_retry_after_partial_failure_reissues_patches(self, db_session_factory):
+        """A partial restore leaves the execution NON-terminal, so a retry
+        re-issues the same PATCHes → same end state (ADR-010 §D8 step 5)."""
+        channels = [
+            {"id": 10, "name": "ESPN", "stream_ids": [501]},
+            {"id": 11, "name": "CNN", "stream_ids": [601]},
+        ]
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, channels=channels,
+        )
+
+        engine, client = _make_engine_with_client()
+
+        # First pass: channel 11 fails (transient) → partial, non-terminal.
+        async def _fail_11(channel_id, payload):
+            if channel_id == 11:
+                raise Exception("transient 503")
+            return {}
+        client.update_channel = AsyncMock(side_effect=_fail_11)
+
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            first = _run(engine.restore_snapshot(execution_id))
+            # Retry: now everything succeeds.
+            client.update_channel = AsyncMock(return_value={})
+            second = _run(engine.restore_snapshot(execution_id))
+
+        assert first["success"] is False
+        assert len(first["failed_channels"]) == 1
+        # Retry re-issued BOTH PATCHes (the run was not terminal) and succeeded.
+        assert second["success"] is True
+        assert second["restored_channels"] == 2
+        assert client.update_channel.await_count == 2
+
+
+class TestRestorePartialFailure:
+    """Missing channel / vanished stream is collected and surfaced, not fatal."""
+
+    def test_failure_on_one_channel_does_not_abort_others(self, db_session_factory):
+        channels = [
+            {"id": 10, "name": "ESPN", "stream_ids": [501]},
+            {"id": 11, "name": "GONE", "stream_ids": [601]},   # channel deleted
+            {"id": 12, "name": "CNN", "stream_ids": [701]},
+        ]
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, channels=channels,
+        )
+
+        engine, client = _make_engine_with_client()
+
+        async def _update(channel_id, payload):
+            if channel_id == 11:
+                raise Exception("404 channel not found")
+            return {}
+
+        client.update_channel = AsyncMock(side_effect=_update)
+
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            result = _run(engine.restore_snapshot(execution_id))
+
+        # NOT a blanket success — one item failed.
+        assert result["success"] is False
+        # The other two were still restored (loop did not abort on first failure).
+        assert result["restored_channels"] == 2
+        assert len(result["failed_channels"]) == 1
+        failed = result["failed_channels"][0]
+        assert failed["id"] == 11
+        assert failed["name"] == "GONE"
+        assert "404" in failed["error"]
+
+        # All three were ATTEMPTED.
+        assert client.update_channel.await_count == 3
+
+        # A partial restore stays re-runnable: execution NOT marked terminal.
+        session = db_session_factory()
+        try:
+            ex = session.query(AutoCreationExecution).filter(
+                AutoCreationExecution.id == execution_id
+            ).first()
+            assert ex.status == "completed", "partial restore must stay re-runnable"
+        finally:
+            session.close()
+
+
+class TestRestoreGuards:
+    """No-snapshot → no_snapshot flag; dry-run / already-reverted refused."""
+
+    def test_no_snapshot_returns_flag(self, db_session_factory):
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, with_snapshot=False,
+        )
+        engine, client = _make_engine_with_client()
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            result = _run(engine.restore_snapshot(execution_id))
+
+        assert result["success"] is False
+        assert result["no_snapshot"] is True
+        assert "rollback" in result["error"].lower()
+        client.update_channel.assert_not_called()
+
+    def test_execution_not_found(self, db_session_factory):
+        engine, client = _make_engine_with_client()
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            result = _run(engine.restore_snapshot(99999))
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_dry_run_refused(self, db_session_factory):
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, mode="dry_run", with_snapshot=False,
+        )
+        engine, client = _make_engine_with_client()
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            result = _run(engine.restore_snapshot(execution_id))
+        assert result["success"] is False
+        assert "dry-run" in result["error"].lower()
+        client.update_channel.assert_not_called()
+
+    def test_already_reverted_refused(self, db_session_factory):
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, status="rolled_back",
+            channels=[{"id": 10, "name": "ESPN", "stream_ids": [501]}],
+        )
+        engine, client = _make_engine_with_client()
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            result = _run(engine.restore_snapshot(execution_id))
+        assert result["success"] is False
+        assert "already reverted" in result["error"].lower()
+        client.update_channel.assert_not_called()

--- a/backend/tests/unit/test_cleanup_task_blob_health_notifications_retention.py
+++ b/backend/tests/unit/test_cleanup_task_blob_health_notifications_retention.py
@@ -578,7 +578,7 @@ class TestCleanupTaskFullExecuteWithAllBlocks:
     without any prune block leaking errors into another's session."""
 
     @pytest.mark.asyncio
-    async def test_all_seven_steps_run_and_total_steps_is_seven(self, tmp_path):
+    async def test_all_eight_steps_run_and_total_steps_is_eight(self, tmp_path):
         db_file = tmp_path / "full.db"
         engine = _make_engine(db_file)
         Base.metadata.create_all(engine)
@@ -613,11 +613,16 @@ class TestCleanupTaskFullExecuteWithAllBlocks:
             result = await task.execute()
 
         assert result.success is True
-        assert result.total_items == 7, (
-            "execute() must report 7 cleanup steps now that bd-ia28g added "
-            "three new prune blocks (was 4: probe + tasks + journal + vacuum)"
+        assert result.total_items == 8, (
+            "execute() must report 8 cleanup steps: bd-ia28g added three prune "
+            "blocks (probe + tasks + journal + blob + health + notifications) "
+            "and ADR-010/uc51o.3 added the auto_creation_snapshots prune before "
+            "VACUUM (was 7)"
         )
         deleted = result.details["deleted"]
         assert deleted["auto_creation_blobs_pruned"] == 1
         assert deleted["health_checks"] == 1
         assert deleted["notifications"] == 1
+        # The snapshot prune block ran (zero eligible rows here, but the key
+        # is present, proving step 7 executed against the session).
+        assert "auto_creation_snapshots" in deleted

--- a/backend/tests/unit/test_cleanup_task_snapshot_retention.py
+++ b/backend/tests/unit/test_cleanup_task_snapshot_retention.py
@@ -1,0 +1,253 @@
+"""Tests for the AutoCreationSnapshot retention prune in ``CleanupTask``
+(ADR-010 §D7 / bead ``enhancedchannelmanager-uc51o.3``).
+
+A per-run snapshot of ~570 channels serializes to roughly 50 KB–3 MB and is
+captured on every execute (incl. hourly run_on_refresh) with NO pruning today
+— an unbounded SQLite-growth bomb. This adds a prune step to ``CleanupTask``,
+BEFORE the VACUUM step, bounded by TWO knobs read from the global Settings
+(config.py), whichever fires first:
+
+* ``auto_creation_snapshot_days`` (default 30) — age window by ``snapshot_time``.
+* ``auto_creation_snapshot_max`` (default 50) — count cap; keep newest N.
+
+Tests use real file-backed SQLite (matching the bd-ia28g pattern) so the
+DELETEs observably hit actual SQLite, not mocks. The settings knobs are patched
+per-test via a stub returned from ``config.get_settings``.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import AutoCreationExecution, AutoCreationSnapshot, Base
+from tasks.cleanup import CleanupTask
+
+
+def _make_engine(db_file: Path):
+    return create_engine(
+        f"sqlite:///{db_file}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+
+
+def _make_session_and_task(engine, vacuum: bool = False):
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    task = CleanupTask()
+    task.vacuum_db = vacuum
+    return session, task
+
+
+def _settings(days: int = 30, max_count: int = 50):
+    """A minimal settings stub carrying just the two retention knobs."""
+    return SimpleNamespace(
+        auto_creation_snapshot_days=days,
+        auto_creation_snapshot_max=max_count,
+    )
+
+
+def _make_snapshot(session, *, age_days: float, channels=None) -> int:
+    """Create an execution + snapshot aged ``age_days`` days; return snapshot id."""
+    ts = datetime.utcnow() - timedelta(days=age_days)
+    execution = AutoCreationExecution(
+        mode="execute",
+        triggered_by="manual",
+        started_at=ts,
+        status="completed",
+    )
+    session.add(execution)
+    session.commit()
+    snapshot = AutoCreationSnapshot(
+        execution_id=execution.id,
+        snapshot_time=ts,
+        channel_count=len(channels or []),
+    )
+    snapshot.set_channels_data({"channels": channels or []})
+    session.add(snapshot)
+    session.commit()
+    return snapshot.id
+
+
+def _count_snapshots(engine) -> int:
+    SessionLocal = sessionmaker(bind=engine)
+    s = SessionLocal()
+    try:
+        return s.query(AutoCreationSnapshot).count()
+    finally:
+        s.close()
+
+
+def _surviving_ids(engine) -> set:
+    SessionLocal = sessionmaker(bind=engine)
+    s = SessionLocal()
+    try:
+        return {row.id for row in s.query(AutoCreationSnapshot.id).all()}
+    finally:
+        s.close()
+
+
+class TestSnapshotAgeWindowPrune:
+    """Snapshots older than auto_creation_snapshot_days are pruned."""
+
+    @pytest.mark.asyncio
+    async def test_prunes_snapshots_older_than_age_window(self, tmp_path):
+        db_file = tmp_path / "snap_age.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        old_id = _make_snapshot(session, age_days=40)   # past the 30d window
+        fresh_id = _make_snapshot(session, age_days=5)  # inside the window
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings(days=30, max_count=50)):
+            result = await task.execute()
+
+        survivors = _surviving_ids(engine)
+        assert old_id not in survivors, "snapshot past the age window must be pruned"
+        assert fresh_id in survivors, "snapshot inside the window must be kept"
+
+        deleted = result.details.get("deleted", {})
+        assert deleted.get("auto_creation_snapshots") == 1
+
+    @pytest.mark.asyncio
+    async def test_age_window_respects_config_knob(self, tmp_path):
+        """A shorter configured window prunes more aggressively."""
+        db_file = tmp_path / "snap_age_cfg.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        s10 = _make_snapshot(session, age_days=10)
+        s3 = _make_snapshot(session, age_days=3)
+
+        # With a 7-day window, the 10-day snapshot is pruned, the 3-day kept.
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings(days=7, max_count=50)):
+            await task.execute()
+
+        survivors = _surviving_ids(engine)
+        assert s10 not in survivors
+        assert s3 in survivors
+
+
+class TestSnapshotCountCapPrune:
+    """At most auto_creation_snapshot_max snapshots are kept (newest N)."""
+
+    @pytest.mark.asyncio
+    async def test_keeps_only_newest_n(self, tmp_path):
+        db_file = tmp_path / "snap_cap.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        # 5 snapshots, all inside the age window, ages 1..5 days.
+        ids_by_age = {}
+        for age in range(1, 6):
+            ids_by_age[age] = _make_snapshot(session, age_days=age)
+
+        # Cap of 3 → keep the 3 NEWEST (ages 1,2,3), prune the 2 oldest (4,5).
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings(days=30, max_count=3)):
+            result = await task.execute()
+
+        survivors = _surviving_ids(engine)
+        assert _count_snapshots(engine) == 3
+        assert ids_by_age[1] in survivors
+        assert ids_by_age[2] in survivors
+        assert ids_by_age[3] in survivors
+        assert ids_by_age[4] not in survivors
+        assert ids_by_age[5] not in survivors
+
+        deleted = result.details.get("deleted", {})
+        assert deleted.get("auto_creation_snapshots") == 2
+
+    @pytest.mark.asyncio
+    async def test_cap_not_exceeded_means_no_prune(self, tmp_path):
+        """When count <= cap and all are fresh, nothing is pruned."""
+        db_file = tmp_path / "snap_cap_under.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        for age in range(1, 4):  # 3 fresh snapshots
+            _make_snapshot(session, age_days=age)
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings(days=30, max_count=50)):
+            result = await task.execute()
+
+        assert _count_snapshots(engine) == 3
+        deleted = result.details.get("deleted", {})
+        assert deleted.get("auto_creation_snapshots") == 0
+
+
+class TestSnapshotPruneRunsBeforeVacuum:
+    """The snapshot prune step must run BEFORE the VACUUM step (ADR-010 §D7)."""
+
+    @pytest.mark.asyncio
+    async def test_prune_step_precedes_vacuum_step(self, tmp_path):
+        """Record the order of the snapshot-prune and VACUUM operations and
+        assert the prune fires first. We spy on the progress steps: step 7 is
+        the snapshot prune, step 8 is VACUUM."""
+        db_file = tmp_path / "snap_order.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine, vacuum=True)
+
+        _make_snapshot(session, age_days=40)  # one prunable snapshot
+
+        progress_items = []
+        orig_set_progress = task._set_progress
+
+        def _spy(*args, **kwargs):
+            if "current_item" in kwargs:
+                progress_items.append(kwargs["current_item"])
+            return orig_set_progress(*args, **kwargs)
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings(days=30, max_count=50)), \
+             patch.object(task, "_set_progress", side_effect=_spy):
+            await task.execute()
+
+        # Both steps ran, and the snapshot prune appears before the vacuum.
+        snap_item = next((i for i in progress_items if "snapshot" in i.lower()), None)
+        vacuum_item = next((i for i in progress_items if "vacuum" in i.lower()), None)
+        assert snap_item is not None, f"no snapshot-prune step seen: {progress_items}"
+        assert vacuum_item is not None, f"no vacuum step seen: {progress_items}"
+        assert progress_items.index(snap_item) < progress_items.index(vacuum_item), (
+            f"snapshot prune must run BEFORE vacuum; order was {progress_items}"
+        )
+
+
+class TestSnapshotPruneConfigDefaults:
+    """Falls back to the documented defaults when the knobs are absent."""
+
+    @pytest.mark.asyncio
+    async def test_defaults_when_settings_missing_knobs(self, tmp_path):
+        """A settings object lacking the knobs → 30d / 50 defaults via getattr."""
+        db_file = tmp_path / "snap_defaults.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        old_id = _make_snapshot(session, age_days=40)
+        fresh_id = _make_snapshot(session, age_days=5)
+
+        # Empty settings stub — getattr() must supply 30d / 50.
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=SimpleNamespace()):
+            await task.execute()
+
+        survivors = _surviving_ids(engine)
+        assert old_id not in survivors   # 40 > default 30d
+        assert fresh_id in survivors

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0019",
+  "version": "0.17.3-0020",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Phase 3 of 4 of the **uc51o epic**, per ADR-010 §D8. The safety-critical core: full-run revert from the pre-run snapshot, plus the retention reaper (bundled because capture is already live on dev with no pruning).

## uc51o.4 — restore (safety-critical, admin-gated)
`POST /api/auto-creation/executions/{id}/restore-snapshot` — `RequireAdminIfEnabled` **and** requires `confirm=true` (acknowledges the optimistic-overwrite warning; raw calls can't skip it). 404 (with "use /rollback" guidance) when no snapshot; guarded against dry-run / already-reverted.

`AutoCreationEngine.restore_snapshot()`:
1. Delete run-created channels/groups (reuses the rollback teardown; 404-swallow → safe on re-run).
2. Per snapshot channel, **full-replace** the stream set (IDs-only) + restore name/group/epg/tvg metadata in one PATCH (optimistic overwrite — intentionally clobbers post-run drift).
3. **Idempotent:** terminal `rolled_back` is set only on full success, so a *partial* restore stays re-runnable.
4. **Partial failures collected & surfaced** (deleted channel / vanished stream-id) — loop continues, result returns `removed_channels`/`restored_channels` + a `failed_channels[]`; `success=False` whenever anything failed (never blanket success).

## uc51o.3 — retention
Prune step in `tasks/cleanup.py` **before VACUUM**: age-window + count-cap, config knobs `auto_creation_snapshot_days` (30) / `auto_creation_snapshot_max` (50). New gauges `ecm_auto_creation_snapshot_count` / `_bytes` published post-prune.

## Verification (independent)
- Read the restore algorithm end-to-end — matches ADR §D8 (delete-created-first, collect-and-continue, terminal-only-on-success). Endpoint confirmed admin-gated + `confirm`-required.
- Gate (`-k "snapshot or restore or retention or cleanup or AdminGating"`): **209 passed, 0 failed** (happy-path / idempotency / partial-failure / guards / prune-before-VACUUM / config knobs / admin matrix).
- Version consistency: all 3 at `0.17.3-0020`.

## Noted (non-blocking, deferred)
- Restore shares the `rolled_back` status with legacy rollback; a distinct `restored` status is left to `uc51o.5` (unify).
- ADR-spec full-replace sends streams+metadata in one PATCH, so a deleted EPG/group reference fails that channel's whole restore (surfaced as a partial failure, recoverable) — splitting writes is an additive future refinement.

Next: Phase 4 (`uc51o.5` unify rollback, `.6` MCP tool, `.7` revert UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)