### PR TITLE
v0.17.3-0022: Auto-creation revert — MCP tool + revert UI (uc51o.6/.7, closes epic)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0021",
+    version="0.17.3-0022",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0021"
+APP_VERSION = "0.17.3-0022"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0021",
+  "version": "0.17.3-0022",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/autoCreation/AutoCreationTab.css
+++ b/frontend/src/components/autoCreation/AutoCreationTab.css
@@ -956,3 +956,135 @@
   flex-shrink: 0;
   margin-top: 1px;
 }
+
+/* =============================================================================
+   Snapshot-Restore Affordance (ADR-010 uc51o.7)
+   Shared classes used: .action-btn (common.css), .detail-row (this file),
+   .modal-container / .modal-header / .modal-body / .modal-footer (ModalBase.css),
+   .btn-secondary / .btn-danger / .btn-primary (common.css), .spinning (common.css)
+   ============================================================================= */
+
+/* Revert button variant — same size as .action-btn, amber tint on hover
+   to signal the destructive nature before the confirm dialog. */
+.action-btn-revert:hover {
+  color: var(--status-warning, #f59e0b);
+}
+
+/* Legacy-run indicator: shown when has_snapshot=false and mode=execute.
+   Muted icon; not a button — just informational. */
+.execution-no-snapshot {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px;
+  color: var(--text-muted);
+  cursor: default;
+  font-size: 18px;
+  opacity: 0.5;
+}
+
+/* Warning banner inside the revert-confirm modal (§D5 mandatory warning). */
+.revert-warning-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: var(--radius-lg);
+  margin-bottom: 12px;
+}
+
+.revert-warning-banner p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+.revert-warning-icon {
+  color: var(--status-warning, #f59e0b);
+  font-size: 20px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.revert-warning-detail {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* Partial-failure warning in the result summary. */
+.revert-partial-failure {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 14px;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: var(--radius-lg);
+  margin-bottom: 12px;
+}
+
+.revert-partial-failure p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* Result stat rows — reuse .detail-row defined above. */
+.revert-result-stats {
+  margin-bottom: 12px;
+}
+
+.revert-failed-count {
+  color: var(--status-error, #ef4444);
+  font-weight: 600;
+}
+
+/* Failed-channels list. */
+.revert-failed-channels {
+  margin-top: 8px;
+}
+
+.revert-failed-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin: 0 0 6px;
+}
+
+.revert-failed-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.revert-failed-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 10px;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-md);
+  font-size: 12px;
+}
+
+.revert-failed-name {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.revert-failed-error {
+  color: var(--status-error, #ef4444);
+  font-style: italic;
+}

--- a/frontend/src/components/autoCreation/AutoCreationTab.test.tsx
+++ b/frontend/src/components/autoCreation/AutoCreationTab.test.tsx
@@ -474,6 +474,182 @@ describe('AutoCreationTab', () => {
     });
   });
 
+  describe('snapshot revert affordance (ADR-010 uc51o.7)', () => {
+    it('shows the revert button when has_snapshot is true', async () => {
+      mockDataStore.autoCreationExecutions.push(
+        createMockAutoCreationExecution({ status: 'completed', mode: 'execute', has_snapshot: true })
+      );
+
+      renderWithProviders(<AutoCreationTab />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /undo this run/i })).toBeInTheDocument();
+      });
+    });
+
+    it('hides the revert button when has_snapshot is false', async () => {
+      mockDataStore.autoCreationExecutions.push(
+        createMockAutoCreationExecution({ status: 'completed', mode: 'execute', has_snapshot: false })
+      );
+
+      renderWithProviders(<AutoCreationTab />);
+
+      await waitFor(() => {
+        // Execution item should appear
+        expect(screen.getByTestId('execution-item')).toBeInTheDocument();
+        // But the revert button must not be rendered
+        expect(screen.queryByRole('button', { name: /undo this run/i })).toBeNull();
+      });
+    });
+
+    it('hides the revert button for dry-run executions even with a snapshot', async () => {
+      // dry-run executions never get a snapshot (ADR-010 §D2), so this combo
+      // should not arise in production — but the UI must still be safe.
+      mockDataStore.autoCreationExecutions.push(
+        createMockAutoCreationExecution({ status: 'completed', mode: 'dry_run', has_snapshot: true })
+      );
+
+      renderWithProviders(<AutoCreationTab />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /undo this run/i })).toBeNull();
+      });
+    });
+
+    it('opens the confirm dialog with the overwrite warning when revert is clicked', async () => {
+      const user = userEvent.setup();
+      mockDataStore.autoCreationExecutions.push(
+        createMockAutoCreationExecution({ status: 'completed', mode: 'execute', has_snapshot: true })
+      );
+
+      renderWithProviders(<AutoCreationTab />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /undo this run/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /undo this run/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        // ADR-010 §D5 mandatory overwrite warning must be visible
+        expect(screen.getByTestId('revert-warning')).toBeInTheDocument();
+        expect(screen.getByText(/overwrite the current stream assignments/i)).toBeInTheDocument();
+      });
+    });
+
+    it('does not call the restore API when the confirm dialog is cancelled', async () => {
+      const user = userEvent.setup();
+      let restoreCalled = false;
+      server.use(
+        http.post('/api/auto-creation/executions/:id/restore-snapshot', () => {
+          restoreCalled = true;
+          return HttpResponse.json({ success: true, removed_channels: 0, restored_channels: 0, failed_channels: [] });
+        })
+      );
+
+      mockDataStore.autoCreationExecutions.push(
+        createMockAutoCreationExecution({ status: 'completed', mode: 'execute', has_snapshot: true })
+      );
+
+      renderWithProviders(<AutoCreationTab />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /undo this run/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /undo this run/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      expect(restoreCalled).toBe(false);
+    });
+
+    it('calls restore-snapshot with confirm=true and shows result summary on confirm', async () => {
+      const user = userEvent.setup();
+      mockDataStore.autoCreationExecutions.push(
+        createMockAutoCreationExecution({
+          status: 'completed',
+          mode: 'execute',
+          has_snapshot: true,
+          channels_created: 3,
+        })
+      );
+
+      renderWithProviders(<AutoCreationTab />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /undo this run/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /undo this run/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('revert-confirm-btn')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('revert-confirm-btn'));
+
+      // After confirm: result summary appears
+      await waitFor(() => {
+        expect(screen.getByTestId('revert-result-stats')).toBeInTheDocument();
+        expect(screen.getByTestId('revert-restored-count')).toBeInTheDocument();
+      });
+    });
+
+    it('surfaces partial failures in the result summary — never shows as plain success', async () => {
+      const user = userEvent.setup();
+      server.use(
+        http.post('/api/auto-creation/executions/:id/restore-snapshot', () => {
+          return HttpResponse.json({
+            success: false,
+            removed_channels: 2,
+            restored_channels: 8,
+            failed_channels: [
+              { id: 101, name: 'ESPN HD', error: 'Channel not found in Dispatcharr' },
+              { id: 102, name: 'CNN', error: 'Stream 9999 no longer exists' },
+            ],
+          });
+        })
+      );
+
+      mockDataStore.autoCreationExecutions.push(
+        createMockAutoCreationExecution({ status: 'completed', mode: 'execute', has_snapshot: true })
+      );
+
+      renderWithProviders(<AutoCreationTab />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /undo this run/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /undo this run/i }));
+      await waitFor(() => screen.getByTestId('revert-confirm-btn'));
+      await user.click(screen.getByTestId('revert-confirm-btn'));
+
+      await waitFor(() => {
+        // Partial-failure warning must be present
+        expect(screen.getByTestId('revert-partial-failure')).toBeInTheDocument();
+        // Failed channels list must appear
+        expect(screen.getByTestId('revert-failed-channels')).toBeInTheDocument();
+        expect(screen.getByText('ESPN HD')).toBeInTheDocument();
+        expect(screen.getByText('CNN')).toBeInTheDocument();
+        expect(screen.getByText('Channel not found in Dispatcharr')).toBeInTheDocument();
+        // Counts rendered
+        expect(screen.getByTestId('revert-restored-count').textContent).toBe('8');
+        expect(screen.getByTestId('revert-failed-count').textContent).toBe('2');
+      });
+    });
+  });
+
   describe('import/export', () => {
     it('shows import/export buttons', () => {
       renderWithProviders(<AutoCreationTab />);

--- a/frontend/src/components/autoCreation/AutoCreationTab.tsx
+++ b/frontend/src/components/autoCreation/AutoCreationTab.tsx
@@ -9,6 +9,8 @@ import type {
   ExecutionLogEntry,
   ActionLogEntry,
   BulkUpdateRulesPatch,
+  RestoreSnapshotResponse,
+  FailedChannel,
 } from '../../types/autoCreation';
 import { useAutoCreationRules } from '../../hooks/useAutoCreationRules';
 import { useAutoCreationExecution } from '../../hooks/useAutoCreationExecution';
@@ -94,6 +96,10 @@ export function AutoCreationTab() {
   const [editingRule, setEditingRule] = useState<AutoCreationRule | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<AutoCreationRule | null>(null);
   const [showRollbackConfirm, setShowRollbackConfirm] = useState<AutoCreationExecution | null>(null);
+  // Snapshot-restore state (ADR-010 §D5 / uc51o.7)
+  const [showRevertConfirm, setShowRevertConfirm] = useState<AutoCreationExecution | null>(null);
+  const [revertLoading, setRevertLoading] = useState(false);
+  const [revertResult, setRevertResult] = useState<RestoreSnapshotResponse | null>(null);
   const [showImportDialog, setShowImportDialog] = useState(false);
   const [showExportDialog, setShowExportDialog] = useState(false);
   const [showExecutionDetails, setShowExecutionDetails] = useState<AutoCreationExecution | null>(null);
@@ -423,6 +429,30 @@ export function AutoCreationTab() {
       }
     }
   }, [showRollbackConfirm, rollback, fetchExecutions, notifications]);
+
+  // Snapshot-restore handlers (ADR-010 §D5/§D8, uc51o.7)
+  const handleRevertClick = useCallback((execution: AutoCreationExecution) => {
+    setRevertResult(null);
+    setShowRevertConfirm(execution);
+  }, []);
+
+  const handleConfirmRevert = useCallback(async () => {
+    if (!showRevertConfirm) return;
+    setRevertLoading(true);
+    try {
+      const result = await autoCreationApi.restoreAutoCreationSnapshot(showRevertConfirm.id);
+      setRevertResult(result);
+      await fetchExecutions();
+    } catch (err) {
+      notifications.error(
+        err instanceof Error ? err.message : 'Failed to restore snapshot',
+        'Auto-Creation',
+      );
+      setShowRevertConfirm(null);
+    } finally {
+      setRevertLoading(false);
+    }
+  }, [showRevertConfirm, fetchExecutions, notifications]);
 
   const handleViewDetails = useCallback(async (execution: AutoCreationExecution) => {
     setShowExecutionDetails(execution);
@@ -940,6 +970,30 @@ export function AutoCreationTab() {
                         <span className="material-icons">undo</span>
                       </button>
                     )}
+                    {/* Snapshot-restore affordance (ADR-010 uc51o.7): shown only
+                        when has_snapshot=true; hidden for dry runs, legacy runs,
+                        and already-reverted executions so the operator always
+                        knows what will happen. */}
+                    {execution.has_snapshot && execution.status === 'completed' && execution.mode === 'execute' && (
+                      <button
+                        className="action-btn action-btn-revert"
+                        onClick={() => handleRevertClick(execution)}
+                        aria-label="Undo this run"
+                        title="Undo this run — restores pre-run channel state from snapshot"
+                        data-testid="revert-btn"
+                      >
+                        <span className="material-icons">settings_backup_restore</span>
+                      </button>
+                    )}
+                    {!execution.has_snapshot && execution.mode === 'execute' && execution.status === 'completed' && (
+                      <span
+                        className="execution-no-snapshot"
+                        title="No pre-run snapshot — only legacy rollback is available for this run"
+                        data-testid="no-snapshot-indicator"
+                      >
+                        <span className="material-icons">history_toggle_off</span>
+                      </span>
+                    )}
                   </div>
                 </div>
               ))}
