### PR TITLE
v0.17.3-0024: P2 batch (fbc50, spzeu, 4sned, p3jpl, svixy)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0023",
+    version="0.17.3-0024",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0023"
+APP_VERSION = "0.17.3-0024"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -3,9 +3,11 @@ Settings router — Dispatcharr connection, preferences, and service management 
 
 Extracted from main.py (Phase 2 of v0.13.0 backend refactor).
 """
+import ipaddress
 import logging
 import re
 import secrets
+import socket
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException
@@ -1135,10 +1137,89 @@ async def test_telegram_bot(request: TelegramTestRequest):
         return {"success": False, "message": "Unexpected error during Telegram test"}
 
 
+def _ip_is_blocked(ip: ipaddress._BaseAddress) -> bool:
+    """Return True if ``ip`` is loopback or link-local (the SSRF denylist).
+
+    Denylist (bd-fbc50 — SSRF hardening, security finding SEC-2 follow-up):
+
+    * **Loopback** — ``127.0.0.0/8`` (IPv4) and ``::1`` (IPv6). Blocks
+      Test Connection from probing services bound to the ECM host itself.
+    * **Link-local** — ``169.254.0.0/16`` (IPv4) and ``fe80::/10`` (IPv6).
+      The IPv4 link-local range contains the cloud instance-metadata
+      endpoint ``169.254.169.254`` (AWS/GCP/Azure IMDS), the canonical
+      SSRF-to-credential-theft pivot.
+
+    We DELIBERATELY do NOT block RFC1918 private ranges (``10.0.0.0/8``,
+    ``172.16.0.0/12``, ``192.168.0.0/16``) or IPv6 ULA (``fc00::/7``):
+    Plex / Emby / Jellyfin legitimately run on the operator's LAN, so
+    blocking those would break the primary use case. The bead allowed
+    an "optionally RFC1918-aware" denylist; the right call here is to
+    leave private LAN ranges reachable. ``ipaddress`` stdlib is used for
+    all range checks (no regex — ReDoS-safe by construction).
+    """
+    if ip.is_loopback:
+        # 127.0.0.0/8 and ::1
+        return True
+    if ip.is_link_local:
+        # 169.254.0.0/16 (incl. 169.254.169.254 metadata) and fe80::/10
+        return True
+    # IPv4-mapped IPv6 (e.g. ``::ffff:127.0.0.1``) reports neither
+    # is_loopback nor is_link_local on the mapped form — unwrap it and
+    # re-check so the v6 spelling of a blocked v4 address can't slip past.
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        return mapped.is_loopback or mapped.is_link_local
+    return False
+
+
+def _host_is_blocked(hostname: str) -> bool:
+    """Return True if ``hostname`` resolves to / is a denylisted address.
+
+    Handles three cases (bd-fbc50):
+
+    1. ``hostname`` is a literal IP (v4 or v6) — check it directly.
+    2. ``hostname`` is the literal name ``localhost`` (any case) — block
+       it without resolving; it is the most common loopback alias and we
+       never want a DNS quirk to make it reachable.
+    3. ``hostname`` is some other name — resolve it (best-effort) and
+       block if ANY resolved address is loopback/link-local. This defends
+       against attacker-controlled DNS that points an innocuous-looking
+       name at ``127.0.0.1`` / ``169.254.169.254`` (DNS-rebinding-style
+       names). Resolution failures are NOT treated as blocks — an
+       unresolvable host simply fails later at the HTTP probe with a
+       normal connection error; failing closed here would reject
+       legitimate-but-currently-offline LAN servers.
+    """
+    name = hostname.strip().rstrip(".")
+    # Case 1: literal IP address.
+    try:
+        return _ip_is_blocked(ipaddress.ip_address(name))
+    except ValueError:
+        pass
+    # Case 2: localhost alias — block without resolving.
+    if name.lower() == "localhost":
+        return True
+    # Case 3: resolve the name and check every returned address.
+    try:
+        infos = socket.getaddrinfo(name, None)
+    except (socket.gaierror, UnicodeError, OSError):
+        # Best-effort: don't block on resolution failure (see docstring).
+        return False
+    for info in infos:
+        sockaddr = info[4]
+        try:
+            if _ip_is_blocked(ipaddress.ip_address(sockaddr[0])):
+                return True
+        except ValueError:
+            continue
+    return False
+
+
 def _sanitize_base_url(raw_url: str) -> tuple[Optional[str], Optional[str]]:
     """Sanitize an operator-supplied base URL for media-server test endpoints.
 
-    SSRF mitigation (security finding SEC-2 — bd-r5f0c.4 backfill).
+    SSRF mitigation (security finding SEC-2 — bd-r5f0c.4 backfill,
+    extended in bd-fbc50 with a loopback/link-local host denylist).
     Mirrors the Dispatcharr ``/test`` endpoint pattern (routers.settings.
     test_connection, around the ``urlparse`` + scheme allowlist +
     ``urlunparse((scheme, netloc, '', '', '', ''))`` reconstruction):
@@ -1150,7 +1231,14 @@ def _sanitize_base_url(raw_url: str) -> tuple[Optional[str], Optional[str]]:
     2. Reject when no hostname is present — without a hostname the
        client would either bind to a default loopback or raise late;
        fail-closed at the entry edge instead.
-    3. Reconstruct the URL from scheme + netloc ONLY, stripping any
+    3. Reject loopback / link-local hosts (bd-fbc50). An admin could
+       otherwise point Test Connection at ``127.0.0.1`` / ``::1`` /
+       ``localhost`` (services on the ECM host) or at the cloud
+       instance-metadata IP ``169.254.169.254`` (credential theft).
+       RFC1918 LAN ranges are intentionally LEFT reachable — see
+       :func:`_ip_is_blocked`. Hostnames are resolved where feasible so a
+       name pointing at a blocked IP is also caught.
+    4. Reconstruct the URL from scheme + netloc ONLY, stripping any
        path / params / query / fragment the operator typed (or an
        attacker tried to embed). The downstream client builds its own
        paths off the base URL — preserving the operator's path would
