### PR TITLE
v0.17.3-0021: Unify auto-creation rollback on snapshot + has_snapshot (bd-uc51o.5)

### DIFF
--- a/backend/auto_creation_engine.py
+++ b/backend/auto_creation_engine.py
@@ -275,16 +275,50 @@ class AutoCreationEngine:
             execution_id=execution_id,
         )
 
-    async def rollback_execution(self, execution_id: int, rolled_back_by: str = "manual") -> dict:
+    async def rollback_execution(
+        self,
+        execution_id: int,
+        rolled_back_by: str = "manual",
+        confirm: bool = False,
+    ) -> dict:
         """
-        Rollback changes from a specific execution.
+        Rollback changes from a specific execution (ADR-010 §D8, uc51o.5).
+
+        UNIFIED REVERT. This is the single revert entry point and chooses its
+        behaviour from whether the execution has a pre-run snapshot:
+
+        * **Snapshot present** — delegates to :meth:`restore_snapshot` for the
+          FULL whole-run revert (re-adds streams the run removed, removes
+          streams it added, restores drifted metadata). This is an OPTIMISTIC
+          OVERWRITE (ADR-010 §D5) that can clobber edits made AFTER the run, so
+          it requires ``confirm=True`` — the same acknowledgement the
+          ``/restore-snapshot`` endpoint demands. Without it, the call is
+          refused with ``requires_confirm=True`` and ``has_snapshot=True`` so
+          the router can surface the overwrite warning (HTTP 409). This is the
+          ONLY behaviour change for existing callers, and it ONLY affects runs
+          that have a snapshot (i.e. runs created after the snapshot feature
+          shipped).
+
+        * **No snapshot** — the legacy delete-created-only path, BYTE-COMPATIBLE
+          with the pre-uc51o.5 behaviour: deletes run-created entities, prefers
+          the surgical journal-driven un-merge, else restores ``modified``
+          entities. It does NOT require ``confirm`` (true backward compat for
+          legacy / dry-run-then-claimed / capture-failure runs that have no
+          snapshot to overwrite from).
 
         Args:
             execution_id: ID of the execution to rollback
             rolled_back_by: Who/what initiated the rollback
+            confirm: Acknowledgement of the optimistic-overwrite warning. Only
+                consulted when a snapshot is present; ignored on the legacy
+                no-snapshot path.
 
         Returns:
-            Dict with rollback results
+            Dict with rollback results. The snapshot path returns the
+            :meth:`restore_snapshot` shape (``removed_channels`` /
+            ``restored_channels`` / ``failed_channels``); the legacy path
+            returns the unchanged ``entities_removed`` / ``entities_restored``
+            shape.
         """
         session = get_session()
         try:
@@ -300,6 +334,52 @@ class AutoCreationEngine:
 
             if execution.mode == "dry_run":
                 return {"success": False, "error": "Cannot rollback a dry-run execution"}
+
+            # --- uc51o.5: unify on the snapshot when one exists ---------------
+            # If this execution has a pre-run snapshot, the FULL restore is the
+            # right revert (the legacy path cannot re-add streams the run
+            # removed — ADR-010 Context). Because restore is an optimistic
+            # overwrite that can clobber post-run edits (§D5), it requires the
+            # SAME confirm acknowledgement as /restore-snapshot. Refuse without
+            # it rather than silently widening the blast radius; the no-snapshot
+            # path below is untouched and keeps its no-confirm semantics.
+            has_snapshot = session.query(AutoCreationSnapshot.id).filter(
+                AutoCreationSnapshot.execution_id == execution_id
+            ).first() is not None
+
+            if has_snapshot:
+                if not confirm:
+                    logger.info(
+                        "[AUTO-CREATE-ENGINE] Rollback of execution %s has a "
+                        "snapshot; refusing without confirm (would overwrite "
+                        "post-run edits)",
+                        execution_id,
+                    )
+                    return {
+                        "success": False,
+                        "has_snapshot": True,
+                        "requires_confirm": True,
+                        "error": (
+                            f"Execution {execution_id} has a pre-run snapshot, "
+                            f"so rollback performs a FULL restore that "
+                            f"overwrites the current stream assignments of "
+                            f"every snapshot channel with the pre-run state — "
+                            f"any changes made after the run will be lost. "
+                            f"Re-send with confirm=true (or use "
+                            f"/restore-snapshot) to acknowledge."
+                        ),
+                    }
+                # Confirmed: delegate to the full snapshot-restore. Close this
+                # session first — restore_snapshot opens its own.
+                logger.info(
+                    "[AUTO-CREATE-ENGINE] Rollback of execution %s delegating "
+                    "to snapshot-restore (snapshot present, confirmed)",
+                    execution_id,
+                )
+                session.close()
+                return await self.restore_snapshot(
+                    execution_id, restored_by=rolled_back_by
+                )
 
             logger.info("[AUTO-CREATE-ENGINE] Rolling back execution %s", execution_id)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0020",
