### PR TITLE
v0.17.3-0025: P3 batch (retention, test fixes, polish, print-guide, Emby)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -205,6 +205,22 @@ class DispatcharrSettings(BaseModel):
     # M3USnapshot newest-N precedent (ADR-010 §D7).
     auto_creation_snapshot_days: int = 30  # Age window — prune snapshots older than this many days (by snapshot_time).
     auto_creation_snapshot_max: int = 50  # Count cap — keep at most this many newest snapshots; older ones pruned regardless of age.
+    # M3U change-tracking retention (bd-wehek / bd-f9gd8 DBA spike). Both tables
+    # grow with every Dispatcharr upstream change (every 5-min poll if upstream
+    # churns): m3u_snapshots stores ~1-10 kB groups_data JSON per row;
+    # m3u_change_logs stores ~500 B per detected change.  Neither had retention.
+    # Prune both by age, BEFORE the VACUUM step, mirroring the established
+    # age-window pattern.  90-day default matches the journal hot-retention window
+    # (bd-dmu8w) and gives operators a comfortable M3U change history without
+    # unbounded growth.
+    m3u_snapshot_days: int = 90  # Delete m3u_snapshots rows older than this many days (by snapshot_time).
+    m3u_change_log_days: int = 90  # Delete m3u_change_logs rows older than this many days (by change_time).
+    # unique_client_connections retention (bd-1wi3y / bd-f9gd8 DBA spike). High
+    # write rate (one row per (channel, IP) connection start) + 6 indexes makes
+    # this table grow quickly.  Currently no retention beyond manual stats reset.
+    # Prune by age, BEFORE the VACUUM step, mirroring the established
+    # age-window pattern.  90-day default mirrors the M3U retention window above.
+    unique_client_connection_days: int = 90  # Delete unique_client_connections rows older than this many days (by connected_at).
     # MCP server API key for Claude integration (empty = not configured)
     mcp_api_key: str = ""
     # Frontend error telemetry toggle (ADR-006 §10, bd-i6a1m).

--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0024",
+    version="0.17.3-0025",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0024"
+APP_VERSION = "0.17.3-0025"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/tasks/cleanup.py
+++ b/backend/tasks/cleanup.py
@@ -9,6 +9,8 @@ Scheduled task to clean up old data:
 - health_checks rows (bd-ia28g)
 - Notifications (bd-ia28g)
 - AutoCreationSnapshot rows (ADR-010 §D7 / uc51o.3)