@@ -1173,6 +1261,11 @@ def _sanitize_base_url(raw_url: str) -> tuple[Optional[str], Optional[str]]:
         return None, "Invalid URL scheme — must be http or https"
     if not parsed.hostname:
         return None, "Invalid base URL — no hostname provided"
+    if _host_is_blocked(parsed.hostname):
+        return None, (
+            "Invalid host — loopback and link-local addresses are not "
+            "allowed (e.g. localhost, 127.0.0.1, ::1, 169.254.169.254)"
+        )
     # Reconstruct from (scheme, netloc, path='', params='', query='',
     # fragment=''). netloc carries hostname + optional port + optional
     # userinfo — the operator's port stays attached, but everything past

--- a/backend/services/attribution_reconciler.py
+++ b/backend/services/attribution_reconciler.py
@@ -24,10 +24,16 @@ NOT correlate** across the NAT boundary, so attribution cannot be an IP
 join. Instead it is a per-channel **set reconciliation**:
 
 * **Eligible connections** = Dispatcharr connections on the channel with
-  NO URL identity (no username embedded in their XC/M3U URL). Connections
-  WITH a URL username keep the bd-gy5nd provider/hostname attribution
-  path and are excluded here. This "no-URL-identity" test is the
-  discriminator that replaces the IP gate.
+  no per-client identity. The LIVE discriminator is the Dispatcharr
+  ACCOUNT identity (``has_account_identity``, bd-rools): a connection with
+  a positive ``user_id`` is a genuine direct-IPTV subscriber, keeps the
+  bd-gy5nd provider/hostname attribution path, and is excluded here. The
+  original "no-URL-identity" discriminator (``has_url_identity`` /
+  :func:`url_embeds_username`) is RETAINED-BUT-NOT-WIRED (bd-4w9w6 /
+  bd-spzeu): it is always ``False`` in production because the only URL
+  available at the call sites is the channel's SHARED upstream provider
+  URL, not a per-client signal. It is kept as dormant scaffolding for a
+  future per-client credentialed-URL signal, not deleted.
 * **Candidate users** = the distinct media-server users the resolvers
   matched to the channel.
 * **Assignment** = each user assigned to AT MOST ONE connection