+    version="0.17.3-0021",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -1235,7 +1235,7 @@ async def get_auto_creation_executions(
     """Get auto-creation execution history."""
     logger.debug("[AUTO-CREATE] GET /executions - limit=%s offset=%s rule_id=%s status=%s", limit, offset, rule_id, status)
     try:
-        from models import AutoCreationExecution
+        from models import AutoCreationExecution, AutoCreationSnapshot
         session = get_session()
         try:
             query = session.query(AutoCreationExecution)
@@ -1250,8 +1250,32 @@ async def get_auto_creation_executions(
                 AutoCreationExecution.started_at.desc()
             ).offset(offset).limit(limit).all()
 
+            # Derive has_snapshot (ADR-010 §D6) — a boolean from the existence
+            # of an AutoCreationSnapshot row, NOT a denormalized column (which
+            # could drift from the FK truth). uc51o.6 (MCP) and uc51o.7 (UI)
+            # gate the snapshot-restore affordance on this flag. Resolve it with
+            # ONE query over the page's execution ids (an IN over the snapshot
+            # FK index) — never one query per execution (no N+1).
+            page_ids = [e.id for e in executions]
+            snapshotted_ids: set[int] = set()
+            if page_ids:
+                snapshotted_ids = {
+                    row[0]
+                    for row in session.query(
+                        AutoCreationSnapshot.execution_id
+                    ).filter(
+                        AutoCreationSnapshot.execution_id.in_(page_ids)
+                    ).all()
+                }
+
+            execution_dicts = []
+            for e in executions:
+                d = e.to_dict()
+                d["has_snapshot"] = e.id in snapshotted_ids
+                execution_dicts.append(d)
+
             return {
-                "executions": [e.to_dict() for e in executions],
+                "executions": execution_dicts,
                 "total": total,
                 "limit": limit,
                 "offset": offset
@@ -1336,9 +1360,49 @@ async def get_auto_creation_execution_snapshot(execution_id: int):
 
 
 @router.post("/executions/{execution_id}/rollback")
-async def rollback_auto_creation_execution(execution_id: int, _admin=RequireAdminIfEnabled):
-    """Rollback an auto-creation execution. Admin only."""
-    logger.debug("[AUTO-CREATE] POST /executions/%s/rollback", execution_id)
+async def rollback_auto_creation_execution(
+    execution_id: int,
+    confirm: bool = Query(
+        False,
+        description=(
+            "Acknowledgement of the optimistic-overwrite warning (ADR-010 §D5), "
+            "REQUIRED only when the execution has a pre-run snapshot. When a "
+            "snapshot exists, rollback performs a FULL restore that overwrites "
+            "the current stream assignments of every snapshot channel with the "
+            "pre-run state — any changes made after the run will be LOST. "
+            "Executions with NO snapshot ignore this flag and keep the legacy "
+            "delete-created-only behaviour (no confirm needed)."
+        ),
+    ),
+    _admin=RequireAdminIfEnabled,
+):
+    """Rollback an auto-creation execution. Admin only.
+
+    UNIFIED REVERT (ADR-010 §D8, uc51o.5). The behaviour is chosen from whether
+    the execution has a pre-run snapshot:
+
+    * **Snapshot present** — performs the FULL whole-run restore (delegates to
+      the same path as ``/restore-snapshot``): re-adds streams the run removed,
+      removes streams it added, restores drifted metadata. Because this is an
+      OPTIMISTIC OVERWRITE that can clobber edits made after the run, it
+      REQUIRES ``confirm=true``; without it the call is refused with HTTP 409
+      and a message explaining the overwrite. The response carries
+      ``removed_channels`` / ``restored_channels`` / ``failed_channels``.
+    * **No snapshot** — the legacy delete-created-only rollback, BYTE-COMPATIBLE
+      with the pre-uc51o.5 behaviour (no ``confirm`` required). The response
+      carries ``entities_removed`` / ``entities_restored``.
+
+    Status codes:
+      * 409 — the execution has a snapshot and ``confirm`` was not set.
+      * 400 — other guard failures (already rolled back, dry-run, nothing to
+        undo).
+      * 200 — rollback performed (legacy or restore shape; on the restore path
+        ``success`` is False with ``failed_channels`` when any channel failed).
+    """
+    logger.debug(
+        "[AUTO-CREATE] POST /executions/%s/rollback (confirm=%s)",
+        execution_id, confirm,
+    )
     try:
         from auto_creation_engine import get_auto_creation_engine, init_auto_creation_engine
 
@@ -1348,23 +1412,56 @@ async def rollback_auto_creation_execution(execution_id: int, _admin=RequireAdmi
             client = get_client()
             engine = await init_auto_creation_engine(client)
 
-        result = await engine.rollback_execution(execution_id, rolled_back_by="api")
+        result = await engine.rollback_execution(
+            execution_id, rolled_back_by="api", confirm=confirm,
+        )
 
         if not result["success"]:
-            raise HTTPException(status_code=400, detail=result.get("error", "Rollback failed"))
+            # Snapshot present + no confirm → 409 (acknowledge the overwrite,
+            # uc51o.5). The restore path still returns success=False WITH
+            # restore counts on a partial failure; that is handled below as a
+            # 200 success-with-warnings, so only guard failures land here.
+            if result.get("requires_confirm"):
+                raise HTTPException(status_code=409, detail=result.get("error"))
+            # A restore that was ATTEMPTED returns counts even when success is
+            # False (partial failure) — let that fall through to 200. Only
+            # pre-attempt guard failures (no counts) become 400.
+            if "restored_channels" not in result:
+                raise HTTPException(
+                    status_code=400, detail=result.get("error", "Rollback failed"),
+                )
 
-        # Log to journal
+        # Journal — the description adapts to whichever revert path ran. The
+        # snapshot-restore path returns removed_channels/restored_channels; the
+        # legacy path returns entities_removed/entities_restored.
         rule_name = result.get("rule_name", f"Execution {execution_id}")
-        removed = result.get("entities_removed", 0)
-        restored = result.get("entities_restored", 0)
         session = get_session()
         try:
+            if "restored_channels" in result:
+                # Full snapshot-restore path.
+                removed = result.get("removed_channels", 0)
+                restored = result.get("restored_channels", 0)
+                failed = len(result.get("failed_channels", []))
+                description = (
+                    f"Rolled back '{rule_name}' via snapshot restore: "
+                    f"removed {removed} created channel(s), "
+                    f"restored {restored} channel(s)"
+                    + (f", {failed} failed" if failed else "")
+                )
+            else:
+                # Legacy delete-created-only path.
+                removed = result.get("entities_removed", 0)
+                restored = result.get("entities_restored", 0)
+                description = (
+                    f"Rolled back '{rule_name}': removed {removed} channel(s), "
+                    f"restored {restored} entit{'y' if restored == 1 else 'ies'}"
+                )
             journal.log_entry(
                 category="auto_creation",
                 action_type="rollback",
                 entity_id=execution_id,
                 entity_name=rule_name,
-                description=f"Rolled back '{rule_name}': removed {removed} channel(s), restored {restored} entit{'y' if restored == 1 else 'ies'}"
+                description=description,
             )
         finally:
             session.close()

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0020"
+APP_VERSION = "0.17.3-0021"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/tests/routers/test_auto_creation.py
+++ b/backend/tests/routers/test_auto_creation.py
@@ -1328,6 +1328,83 @@ class TestGetExecutions:
         assert data["total"] == 5
         assert len(data["executions"]) == 2
 
+    @pytest.mark.asyncio
+    async def test_has_snapshot_flag(self, async_client, test_session):
+        """Each execution carries a derived has_snapshot boolean (ADR-010 §D6):
+        true for executions that have an AutoCreationSnapshot row, false
+        otherwise. uc51o.6/.7 gate the snapshot-restore affordance on it."""
+        from models import AutoCreationSnapshot
+
+        with_snap = _create_execution(test_session, rule_name="HasSnap")
+        without_snap = _create_execution(test_session, rule_name="NoSnap")
+
+        snapshot = AutoCreationSnapshot(
+            execution_id=with_snap.id,
+            snapshot_time=datetime.utcnow(),
+            channel_count=1,
+        )
+        snapshot.set_channels_data({"channels": [
+            {"id": 10, "name": "ESPN", "stream_ids": [501]},
+        ]})
+        test_session.add(snapshot)
+        test_session.commit()
+
+        response = await async_client.get("/api/auto-creation/executions")
+        assert response.status_code == 200
+        flags = {e["id"]: e["has_snapshot"] for e in response.json()["executions"]}
+        assert flags[with_snap.id] is True
+        assert flags[without_snap.id] is False
+
+    @pytest.mark.asyncio
+    async def test_has_snapshot_no_n_plus_one(self, async_client, test_session):
+        """has_snapshot is resolved with a SINGLE existence query over the page's
+        ids, not one query per execution. Asserts the snapshot table is hit at
+        most once regardless of page size (no N+1)."""
+        from models import AutoCreationSnapshot
+
+        execs = [_create_execution(test_session, rule_name=f"E{i}") for i in range(5)]
+        # Snapshot a couple of them.
+        for ex in execs[:2]:
+            snap = AutoCreationSnapshot(
+                execution_id=ex.id, snapshot_time=datetime.utcnow(), channel_count=0,
+            )
+            snap.set_channels_data({"channels": []})
+            test_session.add(snap)
+        test_session.commit()
+
+        # Count how many times the AutoCreationSnapshot table is queried while
+        # building the list response. A per-execution lookup would be 5 (N);
+        # the batched IN query is exactly 1. We wrap Session.query and inspect
+        # its args (the snapshot probe is session.query(AutoCreationSnapshot
+        # .execution_id) — a column attribute owned by AutoCreationSnapshot).
+        from sqlalchemy.orm import Session
+
+        snapshot_query_count = 0
+        orig_query = Session.query
+
+        def _is_snapshot_arg(a):
+            return (
+                a is AutoCreationSnapshot
+                or getattr(a, "class_", None) is AutoCreationSnapshot
+            )
+
+        def counting_query(self, *args, **kwargs):
+            nonlocal snapshot_query_count
+            if any(_is_snapshot_arg(a) for a in args):
+                snapshot_query_count += 1
+            return orig_query(self, *args, **kwargs)
+
+        with patch.object(Session, "query", counting_query):
+            response = await async_client.get("/api/auto-creation/executions")
+
+        assert response.status_code == 200
+        assert len(response.json()["executions"]) == 5
+        # Exactly one query against the snapshot table — never one per execution.
+        assert snapshot_query_count == 1, (
+            f"expected 1 snapshot query (batched IN), got {snapshot_query_count} "
+            "— likely an N+1"
+        )
+
 
 class TestGetExecution:
     """Tests for GET /api/auto-creation/executions/{execution_id}."""
@@ -1443,6 +1520,92 @@ class TestRollbackExecution:
             response = await async_client.post("/api/auto-creation/executions/1/rollback")
 
         assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_legacy_path_needs_no_confirm(self, async_client):
+        """uc51o.5: a no-snapshot run is rolled back without confirm (byte-compat).
+        The endpoint passes confirm=False through to the engine."""
+        mock_engine = AsyncMock()
+        mock_engine.rollback_execution.return_value = {
+            "success": True,
+            "rule_name": "Sports Rule",
+            "entities_removed": 3,
+            "entities_restored": 0,
+        }
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post("/api/auto-creation/executions/1/rollback")
+        assert response.status_code == 200
+        # confirm defaulted to False and was threaded to the engine.
+        _, kwargs = mock_engine.rollback_execution.call_args
+        assert kwargs.get("confirm") is False
+
+    @pytest.mark.asyncio
+    async def test_snapshot_present_without_confirm_returns_409(self, async_client):
+        """uc51o.5: a snapshotted run rolled back WITHOUT confirm → 409 (the
+        overwrite acknowledgement is required). The engine signals this with
+        requires_confirm."""
+        mock_engine = AsyncMock()
+        mock_engine.rollback_execution.return_value = {
+            "success": False,
+            "has_snapshot": True,
+            "requires_confirm": True,
+            "error": (
+                "Execution 1 has a pre-run snapshot, so rollback performs a "
+                "FULL restore that overwrites ... confirm=true."
+            ),
+        }
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine):
+            response = await async_client.post("/api/auto-creation/executions/1/rollback")
+        assert response.status_code == 409
+        assert "confirm" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_snapshot_present_with_confirm_does_full_restore(self, async_client):
+        """uc51o.5: confirm=true on a snapshotted run runs the full restore and
+        returns the restore-shaped result (restored_channels)."""
+        mock_engine = AsyncMock()
+        mock_engine.rollback_execution.return_value = {
+            "success": True,
+            "rule_name": "Sports Rule",
+            "removed_channels": 1,
+            "restored_channels": 5,
+            "failed_channels": [],
+        }
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post(
+                "/api/auto-creation/executions/1/rollback?confirm=true"
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["restored_channels"] == 5
+        _, kwargs = mock_engine.rollback_execution.call_args
+        assert kwargs.get("confirm") is True
+
+    @pytest.mark.asyncio
+    async def test_snapshot_partial_failure_is_200_with_failures(self, async_client):
+        """uc51o.5: a partial restore via /rollback returns 200 success=False
+        with failures surfaced — never a blanket 500."""
+        mock_engine = AsyncMock()
+        mock_engine.rollback_execution.return_value = {
+            "success": False,
+            "rule_name": "Sports Rule",
+            "removed_channels": 0,
+            "restored_channels": 4,
+            "failed_channels": [{"id": 11, "name": "GONE", "error": "404"}],
+        }
+        with patch("auto_creation_engine.get_auto_creation_engine", return_value=mock_engine), \
+             patch("routers.auto_creation.journal"):
+            response = await async_client.post(
+                "/api/auto-creation/executions/1/rollback?confirm=true"
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["restored_channels"] == 4
+        assert len(data["failed_channels"]) == 1
 
 
 class TestRestoreSnapshot:

--- a/backend/tests/unit/test_0hjrk_rollback.py
+++ b/backend/tests/unit/test_0hjrk_rollback.py
@@ -24,6 +24,34 @@ from unittest.mock import MagicMock, AsyncMock, patch
 from auto_creation_engine import AutoCreationEngine
 
 
+def _route_rollback_queries(mock_session, mock_execution):
+    """Route the uc51o.5 snapshot-existence probe to None so these LEGACY
+    (no-snapshot) rollback tests stay on the delete-created-only path.
+
+    ``rollback_execution`` now probes for an AutoCreationSnapshot and diverts to
+    the full restore when one exists. A flat ``mock_session.query.return_value``
+    returns the same chain for every query, so the probe would see the execution
+    mock and wrongly treat the run as snapshotted. These tests model no-snapshot
+    runs, so the snapshot query must return None.
+    """
+    from models import AutoCreationSnapshot
+
+    exec_chain = MagicMock()
+    exec_chain.filter.return_value.first.return_value = mock_execution
+    none_chain = MagicMock()
+    none_chain.filter.return_value.first.return_value = None
+
+    def _is_snapshot_arg(a):
+        return a is AutoCreationSnapshot or getattr(a, "class_", None) is AutoCreationSnapshot
+
+    def _query(*args, **kwargs):
+        if any(_is_snapshot_arg(a) for a in args):
+            return none_chain
+        return exec_chain
+
+    mock_session.query.side_effect = _query
+
+
 class TestRollbackUnmergeMergeOnlyRun:
     """A merge-only run (0 created, modified present) un-merges on rollback."""
 
@@ -55,7 +83,7 @@ class TestRollbackUnmergeMergeOnlyRun:
         mock_execution.get_modified_entities.return_value = [
             {"type": "channel", "id": 3, "name": "ESPN", "previous": {"streams": [10]}},
         ]
-        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+        _route_rollback_queries(mock_session, mock_execution)
 
         result = asyncio.get_event_loop().run_until_complete(
             self.engine.rollback_execution(1)
@@ -92,7 +120,7 @@ class TestRollbackRefusesWhenNoRestoreData:
         mock_execution.mode = "execute"
         mock_execution.get_created_entities.return_value = []
         mock_execution.get_modified_entities.return_value = []
-        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+        _route_rollback_queries(mock_session, mock_execution)
 
         result = asyncio.get_event_loop().run_until_complete(
             self.engine.rollback_execution(42)
@@ -124,7 +152,7 @@ class TestRollbackRefusesWhenNoRestoreData:
             {"type": "channel", "id": 1, "name": "ESPN"},
         ]
         mock_execution.get_modified_entities.return_value = []
-        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+        _route_rollback_queries(mock_session, mock_execution)
 
         result = asyncio.get_event_loop().run_until_complete(
             self.engine.rollback_execution(7)
@@ -147,7 +175,7 @@ class TestRollbackRefusesWhenNoRestoreData:
         mock_execution.get_modified_entities.return_value = [
             {"type": "channel", "id": 3, "name": "ESPN", "previous": {"streams": [10]}},
         ]
-        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+        _route_rollback_queries(mock_session, mock_execution)
 
         result = asyncio.get_event_loop().run_until_complete(
             self.engine.rollback_execution(9)
@@ -165,7 +193,7 @@ class TestRollbackRefusesWhenNoRestoreData:
 
         mock_execution = MagicMock()
         mock_execution.status = "rolled_back"
-        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+        _route_rollback_queries(mock_session, mock_execution)
 
         result = asyncio.get_event_loop().run_until_complete(
             self.engine.rollback_execution(1)

--- a/backend/tests/unit/test_auto_creation_engine.py
+++ b/backend/tests/unit/test_auto_creation_engine.py
@@ -359,6 +359,38 @@ class TestAutoCreationEngineRunPipeline:
         assert result["message"] == "No enabled rules to process"
 
 
+def _route_rollback_queries(mock_session, mock_execution):
+    """Wire a MagicMock session so the LEGACY (no-snapshot) rollback path runs.
+
+    uc51o.5 made ``rollback_execution`` first probe for an AutoCreationSnapshot
+    and divert to the full restore when one exists. A plain
+    ``mock_session.query.return_value...`` returns the SAME chain for every
+    query, so the snapshot-existence probe would wrongly see the execution mock
+    and treat the run as snapshotted. These legacy tests model NO-snapshot runs,
+    so route the AutoCreationSnapshot probe to None and everything else to the
+    execution.
+    """
+    from models import AutoCreationSnapshot
+
+    exec_chain = MagicMock()
+    exec_chain.filter.return_value.first.return_value = mock_execution
+    none_chain = MagicMock()
+    none_chain.filter.return_value.first.return_value = None
+
+    def _is_snapshot_arg(a):
+        # The probe is session.query(AutoCreationSnapshot.id) — a column
+        # attribute whose owning class is AutoCreationSnapshot. Also match the
+        # class itself for robustness.
+        return a is AutoCreationSnapshot or getattr(a, "class_", None) is AutoCreationSnapshot
+
+    def _query(*args, **kwargs):
+        if any(_is_snapshot_arg(a) for a in args):
+            return none_chain
+        return exec_chain
+
+    mock_session.query.side_effect = _query
+
+
 class TestAutoCreationEngineRollback:
     """Tests for rollback functionality."""
 
@@ -435,7 +467,7 @@ class TestAutoCreationEngineRollback:
         mock_execution.get_modified_entities.return_value = [
             {"type": "channel", "id": 3, "name": "CNN", "previous": {"logo_url": "old.png"}},
         ]
-        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+        _route_rollback_queries(mock_session, mock_execution)
 
         result = asyncio.get_event_loop().run_until_complete(
             self.engine.rollback_execution(1)
@@ -467,7 +499,7 @@ class TestAutoCreationEngineRollback:
             {"type": "channel", "id": 1, "name": "ESPN"},
         ]
         mock_execution.get_modified_entities.return_value = []
-        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+        _route_rollback_queries(mock_session, mock_execution)
 
         # Make delete fail
         self.client.delete_channel = AsyncMock(side_effect=Exception("API error"))
@@ -509,7 +541,7 @@ class TestAutoCreationEngineRollback:
             {"type": "channel", "id": 3, "name": "ESPN", "previous": {"streams": [10, 11]}},
             {"type": "channel", "id": 3, "name": "ESPN", "previous": {"streams": [10, 11, 12]}},
         ]
-        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+        _route_rollback_queries(mock_session, mock_execution)
 
         result = asyncio.get_event_loop().run_until_complete(
             self.engine.rollback_execution(1)

--- a/backend/tests/unit/test_auto_creation_snapshot_restore.py
+++ b/backend/tests/unit/test_auto_creation_snapshot_restore.py
@@ -339,3 +339,169 @@ class TestRestoreGuards:
         assert result["success"] is False
         assert "already reverted" in result["error"].lower()
         client.update_channel.assert_not_called()
+
+
+class TestUnifiedRollback:
+    """uc51o.5 — ``rollback_execution`` unifies on the snapshot when present.
+
+    * Snapshot present + confirm → delegates to the FULL snapshot-restore.
+    * Snapshot present + NO confirm → refused with ``requires_confirm`` (the
+      blast-radius guard; the router maps this to 409). NOT a silent overwrite.
+    * NO snapshot → the legacy delete-created-only path, BYTE-COMPATIBLE: no
+      confirm needed, ``entities_removed`` / ``entities_restored`` shape, no
+      full-replace PATCHes.
+    """
+
+    def test_snapshot_present_with_confirm_does_full_restore(self, db_session_factory):
+        """A snapshotted run + confirm=True runs the full restore: created
+        channels deleted, every snapshot channel's streams full-replaced."""
+        channels = [
+            {"id": 10, "name": "ESPN", "channel_group_id": 1,
+             "epg_data_id": 99, "tvg_id": "espn.us", "stream_ids": [501, 502]},
+            {"id": 11, "name": "CNN", "stream_ids": [601]},
+        ]
+        created = [{"type": "channel", "id": 500, "name": "New Sports"}]
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, created_entities=created, channels=channels,
+        )
+
+        engine, client = _make_engine_with_client()
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            result = _run(engine.rollback_execution(execution_id, confirm=True))
+
+        # Restore-shaped result (not the legacy entities_* shape).
+        assert result["success"] is True
+        assert result["restored_channels"] == 2
+        assert result["removed_channels"] == 1
+        assert "entities_removed" not in result
+        # Full-replace PATCHes were issued — the snapshot-restore path ran.
+        assert client.update_channel.await_count == 2
+        client.delete_channel.assert_awaited_once_with(500)
+        # Terminal state set (shared rolled_back).
+        session = db_session_factory()
+        try:
+            ex = session.query(AutoCreationExecution).filter(
+                AutoCreationExecution.id == execution_id
+            ).first()
+            assert ex.status == "rolled_back"
+            assert ex.rolled_back_by == "api" or ex.rolled_back_by == "manual"
+        finally:
+            session.close()
+
+    def test_snapshot_present_passes_rolled_back_by_through(self, db_session_factory):
+        """The unified rollback threads rolled_back_by into restore's
+        restored_by so the audit row records the real initiator."""
+        channels = [{"id": 10, "name": "ESPN", "stream_ids": [501]}]
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, channels=channels,
+        )
+        engine, _client = _make_engine_with_client()
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            _run(engine.rollback_execution(
+                execution_id, rolled_back_by="api", confirm=True,
+            ))
+        session = db_session_factory()
+        try:
+            ex = session.query(AutoCreationExecution).filter(
+                AutoCreationExecution.id == execution_id
+            ).first()
+            assert ex.rolled_back_by == "api"
+        finally:
+            session.close()
+
+    def test_snapshot_present_without_confirm_is_refused(self, db_session_factory):
+        """A snapshotted run with NO confirm must NOT silently overwrite — it is
+        refused with requires_confirm/has_snapshot flags and mutates nothing."""
+        channels = [{"id": 10, "name": "ESPN", "stream_ids": [501]}]
+        created = [{"type": "channel", "id": 500, "name": "New Sports"}]
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, created_entities=created, channels=channels,
+        )
+
+        engine, client = _make_engine_with_client()
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            result = _run(engine.rollback_execution(execution_id))  # confirm defaults False
+
+        assert result["success"] is False
+        assert result["requires_confirm"] is True
+        assert result["has_snapshot"] is True
+        assert "confirm" in result["error"].lower()
+        # Nothing was mutated — no delete, no PATCH.
+        client.update_channel.assert_not_called()
+        client.delete_channel.assert_not_called()
+        # Execution NOT marked terminal.
+        session = db_session_factory()
+        try:
+            ex = session.query(AutoCreationExecution).filter(
+                AutoCreationExecution.id == execution_id
+            ).first()
+            assert ex.status == "completed"
+        finally:
+            session.close()
+
+    def test_no_snapshot_runs_legacy_path_without_confirm(self, db_session_factory):
+        """A run with NO snapshot keeps the legacy delete-created-only behaviour,
+        BYTE-COMPATIBLE: works without confirm, returns entities_* counts, and
+        does NOT issue full-replace restore PATCHes (no snapshot to replace
+        from). This is the true backward-compat path."""
+        created = [
+            {"type": "channel", "id": 500, "name": "New Sports"},
+            {"type": "group", "id": 77, "name": "New Group"},
+        ]
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, created_entities=created, with_snapshot=False,
+        )
+
+        engine, client = _make_engine_with_client()
+        # No merge journal entries → surgical unmerge returns (False, 0); with no
+        # modified entities the legacy path simply deletes created entities.
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory), \
+             patch.object(engine, "_journal_driven_unmerge",
+                          new=AsyncMock(return_value=(False, 0))):
+            result = _run(engine.rollback_execution(execution_id))  # NO confirm
+
+        # Legacy shape — NOT the restore shape.
+        assert result["success"] is True
+        assert result["entities_removed"] == 2
+        assert "restored_channels" not in result
+        # Created entities deleted; no full-replace restore PATCH.
+        client.delete_channel.assert_awaited_once_with(500)
+        client.delete_channel_group.assert_awaited_once_with(77)
+        client.update_channel.assert_not_called()
+        # Terminal state set via the legacy path.
+        session = db_session_factory()
+        try:
+            ex = session.query(AutoCreationExecution).filter(
+                AutoCreationExecution.id == execution_id
+            ).first()
+            assert ex.status == "rolled_back"
+        finally:
+            session.close()
+
+    def test_no_snapshot_confirm_ignored(self, db_session_factory):
+        """On the no-snapshot path the confirm flag is irrelevant — passing it
+        (or not) yields the identical legacy result."""
+        created = [{"type": "channel", "id": 500, "name": "New Sports"}]
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, created_entities=created, with_snapshot=False,
+        )
+        engine, client = _make_engine_with_client()
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory), \
+             patch.object(engine, "_journal_driven_unmerge",
+                          new=AsyncMock(return_value=(False, 0))):
+            result = _run(engine.rollback_execution(execution_id, confirm=True))
+        assert result["success"] is True
+        assert result["entities_removed"] == 1
+        assert "requires_confirm" not in result
+
+    def test_no_snapshot_guards_unchanged(self, db_session_factory):
+        """The legacy refuse-when-nothing-to-undo guard still fires on a
+        no-snapshot run with zero created AND zero modified entities."""
+        execution_id = _seed_execution_and_snapshot(
+            db_session_factory, created_entities=[], with_snapshot=False,
+        )
+        engine, _client = _make_engine_with_client()
+        with patch("auto_creation_engine.get_session", side_effect=db_session_factory):
+            result = _run(engine.rollback_execution(execution_id))
+        assert result["success"] is False
+        assert "no recorded" in result["error"].lower()

--- a/backend/tests/unit/test_scored_fuzzy_rollback.py
+++ b/backend/tests/unit/test_scored_fuzzy_rollback.py
@@ -19,6 +19,37 @@ def _run(coro):
     return asyncio.get_event_loop().run_until_complete(coro)
 
 
+def _route_rollback_queries(mock_session, mock_execution):
+    """Route the uc51o.5 AutoCreationSnapshot-existence probe to None so these
+    LEGACY (no-snapshot) rollback tests stay on the entity-rollback /
+    surgical-unmerge path.
+
+    NOTE: "snapshot restore" in these test names refers to the legacy
+    ``_rollback_modified_entity`` modified-entity fallback, NOT the ADR-010
+    AutoCreationSnapshot table. ``rollback_execution`` now first probes the
+    AutoCreationSnapshot table; a flat ``mock_session.query.return_value``
+    returns the same chain for every query, which would make that probe see the
+    execution mock and divert to the FULL restore. These runs have no
+    AutoCreationSnapshot, so route that probe to None.
+    """
+    from models import AutoCreationSnapshot
+
+    exec_chain = MagicMock()
+    exec_chain.filter.return_value.first.return_value = mock_execution
+    none_chain = MagicMock()
+    none_chain.filter.return_value.first.return_value = None
+
+    def _is_snapshot_arg(a):
+        return a is AutoCreationSnapshot or getattr(a, "class_", None) is AutoCreationSnapshot
+
+    def _query(*args, **kwargs):
+        if any(_is_snapshot_arg(a) for a in args):
+            return none_chain
+        return exec_chain
+
+    mock_session.query.side_effect = _query
+
+
 class TestAddedStreamIds:
     def test_after_minus_before(self):
         added = AutoCreationEngine._added_stream_ids(
@@ -59,7 +90,7 @@ class TestSurgicalUnmerge:
             {"type": "channel", "id": 3, "name": "WBAY",
              "previous": {"streams": [10]}},
         ]
-        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+        _route_rollback_queries(mock_session, mock_execution)
 
         # Journal records the merge: before [10], after [10, 11].
         mock_get_entries.return_value = {
@@ -99,7 +130,7 @@ class TestSurgicalUnmerge:
             {"type": "channel", "id": 3, "name": "ESPN",
              "previous": {"streams": [10]}},
         ]
-        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+        _route_rollback_queries(mock_session, mock_execution)
 
         mock_get_entries.return_value = {"results": []}  # no journal entries
 
@@ -127,7 +158,7 @@ class TestSurgicalUnmerge:
             {"type": "channel", "id": 3, "name": "WBAY",
              "previous": {"streams": [10]}},
         ]