@@ -1037,6 +1091,130 @@ export function AutoCreationTab() {
                 aria-label="Confirm"
               >
                 Rollback
+              </button>
+            </div>
+          </div>
+        </ModalOverlay>
+      )}
+
+      {/* Snapshot-Restore Confirmation Dialog (ADR-010 §D5 mandatory warning, uc51o.7) */}
+      {showRevertConfirm && !revertResult && (
+        <ModalOverlay
+          onClose={() => { setShowRevertConfirm(null); setRevertResult(null); }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="revert-confirm-title"
+        >
+          <div className="modal-container modal-sm">
+            <div className="modal-header">
+              <h2 id="revert-confirm-title">Undo This Run</h2>
+            </div>
+            <div className="modal-body">
+              <div className="revert-warning-banner" data-testid="revert-warning">
+                <span className="material-icons revert-warning-icon">warning</span>
+                <p>
+                  <strong>This will overwrite the current stream assignments</strong> of all
+                  channels with the state captured before this run on{' '}
+                  <strong>{new Date(showRevertConfirm.started_at).toLocaleString()}</strong>.
+                </p>
+              </div>
+              <p className="revert-warning-detail">
+                Any changes made since that snapshot — manual edits, automatic merges, or
+                Dispatcharr updates — <strong>will be lost</strong>. This cannot be undone.
+              </p>
+            </div>
+            <div className="modal-footer">
+              <button
+                className="btn-secondary"
+                onClick={() => { setShowRevertConfirm(null); setRevertResult(null); }}
+                disabled={revertLoading}
+              >
+                Cancel
+              </button>
+              <button
+                className="btn-danger"
+                onClick={handleConfirmRevert}
+                disabled={revertLoading}
+                aria-label="Confirm revert"
+                data-testid="revert-confirm-btn"
+              >
+                {revertLoading ? (
+                  <>
+                    <span className="material-icons spinning" style={{ fontSize: '16px', marginRight: '4px' }}>sync</span>
+                    Reverting...
+                  </>
+                ) : (
+                  'Undo This Run'
+                )}
+              </button>
+            </div>
+          </div>
+        </ModalOverlay>
+      )}
+
+      {/* Snapshot-Restore Result Summary (ADR-010 §D8 step 6 — partial failures never silent) */}
+      {showRevertConfirm && revertResult && (
+        <ModalOverlay
+          onClose={() => { setShowRevertConfirm(null); setRevertResult(null); }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="revert-result-title"
+        >
+          <div className="modal-container modal-sm">
+            <div className="modal-header">
+              <h2 id="revert-result-title">Revert Complete</h2>
+            </div>
+            <div className="modal-body">
+              {/* Partial-failure warning: never show as plain success when channels failed */}
+              {revertResult.failed_channels.length > 0 && (
+                <div className="revert-partial-failure" data-testid="revert-partial-failure">
+                  <span className="material-icons revert-warning-icon">warning</span>
+                  <p>
+                    Revert completed with <strong>{revertResult.failed_channels.length} failure{revertResult.failed_channels.length !== 1 ? 's' : ''}</strong>.
+                    The channels listed below could not be restored.
+                  </p>
+                </div>
+              )}
+              <div className="revert-result-stats" data-testid="revert-result-stats">
+                <div className="detail-row">
+                  <span className="detail-label">Channels restored:</span>
+                  <span data-testid="revert-restored-count">{revertResult.restored_channels}</span>
+                </div>
+                {revertResult.removed_channels > 0 && (
+                  <div className="detail-row">
+                    <span className="detail-label">Created channels removed:</span>
+                    <span data-testid="revert-removed-count">{revertResult.removed_channels}</span>
+                  </div>
+                )}
+                {revertResult.failed_channels.length > 0 && (
+                  <div className="detail-row">
+                    <span className="detail-label">Failed:</span>
+                    <span className="revert-failed-count" data-testid="revert-failed-count">
+                      {revertResult.failed_channels.length}
+                    </span>
+                  </div>
+                )}
+              </div>
+              {revertResult.failed_channels.length > 0 && (
+                <div className="revert-failed-channels" data-testid="revert-failed-channels">
+                  <h4 className="revert-failed-title">Failed channels</h4>
+                  <ul className="revert-failed-list">
+                    {revertResult.failed_channels.map((ch: FailedChannel) => (
+                      <li key={ch.id} className="revert-failed-item">
+                        <span className="revert-failed-name">{ch.name}</span>
+                        <span className="revert-failed-error">{ch.error}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+            <div className="modal-footer">
+              <button
+                className="btn-primary"
+                onClick={() => { setShowRevertConfirm(null); setRevertResult(null); }}
+              >
+                Close
               </button>
             </div>
           </div>

--- a/frontend/src/services/autoCreationApi.ts
+++ b/frontend/src/services/autoCreationApi.ts
@@ -15,6 +15,7 @@ import type {
   ValidationResult,
   RunPipelineEnqueuedResponse,
   RollbackResponse,
+  RestoreSnapshotResponse,
   SchemaResponse,
   ConditionSchema,
   ActionSchema,
@@ -224,6 +225,32 @@ export async function rollbackAutoCreationExecution(id: number): Promise<Rollbac
   return fetchJson<RollbackResponse>(`${API_BASE}/auto-creation/executions/${id}/rollback`, {
     method: 'POST',
   });
+}
+
+/**
+ * Restore an execution from its pre-run snapshot (ADR-010 §D8).
+ *
+ * The ``confirm=true`` query param is the API-level acknowledgement of the
+ * ADR-010 §D5 optimistic-overwrite warning — the UI MUST have shown the
+ * warning before calling this. The backend enforces the param; calls without
+ * it return 400.
+ *
+ * Returns ``RestoreSnapshotResponse`` with ``success``, ``removed_channels``,
+ * ``restored_channels``, and a ``failed_channels`` list for partial failures.
+ * A 200 with ``success: false`` is a partial-failure result — the operation
+ * attempted every channel and at least one failed. The caller must NOT present
+ * this as plain success.
+ *
+ * Status codes:
+ *   - 200 — restore attempted (check ``success`` and ``failed_channels``).
+ *   - 400 — ``confirm`` not set, or the execution is a dry-run / already reverted.
+ *   - 404 — no snapshot for this execution (use ``/rollback`` instead).
+ */
+export async function restoreAutoCreationSnapshot(id: number): Promise<RestoreSnapshotResponse> {
+  return fetchJson<RestoreSnapshotResponse>(
+    `${API_BASE}/auto-creation/executions/${id}/restore-snapshot?confirm=true`,
+    { method: 'POST' },
+  );
 }
 
 // =============================================================================

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -178,12 +178,14 @@ export function createMockAutoCreationExecution(overrides: Partial<MockAutoCreat
     groups_created: overrides.groups_created ?? 1,
     streams_merged: overrides.streams_merged ?? 2,
     streams_skipped: overrides.streams_skipped ?? 0,
+    streams_excluded: overrides.streams_excluded ?? 0,
     created_entities: overrides.created_entities ?? [],
     modified_entities: overrides.modified_entities ?? [],
     dry_run_results: overrides.dry_run_results ?? undefined,
     rolled_back_at: overrides.rolled_back_at ?? undefined,
     rolled_back_by: overrides.rolled_back_by ?? undefined,
     error: overrides.error ?? undefined,
+    has_snapshot: overrides.has_snapshot ?? false,
   }
 }
 
@@ -341,12 +343,15 @@ interface MockAutoCreationExecution {
   groups_created: number
   streams_merged: number
   streams_skipped: number
+  streams_excluded: number
   created_entities: object[]
   modified_entities: object[]
   dry_run_results?: object[]
   rolled_back_at?: string
   rolled_back_by?: string
   error?: string
+  /** ADR-010 §D6 — true when a pre-run AutoCreationSnapshot row exists. */
+  has_snapshot?: boolean
 }
 
 export function createMockPopularityScore(overrides: Partial<MockPopularityScore> = {}): MockPopularityScore {
@@ -1125,6 +1130,56 @@ export const handlers = [
       success: true,
       entities_removed: execution.channels_created,
       entities_restored: 0,
+    })
+  }),
+
+  // Snapshot-restore endpoint (ADR-010 §D8, uc51o.7).
+  // Returns removed_channels / restored_channels counts + failed_channels list.
+  http.post(`${API_BASE}/auto-creation/executions/:id/restore-snapshot`, ({ params, request }) => {
+    const id = parseInt(params.id as string)
+    const url = new URL(request.url)
+    const confirm = url.searchParams.get('confirm') === 'true'
+
+    if (!confirm) {
+      return HttpResponse.json(
+        { detail: 'Restore requires confirm=true' },
+        { status: 400 }
+      )
+    }
+
+    const execution = mockDataStore.autoCreationExecutions.find(e => e.id === id)
+    if (!execution) {
+      return HttpResponse.json(
+        { detail: 'Execution not found' },
+        { status: 404 }
+      )
+    }
+    if (!execution.has_snapshot) {
+      return HttpResponse.json(
+        { detail: 'No snapshot for this execution (use /rollback instead)' },
+        { status: 404 }
+      )
+    }
+    if (execution.mode === 'dry_run') {
+      return HttpResponse.json(
+        { detail: 'Cannot restore a dry-run execution' },
+        { status: 400 }
+      )
+    }
+    if (execution.status === 'rolled_back') {
+      return HttpResponse.json(
+        { detail: 'Execution has already been reverted' },
+        { status: 400 }
+      )
+    }
+
+    execution.status = 'rolled_back'
+    execution.rolled_back_at = new Date().toISOString()
+    return HttpResponse.json({
+      success: true,
+      removed_channels: execution.channels_created,
+      restored_channels: 10,
+      failed_channels: [],
     })
   }),
 

--- a/frontend/src/types/autoCreation.ts
+++ b/frontend/src/types/autoCreation.ts
@@ -346,6 +346,13 @@ export interface AutoCreationExecution {
   execution_log?: ExecutionLogEntry[];
   rolled_back_at?: string;
   rolled_back_by?: string;
+  /**
+   * True when a pre-run snapshot exists for this execution (ADR-010 §D6).
+   * Derived by the backend from the existence of an AutoCreationSnapshot row;
+   * gates the snapshot-restore affordance in the UI. False / absent for
+   * dry-run executions, legacy runs, and runs where snapshot capture failed.
+   */
+  has_snapshot?: boolean;
 }
 
 export interface CreatedEntity {
@@ -479,6 +486,32 @@ export interface RollbackResponse {
   success: boolean;
   entities_removed: number;
   entities_restored: number;
+  error?: string;
+}
+
+/**
+ * A channel that failed to restore during snapshot-restore (ADR-010 §D8 step 6).
+ * Partial failures are always surfaced; a restore that fails on some channels
+ * is never presented as plain success.
+ */
+export interface FailedChannel {
+  id: number;
+  name: string;
+  error: string;
+}
+
+/**
+ * Response from POST /auto-creation/executions/{id}/restore-snapshot (ADR-010 §D8).
+ *
+ * ``success`` is false when any channel failed (partial failures are surfaced
+ * in ``failed_channels``). A 200 with ``success: false`` is a partial-failure
+ * result, NOT a server error.
+ */
+export interface RestoreSnapshotResponse {
+  success: boolean;
+  removed_channels: number;
+  restored_channels: number;
+  failed_channels: FailedChannel[];
   error?: string;
 }
 

--- a/mcp-server/_endpoint_contracts.py
+++ b/mcp-server/_endpoint_contracts.py
@@ -312,6 +312,28 @@ ENDPOINTS: dict[str, Endpoint] = {
         method="POST",
         path="/api/auto-creation/executions/{execution_id}/rollback",
     ),
+    # ADR-010 §D8 / uc51o.4 — full whole-run snapshot restore. ``confirm`` is a
+    # QUERY param (FastAPI ``Query``), the API-level acknowledgement of the §D5
+    # optimistic-overwrite warning; the restore is refused (400) without it. The
+    # restore_auto_creation_snapshot MCP tool (uc51o.6) routes here.
+    "ac_restore_snapshot": Endpoint(
+        name="ac_restore_snapshot",
+        method="POST",
+        path="/api/auto-creation/executions/{execution_id}/restore-snapshot",
+        query_params=frozenset({"confirm"}),
+    ),
+    # ADR-010 §D6 — read-only pre-run snapshot for an execution. The
+    # restore_auto_creation_snapshot tool reads ``channel_count`` from here on
+    # the confirm=False warning path so the operator sees the blast radius
+    # (how many channels a restore would overwrite) before re-invoking.
+    "ac_get_execution_snapshot": Endpoint(
+        name="ac_get_execution_snapshot",
+        method="GET",
+        path="/api/auto-creation/executions/{execution_id}/snapshot",
+        response_fields=frozenset({
+            "id", "execution_id", "snapshot_time", "channel_count", "channels",
+        }),
+    ),
     # -- channel_groups domain --------------------------------------------
     "groups_list": Endpoint(
         name="groups_list",

--- a/mcp-server/ecm_client.py
+++ b/mcp-server/ecm_client.py
@@ -103,11 +103,26 @@ class ECMClient:
             logger.error("[ECM-CLIENT] GET %s failed: %s %s — %s", path, e.response.status_code, e.response.reason_phrase, body)
             raise _http_error("GET", path, e) from e
 
-    async def post(self, path: str, json_data: dict | None = None, timeout: float | None = None) -> dict | list:
-        """POST request to ECM API."""
+    async def post(
+        self,
+        path: str,
+        json_data: dict | None = None,
+        timeout: float | None = None,
+        params: dict | None = None,
+    ) -> dict | list:
+        """POST request to ECM API.
+
+        ``params`` carries query-string keys for endpoints that take a
+        query param on a write verb (e.g. the ADR-010 ``confirm`` gate on
+        ``/restore-snapshot``). ``None`` values are dropped, matching ``get``.
+        """
         client = _get_client()
+        params = {k: v for k, v in (params or {}).items() if v is not None}
+        # Pass ``params`` to httpx ONLY when present so the common no-query call
+        # stays byte-identical (and existing call-signature mocks keep working).
+        extra = {"params": params} if params else {}
         try:
-            r = await client.post(path, json=json_data, timeout=timeout)
+            r = await client.post(path, json=json_data, timeout=timeout, **extra)
             r.raise_for_status()
             return r.json()
         except httpx.TimeoutException:
@@ -142,11 +157,19 @@ class ECMClient:
             logger.error("[ECM-CLIENT] POST(multipart) %s failed: %s %s — %s", path, e.response.status_code, e.response.reason_phrase, body)
             raise _http_error("POST", path, e) from e
 
-    async def patch(self, path: str, json_data: dict | None = None, timeout: float | None = None) -> dict | list:
+    async def patch(
+        self,
+        path: str,
+        json_data: dict | None = None,
+        timeout: float | None = None,
+        params: dict | None = None,
+    ) -> dict | list:
         """PATCH request to ECM API."""
         client = _get_client()
+        params = {k: v for k, v in (params or {}).items() if v is not None}
+        extra = {"params": params} if params else {}
         try:
-            r = await client.patch(path, json=json_data, timeout=timeout)
+            r = await client.patch(path, json=json_data, timeout=timeout, **extra)
             r.raise_for_status()
             return r.json()
         except httpx.TimeoutException:
@@ -157,11 +180,19 @@ class ECMClient:
             logger.error("[ECM-CLIENT] PATCH %s failed: %s %s — %s", path, e.response.status_code, e.response.reason_phrase, body)
             raise _http_error("PATCH", path, e) from e
 
-    async def put(self, path: str, json_data: dict | None = None, timeout: float | None = None) -> dict | list:
+    async def put(
+        self,
+        path: str,
+        json_data: dict | None = None,
+        timeout: float | None = None,
+        params: dict | None = None,
+    ) -> dict | list:
         """PUT request to ECM API."""
         client = _get_client()
+        params = {k: v for k, v in (params or {}).items() if v is not None}
+        extra = {"params": params} if params else {}
         try:
-            r = await client.put(path, json=json_data, timeout=timeout)
+            r = await client.put(path, json=json_data, timeout=timeout, **extra)
             r.raise_for_status()
             return r.json()
         except httpx.TimeoutException:
@@ -172,11 +203,19 @@ class ECMClient:
             logger.error("[ECM-CLIENT] PUT %s failed: %s %s — %s", path, e.response.status_code, e.response.reason_phrase, body)
             raise _http_error("PUT", path, e) from e
 
-    async def delete(self, path: str, json_data: dict | None = None, timeout: float | None = None) -> dict | None:
+    async def delete(
+        self,
+        path: str,
+        json_data: dict | None = None,
+        timeout: float | None = None,
+        params: dict | None = None,
+    ) -> dict | None:
         """DELETE request to ECM API."""
         client = _get_client()
+        params = {k: v for k, v in (params or {}).items() if v is not None}
+        extra = {"params": params} if params else {}
         try:
-            r = await client.request("DELETE", path, json=json_data, timeout=timeout)
+            r = await client.request("DELETE", path, json=json_data, timeout=timeout, **extra)
             r.raise_for_status()
             if r.status_code == 204:
                 return None
@@ -262,14 +301,22 @@ class ECMClient:
         method = ep.method.upper()
         if method == "GET":
             return await self.get(formatted_path, timeout=timeout, **(query or {}))
+        # Write verbs forward ``query`` too (subset-checked above) so endpoints
+        # that take a query param on a write — e.g. the ADR-010 ``confirm`` gate
+        # on /restore-snapshot — work through the contract, not a raw call.
+        # ``params`` is passed ONLY when a query is present, so the common
+        # no-query write call stays byte-identical to the pre-query behaviour.
+        write_kwargs: dict = {"json_data": body, "timeout": timeout}
+        if query:
+            write_kwargs["params"] = query
         if method == "POST":
-            return await self.post(formatted_path, json_data=body, timeout=timeout)
+            return await self.post(formatted_path, **write_kwargs)
         if method == "PATCH":
-            return await self.patch(formatted_path, json_data=body, timeout=timeout)
+            return await self.patch(formatted_path, **write_kwargs)
         if method == "PUT":
-            return await self.put(formatted_path, json_data=body, timeout=timeout)
+            return await self.put(formatted_path, **write_kwargs)
         if method == "DELETE":
-            return await self.delete(formatted_path, json_data=body, timeout=timeout)
+            return await self.delete(formatted_path, **write_kwargs)
         raise ContractError(
             f"call_endpoint({ep.name!r}): unsupported method {ep.method!r}"
         )

--- a/mcp-server/tests/test_uc51o6_restore_snapshot.py
+++ b/mcp-server/tests/test_uc51o6_restore_snapshot.py
@@ -1,0 +1,363 @@
+"""enhancedchannelmanager-uc51o.6 — MCP restore_auto_creation_snapshot tool +
+has_snapshot surfacing on list_auto_creation_executions (ADR-010 §D8).
+
+The restore is a SAFETY-CRITICAL, optimistic-overwrite, non-undoable bulk
+write-back across (often hundreds of) channels. Mirroring the rollback-tool
+tests (test_0hjrk_rollback.py), this module pins the confirm posture and the
+result/error surfacing:
+
+* confirm=False (default) → the tool returns the §D5 warning (with the channel
+  count when the snapshot metadata is readable) and DOES NOT call the restore
+  endpoint.
+* confirm=True → the tool calls the restore endpoint (confirm passed through as
+  the backend query gate) and renders restored/removed counts.
+* partial failure → the per-channel failures are surfaced, never a silent
+  partial success.
+* no snapshot (404) → a helpful message pointing at rollback_auto_creation,
+  on both the confirm=False and confirm=True paths.
+* has_snapshot from the backend list response is surfaced per execution.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from _endpoint_contracts import ENDPOINTS
+
+
+def _register():
+    from tools.auto_creation import register
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP("test")
+    register(mcp)
+    return mcp
+
+
+def _text(result) -> str:
+    return result[0][0].text
+
+
+# ---------------------------------------------------------------------------
+# confirm posture
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmGate:
+    """confirm=False refuses to act; confirm=True performs the restore."""
+
+    @pytest.mark.asyncio
+    async def test_confirm_false_does_not_call_restore_endpoint(self):
+        """Default confirm=False returns the warning and never POSTs the restore.
+
+        It MAY read the snapshot (GET) for the channel count, but it must NOT
+        call the restore endpoint (POST /restore-snapshot).
+        """
+        mcp = _register()
+
+        async def fake_call_endpoint(ep, **kwargs):
+            # The warning path reads the snapshot for the channel count.
+            assert ep is not ENDPOINTS["ac_restore_snapshot"], (
+                "restore endpoint MUST NOT be called when confirm=False"
+            )
+            if ep is ENDPOINTS["ac_get_execution_snapshot"]:
+                return {"execution_id": 3, "channel_count": 42,
+                        "snapshot_time": "2026-05-25T00:00:00Z"}
+            raise AssertionError(f"unexpected endpoint {ep.name}")
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = fake_call_endpoint
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "restore_auto_creation_snapshot", {"execution_id": 3}
+            )
+
+        text = _text(result)
+        assert "confirm" in text.lower()
+        assert "not performed" in text.lower() or "not restored" in text.lower() \
+            or "confirmation required" in text.lower()
+        # Blast radius surfaced.
+        assert "42" in text
+        # Tells the caller how to proceed.
+        assert "confirm=true" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_confirm_false_warning_without_count_when_snapshot_unreadable(self):
+        """If the snapshot metadata read raises a non-404 error, the warning is
+        STILL returned (best-effort count) and the restore is NOT called."""
+        mcp = _register()
+
+        async def fake_call_endpoint(ep, **kwargs):
+            assert ep is not ENDPOINTS["ac_restore_snapshot"]
+            if ep is ENDPOINTS["ac_get_execution_snapshot"]:
+                raise RuntimeError("GET /snapshot -> HTTP 500 Internal Server Error")
+            raise AssertionError(f"unexpected endpoint {ep.name}")
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = fake_call_endpoint
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "restore_auto_creation_snapshot", {"execution_id": 8}
+            )
+
+        text = _text(result)
+        assert "confirm=true" in text.lower()
+        assert "cannot be undone" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_confirm_true_calls_restore_endpoint_with_confirm_query(self):
+        """confirm=True calls the restore endpoint, passing confirm=true as the
+        backend query gate, and returns the result counts."""
+        mcp = _register()
+
+        seen = {}
+
+        async def fake_call_endpoint(ep, **kwargs):
+            seen["ep"] = ep
+            seen["kwargs"] = kwargs
+            return {
+                "success": True,
+                "execution_id": 5,
+                "rule_name": "Sports Rule",
+                "removed_channels": 2,
+                "restored_channels": 40,
+                "failed_channels": [],
+            }
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = fake_call_endpoint
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "restore_auto_creation_snapshot",
+                {"execution_id": 5, "confirm": True},
+            )
+
+        # The restore endpoint was the one called, with confirm in the query.
+        assert seen["ep"] is ENDPOINTS["ac_restore_snapshot"]
+        assert seen["kwargs"].get("query") == {"confirm": True}
+        assert seen["kwargs"].get("path_args") == {"execution_id": 5}
+
+        text = _text(result)
+        assert "40" in text
+        assert "2" in text
+        assert "restored" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# partial-failure surfacing
+# ---------------------------------------------------------------------------
+
+
+class TestPartialFailureSurfaced:
+    @pytest.mark.asyncio
+    async def test_failed_channels_are_surfaced(self):
+        """A restore that failed on some channels names them — never a silent
+        partial success."""
+        mcp = _register()
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.return_value = {
+            "success": False,
+            "execution_id": 9,
+            "rule_name": "News Rule",
+            "removed_channels": 0,
+            "restored_channels": 197,
+            "failed_channels": [
+                {"id": 11, "name": "GONE", "error": "404"},
+                {"id": 12, "name": "VANISHED", "error": "stream 9001 not found"},
+            ],
+        }
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "restore_auto_creation_snapshot",
+                {"execution_id": 9, "confirm": True},
+            )
+
+        text = _text(result)
+        assert "197" in text
+        assert "fail" in text.lower()
+        # Each failed channel is named with its reason.
+        assert "11" in text and "GONE" in text
+        assert "12" in text and "VANISHED" in text
+        assert "404" in text
+        assert "stream 9001 not found" in text
+
+
+# ---------------------------------------------------------------------------
+# no-snapshot (404) → helpful message
+# ---------------------------------------------------------------------------
+
+
+class TestNoSnapshotGuidance:
+    @pytest.mark.asyncio
+    async def test_confirm_true_404_points_at_rollback(self):
+        """confirm=True against a snapshot-less run (backend 404) → guidance to
+        use rollback_auto_creation, not a raw error."""
+        mcp = _register()
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = RuntimeError(
+            "POST /api/auto-creation/executions/4/restore-snapshot -> HTTP 404 "
+            "Not Found: No snapshot for execution 4; use /rollback instead."
+        )
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "restore_auto_creation_snapshot",
+                {"execution_id": 4, "confirm": True},
+            )
+
+        text = _text(result)
+        assert "rollback_auto_creation" in text
+        assert "no" in text.lower() and "snapshot" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_confirm_false_404_points_at_rollback_without_restoring(self):
+        """confirm=False where the snapshot read 404s → guidance to use
+        rollback_auto_creation; the restore endpoint is never called."""
+        mcp = _register()
+
+        async def fake_call_endpoint(ep, **kwargs):
+            assert ep is not ENDPOINTS["ac_restore_snapshot"]
+            if ep is ENDPOINTS["ac_get_execution_snapshot"]:
+                raise RuntimeError(
+                    "GET /api/auto-creation/executions/4/snapshot -> HTTP 404 "
+                    "Not Found: No snapshot for this execution"
+                )
+            raise AssertionError(f"unexpected endpoint {ep.name}")
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.side_effect = fake_call_endpoint
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "restore_auto_creation_snapshot", {"execution_id": 4}
+            )
+
+        text = _text(result)
+        assert "rollback_auto_creation" in text
+
+    @pytest.mark.asyncio
+    async def test_confirm_true_no_snapshot_dict_signal(self):
+        """Defensive: a no_snapshot signal that arrives as a dict (not HTTP 404)
+        is surfaced as the same guidance, not a phantom success."""
+        mcp = _register()
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.return_value = {
+            "success": False,
+            "no_snapshot": True,
+            "error": "No snapshot for execution 6; use /rollback instead.",
+        }
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "restore_auto_creation_snapshot",
+                {"execution_id": 6, "confirm": True},
+            )
+
+        text = _text(result)
+        assert "rollback_auto_creation" in text
+        assert "restored" not in text.lower() or "no" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# has_snapshot surfacing on the list tool
+# ---------------------------------------------------------------------------
+
+
+class TestCallEndpointQueryOnPost:
+    """call_endpoint forwards a query param on a write verb (the confirm gate)
+    while leaving the no-query write path byte-identical (regression guard)."""
+
+    @pytest.mark.asyncio
+    async def test_post_forwards_query_param(self):
+        from ecm_client import ECMClient
+
+        client = ECMClient()
+        with patch.object(ECMClient, "post", new=AsyncMock(return_value={"ok": True})) as post_mock:
+            await client.call_endpoint(
+                ENDPOINTS["ac_restore_snapshot"],
+                path_args={"execution_id": 5},
+                query={"confirm": True},
+                timeout=300.0,
+            )
+        post_mock.assert_awaited_once_with(
+            "/api/auto-creation/executions/5/restore-snapshot",
+            json_data=None,
+            timeout=300.0,
+            params={"confirm": True},
+        )
+
+    @pytest.mark.asyncio
+    async def test_post_without_query_omits_params(self):
+        """No query → the verb method is called WITHOUT params (back-compat)."""
+        from ecm_client import ECMClient
+
+        client = ECMClient()
+        with patch.object(ECMClient, "post", new=AsyncMock(return_value={"ok": True})) as post_mock:
+            await client.call_endpoint(
+                ENDPOINTS["channels_add_stream"],
+                path_args={"channel_id": 42},
+                body={"stream_id": 7},
+            )
+        post_mock.assert_awaited_once_with(
+            "/api/channels/42/add-stream", json_data={"stream_id": 7}, timeout=None
+        )
+
+
+class TestListExecutionsHasSnapshot:
+    @pytest.mark.asyncio
+    async def test_snapshot_marker_appears_per_execution(self):
+        """list_auto_creation_executions marks each run [snapshot] / [no
+        snapshot] from the backend has_snapshot boolean."""
+        mcp = _register()
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.return_value = {
+            "executions": [
+                {"id": 1, "status": "completed", "created_at": "2026-05-25",
+                 "channels_created": 12, "has_snapshot": True},
+                {"id": 2, "status": "completed", "created_at": "2026-05-24",
+                 "channels_created": 0, "has_snapshot": False},
+            ],
+            "total": 2,
+        }
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "list_auto_creation_executions", {"limit": 10}
+            )
+
+        text = _text(result)
+        # Execution 1 (has_snapshot True) shows [snapshot]; execution 2 shows
+        # [no snapshot].
+        line1 = next(ln for ln in text.splitlines() if ln.strip().startswith("#1"))
+        line2 = next(ln for ln in text.splitlines() if ln.strip().startswith("#2"))
+        assert "[snapshot]" in line1 and "[no snapshot]" not in line1
+        assert "[no snapshot]" in line2
+
+    @pytest.mark.asyncio
+    async def test_missing_has_snapshot_defaults_to_no_snapshot(self):
+        """An execution row without has_snapshot (older backend) renders as
+        [no snapshot] rather than erroring."""
+        mcp = _register()
+
+        mock_client = AsyncMock()
+        mock_client.call_endpoint.return_value = {
+            "executions": [
+                {"id": 7, "status": "completed", "created_at": "2026-05-25",
+                 "channels_created": 3},
+            ],
+            "total": 1,
+        }
+
+        with patch("tools.auto_creation.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "list_auto_creation_executions", {"limit": 10}
+            )
+
+        text = _text(result)
+        assert "[no snapshot]" in text

--- a/mcp-server/tools/auto_creation.py
+++ b/mcp-server/tools/auto_creation.py
@@ -658,6 +658,15 @@ def register(mcp: FastMCP):
     async def list_auto_creation_executions(limit: int = 10) -> str:
         """List recent auto-creation pipeline executions.
 
+        Each line ends with a snapshot marker (ADR-010):
+          - ``[snapshot]`` — the run captured a pre-run channel/stream snapshot,
+            so it is FULLY revertible via restore_auto_creation_snapshot (the
+            whole-run revert re-adds removed streams + restores drifted
+            metadata). rollback_auto_creation also uses the snapshot for these.
+          - ``[no snapshot]`` — a dry-run, a legacy run, or a run whose snapshot
+            capture failed. Only the narrower rollback_auto_creation applies
+            (deletes created channels, un-merges run-added streams).
+
         Args:
             limit: Number of executions to return (default 10)
         """
@@ -677,7 +686,12 @@ def register(mcp: FastMCP):
                 created = ex.get("created_at", ex.get("timestamp", "?"))
                 channels = ex.get("channels_created", ex.get("created", 0))
                 dry = " (dry run)" if ex.get("dry_run") else ""
-                lines.append(f"  #{eid}: {status} — {channels} channels{dry} ({created})")
+                # has_snapshot (ADR-010 §D6) tells the operator/agent which runs
+                # are fully revertible via restore_auto_creation_snapshot.
+                snap = "[snapshot]" if ex.get("has_snapshot") else "[no snapshot]"
+                lines.append(
+                    f"  #{eid}: {status} — {channels} channels{dry} {snap} ({created})"
+                )
 
             return "\n".join(lines)
         except Exception as e:
@@ -745,6 +759,145 @@ def register(mcp: FastMCP):
             # it here. Surface it clearly so the user sees WHY nothing changed.
             logger.error("[MCP] rollback_auto_creation failed: %s", e)
             return f"Error rolling back execution {execution_id}: {e}"
+
+    @mcp.tool()
+    async def restore_auto_creation_snapshot(
+        execution_id: int, confirm: bool = False
+    ) -> str:
+        """Full WHOLE-RUN revert of an auto-creation run from its pre-run snapshot (ADR-010 §D8).
+
+        This is the FULLER revert (vs rollback_auto_creation). It restores the
+        entire snapshotted channel<->stream state captured BEFORE the run mutated
+        anything: re-adds streams the run REMOVED, removes streams it added,
+        restores drifted metadata (channel group / EPG link / tvg id). Only runs
+        that captured a snapshot are eligible — check list_auto_creation_executions
+        for the ``[snapshot]`` marker first. Runs without a snapshot (dry-runs,
+        legacy runs, capture-failure runs) are NOT restorable this way; use
+        rollback_auto_creation for those (this tool returns guidance to do so).
+
+        SAFETY — OPTIMISTIC OVERWRITE, NOT UNDOABLE (ADR-010 §D5):
+        A restore spans EVERY channel in the snapshot (often hundreds). It
+        UNCONDITIONALLY OVERWRITES each channel's CURRENT stream assignments and
+        metadata with the pre-run state — any manual edit or Dispatcharr drift
+        made AFTER the run and BEFORE this revert is LOST. There is no conflict
+        detection and the restore CANNOT be undone.
+
+        Because of that blast radius this tool REQUIRES explicit confirmation:
+          - confirm=False (default) → NOTHING is restored. The tool returns the
+            warning (including how many channels would be overwritten, when the
+            snapshot was taken) and tells you to re-invoke with confirm=true.
+          - confirm=true → the restore runs. Partial failures (a channel deleted
+            since the run, a stream id that no longer resolves) are SURFACED
+            per-channel — never a silent partial success.
+
+        Args:
+            execution_id: The execution whose pre-run snapshot to restore.
+            confirm: Must be true to actually perform the (destructive,
+                non-undoable) restore. Defaults to false, which only returns the
+                warning and does NOT touch any channel.
+        """
+        client = get_ecm_client()
+
+        # confirm=False: refuse to act. Surface the §D5 warning + blast radius
+        # WITHOUT calling the restore endpoint at all. Try to read the snapshot's
+        # channel_count so the operator sees how many channels would be
+        # overwritten before re-invoking; best-effort — never block the warning.
+        if not confirm:
+            channel_count = None
+            snapshot_time = None
+            try:
+                snap = await client.call_endpoint(
+                    ENDPOINTS["ac_get_execution_snapshot"],
+                    path_args={"execution_id": execution_id},
+                )
+                if isinstance(snap, dict):
+                    channel_count = snap.get("channel_count")
+                    snapshot_time = snap.get("snapshot_time")
+            except Exception as e:
+                # No snapshot (404) is the common case here — tell the caller to
+                # use rollback_auto_creation instead, and do NOT pretend a
+                # restore is pending.
+                if "404" in str(e) or "no snapshot" in str(e).lower():
+                    return (
+                        f"Execution {execution_id} has NO pre-run snapshot, so it "
+                        f"cannot be restored with this tool. Use "
+                        f"rollback_auto_creation({execution_id}) instead (it deletes "
+                        f"channels the run created and un-merges streams it added)."
+                    )
+                logger.warning(
+                    "[MCP] restore_auto_creation_snapshot: could not read snapshot "
+                    "metadata for execution %s: %s", execution_id, e,
+                )
+
+            count_phrase = (
+                f"{channel_count} channel(s)" if channel_count is not None
+                else "every channel in the snapshot"
+            )
+            taken_phrase = f" (snapshot taken {snapshot_time})" if snapshot_time else ""
+            return (
+                f"CONFIRMATION REQUIRED — restore NOT performed.\n\n"
+                f"Restoring execution {execution_id} will OVERWRITE the current "
+                f"stream assignments and metadata of {count_phrase} with the "
+                f"pre-run state{taken_phrase}. Any changes made after the run "
+                f"(manual edits, Dispatcharr drift) WILL BE LOST. This is an "
+                f"optimistic overwrite with no conflict detection and CANNOT be "
+                f"undone.\n\n"
+                f"To proceed, re-invoke with confirm=true: "
+                f"restore_auto_creation_snapshot(execution_id={execution_id}, confirm=true)"
+            )
+
+        # confirm=True: perform the restore. ``confirm`` is a query param on the
+        # backend (ADR-010 §D8) — pass it through the contract.
+        try:
+            result = await client.call_endpoint(
+                ENDPOINTS["ac_restore_snapshot"],
+                path_args={"execution_id": execution_id},
+                query={"confirm": True},
+                timeout=300.0,
+            )
+        except Exception as e:
+            # 404 → no snapshot: point at the narrower rollback path (§D8 step 1).
+            if "404" in str(e) or "no snapshot" in str(e).lower():
+                return (
+                    f"Execution {execution_id} has NO pre-run snapshot, so it "
+                    f"cannot be restored. Use rollback_auto_creation({execution_id}) "
+                    f"instead."
+                )
+            logger.error("[MCP] restore_auto_creation_snapshot failed: %s", e)
+            return f"Error restoring snapshot for execution {execution_id}: {e}"
+
+        if not isinstance(result, dict):
+            return f"Snapshot restore for execution {execution_id} returned an unexpected response."
+
+        # Defensive: a no_snapshot signal that arrives as a dict instead of HTTP
+        # 404 (changed/direct call paths) → same guidance, not a phantom success.
+        if result.get("no_snapshot"):
+            return (
+                f"Execution {execution_id} has NO pre-run snapshot, so it cannot "
+                f"be restored. Use rollback_auto_creation({execution_id}) instead."
+            )
+
+        removed = result.get("removed_channels", 0)
+        restored = result.get("restored_channels", 0)
+        failed_channels = result.get("failed_channels", []) or []
+
+        msg = (
+            f"Snapshot restore for execution {execution_id}: "
+            f"{restored} channel(s) restored to their pre-run state, "
+            f"{removed} run-created channel(s) deleted."
+        )
+        if failed_channels:
+            # Partial failure — surface exactly which channels failed and why.
+            detail = "; ".join(
+                f"#{fc.get('id', '?')} {fc.get('name', '')}".strip()
+                + (f" ({fc.get('error')})" if fc.get("error") else "")
+                for fc in failed_channels
+            )
+            msg += (
+                f"\nWARNING — {len(failed_channels)} channel(s) FAILED to restore "
+                f"(re-running the restore is safe and idempotent): {detail}"
+            )
+        return msg
 
     @mcp.tool()
     async def analyze_auto_creation_rules(bundle_path: str | None = None) -> str:


### PR DESCRIPTION
Phase 4b (final) of the **uc51o epic** — the two consumers of the snapshot-restore feature. Completes the epic.

## uc51o.6 — MCP tool
New `restore_auto_creation_snapshot(execution_id, confirm=False)` (`mcp-server/tools/auto_creation.py`). **Confirm posture (blast-radius safety):** with `confirm=False` it never calls the restore — it surfaces the channel count + the optimistic-overwrite warning and instructs the caller to re-invoke with `confirm=true`; only then does it call the admin-gated `POST /restore-snapshot?confirm=true`. Partial failures (`failed_channels`) surfaced; no-snapshot 404 → points to `rollback_auto_creation`. `list_auto_creation_executions` now shows a `[snapshot]`/`[no snapshot]` marker per run. Routed through the contract layer (`call_endpoint` now forwards a query param on write verbs — conservatively scoped, no-query path byte-identical).

## uc51o.7 — revert UI
"Undo this run" affordance in `AutoCreationTab` execution history, **gated on `has_snapshot`** (+ completed + execute-mode); a muted indicator for runs without a snapshot. Reuses the existing `ModalOverlay` confirm pattern with the ADR-010 §D5 overwrite warning (incl. snapshot timestamp). On confirm, calls `restoreAutoCreationSnapshot` (new service fn → `POST /restore-snapshot?confirm=true`). Post-revert summary shows restored/removed counts and **surfaces `failed_channels`** — partial failures are never shown as plain success.

## Verification (independent)
- `.6`: MCP gate **14 passed** (confirm-refusal / confirm-acts / partial / no-snapshot / has_snapshot marker); agent's full mcp suite 363 + backend contract 127 green.
- `.7`: `tsc` clean, **46** AutoCreationTab vitest passing (gating / confirm / partial-failure display). Ran cleanly via the now-hardened worktree bootstrap (no `.vite-temp` workaround needed).
- Version consistency: all 3 at `0.17.3-0022`.

## Epic complete (uc51o)
ADR-010 (`.1`) → schema+capture+read API (`.2`) → restore+retention (`.3`/`.4`) → unify rollback + has_snapshot (`.5`) → MCP + UI (`.6`/`.7`). Operators (UI + MCP + API) can now fully revert an auto-creation run to its pre-run channel/stream state, admin-gated, confirm-required, partial-failure-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)