@@ -136,6 +142,24 @@ _XC_BARE_PATH_RE = re.compile(
 def url_embeds_username(url: Optional[str]) -> bool:
     """True when a stream URL embeds XC/M3U credentials (a "URL identity").
 
+    **RETAINED-BUT-NOT-WIRED (bd-spzeu / dormant-code rule).** This function
+    and the ``has_url_identity`` branch of :func:`eligible_connections` are
+    PRODUCTION-DEAD: no live call site passes a per-client credentialed URL
+    into the reconciler. Both production call sites
+    (``routers.stats._build_attribution_connections`` and
+    ``bandwidth_tracker._build_persisted_connection``) hardcode
+    ``has_url_identity=False`` because bd-4w9w6 proved the only URL available
+    there is the channel's SHARED UPSTREAM provider URL — that is the
+    operator's account, NOT a per-client identity, and using it dropped every
+    media-server viewer to User #0. The live per-connection discriminator is
+    now :func:`has_dispatcharr_account_identity` (``has_account_identity``).
+
+    This def and its unit tests are intentionally KEPT, not deleted: they are
+    the ready-made discriminator for the day Dispatcharr (or a future caller)
+    surfaces a genuine PER-CLIENT credentialed stream URL. If that signal
+    appears, wire it into both call sites; until then this code is dormant by
+    design. Do NOT delete it as "dead code".
+
     Detects the two common Xtream-Codes credential surfaces:
 
     * Query form: ``...get.php?username=X&password=Y`` (the M3U-playlist
@@ -144,10 +168,12 @@ def url_embeds_username(url: Optional[str]) -> bool:
       ``movie``/``series`` variants, plus the bare
       ``/<user>/<pass>/<id>`` form without a leading type segment).
 
-    A connection whose active stream URL embeds credentials is a genuine
-    direct-IPTV client — it is attributed via the bd-gy5nd
-    provider/hostname path and EXCLUDED from media-server reconciliation.
-    This is the discriminator that replaces the IP gate.
+    A connection whose active stream URL embeds credentials would be a genuine
+    direct-IPTV client — attributed via the bd-gy5nd provider/hostname path
+    and EXCLUDED from media-server reconciliation. This was the original
+    discriminator that replaced the IP gate (bd-mlcla); it was superseded by
+    the account-identity discriminator (bd-4w9w6 / bd-rools) and is now
+    dormant per the note above.
 
     Returns ``False`` for empty / unparsable / non-XC URLs (e.g. a
     Dispatcharr proxy URL with no embedded credentials) so those
@@ -282,14 +308,17 @@ class Connection:
             :func:`eligible_connections`; this field lets the caller pass
             the full connection list and let the module do the filtering.
 
-            **bd-4w9w6 / bd-rools:** the call sites no longer derive this
-            from the channel's shared upstream URL (that conflated channel
-            SOURCE with client IDENTITY and dropped every media-server
-            viewer to User #0). The per-client discriminator is now
-            :attr:`has_account_identity`. ``has_url_identity`` is retained
-            for the pure-reconciler API and any future caller that has a
-            genuine per-connection credentialed URL, but both call sites
-            currently set it ``False``.
+            **bd-4w9w6 / bd-rools — RETAINED-BUT-NOT-WIRED (bd-spzeu):** the
+            call sites no longer derive this from the channel's shared upstream
+            URL (that conflated channel SOURCE with client IDENTITY and dropped
+            every media-server viewer to User #0). The live per-client
+            discriminator is now :attr:`has_account_identity`. This field is
+            production-dead — both call sites hardcode it ``False`` — but is
+            kept by design for the pure-reconciler API and any future caller
+            that has a genuine per-connection credentialed URL (see
+            :func:`url_embeds_username`). Do NOT delete it as dead code; it is
+            dormant scaffolding awaiting a per-client URL identity signal that
+            Dispatcharr ``/proxy/ts/status`` does not currently provide.
         has_account_identity: True when this connection carries a genuine
             Dispatcharr ACCOUNT identity — a positive ``user_id`` (and/or a
             non-empty ``username``) on the Dispatcharr ``/proxy/ts/status``
@@ -560,6 +589,15 @@ def eligible_connections(connections: list[Connection]) -> list[Connection]:
     (``has_account_identity``). Both mark a genuine direct-IPTV client
     attributed via the bd-gy5nd provider/hostname path; neither must be
     reconciled against media-server sessions.
+
+    **``has_url_identity`` filter is RETAINED-BUT-NOT-WIRED (bd-spzeu /
+    dormant-code rule).** In production ``has_url_identity`` is always
+    ``False`` (both call sites hardcode it — see :func:`url_embeds_username`
+    for why), so the ``not c.has_url_identity`` predicate below is currently
+    always-true and the LIVE discriminator is ``has_account_identity`` alone.
+    The URL-identity branch is kept intact, not deleted, so the eligibility
+    filter is ready the moment a per-client credentialed URL signal surfaces.
+    Do NOT remove it.
 
     bd-rools (re-fix for the bd-cat70 direct-client cross-attribution):
     excluding account-identity connections is what stops a genuine direct

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -6,11 +6,20 @@ They are skipped automatically when the container is unreachable.
 
 Run: cd backend && python -m pytest tests/e2e/ -q
 """
+import time
+
 import httpx
 import pytest
 
 BASE_URL = "http://localhost:6100"
 AUTH_CREDS = {"username": "e2e_test", "password": "e2e_test_password"}
+
+# Login rate limit: 5/minute.  On rapid reruns we may hit 429 before the
+# window resets.  We retry at most _LOGIN_MAX_RETRIES times, honouring the
+# Retry-After header (falling back to _LOGIN_RETRY_WAIT_S seconds) so the
+# suite self-heals without cascading 401s across every authed test.
+_LOGIN_MAX_RETRIES = 2
+_LOGIN_RETRY_WAIT_S = 65  # slightly past the 60-s rate-limit window
 
 
 def _container_reachable() -> bool:
@@ -20,6 +29,33 @@ def _container_reachable() -> bool:
         return resp.status_code == 200
     except (httpx.ConnectError, httpx.TimeoutException):
         return False
+
+
+def _login(client: httpx.Client) -> bool:
+    """
+    Attempt to authenticate, retrying up to _LOGIN_MAX_RETRIES times on 429.
+
+    Returns True when a session cookie has been obtained, False otherwise.
+    The caller is responsible for skipping or failing the session when False
+    is returned — this function never raises.
+    """
+    for attempt in range(1 + _LOGIN_MAX_RETRIES):
+        resp = client.post("/api/auth/login", json=AUTH_CREDS)
+        if resp.status_code == 200:
+            # httpx.Client stores the Set-Cookie automatically
+            return True
+        if resp.status_code == 429:
+            if attempt < _LOGIN_MAX_RETRIES:
+                wait = int(resp.headers.get("Retry-After", _LOGIN_RETRY_WAIT_S))
+                print(  # noqa: T201 — pytest captures this in -s / verbose mode
+                    f"\n[e2e conftest] Login rate-limited (429). "
+                    f"Waiting {wait}s before retry {attempt + 1}/{_LOGIN_MAX_RETRIES}…"
+                )
+                time.sleep(wait)
+                continue
+        # Any other failure (4xx/5xx) or exhausted retries — give up
+        break
+    return False
 
 
 # Skip all E2E tests if container is not available
@@ -37,13 +73,24 @@ def base_url():
 
 @pytest.fixture(scope="session")
 def e2e_client():
-    """Create an authenticated httpx client for E2E tests."""
+    """
+    Create an authenticated httpx client for E2E tests.
+
+    Authentication is attempted once per pytest session (session scope).
+    On a 429 the fixture backs off and retries (up to _LOGIN_MAX_RETRIES
+    times), honouring the Retry-After header.  If login still fails after
+    all retries the entire suite is skipped with an explanatory message
+    rather than letting every authed test fail with 401.
+    """
     with httpx.Client(base_url=BASE_URL, timeout=15) as client:
-        # Login to get session cookie
-        resp = client.post("/api/auth/login", json=AUTH_CREDS)
-        if resp.status_code == 200:
-            # Cookies are automatically stored by httpx Client
-            pass
+        authenticated = _login(client)
+        if not authenticated:
+            pytest.skip(
+                "E2E auth failed: could not obtain a session cookie from "
+                f"{BASE_URL}/api/auth/login after {1 + _LOGIN_MAX_RETRIES} "
+                "attempts (rate-limited or credentials rejected). "
+                "Wait ~60 s and rerun."
+            )
         yield client
 
 

--- a/backend/tests/routers/test_emby_settings.py
+++ b/backend/tests/routers/test_emby_settings.py
@@ -349,3 +349,145 @@ class TestEmbyTestConnectionSsrfMitigation:
         assert response.status_code == 200, response.json()
         assert response.json() == {"ok": True}
         assert captured["base_url"] == "https://emby.example.com:8920"
+
+
+class TestEmbyTestConnectionLoopbackDenylist:
+    """Loopback / link-local SSRF denylist — security finding SEC-2
+    follow-up (bd-fbc50).
+
+    The scheme allowlist alone still permitted an authenticated admin to
+    point Test Connection at the ECM host's own loopback services or at
+    the cloud instance-metadata IP (169.254.169.254). This suite is the
+    regression target for the host denylist added to
+    ``_sanitize_base_url``. RFC1918 LAN ranges are intentionally LEFT
+    reachable (Plex/Emby/Jellyfin run on the operator's LAN) — see the
+    ``Allowed`` cases below.
+
+    Denial coverage lives here on the shared helper (Emby path). Plex and
+    Jellyfin get a single smoke each in their own files, since all three
+    endpoints call the same ``_sanitize_base_url``.
+    """
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "http://169.254.169.254/latest/meta-data/",  # cloud metadata IMDS
+            "http://localhost",
+            "http://localhost:8096",
+            "http://127.0.0.1",
+            "http://127.0.0.5:8096",  # anywhere in 127.0.0.0/8
+            "http://[::1]",
+            "http://[fe80::1]",  # IPv6 link-local
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_rejects_loopback_and_link_local(self, async_client, base_url):
+        """Loopback / link-local hosts are rejected inline before
+        EmbyClient is ever constructed — no HTTP probe is issued."""
+        emby_constructor = AsyncMock()
+        with patch("routers.settings.EmbyClient", side_effect=emby_constructor):
+            response = await async_client.post(
+                "/api/settings/emby/test-connection",
+                json={"base_url": base_url, "api_key": "k"},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ok"] is False
+        assert "host" in body["error"].lower()
+        emby_constructor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_metadata_ip_explicitly(self, async_client):
+        """Explicit guard on the cloud instance-metadata IP — the
+        canonical SSRF-to-credential-theft pivot."""
+        emby_constructor = AsyncMock()
+        with patch("routers.settings.EmbyClient", side_effect=emby_constructor):
+            response = await async_client.post(
+                "/api/settings/emby/test-connection",
+                json={"base_url": "http://169.254.169.254", "api_key": "k"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is False
+        emby_constructor.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "http://192.168.1.50:8096",  # 192.168.0.0/16
+            "http://10.0.0.5:8096",  # 10.0.0.0/8
+            "http://172.16.3.4:8920",  # 172.16.0.0/12
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_allows_rfc1918_private_ranges(self, async_client, base_url):
+        """RFC1918 LAN ranges MUST remain reachable — Plex / Emby /
+        Jellyfin legitimately run on the operator's local network.
+        Blocking these would break the primary use case."""
+        mock_client = AsyncMock()
+        mock_client.get_sessions = AsyncMock(return_value=[])
+        mock_client.close = AsyncMock()
+
+        captured: dict = {}
+
+        def constructor_spy(base_url_arg, api_key):
+            captured["base_url"] = base_url_arg
+            return mock_client
+
+        with patch("routers.settings.EmbyClient", side_effect=constructor_spy):
+            response = await async_client.post(
+                "/api/settings/emby/test-connection",
+                json={"base_url": base_url, "api_key": "k"},
+            )
+
+        assert response.status_code == 200, response.json()
+        assert response.json() == {"ok": True}
+        assert captured["base_url"] == base_url
+
+    @pytest.mark.asyncio
+    async def test_allows_public_host(self, async_client):
+        """A normal public host passes the denylist (sanity)."""
+        mock_client = AsyncMock()
+        mock_client.get_sessions = AsyncMock(return_value=[])
+        mock_client.close = AsyncMock()
+
+        captured: dict = {}
+
+        def constructor_spy(base_url_arg, api_key):
+            captured["base_url"] = base_url_arg
+            return mock_client
+
+        with patch("routers.settings.EmbyClient", side_effect=constructor_spy):
+            response = await async_client.post(
+                "/api/settings/emby/test-connection",
+                json={
+                    "base_url": "https://emby.example.com:8920",
+                    "api_key": "k",
+                },
+            )
+
+        assert response.status_code == 200, response.json()
+        assert response.json() == {"ok": True}
+        assert captured["base_url"] == "https://emby.example.com:8920"
+
+    @pytest.mark.asyncio
+    async def test_resolved_name_pointing_at_loopback_is_blocked(self, async_client):
+        """A hostname that RESOLVES to a loopback/link-local IP is blocked
+        too (defense against DNS pointing an innocuous name at 127.0.0.1).
+        We patch getaddrinfo so the test does not depend on live DNS."""
+        emby_constructor = AsyncMock()
+        fake_getaddrinfo = lambda *a, **k: [  # noqa: E731 — test stub
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+        ]
+        with patch("routers.settings.EmbyClient", side_effect=emby_constructor), patch(
+            "routers.settings.socket.getaddrinfo", side_effect=fake_getaddrinfo
+        ):
+            response = await async_client.post(
+                "/api/settings/emby/test-connection",
+                json={"base_url": "http://sneaky.attacker.example", "api_key": "k"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is False
+        emby_constructor.assert_not_called()

--- a/backend/tests/routers/test_jellyfin_settings.py
+++ b/backend/tests/routers/test_jellyfin_settings.py
@@ -294,3 +294,56 @@ class TestJellyfinTestConnectionSsrfMitigation:
         assert response.status_code == 200, response.json()
         assert response.json() == {"ok": True}
         assert captured["base_url"] == "https://jellyfin.example.com:8920"
+
+    @pytest.mark.asyncio
+    async def test_rejects_loopback_smoke(self, async_client):
+        """Loopback denylist smoke (bd-fbc50) — full coverage is on the
+        shared ``_sanitize_base_url`` helper in the Emby suite; this just
+        confirms the Jellyfin path is wired through the same guard."""
+        jellyfin_constructor = AsyncMock()
+        with patch("routers.settings.JellyfinClient", side_effect=jellyfin_constructor):
+            response = await async_client.post(
+                "/api/settings/jellyfin/test-connection",
+                json={"base_url": "http://[::1]:8096", "api_key": "k"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is False
+        jellyfin_constructor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_metadata_ip_smoke(self, async_client):
+        """Cloud metadata IP is blocked on the Jellyfin path (bd-fbc50)."""
+        jellyfin_constructor = AsyncMock()
+        with patch("routers.settings.JellyfinClient", side_effect=jellyfin_constructor):
+            response = await async_client.post(
+                "/api/settings/jellyfin/test-connection",
+                json={"base_url": "http://169.254.169.254", "api_key": "k"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is False
+        jellyfin_constructor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allows_rfc1918_smoke(self, async_client):
+        """RFC1918 LAN host stays reachable on the Jellyfin path (bd-fbc50)."""
+        mock_client = AsyncMock()
+        mock_client.get_sessions = AsyncMock(return_value=[])
+        mock_client.close = AsyncMock()
+
+        captured: dict = {}
+
+        def constructor_spy(base_url, api_key):
+            captured["base_url"] = base_url
+            return mock_client
+
+        with patch("routers.settings.JellyfinClient", side_effect=constructor_spy):
+            response = await async_client.post(
+                "/api/settings/jellyfin/test-connection",
+                json={"base_url": "http://192.168.1.50:8096", "api_key": "k"},
+            )
+
+        assert response.status_code == 200, response.json()
+        assert response.json() == {"ok": True}
+        assert captured["base_url"] == "http://192.168.1.50:8096"

--- a/backend/tests/routers/test_plex_settings.py
+++ b/backend/tests/routers/test_plex_settings.py
@@ -317,3 +317,56 @@ class TestPlexTestConnectionSsrfMitigation:
         assert response.status_code == 200, response.json()
         assert response.json() == {"ok": True}
         assert captured["base_url"] == "https://plex.example.com:32400"
+
+    @pytest.mark.asyncio
+    async def test_rejects_loopback_smoke(self, async_client):
+        """Loopback denylist smoke (bd-fbc50) — full coverage is on the
+        shared ``_sanitize_base_url`` helper in the Emby suite; this just
+        confirms the Plex path is wired through the same guard."""
+        plex_constructor = AsyncMock()
+        with patch("routers.settings.PlexClient", side_effect=plex_constructor):
+            response = await async_client.post(
+                "/api/settings/plex/test-connection",
+                json={"base_url": "http://127.0.0.1:32400", "token": "tkn"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is False
+        plex_constructor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_metadata_ip_smoke(self, async_client):
+        """Cloud metadata IP is blocked on the Plex path (bd-fbc50)."""
+        plex_constructor = AsyncMock()
+        with patch("routers.settings.PlexClient", side_effect=plex_constructor):
+            response = await async_client.post(
+                "/api/settings/plex/test-connection",
+                json={"base_url": "http://169.254.169.254", "token": "tkn"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is False
+        plex_constructor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allows_rfc1918_smoke(self, async_client):
+        """RFC1918 LAN host stays reachable on the Plex path (bd-fbc50)."""
+        mock_client = AsyncMock()
+        mock_client.get_sessions = AsyncMock(return_value=[])
+        mock_client.close = AsyncMock()
+
+        captured: dict = {}
+
+        def constructor_spy(base_url, token):
+            captured["base_url"] = base_url
+            return mock_client
+
+        with patch("routers.settings.PlexClient", side_effect=constructor_spy):
+            response = await async_client.post(
+                "/api/settings/plex/test-connection",
+                json={"base_url": "http://192.168.1.50:32400", "token": "tkn"},
+            )
+
+        assert response.status_code == 200, response.json()
+        assert response.json() == {"ok": True}
+        assert captured["base_url"] == "http://192.168.1.50:32400"

--- a/backend/tests/services/test_attribution_reconciler.py
+++ b/backend/tests/services/test_attribution_reconciler.py
@@ -97,7 +97,16 @@ def _assigned_names(result) -> dict[str, str | None]:
 
 
 class TestUrlIdentityDiscriminator:
-    """The discriminator that replaces the IP gate (brief test #5)."""
+    """The original (now DORMANT) URL-identity discriminator (brief test #5).
+
+    RETAINED-BUT-NOT-WIRED (bd-spzeu): ``url_embeds_username`` and the
+    ``has_url_identity`` eligibility branch are production-dead — both
+    reconciler call sites hardcode ``has_url_identity=False`` and the live
+    discriminator is ``has_account_identity``. These tests pin the dormant
+    scaffolding so it stays correct for the day a per-client credentialed-URL
+    signal surfaces; they do NOT exercise a live production path. See
+    ``services.attribution_reconciler.url_embeds_username`` for the rationale.
+    """
 
     @pytest.mark.parametrize(
         "url",
@@ -129,7 +138,12 @@ class TestUrlIdentityDiscriminator:
 
 class TestEligibility:
     def test_url_identity_connections_excluded(self):
-        """Connections with an embedded URL username are not reconciled."""
+        """Connections with an embedded URL username are not reconciled.
+
+        Pins the DORMANT ``has_url_identity`` eligibility branch (bd-spzeu:
+        RETAINED-BUT-NOT-WIRED — always ``False`` in production). Kept correct
+        for a future per-client credentialed-URL signal.
+        """
         conns = [
             _conn("c1", ip="172.18.0.1"),
             _conn("c2", ip="10.0.0.5", url_identity=True),
@@ -138,7 +152,11 @@ class TestEligibility:
         assert [c.client_id for c in eligible] == ["c1"]
 
     def test_url_identity_connection_never_gets_a_user(self):
-        """A direct-IPTV client is excluded even when users are available."""
+        """A direct-IPTV client is excluded even when users are available.
+
+        Also pins the DORMANT ``has_url_identity`` branch (bd-spzeu). See
+        :meth:`test_url_identity_connections_excluded`.
+        """
         conns = [_conn("xc1", ip="10.0.0.5", url_identity=True)]
         users = [_user("alice")]
         result = reconcile_channel(conns, users)
@@ -714,6 +732,113 @@ class TestServerProxyBranch:
         # Second proxy → User #0 (no double-count).
         assert by_id["proxy2"].user is None
         assert not by_id["proxy2"].is_proxy_multi
+
+
+# ---------------------------------------------------------------------------
+# bd-spzeu — ACCEPTED LIMITATION boundary pin (mixed media-server + anonymous
+# direct-IPTV/XC on one channel, only the media-server user matched)
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptedMixedDirectBoundary:
+    """Pin the ACCEPTED current outcome of the mixed media-server + genuine
+    direct-IPTV/XC same-channel case (bd-spzeu, follow-up to bd-4w9w6).
+
+    THIS IS NOT A BUG TO FIX. It is the residual, PO-accepted limitation that
+    bd-4w9w6 / bd-rools left in place, pinned here so it cannot silently drift
+    and so it serves as the target if a per-client identity signal ever
+    surfaces.
+
+    The discriminator that distinguishes a genuine direct-IPTV subscriber from
+    an anonymous media-server pull is a per-client identity signal:
+    ``has_account_identity`` (a positive Dispatcharr ``user_id``) or
+    ``has_url_identity`` (per-client credentialed URL). When the direct-IPTV/XC
+    client carries EITHER signal it is correctly excluded — that path is the
+    happy case and is pinned by
+    :class:`TestEligibility.test_account_identity_connection_never_absorbs_media_server_user`.
+
+    The accepted limitation lives in the gap WHERE NO SUCH SIGNAL EXISTS: a
+    genuine direct-IPTV/XC client that is ANONYMOUS to Dispatcharr
+    (``user_id == "0"`` / ``0`` / ``None``, no per-client credentialed URL —
+    exactly what Dispatcharr ``/proxy/ts/status`` surfaces for many real direct
+    clients) is INDISTINGUISHABLE from the anonymous media-server pull. Both
+    reach the reconciler as plain eligible connections with no identity. Source
+    IP only RANKS (soft hint), it never identifies. So when only the
+    media-server user matched, the reconciler may pin that user's name to the
+    direct-IPTV connection (the wrong one) and drop the real media-server pull
+    to User #0 — depending purely on tie-break order.
+
+    Net-positive vs. the prior all-User#0 state (the media-server name DOES
+    surface on the channel; it is the per-connection ROW that can be wrong),
+    which is why this is accepted, not blocked. Would change if a per-client
+    identity signal ever surfaces on the anonymous direct connection.
+    """
+
+    def test_anonymous_direct_iptv_may_take_media_server_name_when_ranked_first(self):
+        """ACCEPTED LIMITATION: an anonymous genuine direct-IPTV/XC client that
+        ranks ahead of the anonymous media-server pull takes the media-server
+        user's name, dropping the real pull to User #0.
+
+        No per-client identity signal exists to tell the two anonymous
+        connections apart, so the mis-pin is structural, not a logic error.
+        Pinned here so it cannot silently drift; the assertions describe
+        TODAY'S behavior, not a desired one. If a per-client identity signal
+        surfaces (e.g. the direct client gains a Dispatcharr account id), this
+        scenario moves to the happy path and this test would be updated to
+        assert the direct client is excluded instead.
+        """
+        # Genuine direct-IPTV/XC viewer, anonymous to Dispatcharr (no account
+        # identity, no per-client URL identity), connected earlier so it sorts
+        # ahead of the media-server pull in the shared UNKNOWN IP-priority
+        # bucket. There is NO signal that marks it as a direct client.
+        direct_xc = _conn("xc_client", ip="203.0.113.50", connected_at=1.0)
+        # The anonymous media-server pull (later connected_at → sorts second).
+        media_pull = _conn("media_pull", ip="172.18.0.1", connected_at=2.0)
+        # Only the media-server user matched on this channel.
+        users = [
+            _user("MotWakorb", user_id="uid-mw", last_activity="2026-05-20T12:00:00Z")
+        ]
+
+        result = reconcile_channel([direct_xc, media_pull], users)
+        names = _assigned_names(result)
+
+        # ACCEPTED current outcome: the media-server name lands on the WRONG
+        # connection (the direct-IPTV client), because nothing distinguishes
+        # the two anonymous connections except rank order.
+        assert names["xc_client"] == "MotWakorb"
+        # The real media-server pull is left at User #0.
+        assert names["media_pull"] is None
+        # Neither is a rollup — only one candidate user, so no Option-B group.
+        by_id = {a.client_id: a for a in result.assignments}
+        assert not by_id["xc_client"].is_rollup
+        assert not by_id["media_pull"].is_rollup
+        # Net-positive invariant that MUST hold: the media-server user still
+        # surfaces somewhere on the channel (not the prior all-User#0 state).
+        assert "MotWakorb" in {u.user_name for u in result.channel_viewers}
+
+    def test_account_identity_direct_client_does_not_trip_the_limitation(self):
+        """Companion to the limitation: the moment the direct-IPTV client DOES
+        carry a per-client identity signal (a Dispatcharr account id), the
+        limitation disappears — it is excluded and the media-server user pairs
+        to the real anonymous pull. This is the target state the limitation
+        would reach if such a signal ever surfaces on the anonymous case.
+        """
+        # Same topology, but now the direct client carries an account identity.
+        direct_xc = _conn(
+            "xc_client", ip="203.0.113.50", connected_at=1.0, account_identity=True
+        )
+        media_pull = _conn("media_pull", ip="172.18.0.1", connected_at=2.0)
+        users = [
+            _user("MotWakorb", user_id="uid-mw", last_activity="2026-05-20T12:00:00Z")
+        ]
+
+        result = reconcile_channel([direct_xc, media_pull], users)
+        names = _assigned_names(result)
+
+        # The identified direct client is excluded entirely (no assignment).
+        assert "xc_client" not in names
+        # The media-server user correctly pairs to the real anonymous pull.
+        assert names["media_pull"] == "MotWakorb"
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0023",
+  "version": "0.17.3-0024",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/services/httpClient.test.ts
+++ b/frontend/src/services/httpClient.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for httpClient extractDetail fallback (bd-p3jpl).
+ *
+ * extractDetail() is module-private; we test it via fetchJson's observable
+ * behaviour: the HttpError thrown on a non-ok response must always carry a
+ * non-empty message, even when the backend sends detail: '' or detail: [].
+ *
+ * Reproduces the bug scenario: FastAPI returns a 422 with an empty detail
+ * field, which previously caused extractDetail to return '' and the modal
+ * error banner to be silently suppressed.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchJson, HttpError } from './httpClient';
+
+// Helper: return a minimal Response-like object that fetch() can return.
+function mockResponse(status: number, body: unknown, statusText = 'Error'): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+    statusText,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('extractDetail fallback (bd-p3jpl)', () => {
+  it('returns a non-empty fallback when detail is empty string', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse(422, { detail: '' }, 'Unprocessable Entity'),
+    );
+
+    await expect(fetchJson('/test')).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).message.trim()).not.toBe('');
+      return true;
+    });
+  });
+
+  it('returns a non-empty fallback when detail is an empty array', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse(422, { detail: [] }, 'Unprocessable Entity'),
+    );
+
+    await expect(fetchJson('/test')).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).message.trim()).not.toBe('');
+      return true;
+    });
+  });
+
+  it('returns the real detail string when detail is non-empty', async () => {
+    const detail = 'Source channels [999] no longer exist';
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse(422, { detail }, 'Unprocessable Entity'),
+    );
+
+    await expect(fetchJson('/test')).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).message).toBe(detail);
+      return true;
+    });
+  });
+
+  it('joins FastAPI validation-error array entries into a single string', async () => {
+    const detail = [
+      { loc: ['body', 'name'], msg: 'field required', type: 'value_error.missing' },
+      { loc: ['body', 'id'], msg: 'value is not a valid integer', type: 'type_error.integer' },
+    ];
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse(422, { detail }, 'Unprocessable Entity'),
+    );
+
+    await expect(fetchJson('/test')).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).message).toBe(
+        'field required; value is not a valid integer',
+      );
+      return true;
+    });
+  });
+
+  it('falls back to statusText when response body has no detail field', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse(500, { error: 'oops' }, 'Internal Server Error'),
+    );
+
+    await expect(fetchJson('/test')).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).message).toBe('Internal Server Error');
+      return true;
+    });
+  });
+});