+- M3USnapshot and M3UChangeLog rows (bd-wehek)
+- UniqueClientConnection rows (bd-1wi3y)
 - Orphaned data
 """
 import logging
@@ -22,9 +24,12 @@ from models import (
     AutoCreationExecution,
     AutoCreationSnapshot,
     JournalEntry,
+    M3UChangeLog,
+    M3USnapshot,
     Notification,
     StreamStats,
     TaskExecution,
+    UniqueClientConnection,
 )
 from task_scheduler import TaskScheduler, TaskResult, ScheduleConfig, ScheduleType
 from task_registry import register_task
@@ -63,6 +68,20 @@ class CleanupTask(TaskScheduler):
     the same maintenance pass. Snapshot counts are bounded (tens, not millions)
     by the count cap, so a single DELETE is fine (no batched-delete-to-dodge-
     the-write-lock concern — ADR-010 §D7).
+
+    M3USnapshot / M3UChangeLog retention (bd-wehek / bd-f9gd8 DBA spike) is
+    age-only, from the global Settings (config.py):
+    - m3u_snapshot_days (default 90): prune m3u_snapshots rows older than this
+      by ``snapshot_time``.
+    - m3u_change_log_days (default 90): prune m3u_change_logs rows older than
+      this by ``change_time``.
+    Both prune steps run BEFORE the VACUUM step (steps 8 and 9 below).
+
+    UniqueClientConnection retention (bd-1wi3y / bd-f9gd8 DBA spike) is
+    age-only, from the global Settings (config.py):
+    - unique_client_connection_days (default 90): prune rows older than this
+      by ``connected_at``.
+    Runs BEFORE the VACUUM step (step 9 below).
 
     Retention rationale (bd-dmu8w): the journal default is 90 days because
     bulk auto-creation now produces per-entity rows (bd-91mcq), amplifying
@@ -158,7 +177,7 @@ class CleanupTask(TaskScheduler):
         deleted_counts = {}
         errors = []
 
-        # 8 prune operations total:
+        # 10 prune operations total:
         # 1. stream_stats failed/pending probes
         # 2. task_executions
         # 3. journal_entries
@@ -166,9 +185,11 @@ class CleanupTask(TaskScheduler):
         # 5. health_checks (bd-ia28g)
         # 6. notifications (bd-ia28g)
         # 7. auto_creation_snapshots age + count prune (ADR-010 §D7, uc51o.3)
-        # 8. VACUUM (must remain LAST — runs after the snapshot prune so the
-        #    freed pages are reclaimed in the same pass)
-        total_steps = 8
+        # 8. m3u_snapshots + m3u_change_logs age prune (bd-wehek)
+        # 9. unique_client_connections age prune (bd-1wi3y)
+        # 10. VACUUM (must remain LAST — runs after all prune steps so freed
+        #     pages are reclaimed in the same maintenance pass)
+        total_steps = 10
 
         self._set_progress(
             total=total_steps,
@@ -498,8 +519,113 @@ class CleanupTask(TaskScheduler):
                     session.close()
                     return self._cancelled_result(started_at, deleted_counts)
 
-                # 8. VACUUM the database
-                self._set_progress(current=8, current_item="Vacuuming database")
+                # 8. bd-wehek: prune m3u_snapshots and m3u_change_logs by age.
+                # Both tables grow with every Dispatcharr upstream change (every
+                # 5-min poll if upstream churns): m3u_snapshots stores ~1-10 kB
+                # groups_data JSON per row; m3u_change_logs ~500 B per change.
+                # Neither had retention. Knobs from global Settings (config.py):
+                # ``m3u_snapshot_days`` (default 90) and
+                # ``m3u_change_log_days`` (default 90).
+                # Change-log rows are pruned first (they FK to snapshots via
+                # SET NULL on delete, so snapshot deletion is safe either way,
+                # but pruning change-logs first keeps the FK FK audit trail
+                # cleaner for operators who set different age windows).
+                self._set_progress(
+                    current=8,
+                    current_item="Pruning M3U snapshots and change logs",
+                )
+
+                try:
+                    from config import get_settings as _get_settings
+                    _settings = _get_settings()
+                    m3u_snapshot_days = getattr(_settings, "m3u_snapshot_days", 90)
+                    m3u_change_log_days = getattr(_settings, "m3u_change_log_days", 90)
+
+                    m3u_pruned = 0
+
+                    # 8a. Prune m3u_change_logs by change_time.
+                    change_log_cutoff = datetime.utcnow() - timedelta(days=m3u_change_log_days)
+                    change_logs_deleted = session.query(M3UChangeLog).filter(
+                        M3UChangeLog.change_time < change_log_cutoff,
+                    ).delete(synchronize_session=False)
+                    m3u_pruned += change_logs_deleted
+
+                    # 8b. Prune m3u_snapshots by snapshot_time. The FK from
+                    # m3u_change_logs to m3u_snapshots uses ON DELETE SET NULL,
+                    # so surviving change-log rows are not cascade-deleted.
+                    snapshot_cutoff = datetime.utcnow() - timedelta(days=m3u_snapshot_days)
+                    snapshots_deleted = session.query(M3USnapshot).filter(
+                        M3USnapshot.snapshot_time < snapshot_cutoff,
+                    ).delete(synchronize_session=False)
+                    m3u_pruned += snapshots_deleted
+
+                    deleted_counts["m3u_snapshots"] = snapshots_deleted
+                    deleted_counts["m3u_change_logs"] = change_logs_deleted
+                    session.commit()
+                    logger.info(
+                        "[%s] Pruned %s m3u_snapshots (older than %s days) and "
+                        "%s m3u_change_logs (older than %s days)",
+                        self.task_id,
+                        snapshots_deleted,
+                        m3u_snapshot_days,
+                        change_logs_deleted,
+                        m3u_change_log_days,
+                    )
+                except Exception as e:
+                    logger.error(
+                        "[%s] Failed to prune M3U snapshots/change logs: %s",
+                        self.task_id,
+                        e,
+                    )
+                    errors.append(f"M3U snapshot/change-log prune: {str(e)}")
+                    session.rollback()
+
+                if self._cancel_requested:
+                    session.close()
+                    return self._cancelled_result(started_at, deleted_counts)
+
+                # 9. bd-1wi3y: prune unique_client_connections by age.
+                # High write rate (one row per (channel, IP) connection start)
+                # + 6 indexes makes this table grow quickly. Currently no
+                # retention beyond manual stats reset. Knob from global Settings
+                # (config.py): ``unique_client_connection_days`` (default 90).
+                self._set_progress(
+                    current=9,
+                    current_item="Pruning unique client connections",
+                )
+
+                try:
+                    from config import get_settings as _get_settings_ucc
+                    _settings_ucc = _get_settings_ucc()
+                    ucc_days = getattr(_settings_ucc, "unique_client_connection_days", 90)
+                    ucc_cutoff = datetime.utcnow() - timedelta(days=ucc_days)
+
+                    ucc_deleted = session.query(UniqueClientConnection).filter(
+                        UniqueClientConnection.connected_at < ucc_cutoff,
+                    ).delete(synchronize_session=False)
+                    deleted_counts["unique_client_connections"] = ucc_deleted
+                    session.commit()
+                    logger.info(
+                        "[%s] Deleted %s unique_client_connections older than %s days",
+                        self.task_id,
+                        ucc_deleted,
+                        ucc_days,
+                    )
+                except Exception as e:
+                    logger.error(
+                        "[%s] Failed to prune unique_client_connections: %s",
+                        self.task_id,
+                        e,
+                    )
+                    errors.append(f"UniqueClientConnection prune: {str(e)}")
+                    session.rollback()
+
+                if self._cancel_requested:
+                    session.close()
+                    return self._cancelled_result(started_at, deleted_counts)
+
+                # 10. VACUUM the database
+                self._set_progress(current=10, current_item="Vacuuming database")
 
                 if self.vacuum_db:
                     try:

--- a/backend/tests/integration/test_emby_attribution_end_to_end.py
+++ b/backend/tests/integration/test_emby_attribution_end_to_end.py
@@ -1,0 +1,332 @@
+"""End-to-end Emby attribution integration test (bd-jn30g, epic bd-2cenq).
+
+Every existing Emby test mocks at exactly ONE layer boundary:
+
+* ``tests/unit/test_emby_client.py`` mocks the httpx transport but never
+  touches the cache or resolver.
+* ``tests/services/test_emby_cache.py`` mocks ``EmbyClient`` and never
+  touches the resolver.
+* ``tests/services/test_emby_resolver.py`` mocks
+  ``get_cached_emby_sessions`` and never touches the client.
+* ``tests/unit/test_bandwidth_tracker_emby.py`` mocks ``resolve_emby_user``
+  and never touches the cache or client.
+
+That layering is good unit hygiene, but it leaves ONE thing unverified:
+that the layers actually COMPOSE. A bug in the PascalCase→snake_case
+mapping, the settings gate, the cache key, or the tier-match thresholds
+could pass every per-layer suite and still break the real pipeline,
+because no test drives a raw Emby ``/Sessions`` JSON payload all the way
+through to a resolved attribution.
+
+This file closes that gap. It wires:
+
+    settings (real get_settings stub)
+      → resolve_emby_users / resolve_emby_user   [REAL — services.emby_resolver]
+        → get_cached_emby_sessions               [REAL — services.emby_cache]
+          → EmbyClient.get_sessions              [MOCKED — httpx transport only]
+
+so only the outermost HTTP boundary is faked. The Emby server is a
+mocked ``httpx.AsyncClient.request`` returning a canned ``/Sessions``
+payload; everything between the JSON and the ``EmbyAttribution`` is the
+production code path.
+
+The two bead-mandated scenarios:
+
+1. **Full attribution flow** — a mocked Emby ``/Sessions`` payload +
+   matching ECM stream/channel produces the correct
+   ``EmbyAttribution`` through the un-mocked resolver + cache.
+2. **Settings-disabled path** — ``emby_enabled=False`` issues ZERO Emby
+   HTTP requests (the transport mock is never awaited).
+"""
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+import observability
+from services import emby_cache, emby_resolver
+from services.emby_resolver import EmbyAttribution, resolve_emby_user, resolve_emby_users
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_emby_module_state():
+    """Clear cache + resolver module-level state before and after each test.
+
+    The cache holds a single-slot module global and the resolver holds a
+    module-level DNS cache + no-match WARN rate-limit map. Without a reset
+    a populated cache from one test produces a false cache-hit in the
+    next, and a resolved hostname leaks an IP into a later test that
+    expects a different one. Observability metrics are reset so the
+    cache's ``.inc()`` / ``.time()`` calls have a live registry to write
+    to (the cache references metrics unconditionally on the hit path).
+    """
+    emby_cache._reset_for_tests()
+    emby_resolver._reset_for_tests()
+    observability.reset_for_tests()
+    observability.install_metrics()
+    yield
+    emby_cache._reset_for_tests()
+    emby_resolver._reset_for_tests()
+    observability.reset_for_tests()
+
+
+def _enabled_settings(base_url: str = "http://192.168.1.50:8096") -> MagicMock:
+    """Settings stub: Emby enabled with an IP-literal base URL.
+
+    IP-literal so the resolver's server-IP extraction does not need a DNS
+    mock — ``_resolve_emby_server_ip`` returns the literal directly. The
+    cache reads ``emby_enabled`` / ``emby_base_url`` / ``emby_api_key``;
+    the resolver reads ``emby_base_url`` for the server-IP gate.
+    """
+    settings = MagicMock()
+    settings.emby_enabled = True
+    settings.emby_base_url = base_url
+    settings.emby_api_key = "integration-key"
+    return settings
+
+
+def _disabled_settings() -> MagicMock:
+    settings = MagicMock()
+    settings.emby_enabled = False
+    settings.emby_base_url = ""
+    settings.emby_api_key = ""
+    return settings
+
+
+def _sessions_payload() -> list[dict]:
+    """Canned Emby ``/Sessions`` response (upstream PascalCase shape).
+
+    Two sessions: ``alice`` is live-watching ESPN (the live-TV
+    ``"<number> | <name>"`` item-name format Emby uses); ``bob`` is idle
+    (no ``NowPlayingItem``). Field names match the real Emby API so the
+    client's mapping layer is exercised verbatim.
+    """
+    return [
+        {
+            "Id": "sess-alice",
+            "UserId": "uid-alice",
+            "UserName": "alice",
+            "RemoteEndPoint": "203.0.113.7",
+            "NowPlayingItem": {
+                "Name": "408 | ESPN",
+                "ChannelName": "ESPN",
+                "ChannelNumber": "408",
+            },
+            "LastActivityDate": "2026-05-16T14:32:01.0000000Z",
+        },
+        {
+            "Id": "sess-bob",
+            "UserId": "uid-bob",
+            "UserName": "bob",
+            "RemoteEndPoint": "203.0.113.8",
+            "LastActivityDate": "2026-05-16T14:30:00.0000000Z",
+        },
+    ]
+
+
+def _mock_emby_transport(payload: list[dict], status_code: int = 200) -> AsyncMock:
+    """Patch ``httpx.AsyncClient.request`` so the REAL ``EmbyClient`` runs
+    against a faked Emby ``/Sessions`` HTTP boundary.
+
+    Returns the request mock so callers can assert call count (e.g. the
+    settings-disabled test asserts it was never awaited). Only the
+    transport is faked — ``EmbyClient.get_sessions`` (status checks, JSON
+    decode, mapping), the cache, and the resolver all run for real.
+    """
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.json = lambda: payload
+    return AsyncMock(return_value=response)
+
+
+@contextlib.contextmanager
+def _stack(settings: MagicMock, request_mock: AsyncMock):
+    """Patch the full Emby attribution stack for an end-to-end run.
+
+    Both :mod:`services.emby_cache` and :mod:`services.emby_resolver` bind
+    ``get_settings`` at import time via ``from config import get_settings``,
+    so patching ``config.get_settings`` would NOT rebind the names those
+    modules already resolved — each module's local binding must be patched
+    directly (the same module-level patch discipline ``backend/CLAUDE.md``
+    documents for routers). The httpx transport is patched so the REAL
+    ``EmbyClient`` issues its request against the canned payload.
+    """
+    with patch.object(emby_cache, "get_settings", return_value=settings), patch.object(
+        emby_resolver, "get_settings", return_value=settings
+    ), patch.object(httpx.AsyncClient, "request", request_mock):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — full attribution flow through the real cache + resolver
+# ---------------------------------------------------------------------------
+
+
+class TestEmbyAttributionEndToEnd:
+    """Mocked Emby server + real cache + real resolver → attribution."""
+
+    @pytest.mark.asyncio
+    async def test_live_tv_match_resolves_attribution_through_full_stack(self):
+        """A raw Emby /Sessions payload flows through the un-mocked cache +
+        resolver to the correct EmbyAttribution.
+
+        The ECM session is keyed on the Emby server IP + channel "ESPN" /
+        number "408"; the resolver's Tier-1 (channel-name) match must
+        accept alice's ``"408 | ESPN"`` session. This proves the whole
+        chain composes: JSON mapping → cache store → tier match →
+        attribution — none of which is exercised together by any
+        per-layer suite.
+        """
+        request_mock = _mock_emby_transport(_sessions_payload())
+
+        with _stack(_enabled_settings(), request_mock):
+            attribution = await resolve_emby_user(
+                "192.168.1.50",  # == Emby server IP
+                "US: ESPN FHD",  # Dispatcharr stream name (fuzzy-only, not needed for Tier 1)
+                ecm_channel_name="ESPN",
+                ecm_channel_number="408",
+            )
+
+        assert attribution is not None
+        assert attribution.user_id == "uid-alice"
+        assert attribution.user_name == "alice"
+        # client_ip is the REAL requesting-device IP from RemoteEndPoint,
+        # normalized to a bare IP — proves the mapping carried it through.
+        assert attribution.client_ip == "203.0.113.7"
+        # Exactly one upstream HTTP request was issued through the real
+        # client (the cache fired it once on the cold miss).
+        request_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_idle_sessions_produce_no_match(self):
+        """A payload of only idle sessions (no NowPlayingItem) resolves to
+        None — the resolver must not attribute an idle viewer to a channel.
+        """
+        idle_only = [
+            {
+                "Id": "sess-bob",
+                "UserId": "uid-bob",
+                "UserName": "bob",
+                "RemoteEndPoint": "203.0.113.8",
+                "LastActivityDate": "2026-05-16T14:30:00.0000000Z",
+            }
+        ]
+        request_mock = _mock_emby_transport(idle_only)
+
+        with _stack(_enabled_settings(), request_mock):
+            attribution = await resolve_emby_user(
+                "192.168.1.50",
+                "ESPN",
+                ecm_channel_name="ESPN",
+                ecm_channel_number="408",
+            )
+
+        assert attribution is None
+
+    @pytest.mark.asyncio
+    async def test_multi_viewer_same_channel_returns_all_through_full_stack(self):
+        """Two Emby sessions on the same channel → the plural resolver
+        returns BOTH viewers, most-recent first — proving the bd-r5f0c.9
+        multi-viewer path composes with the real cache + JSON mapping.
+        """
+        payload = [
+            {
+                "Id": "sess-alice",
+                "UserId": "uid-alice",
+                "UserName": "alice",
+                "RemoteEndPoint": "203.0.113.7",
+                "NowPlayingItem": {"Name": "408 | ESPN", "ChannelName": "ESPN"},
+                "LastActivityDate": "2026-05-16T14:30:00.0000000Z",
+            },
+            {
+                "Id": "sess-carol",
+                "UserId": "uid-carol",
+                "UserName": "carol",
+                "RemoteEndPoint": "203.0.113.9",
+                "NowPlayingItem": {"Name": "408 | ESPN", "ChannelName": "ESPN"},
+                # More recent — must sort to position 0.
+                "LastActivityDate": "2026-05-16T14:35:00.0000000Z",
+            },
+        ]
+        request_mock = _mock_emby_transport(payload)
+
+        with _stack(_enabled_settings(), request_mock):
+            viewers = await resolve_emby_users(
+                "192.168.1.50",
+                "ESPN",
+                ecm_channel_name="ESPN",
+            )
+
+        assert [v.user_name for v in viewers] == ["carol", "alice"]
+        assert {v.user_id for v in viewers} == {"uid-carol", "uid-alice"}
+
+    @pytest.mark.asyncio
+    async def test_cache_collapses_repeated_resolves_to_one_http_call(self):
+        """Two resolves inside the TTL window issue exactly ONE Emby HTTP
+        request — the real cache's TTL is exercised end-to-end, not just
+        in the cache unit suite with a mocked client.
+        """
+        request_mock = _mock_emby_transport(_sessions_payload())
+
+        with _stack(_enabled_settings(), request_mock):
+            first = await resolve_emby_user(
+                "192.168.1.50", "ESPN", ecm_channel_name="ESPN"
+            )
+            second = await resolve_emby_user(
+                "192.168.1.50", "ESPN", ecm_channel_name="ESPN"
+            )
+
+        assert first is not None and second is not None
+        assert first.user_name == second.user_name == "alice"
+        # Cache hit on the second resolve → still exactly one HTTP request.
+        request_mock.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — settings-disabled path issues ZERO Emby HTTP requests
+# ---------------------------------------------------------------------------
+
+
+class TestEmbyDisabledIssuesNoHttp:
+    """``emby_enabled=False`` short-circuits before any Emby network I/O."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_resolver_issues_zero_http_requests(self):
+        """With Emby disabled, resolving must return None AND never touch
+        the Emby HTTP transport. The settings gate lives in the cache; this
+        proves it holds when reached through the real resolver entrypoint.
+        """
+        request_mock = _mock_emby_transport(_sessions_payload())
+
+        with _stack(_disabled_settings(), request_mock):
+            attribution = await resolve_emby_user(
+                "192.168.1.50",
+                "ESPN",
+                ecm_channel_name="ESPN",
+                ecm_channel_number="408",
+            )
+
+        assert attribution is None
+        request_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_disabled_cache_entrypoint_issues_zero_http_requests(self):
+        """The cache entrypoint itself returns [] with zero HTTP when
+        disabled — the lowest level of the settings gate, verified with a
+        real (un-mocked) EmbyClient that would otherwise fire a request.
+        """
+        request_mock = _mock_emby_transport(_sessions_payload())
+
+        with _stack(_disabled_settings(), request_mock):
+            sessions = await emby_cache.get_cached_emby_sessions()
+
+        assert sessions == []
+        request_mock.assert_not_awaited()