-        mock_session.query.return_value.filter.return_value.first.return_value = mock_execution
+        _route_rollback_queries(mock_session, mock_execution)
         mock_get_entries.return_value = {
             "results": [
                 {"entity_id": 3, "action_type": "merge_stream",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0020",
+  "version": "0.17.3-0021",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Phase 4a of the **uc51o epic** — unify the legacy rollback with snapshot-restore, and surface the `has_snapshot` contract that the MCP (`.6`) and UI (`.7`) consumers need.

## uc51o.5 — unified rollback
`rollback_execution` / `POST /executions/{id}/rollback` now: if a snapshot exists → full snapshot-restore (`restore_snapshot`); if none → unchanged legacy delete-created-only.

**Behavioral change (PO-aware, fails safe):**
- **No-snapshot runs** (all pre-feature executions, dry-run-then-claimed, capture-failures): `/rollback` works with **no confirm**, exactly as before — byte-compatible.
- **Snapshotted runs** (post-feature only): `/rollback` now performs a full optimistic-overwrite restore, so it **requires `confirm=true`** — without it, **409** explaining the overwrite and pointing to `confirm=true` or `/restore-snapshot`. This deliberately refuses to silently widen `/rollback`'s blast radius; `.6`/`.7` build the confirm affordance and gate on `has_snapshot`.

## Shared — `has_snapshot` on the executions list
`GET /executions` adds a derived `has_snapshot` boolean per execution (from snapshot-row existence), **batched** (one `IN` query per page, no N+1).

## Verification (independent)
- Gate (`-k "rollback or snapshot or restore or executions"`): **155 passed, 0 failed**; full backend suite green per the engineer (5152 passed). Sibling rollback tests updated to model no-snapshot runs.
- Version consistency: all 3 at `0.17.3-0021`.

Next: Phase 4b — `.6` (MCP `restore_auto_creation_snapshot` + `has_snapshot`) and `.7` (revert UI), built in parallel against this contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)