--- a/frontend/src/services/httpClient.ts
+++ b/frontend/src/services/httpClient.ts
@@ -18,12 +18,16 @@ export class HttpError extends Error {
 
 /** Extract a human-readable message from a FastAPI error detail field. */
 function extractDetail(detail: unknown): string {
-  if (typeof detail === 'string') return detail;
-  if (Array.isArray(detail)) {
+  let msg: string;
+  if (typeof detail === 'string') {
+    msg = detail;
+  } else if (Array.isArray(detail)) {
     // FastAPI validation errors: [{loc: [...], msg: "...", type: "..."}]
-    return detail.map((e: Record<string, unknown>) => e.msg || JSON.stringify(e)).join('; ');
+    msg = detail.map((e: Record<string, unknown>) => e.msg || JSON.stringify(e)).join('; ');
+  } else {
+    msg = JSON.stringify(detail);
   }
-  return JSON.stringify(detail);
+  return msg.trim() || 'Server returned an empty error';
 }
 
 /**

--- a/mcp-server/_endpoint_contracts.py
+++ b/mcp-server/_endpoint_contracts.py
@@ -558,6 +558,18 @@ ENDPOINTS: dict[str, Endpoint] = {
         method="GET",
         path="/api/normalization/rules",
     ),
+    # PATCH /api/normalization/groups/{group_id} — UpdateRuleGroupRequest
+    # (backend/routers/normalization.py:249 update_normalization_group).
+    # Wraps the existing backend endpoint; the MCP tool uses only ``enabled``
+    # to toggle the global enabled flag on a NormalizationRuleGroup, but the
+    # full UpdateRuleGroupRequest field set is declared here so request_fields
+    # subset check matches the Pydantic model (bd-svixy).
+    "normalization_update_group": Endpoint(
+        name="normalization_update_group",
+        method="PATCH",
+        path="/api/normalization/groups/{group_id}",
+        request_fields=frozenset({"name", "description", "enabled", "priority"}),
+    ),
     # -- notifications domain ---------------------------------------------
     "notifications_list": Endpoint(
         name="notifications_list",

--- a/mcp-server/tests/test_tools.py
+++ b/mcp-server/tests/test_tools.py
@@ -2952,3 +2952,160 @@ class TestRunAutoCreationMergeLabels:
         # Should render 0 gracefully, not crash.
         assert "Stream merges: 0" in text
         assert "Channels touched: 0" in text
+
+
+# --- TestSetNormalizationGroupEnabled (bd-svixy) ---
+class TestSetNormalizationGroupEnabled:
+    """Tests for set_normalization_group_enabled tool.
+
+    The tool wraps PATCH /api/normalization/groups/{group_id} with {enabled}
+    in the body (backend/routers/normalization.py:249 update_normalization_group).
+    """
+
+    @pytest.mark.asyncio
+    async def test_enable_group_calls_correct_endpoint(self):
+        """Enabling a group calls PATCH with group_id path arg and enabled=True body."""
+        from tools.normalization import register
+        from mcp.server.fastmcp import FastMCP
+        from _endpoint_contracts import ENDPOINTS
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = _make_ecm_client_mock(
+            call_endpoint={"id": 3, "name": "Strip Quality", "enabled": True}
+        )
+
+        with patch("tools.normalization.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "set_normalization_group_enabled", {"group_id": 3, "enabled": True}
+            )
+
+        text = result[0][0].text
+        assert "Strip Quality" in text
+        assert "3" in text
+        assert "enabled" in text
+        mock_client.call_endpoint.assert_awaited_once_with(
+            ENDPOINTS["normalization_update_group"],
+            path_args={"group_id": 3},
+            body={"enabled": True},
+        )
+
+    @pytest.mark.asyncio
+    async def test_disable_group_calls_correct_endpoint(self):
+        """Disabling a group calls PATCH with enabled=False body."""
+        from tools.normalization import register
+        from mcp.server.fastmcp import FastMCP
+        from _endpoint_contracts import ENDPOINTS
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = _make_ecm_client_mock(
+            call_endpoint={"id": 7, "name": "Title Case", "enabled": False}
+        )
+
+        with patch("tools.normalization.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "set_normalization_group_enabled", {"group_id": 7, "enabled": False}
+            )
+
+        text = result[0][0].text
+        assert "Title Case" in text
+        assert "disabled" in text
+        mock_client.call_endpoint.assert_awaited_once_with(
+            ENDPOINTS["normalization_update_group"],
+            path_args={"group_id": 7},
+            body={"enabled": False},
+        )
+
+    @pytest.mark.asyncio
+    async def test_success_message_includes_group_name_and_state(self):
+        """Success response surfaces group name, id, and new state."""
+        from tools.normalization import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = _make_ecm_client_mock(
+            call_endpoint={"id": 5, "name": "My Group", "enabled": True}
+        )
+
+        with patch("tools.normalization.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "set_normalization_group_enabled", {"group_id": 5, "enabled": True}
+            )
+
+        text = result[0][0].text
+        assert "My Group" in text
+        assert "5" in text
+        assert "enabled" in text
+
+    @pytest.mark.asyncio
+    async def test_404_error_surfaces_in_output(self):
+        """When the backend returns 404, the error message is surfaced to the operator."""
+        from tools.normalization import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        mock_client = _make_ecm_client_mock()
+        mock_client.call_endpoint.side_effect = Exception("404: Group not found")
+
+        with patch("tools.normalization.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "set_normalization_group_enabled", {"group_id": 999, "enabled": True}
+            )
+
+        text = result[0][0].text
+        assert "Error" in text
+        assert "999" in text
+
+    @pytest.mark.asyncio
+    async def test_missing_name_in_response_falls_back_gracefully(self):
+        """When the backend omits 'name' in its response, the tool falls back to 'group {id}'."""
+        from tools.normalization import register
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        register(mcp)
+
+        # Backend response missing 'name' key.
+        mock_client = _make_ecm_client_mock(call_endpoint={"id": 2, "enabled": False})
+
+        with patch("tools.normalization.get_ecm_client", return_value=mock_client):
+            result = await mcp.call_tool(
+                "set_normalization_group_enabled", {"group_id": 2, "enabled": False}
+            )
+
+        text = result[0][0].text
+        assert "2" in text
+        assert "disabled" in text
+
+    def test_normalization_update_group_endpoint_registered(self):
+        """normalization_update_group is in the registry with correct PATCH method/path."""
+        from _endpoint_contracts import ENDPOINTS
+
+        ep = ENDPOINTS["normalization_update_group"]
+        assert ep.method == "PATCH"
+        assert ep.path == "/api/normalization/groups/{group_id}"
+        assert "enabled" in ep.request_fields
+
+    def test_list_normalization_rules_shows_id_and_enabled(self):
+        """list_normalization_rules rendering includes id= and enabled/disabled per group.
+
+        Verifies that operators can read the group_id they need to pass to
+        set_normalization_group_enabled directly from the list output (bd-svixy scope §3).
+        """
+        # The rendering is in tools/normalization.py list_normalization_rules.
+        # Lines render as: "  {name} (id={gid}) — {enabled}, {count} rules"
+        # Check that the format matches by inspecting the source directly.
+        import inspect
+        from tools import normalization
+        src = inspect.getsource(normalization)
+        assert "id={gid}" in src or "id=" in src, (
+            "list_normalization_rules must render the group id so the operator "
+            "knows which group_id to pass to set_normalization_group_enabled"
+        )

--- a/mcp-server/tools/normalization.py
+++ b/mcp-server/tools/normalization.py
@@ -48,6 +48,35 @@ def register(mcp: FastMCP):
             return f"Error testing normalization: {e}"
 
     @mcp.tool()
+    async def set_normalization_group_enabled(group_id: int, enabled: bool) -> str:
+        """Enable or disable a normalization rule group globally.
+
+        A normalization group must be globally enabled for its rules to be applied
+        by the engine — even if the group is listed in an auto-creation rule's
+        normalization_group_ids, the engine skips it when enabled=False.
+
+        Use list_normalization_rules to discover group IDs and their current
+        enabled status.
+
+        Args:
+            group_id: ID of the NormalizationRuleGroup to update.
+            enabled: True to enable the group; False to disable it.
+        """
+        try:
+            client = get_ecm_client()
+            result = await client.call_endpoint(
+                ENDPOINTS["normalization_update_group"],
+                path_args={"group_id": group_id},
+                body={"enabled": enabled},
+            )
+            name = result.get("name", f"group {group_id}") if isinstance(result, dict) else f"group {group_id}"
+            state = "enabled" if enabled else "disabled"
+            return f"Normalization group '{name}' (id={group_id}) is now {state}."
+        except Exception as e:
+            logger.error("[MCP] set_normalization_group_enabled failed: %s", e)
+            return f"Error updating normalization group {group_id}: {e}"
+
+    @mcp.tool()
     async def list_normalization_rules() -> str:
         """List all normalization rule groups and their rules."""
         try:


### PR DESCRIPTION
Five independent non-0.18.0 P2s, each built in its own worktree and gate-verified independently, bundled into one batch (one version bump / CI cycle).

- **`fbc50` (security/SSRF):** `_sanitize_base_url` (shared by emby/plex/jellyfin test-connection) now blocks loopback (`127/8`, `::1`, `localhost`) + link-local (`169.254/16` incl. the `169.254.169.254` metadata IP, `fe80::/10`), resolves hostnames and checks the resolved IP, and unwraps IPv4-mapped IPv6 — **RFC1918 deliberately allowed** (LAN media servers are the primary use case). stdlib `ipaddress`/`socket`, no regex. +19 tests. *(Admin-gated surface; residual DNS-rebinding TOCTOU noted, out of scope.)*
- **`spzeu` (attribution):** pins the accepted mixed media-server + anonymous-direct-IPTV boundary with a passing test so it can't silently drift, and doc-syncs the dormant URL-identity code (`url_embeds_username`/`eligible_connections`) as retained-but-not-wired. **No behavior change, no code deleted** (dormant-code rule; AST-verified).
- **`4sned` (test infra):** the session-scoped e2e auth fixture was swallowing a login 429 → cascading 401s; now retries with `Retry-After` backoff and skips the session cleanly if auth still fails. Verified over 6 rapid reruns (one hit 429, recovered). Test-only.
- **`p3jpl` (UI bug):** real cause was `detail: []` (truthy) → `extractDetail([])` returning `''` → silenced modal banner. `extractDetail` now never returns empty (falls back), so the merge/find-duplicates error banners always render. +tests.
- **`svixy` (MCP feature):** new `set_normalization_group_enabled(group_id, enabled)` tool wrapping the existing `PATCH /api/normalization/groups/{id}` (+ contract entry); `list_normalization_rules` already surfaces id/enabled. +7 tests.

## Verification (independent)
- fbc50 488 / spzeu 164 / svixy 75 backend|mcp tests; p3jpl tsc clean + vitest; 4sned conftest sound. No file overlap; clean cherry-pick.
- Version consistency: all 3 at `0.17.3-0024`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)