--- a/backend/tests/integration/test_normalize_channel_create.py
+++ b/backend/tests/integration/test_normalize_channel_create.py
@@ -9,34 +9,83 @@ Tests the normalize flag functionality in:
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
+import config
+
+
+@pytest.fixture
+def isolated_settings_file():
+    """Isolate the persisted settings file for a single test.
+
+    The two settings tests below exercise the *real* settings round-trip
+    (GET /api/settings → POST /api/settings → GET /api/settings) without
+    mocking ``get_settings``/``save_settings``. Both therefore read and
+    mutate the shared on-disk settings file (``config.CONFIG_FILE``, i.e.
+    ``$CONFIG_DIR/settings.json``).
+
+    Without isolation these tests are order-dependent (bead
+    enhancedchannelmanager-o076m):
+
+    - ``test_get_settings_includes_normalize_on_channel_create`` asserts the
+      default is ``False``, but fails in full-suite runs where an earlier
+      test left ``normalize_on_channel_create: True`` in the file.
+    - ``test_update_settings_with_normalize_on_channel_create`` failed in
+      isolation because, starting from the empty default URL/username, any
+      earlier-leftover state changed whether the auth guard demanded a
+      password.
+
+    This fixture stashes the existing file, removes it (so the test starts
+    from a known-clean default), clears the settings cache, and restores the
+    original file + cache afterwards so the test neither depends on nor
+    pollutes shared state.
+    """
+    config_file = config.CONFIG_FILE
+    backup = config_file.read_bytes() if config_file.exists() else None
+    if config_file.exists():
+        config_file.unlink()
+    config.clear_settings_cache()
+    try:
+        yield
+    finally:
+        if backup is not None:
+            config_file.write_bytes(backup)
+        elif config_file.exists():
+            config_file.unlink()
+        config.clear_settings_cache()
+
 
 class TestNormalizeOnChannelCreateSetting:
     """Tests for the normalize_on_channel_create setting."""
 
     @pytest.mark.asyncio
-    async def test_get_settings_includes_normalize_on_channel_create(self, async_client):
+    async def test_get_settings_includes_normalize_on_channel_create(
+        self, async_client, isolated_settings_file
+    ):
         """GET /api/settings returns normalize_on_channel_create field."""
         response = await async_client.get("/api/settings")
         assert response.status_code == 200
 
         data = response.json()
         assert "normalize_on_channel_create" in data
-        # Default should be False
+        # Default should be False on a clean install.
         assert data["normalize_on_channel_create"] is False
 
     @pytest.mark.asyncio
-    async def test_update_settings_with_normalize_on_channel_create(self, async_client):
+    async def test_update_settings_with_normalize_on_channel_create(
+        self, async_client, isolated_settings_file
+    ):
         """POST /api/settings can update normalize_on_channel_create."""
-        # First get current settings to have valid base
-        get_response = await async_client.get("/api/settings")
-        current = get_response.json()
-
-        # Update with normalize_on_channel_create = True
+        # Starting from a clean settings file, GET returns the defaults
+        # (empty url/username). Send a complete, valid auth payload —
+        # including a password — because the settings endpoint correctly
+        # rejects a URL/username change in password mode without one
+        # ("password required when changing auth mode, URL or username").
         response = await async_client.post(
             "/api/settings",
             json={
-                "url": current.get("url") or "http://localhost:8090",
-                "username": current.get("username") or "admin",
+                "url": "http://localhost:8090",
+                "auth_method": "password",
+                "username": "admin",
+                "password": "test-password",
                 "normalize_on_channel_create": True,
             },
         )

--- a/backend/tests/unit/test_bandwidth_tracker_session_telemetry.py
+++ b/backend/tests/unit/test_bandwidth_tracker_session_telemetry.py
@@ -3113,3 +3113,116 @@ async def test_write_path_stream_id_without_name_when_stream_response_lacks_name
     assert all(r.stream_id == stream_id for r in rows)
     assert all(r.stream_name is None for r in rows)
     assert all(r.provider_id == 7 for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# dispatcharr_username write path (bd-gsn3r / bd-qgafp)
+# ---------------------------------------------------------------------------
+#
+# The per-poll ``get_users()`` call populates a ``dispatcharr_user_map``
+# (str(user_id) → username) that ``_write_session_telemetry`` uses to stamp
+# ``dispatcharr_username`` at write time.  Existing tests hold
+# ``client.get_users = AsyncMock(return_value=[])`` so the map is always
+# empty and the column always writes NULL.  These tests exercise the two
+# non-trivial paths:
+#
+# 1. Non-empty map → username lands in ``dispatcharr_username``.
+# 2. Empty-string username coerced to NULL (``... or None`` at the
+#    call site in bandwidth_tracker).
+
+
+@pytest.mark.asyncio
+async def test_dispatcharr_username_populated_from_user_map(
+    patched_session_local,
+    seed_synthetic_user,
+    tracker,
+    mock_client,
+):
+    """When ``get_users()`` returns a non-empty list that includes the
+    viewer's Dispatcharr user_id, ``_write_session_telemetry`` writes the
+    corresponding username into ``session_telemetry.dispatcharr_username``.
+
+    Setup mirrors the bead spec:
+    - ``mock_client.get_users`` returns ``[{'id': 42, 'username': 'alice'}]``
+    - Channel payload carries ``client_user_ids={'10.0.0.1': 42}``
+    - Asserts ``rows[0].dispatcharr_username == 'alice'``
+
+    ``seed_synthetic_user`` inserts ECM User(id=42) so the FK constraint on
+    ``session_telemetry.user_id`` is satisfied.
+    """
+    mock_client.get_users = AsyncMock(
+        return_value=[{"id": 42, "username": "alice"}]
+    )
+    first = _channel_payload(
+        total_bytes=1_000_000,
+        client_user_ids={"10.0.0.1": seed_synthetic_user},  # seed_synthetic_user == 42
+    )
+    second = _channel_payload(
+        total_bytes=2_000_000,
+        client_user_ids={"10.0.0.1": seed_synthetic_user},
+    )
+
+    await _drive_two_polls(tracker, mock_client, first, second)
+
+    session = patched_session_local()
+    try:
+        rows = (
+            session.query(SessionTelemetry)
+            .order_by(SessionTelemetry.id)
+            .all()
+        )
+    finally:
+        session.close()
+
+    assert len(rows) == 2, f"expected 2 rows, got {len(rows)}"
+    assert rows[0].dispatcharr_username == "alice", (
+        f"expected 'alice', got {rows[0].dispatcharr_username!r}"
+    )
+    assert rows[1].dispatcharr_username == "alice"
+
+
+@pytest.mark.asyncio
+async def test_dispatcharr_username_empty_string_coerced_to_null(
+    patched_session_local,
+    seed_synthetic_user,
+    tracker,
+    mock_client,
+):
+    """When ``get_users()`` returns a user whose ``username`` is an empty
+    string, the ``... or None`` coercion in ``_write_session_telemetry``
+    must land the column as NULL — not as an empty string.
+
+    Empty-string usernames are valid Dispatcharr API responses for
+    partially-configured accounts; writing ``''`` to the column would break
+    the UI's "Unknown viewer" fallback which gates on ``IS NULL``.
+    """
+    mock_client.get_users = AsyncMock(
+        return_value=[{"id": 42, "username": ""}]
+    )
+    first = _channel_payload(
+        total_bytes=1_000_000,
+        client_user_ids={"10.0.0.1": seed_synthetic_user},
+    )
+    second = _channel_payload(
+        total_bytes=2_000_000,
+        client_user_ids={"10.0.0.1": seed_synthetic_user},
+    )
+
+    await _drive_two_polls(tracker, mock_client, first, second)
+
+    session = patched_session_local()
+    try:
+        rows = (
+            session.query(SessionTelemetry)
+            .order_by(SessionTelemetry.id)
+            .all()
+        )
+    finally:
+        session.close()
+
+    assert len(rows) == 2, f"expected 2 rows, got {len(rows)}"
+    assert rows[0].dispatcharr_username is None, (
+        f"expected NULL (empty string coerced), "
+        f"got {rows[0].dispatcharr_username!r}"
+    )
+    assert rows[1].dispatcharr_username is None

--- a/backend/tests/unit/test_cleanup_task_blob_health_notifications_retention.py
+++ b/backend/tests/unit/test_cleanup_task_blob_health_notifications_retention.py
@@ -573,12 +573,12 @@ class TestNotificationsPrune:
 
 
 class TestCleanupTaskFullExecuteWithAllBlocks:
-    """End-to-end: a single execute() call must run all three new prune
-    blocks AND the original three (probe / task_executions / journal)
-    without any prune block leaking errors into another's session."""
+    """End-to-end: a single execute() call must run all prune blocks without
+    any prune block leaking errors into another's session."""
 
     @pytest.mark.asyncio
-    async def test_all_eight_steps_run_and_total_steps_is_eight(self, tmp_path):
+    async def test_all_ten_steps_run_and_total_steps_is_ten(self, tmp_path):
+        from types import SimpleNamespace
         db_file = tmp_path / "full.db"
         engine = _make_engine(db_file)
         Base.metadata.create_all(engine)
@@ -607,17 +607,26 @@ class TestCleanupTaskFullExecuteWithAllBlocks:
         session.add(Notification(message="old", created_at=old))
         session.commit()
 
+        # Minimal settings stub needed for the new prune steps (steps 8 and 9).
+        _settings_stub = SimpleNamespace(
+            auto_creation_snapshot_days=30,
+            auto_creation_snapshot_max=50,
+            m3u_snapshot_days=90,
+            m3u_change_log_days=90,
+            unique_client_connection_days=90,
+        )
+
         task = CleanupTask()
         task.vacuum_db = False  # See _make_session_and_task docstring.
-        with patch("tasks.cleanup.get_session", return_value=session):
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings_stub):
             result = await task.execute()
 
         assert result.success is True
-        assert result.total_items == 8, (
-            "execute() must report 8 cleanup steps: bd-ia28g added three prune "
-            "blocks (probe + tasks + journal + blob + health + notifications) "
-            "and ADR-010/uc51o.3 added the auto_creation_snapshots prune before "
-            "VACUUM (was 7)"
+        assert result.total_items == 10, (
+            "execute() must report 10 cleanup steps now that bd-wehek and "
+            "bd-1wi3y added two more prune blocks (m3u_snapshots/change_logs "
+            "and unique_client_connections) before VACUUM (was 8 after uc51o.3)"
         )
         deleted = result.details["deleted"]
         assert deleted["auto_creation_blobs_pruned"] == 1

--- a/backend/tests/unit/test_cleanup_task_m3u_retention.py
+++ b/backend/tests/unit/test_cleanup_task_m3u_retention.py
@@ -1,0 +1,424 @@
+"""Tests for the M3U snapshot and change-log retention prune in ``CleanupTask``
+(bd-wehek / bd-f9gd8 DBA spike).
+
+``m3u_snapshots`` stores ~1-10 kB groups_data JSON per row; ``m3u_change_logs``
+stores ~500 B per detected change.  Both grow with every Dispatcharr upstream
+change (every 5-min poll if upstream churns).  Neither had retention.
+
+This bundle adds two age-based prune blocks to step 8 of ``CleanupTask``,
+BEFORE the VACUUM step:
+1. Delete ``m3u_change_logs`` rows older than ``m3u_change_log_days`` (default
+   90) by ``change_time``.
+2. Delete ``m3u_snapshots`` rows older than ``m3u_snapshot_days`` (default 90)
+   by ``snapshot_time``.
+
+The change-log prune runs before the snapshot prune because the FK from
+``m3u_change_logs.snapshot_id`` uses ON DELETE SET NULL — surviving change-log
+rows are NOT cascade-deleted when a snapshot is deleted, so order doesn't
+affect correctness, but pruning change-logs first keeps the audit trail cleaner
+for operators who configure different windows.
+
+Tests use real file-backed SQLite (matching the bd-ia28g / uc51o.3 pattern) so
+the DELETEs observably hit actual SQLite, not mocks.  Settings knobs are
+patched per-test via a SimpleNamespace stub returned from ``config.get_settings``.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import Base, M3UChangeLog, M3USnapshot
+from tasks.cleanup import CleanupTask
+
+
+def _make_engine(db_file: Path):
+    """File-backed SQLite engine — matches the bd-ia28g / uc51o.3 pattern."""
+    return create_engine(
+        f"sqlite:///{db_file}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+
+
+def _make_session_and_task(engine, vacuum: bool = False):
+    """Build a session + CleanupTask wired to run against the given engine."""
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    task = CleanupTask()
+    task.vacuum_db = vacuum
+    return session, task
+
+
+def _settings(
+    snapshot_days: int = 90,
+    change_log_days: int = 90,
+    snapshot_max: int = 50,
+    auto_creation_snapshot_days: int = 30,
+) -> SimpleNamespace:
+    """Minimal settings stub carrying the M3U retention knobs plus the
+    auto_creation_snapshot knobs needed by step 7."""
+    return SimpleNamespace(
+        m3u_snapshot_days=snapshot_days,
+        m3u_change_log_days=change_log_days,
+        auto_creation_snapshot_days=auto_creation_snapshot_days,
+        auto_creation_snapshot_max=snapshot_max,
+        unique_client_connection_days=90,
+    )
+
+
+def _add_snapshot(session, *, age_days: float, m3u_account_id: int = 1) -> int:
+    """Insert an M3USnapshot aged ``age_days`` days; return its id."""
+    ts = datetime.utcnow() - timedelta(days=age_days)
+    snap = M3USnapshot(
+        m3u_account_id=m3u_account_id,
+        snapshot_time=ts,
+        groups_data=json.dumps({"groups": [{"name": "G1", "stream_count": 5}]}),
+        total_streams=5,
+        created_at=ts,
+    )
+    session.add(snap)
+    session.commit()
+    return snap.id
+
+
+def _add_change_log(
+    session, *, age_days: float, m3u_account_id: int = 1, snapshot_id: int | None = None
+) -> int:
+    """Insert an M3UChangeLog aged ``age_days`` days; return its id."""
+    ts = datetime.utcnow() - timedelta(days=age_days)
+    log = M3UChangeLog(
+        m3u_account_id=m3u_account_id,
+        change_time=ts,
+        change_type="streams_added",
+        group_name="Sports",
+        count=3,
+        enabled=True,
+        snapshot_id=snapshot_id,
+    )
+    session.add(log)
+    session.commit()
+    return log.id
+
+
+def _count(engine, Model) -> int:
+    SessionLocal = sessionmaker(bind=engine)
+    s = SessionLocal()
+    try:
+        return s.query(Model).count()
+    finally:
+        s.close()
+
+
+# ============================================================================
+# M3USnapshot prune
+# ============================================================================
+
+
+class TestM3USnapshotPrune:
+    """M3USnapshot rows older than ``m3u_snapshot_days`` are deleted."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_old_snapshots_keeps_fresh(self, tmp_path):
+        """A 100-day-old snapshot is deleted; a 5-day-old one survives.
+        Default window is 90 days."""
+        db_file = tmp_path / "snap.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        old_id = _add_snapshot(session, age_days=100)
+        fresh_id = _add_snapshot(session, age_days=5)
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings(snapshot_days=90)):
+            result = await task.execute()
+
+        SessionLocal = sessionmaker(bind=engine)
+        verify = SessionLocal()
+        try:
+            surviving_ids = {r.id for r in verify.query(M3USnapshot).all()}
+        finally:
+            verify.close()
+
+        assert old_id not in surviving_ids, "snapshot past the age window must be deleted"
+        assert fresh_id in surviving_ids, "fresh snapshot must survive"
+        assert result.details["deleted"]["m3u_snapshots"] == 1
+
+    @pytest.mark.asyncio
+    async def test_respects_config_knob(self, tmp_path):
+        """A shorter configured window prunes more aggressively."""
+        db_file = tmp_path / "snap_cfg.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        s45 = _add_snapshot(session, age_days=45)
+        s10 = _add_snapshot(session, age_days=10)
+
+        # 30-day window: the 45-day snapshot is pruned, the 10-day kept.
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings(snapshot_days=30)):
+            result = await task.execute()
+
+        SessionLocal = sessionmaker(bind=engine)
+        verify = SessionLocal()
+        try:
+            surviving_ids = {r.id for r in verify.query(M3USnapshot).all()}
+        finally:
+            verify.close()
+
+        assert s45 not in surviving_ids
+        assert s10 in surviving_ids
+        assert result.details["deleted"]["m3u_snapshots"] == 1
+
+    @pytest.mark.asyncio
+    async def test_idempotent_across_runs(self, tmp_path):
+        """Second run is a no-op once eligible rows are gone."""
+        db_file = tmp_path / "snap_idem.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        _add_snapshot(session, age_days=100)
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings()):
+            first = await task.execute()
+            second = await task.execute()
+
+        assert first.details["deleted"]["m3u_snapshots"] == 1
+        assert second.details["deleted"]["m3u_snapshots"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_rows_is_silent_noop(self, tmp_path):
+        """Empty table produces zero deletions without error."""
+        db_file = tmp_path / "snap_empty.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings()):
+            result = await task.execute()
+
+        assert result.details["deleted"]["m3u_snapshots"] == 0
+        errors = result.details.get("errors", [])
+        assert not any("M3U" in e for e in errors)
+
+
+# ============================================================================
+# M3UChangeLog prune
+# ============================================================================
+
+
+class TestM3UChangeLogPrune:
+    """M3UChangeLog rows older than ``m3u_change_log_days`` are deleted."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_old_change_logs_keeps_fresh(self, tmp_path):
+        """A 100-day-old change log is deleted; a 5-day-old one survives."""
+        db_file = tmp_path / "chlog.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        old_id = _add_change_log(session, age_days=100)
+        fresh_id = _add_change_log(session, age_days=5)
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings(change_log_days=90)):
+            result = await task.execute()
+
+        SessionLocal = sessionmaker(bind=engine)
+        verify = SessionLocal()
+        try:
+            surviving_ids = {r.id for r in verify.query(M3UChangeLog).all()}
+        finally:
+            verify.close()
+
+        assert old_id not in surviving_ids, "change log past the age window must be deleted"
+        assert fresh_id in surviving_ids, "fresh change log must survive"
+        assert result.details["deleted"]["m3u_change_logs"] == 1
+
+    @pytest.mark.asyncio
+    async def test_respects_config_knob(self, tmp_path):
+        """A shorter change-log window prunes more aggressively than the
+        snapshot window when both are configured independently."""
+        db_file = tmp_path / "chlog_cfg.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        old_id = _add_change_log(session, age_days=45)
+        fresh_id = _add_change_log(session, age_days=10)
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings(change_log_days=30)):
+            result = await task.execute()
+
+        SessionLocal = sessionmaker(bind=engine)
+        verify = SessionLocal()
+        try:
+            surviving_ids = {r.id for r in verify.query(M3UChangeLog).all()}
+        finally:
+            verify.close()
+
+        assert old_id not in surviving_ids
+        assert fresh_id in surviving_ids
+        assert result.details["deleted"]["m3u_change_logs"] == 1
+
+    @pytest.mark.asyncio
+    async def test_change_log_with_fk_to_snapshot_set_null_on_snapshot_delete(
+        self, tmp_path
+    ):
+        """When a snapshot is deleted the FK on its change-log rows becomes
+        NULL (ON DELETE SET NULL) — surviving change-log rows are NOT deleted
+        as a side-effect of the snapshot prune."""
+        db_file = tmp_path / "chlog_fk.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        # Old snapshot (to be pruned) with a FRESH change-log pointing at it.
+        old_snap_id = _add_snapshot(session, age_days=100)
+        fresh_log_id = _add_change_log(
+            session, age_days=5, snapshot_id=old_snap_id
+        )
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings()):
+            result = await task.execute()
+
+        SessionLocal = sessionmaker(bind=engine)
+        verify = SessionLocal()
+        try:
+            # Snapshot must be gone (older than 90d window).
+            assert verify.query(M3USnapshot).count() == 0
+            # Change-log row must SURVIVE (only 5 days old < 90d window).
+            surviving_log = verify.query(M3UChangeLog).filter(
+                M3UChangeLog.id == fresh_log_id
+            ).one_or_none()
+            assert surviving_log is not None, (
+                "fresh change-log row must survive even when its FK snapshot "
+                "was pruned (ON DELETE SET NULL)"
+            )
+            # FK should now be NULL (set by ON DELETE SET NULL cascade).
+            assert surviving_log.snapshot_id is None
+        finally:
+            verify.close()
+
+        assert result.details["deleted"]["m3u_snapshots"] == 1
+        assert result.details["deleted"]["m3u_change_logs"] == 0
+
+    @pytest.mark.asyncio
+    async def test_idempotent_across_runs(self, tmp_path):
+        """Second run is a no-op once eligible rows are gone."""
+        db_file = tmp_path / "chlog_idem.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        _add_change_log(session, age_days=100)
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings()):
+            first = await task.execute()
+            second = await task.execute()
+
+        assert first.details["deleted"]["m3u_change_logs"] == 1
+        assert second.details["deleted"]["m3u_change_logs"] == 0
+
+
+# ============================================================================
+# Order: prune runs before VACUUM (step 8 < step 10)
+# ============================================================================
+
+
+class TestM3UPruneRunsBeforeVacuum:
+    """The M3U prune step (step 8) must run BEFORE the VACUUM step (step 10)."""
+
+    @pytest.mark.asyncio
+    async def test_prune_step_precedes_vacuum_step(self, tmp_path):
+        """Record progress step labels and assert the M3U prune fires before
+        VACUUM.  Step 8 emits 'Pruning M3U snapshots'; step 10 emits
+        'Vacuuming database'."""
+        db_file = tmp_path / "order.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine, vacuum=True)
+
+        _add_snapshot(session, age_days=100)
+
+        progress_items = []
+        orig = task._set_progress
+
+        def _spy(*args, **kwargs):
+            if "current_item" in kwargs:
+                progress_items.append(kwargs["current_item"])
+            return orig(*args, **kwargs)
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings()), \
+             patch.object(task, "_set_progress", side_effect=_spy):
+            await task.execute()
+
+        m3u_item = next(
+            (i for i in progress_items if "M3U" in i or "snapshot" in i.lower()), None
+        )
+        vacuum_item = next(
+            (i for i in progress_items if "vacuum" in i.lower()), None
+        )
+        assert m3u_item is not None, f"no M3U-prune step in progress: {progress_items}"
+        assert vacuum_item is not None, f"no vacuum step in progress: {progress_items}"
+        assert progress_items.index(m3u_item) < progress_items.index(vacuum_item), (
+            f"M3U prune must run BEFORE vacuum; order was {progress_items}"
+        )
+
+
+# ============================================================================
+# Config defaults: getattr fallback when knobs absent from Settings stub
+# ============================================================================
+
+
+class TestM3UPruneConfigDefaults:
+    """Falls back to the documented defaults (90d) when the knobs are absent."""
+
+    @pytest.mark.asyncio
+    async def test_defaults_when_knobs_absent_from_settings(self, tmp_path):
+        """A settings object lacking ``m3u_snapshot_days`` / ``m3u_change_log_days``
+        defaults via getattr() to 90 days each — a 100-day-old row is still pruned."""
+        db_file = tmp_path / "defaults.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        old_snap = _add_snapshot(session, age_days=100)
+        old_log = _add_change_log(session, age_days=100)
+
+        # Empty-ish stub — the new steps use getattr(_, ..., 90) so absent knobs
+        # are fine.  Include snapshot knobs so step 7 doesn't error.
+        stub = SimpleNamespace(
+            auto_creation_snapshot_days=30,
+            auto_creation_snapshot_max=50,
+            unique_client_connection_days=90,
+        )
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=stub):
+            result = await task.execute()
+
+        SessionLocal = sessionmaker(bind=engine)
+        verify = SessionLocal()
+        try:
+            assert verify.query(M3USnapshot).count() == 0, "100d-old snapshot pruned at default 90d"
+            assert verify.query(M3UChangeLog).count() == 0, "100d-old change-log pruned at default 90d"
+        finally:
+            verify.close()

--- a/backend/tests/unit/test_cleanup_task_ucc_retention.py
+++ b/backend/tests/unit/test_cleanup_task_ucc_retention.py
@@ -1,0 +1,305 @@
+"""Tests for the UniqueClientConnection retention prune in ``CleanupTask``
+(bd-1wi3y / bd-f9gd8 DBA spike).
+
+``unique_client_connections`` has a high write rate (one row per (channel, IP)
+connection start) plus 6 indexes (~500 B effective per row on disk).  Currently
+no retention beyond manual stats reset.
+
+This adds an age-based prune block to step 9 of ``CleanupTask``, BEFORE the
+VACUUM step, mirroring the established age-window pattern.  Knob from global
+Settings (config.py): ``unique_client_connection_days`` (default 90), pruned
+by ``connected_at``.
+
+Tests use real file-backed SQLite (matching the bd-ia28g / uc51o.3 pattern) so
+the DELETEs observably hit actual SQLite, not mocks.  The settings knob is
+patched per-test via a SimpleNamespace stub returned from ``config.get_settings``.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import Base, UniqueClientConnection
+from tasks.cleanup import CleanupTask
+
+
+def _make_engine(db_file: Path):
+    return create_engine(
+        f"sqlite:///{db_file}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+
+
+def _make_session_and_task(engine, vacuum: bool = False):
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    task = CleanupTask()
+    task.vacuum_db = vacuum
+    return session, task
+
+
+def _settings(ucc_days: int = 90) -> SimpleNamespace:
+    """Minimal settings stub with the UCC knob plus the knobs needed by
+    steps 7 and 8 so those prune blocks don't error."""
+    return SimpleNamespace(
+        unique_client_connection_days=ucc_days,
+        auto_creation_snapshot_days=30,
+        auto_creation_snapshot_max=50,
+        m3u_snapshot_days=90,
+        m3u_change_log_days=90,
+    )
+
+
+def _add_ucc(
+    session,
+    *,
+    age_days: float,
+    ip: str = "192.168.1.1",
+    channel_id: str = "ch-001",
+    channel_name: str = "Test Channel",
+) -> int:
+    """Insert a UniqueClientConnection aged ``age_days`` days; return its id."""
+    ts = datetime.utcnow() - timedelta(days=age_days)
+    row = UniqueClientConnection(
+        ip_address=ip,
+        channel_id=channel_id,
+        channel_name=channel_name,
+        date=date.today() - timedelta(days=int(age_days)),
+        connected_at=ts,
+        watch_seconds=60,
+        created_at=ts,
+    )
+    session.add(row)
+    session.commit()
+    return row.id
+
+
+# ============================================================================
+# Age-window prune
+# ============================================================================
+
+
+class TestUCCAgeWindowPrune:
+    """Rows older than ``unique_client_connection_days`` are deleted by
+    ``connected_at``."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_old_rows_keeps_fresh(self, tmp_path):
+        """A 100-day-old connection is deleted; a 5-day-old one survives.
+        Default window is 90 days."""
+        db_file = tmp_path / "ucc_age.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        old_id = _add_ucc(session, age_days=100)
+        fresh_id = _add_ucc(session, age_days=5)
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings(ucc_days=90)):
+            result = await task.execute()
+
+        SessionLocal = sessionmaker(bind=engine)
+        verify = SessionLocal()
+        try:
+            surviving_ids = {r.id for r in verify.query(UniqueClientConnection).all()}
+        finally:
+            verify.close()
+
+        assert old_id not in surviving_ids, "connection past the age window must be deleted"
+        assert fresh_id in surviving_ids, "fresh connection must survive"
+        assert result.details["deleted"]["unique_client_connections"] == 1
+
+    @pytest.mark.asyncio
+    async def test_respects_config_knob(self, tmp_path):
+        """A shorter configured window prunes more aggressively."""
+        db_file = tmp_path / "ucc_cfg.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        s45 = _add_ucc(session, age_days=45, ip="192.168.1.2")
+        s10 = _add_ucc(session, age_days=10, ip="192.168.1.3")
+
+        # 30-day window: 45-day row is pruned, 10-day kept.
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings(ucc_days=30)):
+            result = await task.execute()
+
+        SessionLocal = sessionmaker(bind=engine)
+        verify = SessionLocal()
+        try:
+            surviving_ids = {r.id for r in verify.query(UniqueClientConnection).all()}
+        finally:
+            verify.close()
+
+        assert s45 not in surviving_ids
+        assert s10 in surviving_ids
+        assert result.details["deleted"]["unique_client_connections"] == 1
+
+    @pytest.mark.asyncio
+    async def test_idempotent_across_runs(self, tmp_path):
+        """Second run is a no-op once eligible rows are gone."""
+        db_file = tmp_path / "ucc_idem.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        _add_ucc(session, age_days=100)
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings()):
+            first = await task.execute()
+            second = await task.execute()
+
+        assert first.details["deleted"]["unique_client_connections"] == 1
+        assert second.details["deleted"]["unique_client_connections"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_rows_is_silent_noop(self, tmp_path):
+        """Empty table produces zero deletions without error."""
+        db_file = tmp_path / "ucc_empty.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings()):
+            result = await task.execute()
+
+        assert result.details["deleted"]["unique_client_connections"] == 0
+        errors = result.details.get("errors", [])
+        assert not any("UniqueClient" in e for e in errors)
+
+    @pytest.mark.asyncio
+    async def test_multiple_channels_and_ips_mixed_ages(self, tmp_path):
+        """Rows spanning multiple (channel, IP) combinations are each pruned
+        or kept individually based on their own ``connected_at``.  This
+        validates the simple WHERE-clause prune handles high-cardinality tables
+        (no GROUP BY / PARTITION quirks)."""
+        db_file = tmp_path / "ucc_multi.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        # 3 old (prune), 2 fresh (keep).
+        old_ids = [
+            _add_ucc(session, age_days=100, ip=f"10.0.0.{i}", channel_id=f"ch-{i}")
+            for i in range(1, 4)
+        ]
+        fresh_ids = [
+            _add_ucc(session, age_days=5, ip=f"10.0.1.{i}", channel_id=f"ch-{i+10}")
+            for i in range(1, 3)
+        ]
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings(ucc_days=90)):
+            result = await task.execute()
+
+        SessionLocal = sessionmaker(bind=engine)
+        verify = SessionLocal()
+        try:
+            surviving_ids = {r.id for r in verify.query(UniqueClientConnection).all()}
+        finally:
+            verify.close()
+
+        for oid in old_ids:
+            assert oid not in surviving_ids, f"old row {oid} must be pruned"
+        for fid in fresh_ids:
+            assert fid in surviving_ids, f"fresh row {fid} must survive"
+
+        assert result.details["deleted"]["unique_client_connections"] == 3
+
+
+# ============================================================================
+# Order: prune runs before VACUUM (step 9 < step 10)
+# ============================================================================
+
+
+class TestUCCPruneRunsBeforeVacuum:
+    """The UCC prune step (step 9) must run BEFORE the VACUUM step (step 10)."""
+
+    @pytest.mark.asyncio
+    async def test_prune_step_precedes_vacuum_step(self, tmp_path):
+        db_file = tmp_path / "ucc_order.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine, vacuum=True)
+
+        _add_ucc(session, age_days=100)
+
+        progress_items = []
+        orig = task._set_progress
+
+        def _spy(*args, **kwargs):
+            if "current_item" in kwargs:
+                progress_items.append(kwargs["current_item"])
+            return orig(*args, **kwargs)
+
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=_settings()), \
+             patch.object(task, "_set_progress", side_effect=_spy):
+            await task.execute()
+
+        ucc_item = next(
+            (i for i in progress_items if "unique" in i.lower() or "client" in i.lower()),
+            None,
+        )
+        vacuum_item = next(
+            (i for i in progress_items if "vacuum" in i.lower()), None
+        )
+        assert ucc_item is not None, f"no UCC-prune step in progress: {progress_items}"
+        assert vacuum_item is not None, f"no vacuum step in progress: {progress_items}"
+        assert progress_items.index(ucc_item) < progress_items.index(vacuum_item), (
+            f"UCC prune must run BEFORE vacuum; order was {progress_items}"
+        )
+
+
+# ============================================================================
+# Config defaults: getattr fallback when knob absent from Settings stub
+# ============================================================================
+
+
+class TestUCCPruneConfigDefaults:
+    """Falls back to 90 days when the knob is absent from the Settings stub."""
+
+    @pytest.mark.asyncio
+    async def test_defaults_when_knob_absent_from_settings(self, tmp_path):
+        """A settings object lacking ``unique_client_connection_days`` defaults
+        via getattr() to 90 days — a 100-day-old row is still pruned."""
+        db_file = tmp_path / "ucc_defaults.db"
+        engine = _make_engine(db_file)
+        Base.metadata.create_all(engine)
+        session, task = _make_session_and_task(engine)
+
+        old_id = _add_ucc(session, age_days=100)
+
+        # Stub without the UCC knob; step 7/8 knobs included so those don't error.
+        stub = SimpleNamespace(
+            auto_creation_snapshot_days=30,
+            auto_creation_snapshot_max=50,
+            m3u_snapshot_days=90,
+            m3u_change_log_days=90,
+        )
+        with patch("tasks.cleanup.get_session", return_value=session), \
+             patch("config.get_settings", return_value=stub):
+            result = await task.execute()
+
+        SessionLocal = sessionmaker(bind=engine)
+        verify = SessionLocal()
+        try:
+            surviving_ids = {r.id for r in verify.query(UniqueClientConnection).all()}
+        finally:
+            verify.close()
+
+        assert old_id not in surviving_ids, "100d-old row must be pruned at default 90d"
+        assert result.details["deleted"]["unique_client_connections"] == 1

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -49,6 +49,9 @@ usernames instead of raw IP addresses. Also covers the full MCP / Claude AI
 connection reference — the mcp-remote bridge (Claude Desktop) and the Claude
 Code `.mcp.json` path, both using the static `?api_key=` authentication method.
 
+- **[Emby Integration](integrations/emby.md)** — full Emby walkthrough:
+  prerequisites, getting a server-local API key, configuration, what
+  attribution looks like in Stats, network requirements, and troubleshooting.
 - **[MCP Integration](integrations/mcp.md)** — step-by-step mcp-remote bridge
   setup, Claude Code `.mcp.json`, key rotation, and troubleshooting.
 

--- a/docs/user_guide/integrations/emby.md
+++ b/docs/user_guide/integrations/emby.md
@@ -1,0 +1,187 @@
+# Emby Integration
+
+> **Audience:** Operator who runs an Emby server alongside ECM and wants the
+> Stats tab to show real Emby usernames (e.g., "Alice via Emby") instead of
+> raw IP addresses.
+>
+> This is the Emby-specific deep dive. For the at-a-glance comparison of all
+> three media-server integrations (Emby, Plex, Jellyfin), start at the
+> [Integrations overview](index.md).
+
+ECM polls your Emby server's live-session feed (`GET /Sessions`) and
+cross-references it against ECM's own bandwidth telemetry. When a viewer is
+watching an ECM-managed channel *through* Emby, ECM otherwise sees only the
+Emby server's IP — every Emby viewer collapses into one "Emby server"
+identity. This integration recovers the real Emby username so the Stats tab
+attributes each session to the person actually watching.
+
+## Prerequisites
+
+Before you start, confirm:
+
+1. **An Emby server you administer.** You need Dashboard access to create an
+   API key. A regular Emby user account is not enough.
+2. **Network reach from the ECM container to the Emby server.** ECM makes an
+   *outbound* connection to the Emby URL you configure — Emby does not need
+   to reach ECM. See [Network requirements](#network-requirements).
+3. **ECM admin access** (when ECM authentication is enabled). The Emby
+   settings and the Test Connection action are admin-only, because saving and
+   testing involve handling a secret (the API key).
+
+## How to get an Emby API key
+
+1. Open the **Emby Dashboard** (the gear/settings menu, top-right in Emby
+   Web).
+2. Go to **Advanced → API Keys** (older Emby builds: **Expert → API Keys**).
+3. Click **New API Key** (the **+** button).
+4. Give it a recognizable name so it's identifiable in Emby's audit log —
+   e.g. `ECM attribution`.
+5. Copy the generated key. It is a 32-character hex string.
+
+This is a **server-local API key**, not a user password and not a
+Connect/account credential. It grants programmatic access scoped to *this*
+Emby server. ECM only ever calls the read-only `/Sessions` endpoint with it.
+If you ever need to revoke ECM's access, delete this key from the same
+Dashboard screen — ECM's attribution simply stops; nothing else breaks.
+
+> **Token model in one line:** one server-local API key per Emby server,
+> created by you in the Emby Dashboard, used by ECM only to read the live
+> session list.
+
+## Configure it in ECM Settings
+
+1. In ECM: **Settings → Integrations → Emby**.
+2. **Enable** the Emby toggle.
+3. **Base URL** — the URL of your Emby server as reachable *from the ECM
+   container*. Examples:
+   - `http://emby:8096` (Docker service name on the same network)
+   - `http://192.168.1.50:8096` (LAN IP)
+   - `https://emby.example.com` (reverse-proxy with TLS)
+   - `http://proxy.example.com/emby` (reverse proxy with a sub-path — the
+     sub-path is preserved)
+4. **API Key** — paste the key from the Emby Dashboard.
+5. Click **Test Connection**. A green result means ECM reached Emby and the
+   key authenticated. See [Troubleshooting](#troubleshooting) for failure
+   modes.
+6. **Save**.
+
+Attribution begins on the next telemetry poll cycle (within ~5 seconds — see
+[How matching works](#how-matching-works)). You do not need to restart ECM.
+
+### Re-saving without re-entering the key
+
+The API key field uses a **preserve-on-omit** contract: if you change the
+toggle or Base URL and save *without* re-typing the key, ECM keeps the
+previously stored key. You only need to re-enter the key when you actually
+want to rotate it. The Settings response never returns the stored key back to
+the browser — it only reports whether one is configured.
+
+## What attribution looks like in Stats
+
+Once Emby is enabled and Test Connection succeeds:
+
+- **Connected Clients (Active Channels):** each viewer row shows the Emby
+  username with a **"via Emby"** badge instead of a bare IP. When several
+  people watch the same channel through Emby, all their names appear on that
+  channel's row.
+- **User Stats / Watch Time:** per-user watch-time aggregates use the Emby
+  username as the display name. The `attribution_source` field marks the row
+  as Emby-attributed so the UI can render the badge.
+- **Client IP:** ECM surfaces the *real* requesting-device IP that Emby
+  reported for the session (`RemoteEndPoint`) as a separate field — distinct
+  from the Dispatcharr connection IP ECM itself observes.
+
+If a session can't be matched to any Emby viewer, the row simply shows the IP
+as before. Attribution is additive — it never hides a session, it only
+enriches the ones it can identify.
+
+## How matching works
+
+ECM caches the Emby `/Sessions` response for **5 seconds** (the cache TTL,
+matched to the telemetry poll cadence). Within that window every internal
+lookup hits the cache, so enabling Emby adds at most one `/Sessions` request
+to Emby roughly every 5 seconds regardless of how many channels or viewers
+are active. Concurrent lookups during a cache miss collapse to a single
+upstream request (a thundering-herd guard), and a brief Emby outage falls
+back to the last-known session list rather than blanking attribution.
+
+For each active ECM session, ECM matches against the live Emby sessions in
+tiers: channel-name match first (Emby renders live TV as
+`"<number> | <channel>"`, e.g. `"408 | ESPN"`), then channel-number, then a
+fuzzy stream-name fallback. The fuzzy fallback is the loosest tier and is
+used only for direct same-host playback; the strict channel tiers do the
+heavy lifting for normal live-TV viewing.
+
+### Safe poll rate
+
+You do not configure the poll rate — it is driven by ECM's bandwidth
+telemetry cycle and bounded by the 5-second session cache. **The cache is the
+rate limiter:** even under heavy concurrent attribution, Emby sees about one
+`/Sessions` call every 5 seconds. There is no operator knob that can make ECM
+poll Emby faster than the cache TTL allows, so there is no thundering-herd
+risk to your Emby server from this integration.
+
+## Network requirements
+
+- ECM initiates an **outbound** HTTP(S) connection from the ECM container to
+  the Base URL you configure. Emby never initiates a connection to ECM.
+- The Base URL must be reachable from *inside* the ECM container, which is not
+  always the same as from your desktop. To verify reach from the container:
+
+  ```bash
+  docker exec ecm-ecm-1 wget -qO- http://192.168.1.50:8096/System/Info/Public
+  ```
+
+  A JSON blob means the container can reach Emby; a hang or error means it
+  cannot (firewall, wrong hostname, Emby not on the container's network).
+- **Loopback and link-local addresses are rejected** by Test Connection as a
+  safety measure: `localhost`, `127.0.0.1`, `::1`, and the cloud
+  instance-metadata address `169.254.169.254` are blocked. Point ECM at
+  Emby's LAN IP, Docker service name, or public hostname instead — private
+  LAN ranges (`10.x`, `172.16–31.x`, `192.168.x`) are intentionally allowed
+  because that's where home media servers live.
+- Connect/read timeouts are 5 s / 10 s — a misconfigured URL fails Test
+  Connection promptly rather than hanging the UI.
+
+## Token storage and privacy posture
+
+The Emby API key is stored **in plaintext** in ECM's settings file
+(`/config/settings.json` inside the container). This matches how ECM stores
+every other integration credential (the Dispatcharr API key, SMTP password,
+Plex token, Jellyfin key). ECM does **not** encrypt secrets at rest in this
+release, and it does **not** transmit the key anywhere except to the Emby
+server you configured.
+
+Practical implications:
+
+- Treat the ECM config volume as sensitive — anyone with read access to
+  `/config/settings.json` (or a backup of it) can read the Emby key.
+- The key is **never** returned to the browser by the Settings API and is
+  **never** written to logs (logs record the Base URL, not the key).
+- Rotating is cheap: delete the key in the Emby Dashboard, create a new one,
+  paste it into ECM, Test Connection, Save.
+
+## Troubleshooting
+
+Test Connection is designed to show you the *actual* failure message inline
+rather than a generic error. Common results:
+
+| What you see | Likely cause | Fix |
+|---|---|---|
+| **"401 unauthorized — check API key"** | Wrong, revoked, or mistyped API key | Recreate the key in the Emby Dashboard and paste it again. |
+| **"Emby request failed: …" / connection refused / timeout** | ECM container can't reach the Base URL | Verify reach with the `docker exec … wget` command above; check hostname/port and the container network. |
+| **"Invalid URL scheme — must be http or https"** | Base URL used `file://`, `ftp://`, etc. | Use an `http://` or `https://` URL. |
+| **"Invalid host — loopback and link-local addresses are not allowed"** | Base URL pointed at `localhost`, `127.0.0.1`, `::1`, or `169.254.169.254` | Use Emby's LAN IP, Docker service name, or public hostname. |
+| **"Emby /Sessions returned 5xx"** | Emby server-side error | Check the Emby server logs; confirm Emby is healthy. |
+| Test passes, but **no usernames appear in Connected Clients** | Integration enabled but no Emby-mediated playback yet, or the channel names don't line up | Start playback through Emby; confirm the ECM channel name matches the Emby channel display name. Connected Clients updates within ~5 s (the session-cache TTL). |
+
+If usernames still don't appear after successful playback, ECM emits a
+rate-limited diagnostic line in its logs (prefix `[EMBY-RESOLVER]`) showing
+exactly what each match tier compared and rejected — useful for support.
+
+## See also
+
+- [Integrations overview](index.md) — all three media-server integrations
+  side by side, plus the multi-viewer and same-IP limitations.
+- [`docs/api.md` — Enhanced Stats § per-channel attribution fields](../../api.md)
+- [`docs/architecture.md` — User Attribution Pipeline](../../architecture.md)

--- a/docs/user_guide/integrations/index.md
+++ b/docs/user_guide/integrations/index.md
@@ -32,6 +32,11 @@ enabled, it shows usernames (e.g., `Alice via Emby`).
 5. Click "Test Connection" to verify
 6. Save
 
+> For the full Emby walkthrough — prerequisites, the server-local token
+> model, what attribution looks like in Stats, network requirements, and
+> per-failure-mode troubleshooting — see the **[Emby Integration
+> reference](emby.md)**.
+
 ## Setup — Plex
 
 1. In ECM: Settings → Integrations → Plex

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0024",
+  "version": "0.17.3-0025",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/PrintGuideModal.css
+++ b/frontend/src/components/PrintGuideModal.css
@@ -149,6 +149,38 @@
   margin-bottom: 0.5rem;
 }
 
+/* Empty-slots toggle row (bd-w532y) */
+.print-guide-empty-slots-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-bottom: 0.75rem;
+}
+
+.print-guide-empty-slots-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  user-select: none;
+}
+
+.print-guide-empty-slots-label input[type="checkbox"] {
+  width: 15px;
+  height: 15px;
+  cursor: pointer;
+  accent-color: var(--accent-primary);
+  flex-shrink: 0;
+}
+
+.print-guide-empty-slots-hint {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  padding-left: 1.6rem;
+}
+
 /* Empty-range state */
 .print-guide-empty-range {
   display: flex;

--- a/frontend/src/components/PrintGuideModal.test.tsx
+++ b/frontend/src/components/PrintGuideModal.test.tsx
@@ -1,14 +1,22 @@
 /**
- * Unit tests for PrintGuideModal — channel-number range filter.
+ * Unit tests for PrintGuideModal — channel-number range filter and empty-slot
+ * placeholders.
  *
  * bd-9q9z0: Operator-selectable channel-number range filter for the Print
  * Channel Guide modal. Defaults to the full range so existing all-channels
  * behaviour is preserved; operators can narrow to a sub-range (e.g. 100–199)
  * for booklet sections. Range is applied before the existing group filter.
+ *
+ * bd-w532y: Empty-slot placeholders — when "Show empty slots" is enabled,
+ * generatePrintHtml fills in placeholder rows for channel numbers within a
+ * group's range that have no real channel assigned. This lets operators print
+ * a guide that reflects the INTENDED channel layout of a sparse auto-sync
+ * group, not just what exists today.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { PrintGuideModal } from './PrintGuideModal';
+import { PrintGuideModal, generatePrintHtml, MAX_EMPTY_SLOTS_PER_GROUP } from './PrintGuideModal';
+import type { GroupPrintSettings } from './PrintGuideModal';
 import type { Channel, ChannelGroup } from '../types';
 
 // --- Test fixtures ---
@@ -174,6 +182,262 @@ describe('PrintGuideModal — channel range filter (bd-9q9z0)', () => {
       fireEvent.change(getFromInput(), { target: { value: '300' } });
       fireEvent.change(getToInput(), { target: { value: '400' } });
       expect(screen.getByRole('button', { name: /print selected/i })).toBeDisabled();
+    });
+  });
+
+  describe('Show empty slots toggle (bd-w532y)', () => {
+    it('renders the empty-slots checkbox', () => {
+      renderModal();
+      expect(screen.getByLabelText(/show empty slots/i)).toBeInTheDocument();
+    });
+
+    it('empty-slots checkbox is checked by default', () => {
+      renderModal();
+      const cb = screen.getByLabelText(/show empty slots/i) as HTMLInputElement;
+      expect(cb.checked).toBe(true);
+    });
+
+    it('unchecking the empty-slots checkbox does not disable the Print button', () => {
+      renderModal();
+      const cb = screen.getByLabelText(/show empty slots/i);
+      fireEvent.click(cb);
+      expect(screen.getByRole('button', { name: /print selected/i })).not.toBeDisabled();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generatePrintHtml — empty-slot placeholder unit tests (bd-w532y)
+// ---------------------------------------------------------------------------
+//
+// These tests exercise the HTML-generation helper directly so we can assert on
+// the rendered output without spinning up a full React component tree.
+
+/** Build a minimal Channel for generatePrintHtml tests. */
+function makeChannelForHtml(
+  id: number,
+  num: number,
+  groupId: number,
+  name = `Ch ${num}`,
+): Channel {
+  return {
+    id,
+    channel_number: num,
+    name,
+    channel_group_id: groupId,
+    tvg_id: null,
+    tvc_guide_stationid: null,
+    epg_data_id: null,
+    streams: [],
+    stream_profile_id: null,
+    uuid: `uuid-${id}`,
+    logo_id: null,
+    auto_created: false,
+    auto_created_by: null,
+    auto_created_by_name: null,
+  };
+}
+
+function makeGroupSettings(
+  groupId: number,
+  selected = true,
+  mode: 'detailed' | 'summary' = 'detailed',
+): GroupPrintSettings {
+  return { groupId, selected, mode };
+}
+
+describe('generatePrintHtml — empty-slot placeholders (bd-w532y)', () => {
+  const GROUP: ChannelGroup = { id: 1, name: 'Sports', channel_count: 3 };
+
+  // Sparse group: channels at 100, 105, 110. Range 100–115. Gaps: 101-104, 106-109, 111-115.
+  const SPARSE_CHANNELS = [
+    makeChannelForHtml(1, 100, 1),
+    makeChannelForHtml(2, 105, 1),
+    makeChannelForHtml(3, 110, 1),
+  ];
+
+  describe('showEmptySlots = false (default-off path)', () => {
+    it('renders only real channel rows — no placeholder rows', () => {
+      const html = generatePrintHtml(
+        SPARSE_CHANNELS,
+        [GROUP],
+        [makeGroupSettings(1)],
+        'Test Guide',
+        100,
+        115,
+        false,
+      );
+      // Real channels present
+      expect(html).toContain('>100<');
+      expect(html).toContain('>105<');
+      expect(html).toContain('>110<');
+      // No placeholder element (class="ch-slot-label" in HTML — CSS rule presence is expected)
+      expect(html).not.toContain('class="ch-slot-label"');
+    });
+  });
+
+  describe('showEmptySlots = true', () => {
+    it('includes a placeholder row for each gap channel number in the range', () => {
+      const html = generatePrintHtml(
+        SPARSE_CHANNELS,
+        [GROUP],
+        [makeGroupSettings(1)],
+        'Test Guide',
+        100,
+        112,
+        true,
+      );
+      // Real channels
+      expect(html).toContain('>100<');
+      expect(html).toContain('>105<');
+      expect(html).toContain('>110<');
+      // Placeholder slots — gap numbers 101, 102, 103, 104, 106, 107, 108, 109, 111, 112
+      expect(html).toContain('>101<');
+      expect(html).toContain('>104<');
+      expect(html).toContain('>106<');
+      expect(html).toContain('>109<');
+      expect(html).toContain('>111<');
+      expect(html).toContain('>112<');
+      // Placeholder marker element present
+      expect(html).toContain('class="ch-slot-label"');
+    });
+
+    it('does not add placeholders before the first real channel in the group', () => {
+      // First real channel is 105, range starts at 100. Slots 100-104 should NOT appear.
+      const channelsStartingAt105 = [
+        makeChannelForHtml(2, 105, 1),
+        makeChannelForHtml(3, 110, 1),
+      ];
+      const html = generatePrintHtml(
+        channelsStartingAt105,
+        [GROUP],
+        [makeGroupSettings(1)],
+        'Test Guide',
+        100,
+        112,
+        true,
+      );
+      // 105 and 110 present as real channels
+      expect(html).toContain('>105<');
+      expect(html).toContain('>110<');
+      // 100–104 are before the group's first channel — should NOT appear in channel rows
+      // (they may appear in CSS, but not as ch-num span content in a channel-line)
+      expect(html).not.toContain('>100<');
+      expect(html).not.toContain('>101<');
+      expect(html).not.toContain('>104<');
+      // 106–109, 111–112 are gaps within group range — should appear as placeholder rows
+      expect(html).toContain('>106<');
+      expect(html).toContain('>111<');
+    });
+
+    it('extends placeholders to rangeTo when rangeTo > group last channel', () => {
+      // Group has channels at 100 and 105 only; range extends to 108.
+      const channels = [
+        makeChannelForHtml(1, 100, 1),
+        makeChannelForHtml(2, 105, 1),
+      ];
+      const html = generatePrintHtml(
+        channels,
+        [GROUP],
+        [makeGroupSettings(1)],
+        'Test Guide',
+        100,
+        108,
+        true,
+      );
+      // Real channels
+      expect(html).toContain('>100<');
+      expect(html).toContain('>105<');
+      // Placeholder slots 101-104, 106-108
+      expect(html).toContain('>101<');
+      expect(html).toContain('>106<');
+      expect(html).toContain('>107<');
+      expect(html).toContain('>108<');
+    });
+
+    it('inclusive bounds: rangeFrom and rangeTo endpoints are included', () => {
+      const channels = [makeChannelForHtml(1, 100, 1)];
+      const html = generatePrintHtml(
+        channels,
+        [GROUP],
+        [makeGroupSettings(1)],
+        'Test Guide',
+        100,
+        102,
+        true,
+      );
+      expect(html).toContain('>101<');
+      expect(html).toContain('>102<');
+      // 103 is outside rangeTo — should NOT appear
+      expect(html).not.toContain('>103<');
+    });
+
+    it('no placeholders when group channels are fully contiguous in the range', () => {
+      // 100, 101, 102 — no gaps
+      const contiguous = [
+        makeChannelForHtml(1, 100, 1),
+        makeChannelForHtml(2, 101, 1),
+        makeChannelForHtml(3, 102, 1),
+      ];
+      const html = generatePrintHtml(
+        contiguous,
+        [GROUP],
+        [makeGroupSettings(1)],
+        'Test Guide',
+        100,
+        102,
+        true,
+      );
+      // No placeholder elements (CSS class definition present in <style> is expected)
+      expect(html).not.toContain('class="ch-slot-label"');
+    });
+
+    it('summary mode groups never emit empty-slot rows regardless of showEmptySlots', () => {
+      const html = generatePrintHtml(
+        SPARSE_CHANNELS,
+        [GROUP],
+        [makeGroupSettings(1, true, 'summary')],
+        'Test Guide',
+        100,
+        115,
+        true,
+      );
+      // Summary mode just shows a range label — no per-number placeholder elements
+      expect(html).not.toContain('class="ch-slot-label"');
+    });
+
+    it(`truncates at ${MAX_EMPTY_SLOTS_PER_GROUP} empty slots and appends a warning row`, () => {
+      // Single channel at 1; range extends far enough to exceed the cap.
+      const bigRange = [makeChannelForHtml(1, 1, 1)];
+      const rangeEnd = MAX_EMPTY_SLOTS_PER_GROUP + 50; // well over cap
+      const html = generatePrintHtml(
+        bigRange,
+        [GROUP],
+        [makeGroupSettings(1)],
+        'Test Guide',
+        1,
+        rangeEnd,
+        true,
+      );
+      // Truncation warning row must appear
+      expect(html).toContain('empty-slot limit reached');
+      // Should NOT contain channel numbers beyond the cap
+      expect(html).not.toContain(`>${rangeEnd}<`);
+    });
+
+    it('deselected group produces no output even with showEmptySlots=true', () => {
+      const html = generatePrintHtml(
+        SPARSE_CHANNELS,
+        [GROUP],
+        [makeGroupSettings(1, false)], // not selected
+        'Test Guide',
+        100,
+        115,
+        true,
+      );
+      // Group completely absent — no real channels, no placeholder elements
+      expect(html).not.toContain('>Sports<');
+      expect(html).not.toContain('class="ch-slot-label"');
     });
   });
 });

--- a/frontend/src/components/PrintGuideModal.tsx
+++ b/frontend/src/components/PrintGuideModal.tsx
@@ -37,11 +37,17 @@ const GROUP_COLORS = [
   { header: '#8E44AD', bg: '#F5EEF8' },  // Violet
 ];
 
-interface GroupPrintSettings {
+// Exported for unit testing of generatePrintHtml.
+export interface GroupPrintSettings {
   groupId: number;
   selected: boolean;
   mode: 'detailed' | 'summary';
 }
+
+// Maximum empty-slot placeholders rendered per group to prevent runaway output
+// (e.g. operator sets 1–9999 with only one real channel).
+// Exported for unit testing.
+export const MAX_EMPTY_SLOTS_PER_GROUP = 500;
 
 interface PrintGuideModalProps {
   isOpen: boolean;
@@ -72,6 +78,10 @@ function PrintGuideModalInner({
   // Range filter state — raw string values for controlled inputs
   const [fromRaw, setFromRaw] = useState<string>(() => String(globalMin));
   const [toRaw, setToRaw] = useState<string>(() => String(globalMax));
+
+  // Empty-slot placeholder toggle — on by default so the printed guide shows
+  // the full intended channel-number layout (bd-w532y).
+  const [showEmptySlots, setShowEmptySlots] = useState(true);
 
   // Track whether a clamp hint should be shown (cleared on next manual change)
   const [clampHint, setClampHint] = useState<string | null>(null);
@@ -276,7 +286,8 @@ function PrintGuideModalInner({
       groupSettings,
       title,
       rangeFrom,
-      rangeTo
+      rangeTo,
+      showEmptySlots,
     );
 
     // Open new window and write content
@@ -287,7 +298,7 @@ function PrintGuideModalInner({
     }
 
     onClose();
-  }, [channels, rangeFilteredGroups, groupSettings, title, onClose, rangeError, fromNum, toNum, globalMin, globalMax]);
+  }, [channels, rangeFilteredGroups, groupSettings, title, onClose, rangeError, fromNum, toNum, globalMin, globalMax, showEmptySlots]);
 
   // isOpen gating handled by outer wrapper.
 
@@ -347,6 +358,22 @@ function PrintGuideModalInner({
           {clampHint && !rangeError && (
             <p className="form-hint print-guide-clamp-hint">{clampHint}</p>
           )}
+
+          {/* Empty-slot placeholder toggle (bd-w532y) */}
+          <div className="print-guide-empty-slots-row">
+            <label className="print-guide-empty-slots-label">
+              <input
+                type="checkbox"
+                checked={showEmptySlots}
+                onChange={e => setShowEmptySlots(e.target.checked)}
+                aria-label="Show empty slots"
+              />
+              <span>Show empty slots</span>
+            </label>
+            <span className="print-guide-empty-slots-hint">
+              Fills missing channel numbers in the range with placeholder rows
+            </span>
+          </div>
 
           {/* Empty state when range has no channels */}
           {!rangeError && rangeFilteredGroups.length === 0 && (
@@ -446,14 +473,17 @@ export const PrintGuideModal = memo(function PrintGuideModal(
   );
 });
 
-// Generate the complete HTML for the print window
-function generatePrintHtml(
+// Generate the complete HTML for the print window.
+// Exported for unit testing; not part of the public component API.
+// eslint-disable-next-line react-refresh/only-export-components -- pure function exported for unit testing; HMR handles the component export fine
+export function generatePrintHtml(
   channels: Channel[],
   sortedGroups: ChannelGroup[],
   groupSettings: GroupPrintSettings[],
   title: string,
   rangeFrom: number,
-  rangeTo: number
+  rangeTo: number,
+  showEmptySlots: boolean = false,
 ): string {
   const selectedGroupIds = new Set(
     groupSettings.filter(s => s.selected).map(s => s.groupId)
@@ -502,12 +532,60 @@ function generatePrintHtml(
         </div>
       `;
     } else {
-      // Detailed mode: show all channels
+      // Detailed mode: show all channels, with optional empty-slot placeholders.
+      //
+      // When showEmptySlots is true we walk every integer channel number from
+      // the group's first real channel to the rangeTo bound (inclusive) and
+      // emit a placeholder row for any number that has no real channel.
+      //
+      // Scope: placeholders are bounded by [group's first real ch, rangeTo] so
+      // that numbers before the group's lowest real channel aren't attributed to
+      // this group (they may belong to a different group or be genuinely empty).
+      // rangeFrom already ensures groupChannels only contains in-range channels.
+      //
+      // Performance cap: if the slot count exceeds MAX_EMPTY_SLOTS_PER_GROUP we
+      // truncate and append a warning row rather than silently producing massive
+      // output.
       let channelsHtml = '';
-      for (const ch of groupChannels) {
-        const num = ch.channel_number === null ? 'N/A' : (Number.isInteger(ch.channel_number) ? String(ch.channel_number) : String(ch.channel_number));
-        const displayName = cleanChannelName(ch.name, ch.channel_number);
-        channelsHtml += `<div class="channel-line"><span class="ch-num">${num}</span> ${escapeHtml(displayName)}</div>\n`;
+
+      if (showEmptySlots && groupChannels.length > 0) {
+        const firstNum = groupChannels[0].channel_number!;
+        const slotEnd = rangeTo;
+        const realByNum = new Map(
+          groupChannels
+            .filter(ch => ch.channel_number !== null)
+            .map(ch => [ch.channel_number!, ch])
+        );
+
+        let emptyCount = 0;
+        let truncated = false;
+
+        for (let n = firstNum; n <= slotEnd; n++) {
+          const ch = realByNum.get(n);
+          if (ch) {
+            const num = Number.isInteger(ch.channel_number!) ? String(ch.channel_number!) : String(ch.channel_number!);
+            const displayName = cleanChannelName(ch.name, ch.channel_number);
+            channelsHtml += `<div class="channel-line"><span class="ch-num">${num}</span> ${escapeHtml(displayName)}</div>\n`;
+          } else {
+            if (emptyCount >= MAX_EMPTY_SLOTS_PER_GROUP) {
+              truncated = true;
+              break;
+            }
+            channelsHtml += `<div class="channel-line channel-line-empty"><span class="ch-num ch-num-empty">${n}</span> <span class="ch-slot-label">—</span></div>\n`;
+            emptyCount++;
+          }
+        }
+
+        if (truncated) {
+          channelsHtml += `<div class="channel-line channel-line-truncated">… (empty-slot limit reached — narrow the range)</div>\n`;
+        }
+      } else {
+        // No empty slots — render only real channels
+        for (const ch of groupChannels) {
+          const num = ch.channel_number === null ? 'N/A' : (Number.isInteger(ch.channel_number) ? String(ch.channel_number) : String(ch.channel_number));
+          const displayName = cleanChannelName(ch.name, ch.channel_number);
+          channelsHtml += `<div class="channel-line"><span class="ch-num">${num}</span> ${escapeHtml(displayName)}</div>\n`;
+        }
       }
 
       groupsHtml += `
@@ -630,6 +708,26 @@ function generatePrintHtml(
 
     .summary-mode .channel-line {
       font-style: italic;
+    }
+
+    .channel-line-empty {
+      opacity: 0.45;
+    }
+
+    .ch-num-empty {
+      color: #999;
+      font-weight: normal;
+    }
+
+    .ch-slot-label {
+      color: #aaa;
+    }
+
+    .channel-line-truncated {
+      font-style: italic;
+      color: #c00;
+      font-size: 5.5pt;
+      margin-top: 1px;
     }
 
     .content {

--- a/frontend/src/components/tabs/StatsTab.tsx
+++ b/frontend/src/components/tabs/StatsTab.tsx
@@ -609,6 +609,15 @@ export function StatsTab() {
   //      payload where the backend resolver didn't populate the field.
   //   3. Otherwise → "Unknown" bucket.
   const m3uConnectionStats = (() => {
+    // Predicate: an M3U account that should appear as its own badge.
+    // Active accounts with the name "custom" are provider-internal
+    // pseudo-accounts that should never surface to the operator as a
+    // first-class capacity badge. Extracting the predicate once prevents
+    // silent divergence between the displayedAccountIds set and the
+    // result filter below (bd-ib3c9).
+    const isDisplayedAccount = (a: { is_active: boolean; name: string }) =>
+      a.is_active && a.name.toLowerCase() !== 'custom';
+
     // Build a map of profile ID -> account ID for the legacy fallback.
     const profileToAccountMap = new Map<number, number>();
     for (const account of m3uAccounts) {
@@ -623,7 +632,7 @@ export function StatsTab() {
     // is_active=false) or hasn't been side-loaded yet.
     const displayedAccountIds = new Set<number>(
       m3uAccounts
-        .filter(a => a.is_active && a.name.toLowerCase() !== 'custom')
+        .filter(isDisplayedAccount)
         .map(a => a.id),
     );
 
@@ -661,9 +670,14 @@ export function StatsTab() {
     // If profiles exist, use sum of active profile max_streams (profiles include the base account)
     // Otherwise use account.max_streams directly.
     logger.debug(`Stats Tab M3U Debug: Processing ${m3uAccounts.length} M3U accounts`);
-    const result = m3uAccounts
+    // bd-gcuk8: explicit row shape so `max` is typed as `number | null`.
+    // The Unknown bucket sentinel uses `null` (no upstream capacity is
+    // knowable); widening the type here lets the type-checker enforce
+    // null-guards at every render site instead of hiding the nullability
+    // behind an `as unknown as number` cast.
+    const result: { id: number; name: string; current: number; max: number | null }[] = m3uAccounts
       .filter(account => {
-        const include = account.is_active && account.name.toLowerCase() !== 'custom';
+        const include = isDisplayedAccount(account);
         if (!include) {
           logger.debug(`Stats Tab M3U Debug: Excluding M3U account "${account.name}" (id=${account.id}) - is_active: ${account.is_active}, name check: ${account.name.toLowerCase() !== 'custom'}`);
         }
@@ -703,7 +717,7 @@ export function StatsTab() {
         id: -1,
         name: 'Unknown',
         current: unknownCount,
-        max: null as unknown as number,
+        max: null,
       });
       logger.debug(`Stats Tab M3U Debug: Added Unknown bucket with ${unknownCount} unattributed channels`);
     }


### PR DESCRIPTION
The actionable P3 backlog, built in parallel worktrees, gate-verified independently, bundled (no file overlap, clean cherry-pick).

- **Retention** (`wehek`, `1wi3y`): added age-based prune for `m3u_snapshots`/`m3u_change_logs` and `unique_client_connections` in `CleanupTask` (config knobs, before VACUUM, metrics). `vrvcg` (notification prune) and `teeiv` (auto-creation blob null-out) were **already implemented** in earlier work — closed, no new code.
- **`o076m`** (test-isolation fix): `test_normalize_channel_create` tests were mutating the shared on-disk `settings.json` and one sent an auth-change without a password (correctly tripping the guard). Added an `isolated_settings_file` fixture + fixed the payload. Red→green (6 pass).
- **`7f0j1`**: not reproducible at dev tip — the `CircularDependencyError` was the GC-attribution flake already fixed by `bd-gqtyf`. Closed as resolved-by-gqtyf; no code.
- **Polish** (`qgafp` telemetry unit test, `ib3c9` extract the displayed-account predicate, `gcuk8` widen the row type / drop the cast).
- **`w532y`**: Print Channel Guide empty-slot placeholder rows for sparse auto-sync ranges (the From/To range itself shipped earlier).
- **`jn30g`**: Emby end-to-end attribution tests (real cache+resolver) + operator setup doc + security review.

## Verification (independent)
retention 87 · o076m 6 · emby 174 · polish backend 96 + tsc/vitest · w532y tsc/vitest — all green. Version consistency at `0.17.3-0025`.

## Security finding from jn30g's review (NOT in this PR — needs a decision)
`POST /api/settings` stores `emby_base_url` (and `plex`/`jellyfin`/Dispatcharr/webhook URLs) **verbatim, auth-only (no admin gate, no SSRF sanitization)** — so the `fbc50` SSRF guard covers the *test-connection* endpoint but **not** the runtime/save path. Pre-existing, spans all outbound-URL settings, bounded severity (auth required, GET-only, response not returned). Filing as a follow-up bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)