### PR TITLE
v0.17.3-0026: Print Guide per-group channel range (bd-9eyqp, w532y correction)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0025",
+    version="0.17.3-0026",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0025"
+APP_VERSION = "0.17.3-0026"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0025",
+  "version": "0.17.3-0026",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/PrintGuideModal.css
+++ b/frontend/src/components/PrintGuideModal.css
@@ -86,7 +86,6 @@
   display: flex;
   gap: 4px;
   flex-shrink: 0;
-  margin-left: 0.75rem;
 }
 
 .mode-toggle .mode-btn {
@@ -128,25 +127,48 @@
   color: var(--error-color, #ef4444);
 }
 
-/* Channel number range filter row */
-.print-guide-range-row {
+/* Per-group controls area — wraps range inputs + mode toggle */
+.group-item-controls {
   display: flex;
-  gap: 1rem;
-  margin-bottom: 0.5rem;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.3rem;
+  flex-shrink: 0;
+  margin-left: 0.75rem;
 }
 
-.print-guide-range-field {
-  flex: 1;
-  min-width: 0;
+/* Per-group From/To range inputs */
+.print-guide-group-range {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
 }
 
-.print-guide-range-field input[type="number"] {
-  width: 100%;
+.print-guide-group-range-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
 }
 
-/* Clamp hint */
-.print-guide-clamp-hint {
-  margin-bottom: 0.5rem;
+.print-guide-group-range-field label {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.print-guide-group-range-field input[type="number"] {
+  width: 72px;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.8rem;
+}
+
+/* Per-group range error */
+.print-guide-group-range-error {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 0.75rem;
 }
 
 /* Empty-slots toggle row (bd-w532y) */

--- a/frontend/src/components/PrintGuideModal.test.tsx
+++ b/frontend/src/components/PrintGuideModal.test.tsx
@@ -1,22 +1,20 @@
 /**
- * Unit tests for PrintGuideModal — channel-number range filter and empty-slot
+ * Unit tests for PrintGuideModal — per-group channel-number range and empty-slot
  * placeholders.
  *
- * bd-9q9z0: Operator-selectable channel-number range filter for the Print
- * Channel Guide modal. Defaults to the full range so existing all-channels
- * behaviour is preserved; operators can narrow to a sub-range (e.g. 100–199)
- * for booklet sections. Range is applied before the existing group filter.
+ * bd-9eyqp: Replace the single global From/To range (bd-9q9z0) with per-group
+ * From/To inputs that default to each group's min/max used channel number and
+ * are independently editable. The empty-slot fill (bd-w532y) uses each group's
+ * own [From,To].
  *
  * bd-w532y: Empty-slot placeholders — when "Show empty slots" is enabled,
  * generatePrintHtml fills in placeholder rows for channel numbers within a
- * group's range that have no real channel assigned. This lets operators print
- * a guide that reflects the INTENDED channel layout of a sparse auto-sync
- * group, not just what exists today.
+ * group's per-group range that have no real channel assigned.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { PrintGuideModal, generatePrintHtml, MAX_EMPTY_SLOTS_PER_GROUP } from './PrintGuideModal';
-import type { GroupPrintSettings } from './PrintGuideModal';
+import type { GroupPrintSettings, GroupRangeMap } from './PrintGuideModal';
 import type { Channel, ChannelGroup } from '../types';
 
 // --- Test fixtures ---
@@ -43,7 +41,7 @@ function makeChannel(id: number, num: number | null, groupId: number | null): Ch
   };
 }
 
-// Channels 100–110 in Sports, 200–210 in News
+// Sports: 100, 105, 110 — News: 200, 205, 210
 const CHANNELS: Channel[] = [
   makeChannel(1, 100, 1),
   makeChannel(2, 105, 1),
@@ -69,149 +67,124 @@ function renderModal(channels = CHANNELS, groups = GROUPS) {
   return { onClose };
 }
 
-function getFromInput() {
-  return screen.getByLabelText(/from channel/i) as HTMLInputElement;
-}
-
-function getToInput() {
-  return screen.getByLabelText(/to channel/i) as HTMLInputElement;
-}
-
 // --- Test suite ---
 
-describe('PrintGuideModal — channel range filter (bd-9q9z0)', () => {
-  describe('default range covers all channels (regression guard)', () => {
-    it('From input defaults to the lowest channel number in the guide', () => {
-      renderModal();
-      expect(getFromInput().value).toBe('100');
-    });
-
-    it('To input defaults to the highest channel number in the guide', () => {
-      renderModal();
-      expect(getToInput().value).toBe('210');
-    });
-
-    it('all groups remain visible at default range', () => {
-      renderModal();
-      expect(screen.getByText('Sports')).toBeInTheDocument();
-      expect(screen.getByText('News')).toBeInTheDocument();
-    });
-
-    it('Print button is enabled at default range', () => {
-      renderModal();
-      expect(
-        screen.getByRole('button', { name: /print selected/i })
-      ).not.toBeDisabled();
-    });
+describe('PrintGuideModal — per-group range defaults (bd-9eyqp)', () => {
+  it('Sports group From input defaults to its minimum channel (100)', () => {
+    renderModal();
+    // Each group-item renders its own From/To inputs labeled with the group name context
+    const sportsSection = screen.getByText('Sports').closest('.group-item') as HTMLElement;
+    const fromInput = within(sportsSection).getByLabelText(/from/i) as HTMLInputElement;
+    expect(fromInput.value).toBe('100');
   });
 
-  describe('narrowed range filters channels in the group list', () => {
-    it('setting To=150 hides the News group (200–210) from the group list', () => {
-      renderModal();
-      const toInput = getToInput();
-      fireEvent.change(toInput, { target: { value: '150' } });
-      // News group has no channels in 100–150, should be hidden from group list
-      expect(screen.queryByText('News')).not.toBeInTheDocument();
-      expect(screen.getByText('Sports')).toBeInTheDocument();
-    });
-
-    it('setting From=200 hides the Sports group (100–110) from the group list', () => {
-      renderModal();
-      const fromInput = getFromInput();
-      fireEvent.change(fromInput, { target: { value: '200' } });
-      expect(screen.queryByText('Sports')).not.toBeInTheDocument();
-      expect(screen.getByText('News')).toBeInTheDocument();
-    });
-
-    it('setting From=105 To=205 shows both groups (each has at least one channel in range)', () => {
-      renderModal();
-      fireEvent.change(getFromInput(), { target: { value: '105' } });
-      fireEvent.change(getToInput(), { target: { value: '205' } });
-      expect(screen.getByText('Sports')).toBeInTheDocument();
-      expect(screen.getByText('News')).toBeInTheDocument();
-    });
+  it('Sports group To input defaults to its maximum channel (110)', () => {
+    renderModal();
+    const sportsSection = screen.getByText('Sports').closest('.group-item') as HTMLElement;
+    const toInput = within(sportsSection).getByLabelText(/to/i) as HTMLInputElement;
+    expect(toInput.value).toBe('110');
   });
 
-  describe('invalid range — From > To', () => {
-    it('shows a validation error when From > To', () => {
-      renderModal();
-      fireEvent.change(getFromInput(), { target: { value: '210' } });
-      fireEvent.change(getToInput(), { target: { value: '100' } });
-      expect(screen.getByRole('alert')).toBeInTheDocument();
-      expect(screen.getByRole('alert').textContent).toMatch(/from.*must.*to|range.*invalid/i);
-    });
-
-    it('disables the Print button when From > To', () => {
-      renderModal();
-      fireEvent.change(getFromInput(), { target: { value: '210' } });
-      fireEvent.change(getToInput(), { target: { value: '100' } });
-      expect(screen.getByRole('button', { name: /print selected/i })).toBeDisabled();
-    });
+  it('News group From input defaults to its minimum channel (200)', () => {
+    renderModal();
+    const newsSection = screen.getByText('News').closest('.group-item') as HTMLElement;
+    const fromInput = within(newsSection).getByLabelText(/from/i) as HTMLInputElement;
+    expect(fromInput.value).toBe('200');
   });
 
-  describe('out-of-bounds clamping with operator hint', () => {
-    it('clamps From below the minimum and shows an Adjusted hint', () => {
-      renderModal();
-      fireEvent.change(getFromInput(), { target: { value: '1' } });
-      fireEvent.blur(getFromInput());
-      // Should clamp to 100 (the minimum)
-      expect(getFromInput().value).toBe('100');
-      expect(screen.getByText(/adjusted to/i)).toBeInTheDocument();
-    });
-
-    it('clamps To above the maximum and shows an Adjusted hint', () => {
-      renderModal();
-      fireEvent.change(getToInput(), { target: { value: '9999' } });
-      fireEvent.blur(getToInput());
-      // Should clamp to 210 (the maximum)
-      expect(getToInput().value).toBe('210');
-      expect(screen.getByText(/adjusted to/i)).toBeInTheDocument();
-    });
+  it('News group To input defaults to its maximum channel (210)', () => {
+    renderModal();
+    const newsSection = screen.getByText('News').closest('.group-item') as HTMLElement;
+    const toInput = within(newsSection).getByLabelText(/to/i) as HTMLInputElement;
+    expect(toInput.value).toBe('210');
   });
 
-  describe('no channels in range — graceful empty state', () => {
-    it('shows an empty state message when no groups have channels in the range', () => {
-      renderModal();
-      fireEvent.change(getFromInput(), { target: { value: '300' } });
-      fireEvent.change(getToInput(), { target: { value: '400' } });
-      expect(screen.getByText(/no channels in range/i)).toBeInTheDocument();
-    });
-
-    it('disables the Print button when no channels are in range', () => {
-      renderModal();
-      fireEvent.change(getFromInput(), { target: { value: '300' } });
-      fireEvent.change(getToInput(), { target: { value: '400' } });
-      expect(screen.getByRole('button', { name: /print selected/i })).toBeDisabled();
-    });
+  it('both groups are visible by default (no global range filter)', () => {
+    renderModal();
+    expect(screen.getByText('Sports')).toBeInTheDocument();
+    expect(screen.getByText('News')).toBeInTheDocument();
   });
 
-  describe('Show empty slots toggle (bd-w532y)', () => {
-    it('renders the empty-slots checkbox', () => {
-      renderModal();
-      expect(screen.getByLabelText(/show empty slots/i)).toBeInTheDocument();
-    });
+  it('Print button is enabled at default ranges', () => {
+    renderModal();
+    expect(
+      screen.getByRole('button', { name: /print selected/i })
+    ).not.toBeDisabled();
+  });
+});
 
-    it('empty-slots checkbox is checked by default', () => {
-      renderModal();
-      const cb = screen.getByLabelText(/show empty slots/i) as HTMLInputElement;
-      expect(cb.checked).toBe(true);
-    });
+describe('PrintGuideModal — per-group range editing is independent (bd-9eyqp)', () => {
+  it('editing News group To does not affect Sports group To', () => {
+    renderModal();
+    const newsSection = screen.getByText('News').closest('.group-item') as HTMLElement;
+    const newsToInput = within(newsSection).getByLabelText(/to/i) as HTMLInputElement;
+    fireEvent.change(newsToInput, { target: { value: '251' } });
 
-    it('unchecking the empty-slots checkbox does not disable the Print button', () => {
-      renderModal();
-      const cb = screen.getByLabelText(/show empty slots/i);
-      fireEvent.click(cb);
-      expect(screen.getByRole('button', { name: /print selected/i })).not.toBeDisabled();
+    const sportsSection = screen.getByText('Sports').closest('.group-item') as HTMLElement;
+    const sportsToInput = within(sportsSection).getByLabelText(/to/i) as HTMLInputElement;
+    expect(sportsToInput.value).toBe('110'); // unchanged
+  });
+
+  it('editing Sports From does not affect News From', () => {
+    renderModal();
+    const sportsSection = screen.getByText('Sports').closest('.group-item') as HTMLElement;
+    const sportsFromInput = within(sportsSection).getByLabelText(/from/i) as HTMLInputElement;
+    fireEvent.change(sportsFromInput, { target: { value: '105' } });
+
+    const newsSection = screen.getByText('News').closest('.group-item') as HTMLElement;
+    const newsFromInput = within(newsSection).getByLabelText(/from/i) as HTMLInputElement;
+    expect(newsFromInput.value).toBe('200'); // unchanged
+  });
+
+  it('Print button remains enabled when only one group has From > To (other group ok)', () => {
+    // Per-group validation: only blocks that group's print, not the whole button
+    // (unless ALL selected groups have invalid ranges — but here News is still valid)
+    renderModal();
+    const sportsSection = screen.getByText('Sports').closest('.group-item') as HTMLElement;
+    const sportsFromInput = within(sportsSection).getByLabelText(/from/i) as HTMLInputElement;
+    const sportsToInput = within(sportsSection).getByLabelText(/to/i) as HTMLInputElement;
+    fireEvent.change(sportsFromInput, { target: { value: '110' } });
+    fireEvent.change(sportsToInput, { target: { value: '100' } });
+    // News group is still valid; Print should remain enabled
+    expect(screen.getByRole('button', { name: /print selected/i })).not.toBeDisabled();
+  });
+});
+
+describe('PrintGuideModal — no global From/To controls (bd-9eyqp)', () => {
+  it('does not render a standalone global "From channel #" input outside group rows', () => {
+    renderModal();
+    // There should be no single global From/To — only per-group ones inside .group-item
+    const allFromLabels = screen.getAllByLabelText(/from/i) as HTMLInputElement[];
+    // Each From label should be inside a .group-item
+    allFromLabels.forEach(input => {
+      expect(input.closest('.group-item')).not.toBeNull();
     });
   });
 });
 
+describe('PrintGuideModal — Show empty slots toggle (bd-w532y, preserved)', () => {
+  it('renders the empty-slots checkbox', () => {
+    renderModal();
+    expect(screen.getByLabelText(/show empty slots/i)).toBeInTheDocument();
+  });
+
+  it('empty-slots checkbox is checked by default', () => {
+    renderModal();
+    const cb = screen.getByLabelText(/show empty slots/i) as HTMLInputElement;
+    expect(cb.checked).toBe(true);
+  });
+
+  it('unchecking the empty-slots checkbox does not disable the Print button', () => {
+    renderModal();
+    const cb = screen.getByLabelText(/show empty slots/i);
+    fireEvent.click(cb);
+    expect(screen.getByRole('button', { name: /print selected/i })).not.toBeDisabled();
+  });
+});
+
 // ---------------------------------------------------------------------------
-// generatePrintHtml — empty-slot placeholder unit tests (bd-w532y)
+// generatePrintHtml — per-group range + empty-slot tests (bd-9eyqp + bd-w532y)
 // ---------------------------------------------------------------------------
-//
-// These tests exercise the HTML-generation helper directly so we can assert on
-// the rendered output without spinning up a full React component tree.
 
 /** Build a minimal Channel for generatePrintHtml tests. */
 function makeChannelForHtml(
@@ -242,200 +215,275 @@ function makeGroupSettings(
   groupId: number,
   selected = true,
   mode: 'detailed' | 'summary' = 'detailed',
+  fromRaw = '1',
+  toRaw = '9999',
 ): GroupPrintSettings {
-  return { groupId, selected, mode };
+  return { groupId, selected, mode, fromRaw, toRaw };
 }
 
-describe('generatePrintHtml — empty-slot placeholders (bd-w532y)', () => {
+describe('generatePrintHtml — per-group range filter (bd-9eyqp)', () => {
+  const GROUP_PPV: ChannelGroup = { id: 10, name: 'PPV', channel_count: 5 };
+  const GROUP_SPORTS: ChannelGroup = { id: 20, name: 'Sports', channel_count: 3 };
+
+  // PPV: 1101..1201, Sports: 100..110
+  const PPV_CHANNELS = Array.from({ length: 101 }, (_, i) =>
+    makeChannelForHtml(1000 + i, 1101 + i, 10)
+  );
+  const SPORTS_CHANNELS = [
+    makeChannelForHtml(1, 100, 20),
+    makeChannelForHtml(2, 105, 20),
+    makeChannelForHtml(3, 110, 20),
+  ];
+  const ALL_CHANNELS = [...PPV_CHANNELS, ...SPORTS_CHANNELS];
+
+  it('PO example: PPV defaults From=1101 To=1201 — no empty slots', () => {
+    // With per-group range defaulting to the group's own min/max, no empty slots appear
+    const rangeMap: GroupRangeMap = { 10: { from: 1101, to: 1201 }, 20: { from: 100, to: 110 } };
+    const html = generatePrintHtml(
+      ALL_CHANNELS,
+      [GROUP_PPV, GROUP_SPORTS],
+      [makeGroupSettings(10), makeGroupSettings(20)],
+      'Test Guide',
+      rangeMap,
+      false, // showEmptySlots off — no gaps expected anyway
+    );
+    expect(html).toContain('>1101<');
+    expect(html).toContain('>1201<');
+    expect(html).not.toContain('class="ch-slot-label"');
+  });
+
+  it('PO example: operator edits PPV To to 1251 → empty slots 1202-1251 for PPV only', () => {
+    // Sports remains at 100-110 unchanged
+    const rangeMap: GroupRangeMap = { 10: { from: 1101, to: 1251 }, 20: { from: 100, to: 110 } };
+    const html = generatePrintHtml(
+      ALL_CHANNELS,
+      [GROUP_PPV, GROUP_SPORTS],
+      [makeGroupSettings(10), makeGroupSettings(20)],
+      'Test Guide',
+      rangeMap,
+      true,
+    );
+    // PPV real channels present
+    expect(html).toContain('>1101<');
+    expect(html).toContain('>1201<');
+    // PPV empty slots 1202-1251 present
+    expect(html).toContain('>1202<');
+    expect(html).toContain('>1251<');
+    // Sports real channels present
+    expect(html).toContain('>100<');
+    expect(html).toContain('>110<');
+    // Sports does NOT have channels at 111-..., empty slots only for PPV beyond 1201
+    // (Sports group ends at 110, its To is 110 — no extension)
+    expect(html).not.toContain('>111<');
+  });
+
+  it('narrowing a group From/To filters that group\'s real channels', () => {
+    // Sports From=105 To=110 — channel 100 excluded
+    const rangeMap: GroupRangeMap = { 20: { from: 105, to: 110 } };
+    const html = generatePrintHtml(
+      SPORTS_CHANNELS,
+      [GROUP_SPORTS],
+      [makeGroupSettings(20)],
+      'Test Guide',
+      rangeMap,
+      false,
+    );
+    expect(html).not.toContain('>100<');
+    expect(html).toContain('>105<');
+    expect(html).toContain('>110<');
+  });
+
+  it('each group uses only its own range — other groups unaffected', () => {
+    const rangeMap: GroupRangeMap = {
+      10: { from: 1101, to: 1110 }, // narrow PPV to first 10
+      20: { from: 100, to: 110 },
+    };
+    const html = generatePrintHtml(
+      ALL_CHANNELS,
+      [GROUP_PPV, GROUP_SPORTS],
+      [makeGroupSettings(10), makeGroupSettings(20)],
+      'Test Guide',
+      rangeMap,
+      false,
+    );
+    // Only PPV channels 1101-1110 present
+    expect(html).toContain('>1101<');
+    expect(html).toContain('>1110<');
+    expect(html).not.toContain('>1111<');
+    // Sports unaffected — all 3 channels present
+    expect(html).toContain('>100<');
+    expect(html).toContain('>105<');
+    expect(html).toContain('>110<');
+  });
+});
+
+describe('generatePrintHtml — empty-slot placeholders with per-group range (bd-w532y)', () => {
   const GROUP: ChannelGroup = { id: 1, name: 'Sports', channel_count: 3 };
 
-  // Sparse group: channels at 100, 105, 110. Range 100–115. Gaps: 101-104, 106-109, 111-115.
+  // Sparse group: channels at 100, 105, 110
   const SPARSE_CHANNELS = [
     makeChannelForHtml(1, 100, 1),
     makeChannelForHtml(2, 105, 1),
     makeChannelForHtml(3, 110, 1),
   ];
 
-  describe('showEmptySlots = false (default-off path)', () => {
+  describe('showEmptySlots = false', () => {
     it('renders only real channel rows — no placeholder rows', () => {
+      const rangeMap: GroupRangeMap = { 1: { from: 100, to: 115 } };
       const html = generatePrintHtml(
         SPARSE_CHANNELS,
         [GROUP],
         [makeGroupSettings(1)],
         'Test Guide',
-        100,
-        115,
+        rangeMap,
         false,
       );
-      // Real channels present
       expect(html).toContain('>100<');
       expect(html).toContain('>105<');
       expect(html).toContain('>110<');
-      // No placeholder element (class="ch-slot-label" in HTML — CSS rule presence is expected)
       expect(html).not.toContain('class="ch-slot-label"');
     });
   });
 
   describe('showEmptySlots = true', () => {
-    it('includes a placeholder row for each gap channel number in the range', () => {
+    it('includes a placeholder row for each gap in the group range', () => {
+      const rangeMap: GroupRangeMap = { 1: { from: 100, to: 112 } };
       const html = generatePrintHtml(
         SPARSE_CHANNELS,
         [GROUP],
         [makeGroupSettings(1)],
         'Test Guide',
-        100,
-        112,
+        rangeMap,
         true,
       );
-      // Real channels
       expect(html).toContain('>100<');
       expect(html).toContain('>105<');
       expect(html).toContain('>110<');
-      // Placeholder slots — gap numbers 101, 102, 103, 104, 106, 107, 108, 109, 111, 112
+      // Gap numbers
       expect(html).toContain('>101<');
       expect(html).toContain('>104<');
       expect(html).toContain('>106<');
       expect(html).toContain('>109<');
       expect(html).toContain('>111<');
       expect(html).toContain('>112<');
-      // Placeholder marker element present
       expect(html).toContain('class="ch-slot-label"');
     });
 
-    it('does not add placeholders before the first real channel in the group', () => {
-      // First real channel is 105, range starts at 100. Slots 100-104 should NOT appear.
-      const channelsStartingAt105 = [
-        makeChannelForHtml(2, 105, 1),
-        makeChannelForHtml(3, 110, 1),
-      ];
+    it('does not add placeholders before the group From value', () => {
+      // From=105: channel 100 excluded; gaps start at 106
+      const rangeMap: GroupRangeMap = { 1: { from: 105, to: 112 } };
       const html = generatePrintHtml(
-        channelsStartingAt105,
+        SPARSE_CHANNELS,
         [GROUP],
         [makeGroupSettings(1)],
         'Test Guide',
-        100,
-        112,
+        rangeMap,
         true,
       );
-      // 105 and 110 present as real channels
       expect(html).toContain('>105<');
       expect(html).toContain('>110<');
-      // 100–104 are before the group's first channel — should NOT appear in channel rows
-      // (they may appear in CSS, but not as ch-num span content in a channel-line)
       expect(html).not.toContain('>100<');
-      expect(html).not.toContain('>101<');
       expect(html).not.toContain('>104<');
-      // 106–109, 111–112 are gaps within group range — should appear as placeholder rows
       expect(html).toContain('>106<');
       expect(html).toContain('>111<');
+      expect(html).toContain('>112<');
     });
 
-    it('extends placeholders to rangeTo when rangeTo > group last channel', () => {
-      // Group has channels at 100 and 105 only; range extends to 108.
+    it('extends placeholders to group To when To > group last channel', () => {
       const channels = [
         makeChannelForHtml(1, 100, 1),
         makeChannelForHtml(2, 105, 1),
       ];
+      const rangeMap: GroupRangeMap = { 1: { from: 100, to: 108 } };
       const html = generatePrintHtml(
         channels,
         [GROUP],
         [makeGroupSettings(1)],
         'Test Guide',
-        100,
-        108,
+        rangeMap,
         true,
       );
-      // Real channels
       expect(html).toContain('>100<');
       expect(html).toContain('>105<');
-      // Placeholder slots 101-104, 106-108
       expect(html).toContain('>101<');
       expect(html).toContain('>106<');
       expect(html).toContain('>107<');
       expect(html).toContain('>108<');
     });
 
-    it('inclusive bounds: rangeFrom and rangeTo endpoints are included', () => {
+    it('inclusive bounds: group From and To endpoints are included', () => {
       const channels = [makeChannelForHtml(1, 100, 1)];
+      const rangeMap: GroupRangeMap = { 1: { from: 100, to: 102 } };
       const html = generatePrintHtml(
         channels,
         [GROUP],
         [makeGroupSettings(1)],
         'Test Guide',
-        100,
-        102,
+        rangeMap,
         true,
       );
       expect(html).toContain('>101<');
       expect(html).toContain('>102<');
-      // 103 is outside rangeTo — should NOT appear
       expect(html).not.toContain('>103<');
     });
 
     it('no placeholders when group channels are fully contiguous in the range', () => {
-      // 100, 101, 102 — no gaps
       const contiguous = [
         makeChannelForHtml(1, 100, 1),
         makeChannelForHtml(2, 101, 1),
         makeChannelForHtml(3, 102, 1),
       ];
+      const rangeMap: GroupRangeMap = { 1: { from: 100, to: 102 } };
       const html = generatePrintHtml(
         contiguous,
         [GROUP],
         [makeGroupSettings(1)],
         'Test Guide',
-        100,
-        102,
+        rangeMap,
         true,
       );
-      // No placeholder elements (CSS class definition present in <style> is expected)
       expect(html).not.toContain('class="ch-slot-label"');
     });
 
     it('summary mode groups never emit empty-slot rows regardless of showEmptySlots', () => {
+      const rangeMap: GroupRangeMap = { 1: { from: 100, to: 115 } };
       const html = generatePrintHtml(
         SPARSE_CHANNELS,
         [GROUP],
         [makeGroupSettings(1, true, 'summary')],
         'Test Guide',
-        100,
-        115,
+        rangeMap,
         true,
       );
-      // Summary mode just shows a range label — no per-number placeholder elements
       expect(html).not.toContain('class="ch-slot-label"');
     });
 
     it(`truncates at ${MAX_EMPTY_SLOTS_PER_GROUP} empty slots and appends a warning row`, () => {
-      // Single channel at 1; range extends far enough to exceed the cap.
       const bigRange = [makeChannelForHtml(1, 1, 1)];
-      const rangeEnd = MAX_EMPTY_SLOTS_PER_GROUP + 50; // well over cap
+      const rangeEnd = MAX_EMPTY_SLOTS_PER_GROUP + 50;
+      const rangeMap: GroupRangeMap = { 1: { from: 1, to: rangeEnd } };
       const html = generatePrintHtml(
         bigRange,
         [GROUP],
         [makeGroupSettings(1)],
         'Test Guide',
-        1,
-        rangeEnd,
+        rangeMap,
         true,
       );
-      // Truncation warning row must appear
       expect(html).toContain('empty-slot limit reached');
-      // Should NOT contain channel numbers beyond the cap
       expect(html).not.toContain(`>${rangeEnd}<`);
     });
 
     it('deselected group produces no output even with showEmptySlots=true', () => {
+      const rangeMap: GroupRangeMap = { 1: { from: 100, to: 115 } };
       const html = generatePrintHtml(
         SPARSE_CHANNELS,
         [GROUP],
-        [makeGroupSettings(1, false)], // not selected
+        [makeGroupSettings(1, false)],
         'Test Guide',
-        100,
-        115,
+        rangeMap,
         true,
       );
-      // Group completely absent — no real channels, no placeholder elements
       expect(html).not.toContain('>Sports<');
       expect(html).not.toContain('class="ch-slot-label"');
     });

--- a/frontend/src/components/PrintGuideModal.tsx
+++ b/frontend/src/components/PrintGuideModal.tsx
@@ -42,7 +42,18 @@ export interface GroupPrintSettings {
   groupId: number;
   selected: boolean;
   mode: 'detailed' | 'summary';
+  /** Per-group range From (raw string for controlled input) */
+  fromRaw: string;
+  /** Per-group range To (raw string for controlled input) */
+  toRaw: string;
 }
+
+/**
+ * Per-group numeric range map consumed by generatePrintHtml.
+ * Key: group id; value: { from, to } inclusive channel-number bounds.
+ * Exported for unit testing.
+ */
+export type GroupRangeMap = Record<number, { from: number; to: number }>;
 
 // Maximum empty-slot placeholders rendered per group to prevent runaway output
 // (e.g. operator sets 1–9999 with only one real channel).
@@ -66,34 +77,9 @@ function PrintGuideModalInner({
   channels,
   title = 'TV Channel Guide',
 }: Omit<PrintGuideModalProps, 'isOpen'>) {
-  // Compute global min/max channel numbers across all channels that have a number
-  const { globalMin, globalMax } = useMemo(() => {
-    const nums = channels
-      .map(ch => ch.channel_number)
-      .filter((n): n is number => n !== null);
-    if (nums.length === 0) return { globalMin: 1, globalMax: 9999 };
-    return { globalMin: Math.min(...nums), globalMax: Math.max(...nums) };
-  }, [channels]);
-
-  // Range filter state — raw string values for controlled inputs
-  const [fromRaw, setFromRaw] = useState<string>(() => String(globalMin));
-  const [toRaw, setToRaw] = useState<string>(() => String(globalMax));
-
   // Empty-slot placeholder toggle — on by default so the printed guide shows
   // the full intended channel-number layout (bd-w532y).
   const [showEmptySlots, setShowEmptySlots] = useState(true);
-
-  // Track whether a clamp hint should be shown (cleared on next manual change)
-  const [clampHint, setClampHint] = useState<string | null>(null);
-
-  // Parsed numeric values (used for filtering)
-  const fromNum = parseInt(fromRaw, 10);
-  const toNum = parseInt(toRaw, 10);
-
-  const rangeError =
-    !Number.isNaN(fromNum) && !Number.isNaN(toNum) && fromNum > toNum
-      ? '"From" must be less than or equal to "To"'
-      : null;
 
   // Sort groups by first channel number in each group
   const sortedGroups = useMemo(() => {
@@ -116,42 +102,52 @@ function PrintGuideModalInner({
       });
   }, [channelGroups, channels]);
 
-  // Groups whose channels overlap with the current range — this is what the
-  // operator sees in the list and what gets passed to the print function.
-  const rangeFilteredGroups = useMemo(() => {
-    if (rangeError || Number.isNaN(fromNum) || Number.isNaN(toNum)) {
-      // Keep showing groups even during an error so the operator can see what
-      // was previously visible, but Print will be blocked by the error.
-      return sortedGroups;
-    }
-    return sortedGroups.filter(g =>
-      channels.some(
-        ch =>
-          ch.channel_group_id === g.id &&
-          ch.channel_number !== null &&
-          ch.channel_number >= fromNum &&
-          ch.channel_number <= toNum
-      )
-    );
-  }, [sortedGroups, channels, fromNum, toNum, rangeError]);
+  // Compute per-group min/max from the channels data.
+  // Returns { min, max } for each group id that has numbered channels.
+  const groupMinMax = useMemo(() => {
+    const result = new Map<number, { min: number; max: number }>();
+    channels.forEach(ch => {
+      if (ch.channel_number !== null && ch.channel_group_id !== null) {
+        const existing = result.get(ch.channel_group_id);
+        if (existing === undefined) {
+          result.set(ch.channel_group_id, { min: ch.channel_number, max: ch.channel_number });
+        } else {
+          if (ch.channel_number < existing.min) existing.min = ch.channel_number;
+          if (ch.channel_number > existing.max) existing.max = ch.channel_number;
+        }
+      }
+    });
+    return result;
+  }, [channels]);
 
-  // Initialize group settings - all selected, detailed mode by default. Since
-  // this component remounts on each open (via outer wrapper), we can seed
-  // directly from the first sorted list with a useState initializer.
+  // Initialize group settings — all selected, detailed mode, per-group From/To
+  // defaulting to each group's min/max used channel number. Since this component
+  // remounts on each open (via outer wrapper), we can seed directly from the
+  // first sorted list with a useState initializer.
   const [groupSettings, setGroupSettings] = useState<GroupPrintSettings[]>(() =>
-    sortedGroups.map(g => ({
-      groupId: g.id,
-      selected: true,
-      mode: 'detailed',
-    }))
+    sortedGroups.map(g => {
+      const mm = groupMinMax.get(g.id);
+      const groupMin = mm?.min ?? 1;
+      const groupMax = mm?.max ?? 9999;
+      return {
+        groupId: g.id,
+        selected: true,
+        mode: 'detailed',
+        fromRaw: String(groupMin),
+        toRaw: String(groupMax),
+      };
+    })
   );
 
   // Get settings for a specific group
   const getGroupSettings = (groupId: number): GroupPrintSettings => {
+    const mm = groupMinMax.get(groupId);
     return groupSettings.find(s => s.groupId === groupId) ?? {
       groupId,
       selected: true,
       mode: 'detailed',
+      fromRaw: String(mm?.min ?? 1),
+      toRaw: String(mm?.max ?? 9999),
     };
   };
 
@@ -173,97 +169,99 @@ function PrintGuideModalInner({
     );
   }, []);
 
-  // Select/deselect all (operates on currently visible range-filtered groups)
-  const toggleAll = useCallback(() => {
-    const visibleIds = new Set(rangeFilteredGroups.map(g => g.id));
-    const allSelected = groupSettings
-      .filter(s => visibleIds.has(s.groupId))
-      .every(s => s.selected);
+  // Update per-group From raw value
+  const setGroupFrom = useCallback((groupId: number, value: string) => {
     setGroupSettings(prev =>
-      prev.map(s =>
-        visibleIds.has(s.groupId) ? { ...s, selected: !allSelected } : s
-      )
+      prev.map(s => s.groupId === groupId ? { ...s, fromRaw: value } : s)
     );
-  }, [groupSettings, rangeFilteredGroups]);
+  }, []);
 
-  // Label for the toggleAll button — scoped to visible (range-filtered) groups
-  // so the label matches the toggleAll behaviour. An operator who deselects an
-  // out-of-range group and narrows the range should still see "Deselect All"
-  // when every visible group is selected. (bd-9q9z0 reviewer Warn-1 fix-forward.)
-  const allVisibleSelected = useMemo(() => {
-    const visibleIds = new Set(rangeFilteredGroups.map(g => g.id));
-    return groupSettings
-      .filter(s => visibleIds.has(s.groupId))
-      .every(s => s.selected);
-  }, [groupSettings, rangeFilteredGroups]);
+  // Update per-group To raw value
+  const setGroupTo = useCallback((groupId: number, value: string) => {
+    setGroupSettings(prev =>
+      prev.map(s => s.groupId === groupId ? { ...s, toRaw: value } : s)
+    );
+  }, []);
 
-  // Clamp a value to [globalMin, globalMax] and return the clamped value plus
-  // whether clamping actually occurred.
-  const clamp = useCallback((val: number): { clamped: number; didClamp: boolean } => {
-    if (val < globalMin) return { clamped: globalMin, didClamp: true };
-    if (val > globalMax) return { clamped: globalMax, didClamp: true };
-    return { clamped: val, didClamp: false };
-  }, [globalMin, globalMax]);
+  // Select/deselect all (operates on all groups)
+  const toggleAll = useCallback(() => {
+    const allSelected = groupSettings.every(s => s.selected);
+    setGroupSettings(prev =>
+      prev.map(s => ({ ...s, selected: !allSelected }))
+    );
+  }, [groupSettings]);
 
-  // Handle blur on From/To to apply clamping
-  const handleFromBlur = useCallback(() => {
-    const parsed = parseInt(fromRaw, 10);
-    if (Number.isNaN(parsed)) {
-      setFromRaw(String(globalMin));
-      setClampHint(`Adjusted to ${globalMin}–${toRaw}`);
-      return;
-    }
-    const { clamped, didClamp } = clamp(parsed);
-    if (didClamp) {
-      setFromRaw(String(clamped));
-      setClampHint(`Adjusted to ${clamped}–${toRaw}`);
-    }
-  }, [fromRaw, toRaw, globalMin, clamp]);
+  const allSelected = useMemo(
+    () => groupSettings.every(s => s.selected),
+    [groupSettings]
+  );
 
-  const handleToBlur = useCallback(() => {
-    const parsed = parseInt(toRaw, 10);
-    if (Number.isNaN(parsed)) {
-      setToRaw(String(globalMax));
-      setClampHint(`Adjusted to ${fromRaw}–${globalMax}`);
-      return;
-    }
-    const { clamped, didClamp } = clamp(parsed);
-    if (didClamp) {
-      setToRaw(String(clamped));
-      setClampHint(`Adjusted to ${fromRaw}–${clamped}`);
-    }
-  }, [toRaw, fromRaw, globalMax, clamp]);
-
-  // Get channel count and range for a group, limited to the selected range
+  // Get channel count and range for a group within its current per-group range
   const getGroupInfo = useCallback((groupId: number) => {
-    const rangeFrom = !rangeError && !Number.isNaN(fromNum) ? fromNum : globalMin;
-    const rangeTo = !rangeError && !Number.isNaN(toNum) ? toNum : globalMax;
+    const settings = getGroupSettings(groupId);
+    const fromNum = parseInt(settings.fromRaw, 10);
+    const toNum = parseInt(settings.toRaw, 10);
+    const rangeValid = !Number.isNaN(fromNum) && !Number.isNaN(toNum) && fromNum <= toNum;
+
+    if (!rangeValid) return { count: 0, first: null, last: null, rangeError: true };
+
     const groupChannels = channels
       .filter(
         ch =>
           ch.channel_group_id === groupId &&
           ch.channel_number !== null &&
-          ch.channel_number >= rangeFrom &&
-          ch.channel_number <= rangeTo
+          ch.channel_number >= fromNum &&
+          ch.channel_number <= toNum
       )
       .sort((a, b) => (a.channel_number ?? 0) - (b.channel_number ?? 0));
 
     if (groupChannels.length === 0) {
-      return { count: 0, first: null, last: null };
+      return { count: 0, first: null, last: null, rangeError: false };
     }
 
     return {
       count: groupChannels.length,
       first: groupChannels[0].channel_number,
       last: groupChannels[groupChannels.length - 1].channel_number,
+      rangeError: false,
     };
-  }, [channels, fromNum, toNum, rangeError, globalMin, globalMax]);
+  }, [channels, groupSettings]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Format channel number (remove .0 for whole numbers)
   const formatChannelNumber = (num: number | null): string => {
     if (num === null) return 'N/A';
     return Number.isInteger(num) ? String(num) : String(num);
   };
+
+  // Build the GroupRangeMap for generatePrintHtml — use valid per-group ranges,
+  // fall back to group min/max for invalid inputs.
+  const buildRangeMap = useCallback((): GroupRangeMap => {
+    const map: GroupRangeMap = {};
+    groupSettings.forEach(s => {
+      const fromNum = parseInt(s.fromRaw, 10);
+      const toNum = parseInt(s.toRaw, 10);
+      const mm = groupMinMax.get(s.groupId);
+      if (!Number.isNaN(fromNum) && !Number.isNaN(toNum) && fromNum <= toNum) {
+        map[s.groupId] = { from: fromNum, to: toNum };
+      } else {
+        // Invalid input: fall back to group min/max so the print still works
+        map[s.groupId] = { from: mm?.min ?? 1, to: mm?.max ?? 9999 };
+      }
+    });
+    return map;
+  }, [groupSettings, groupMinMax]);
+
+  // Whether any selected group has a valid range (for Print button)
+  const anySelectedGroupPrintable = useMemo(() => {
+    return groupSettings.some(s => {
+      if (!s.selected) return false;
+      const fromNum = parseInt(s.fromRaw, 10);
+      const toNum = parseInt(s.toRaw, 10);
+      if (Number.isNaN(fromNum) || Number.isNaN(toNum) || fromNum > toNum) return false;
+      // Check at least one channel exists for this group (even without range filter)
+      return channels.some(ch => ch.channel_group_id === s.groupId && ch.channel_number !== null);
+    });
+  }, [groupSettings, channels]);
 
   // Generate and open print window
   const handlePrint = useCallback(() => {
@@ -276,17 +274,15 @@ function PrintGuideModalInner({
       return;
     }
 
-    const rangeFrom = !rangeError && !Number.isNaN(fromNum) ? fromNum : globalMin;
-    const rangeTo = !rangeError && !Number.isNaN(toNum) ? toNum : globalMax;
+    const rangeMap = buildRangeMap();
 
     // Build HTML content for the print window
     const printHtml = generatePrintHtml(
       channels,
-      rangeFilteredGroups,
+      sortedGroups,
       groupSettings,
       title,
-      rangeFrom,
-      rangeTo,
+      rangeMap,
       showEmptySlots,
     );
 
@@ -298,7 +294,7 @@ function PrintGuideModalInner({
     }
 
     onClose();
-  }, [channels, rangeFilteredGroups, groupSettings, title, onClose, rangeError, fromNum, toNum, globalMin, globalMax, showEmptySlots]);
+  }, [channels, sortedGroups, groupSettings, title, onClose, buildRangeMap, showEmptySlots]);
 
   // isOpen gating handled by outer wrapper.
 
@@ -314,50 +310,8 @@ function PrintGuideModalInner({
 
         <div className="modal-body">
           <p className="print-guide-description">
-            Select channel groups to include and choose detailed (all channels) or summary (channel range) for each.
+            Select channel groups to include and choose detailed (all channels) or summary (channel range) for each. Set each group's From/To to control its printed range.
           </p>
-
-          {/* Channel number range filter */}
-          <div className="print-guide-range-row">
-            <div className="modal-form-group print-guide-range-field">
-              <label htmlFor="pgm-from">From channel #</label>
-              <input
-                id="pgm-from"
-                type="number"
-                min={globalMin}
-                max={globalMax}
-                value={fromRaw}
-                onChange={e => {
-                  setFromRaw(e.target.value);
-                  setClampHint(null);
-                }}
-                onBlur={handleFromBlur}
-                aria-label="From channel"
-              />
-            </div>
-            <div className="modal-form-group print-guide-range-field">
-              <label htmlFor="pgm-to">To channel #</label>
-              <input
-                id="pgm-to"
-                type="number"
-                min={globalMin}
-                max={globalMax}
-                value={toRaw}
-                onChange={e => {
-                  setToRaw(e.target.value);
-                  setClampHint(null);
-                }}
-                onBlur={handleToBlur}
-                aria-label="To channel"
-              />
-            </div>
-          </div>
-          {rangeError && (
-            <div className="field-error" role="alert">{rangeError}</div>
-          )}
-          {clampHint && !rangeError && (
-            <p className="form-hint print-guide-clamp-hint">{clampHint}</p>
-          )}
 
           {/* Empty-slot placeholder toggle (bd-w532y) */}
           <div className="print-guide-empty-slots-row">
@@ -371,23 +325,30 @@ function PrintGuideModalInner({
               <span>Show empty slots</span>
             </label>
             <span className="print-guide-empty-slots-hint">
-              Fills missing channel numbers in the range with placeholder rows
+              Fills missing channel numbers in each group's range with placeholder rows
             </span>
           </div>
 
-          {/* Empty state when range has no channels */}
-          {!rangeError && rangeFilteredGroups.length === 0 && (
+          {/* Empty state when no groups */}
+          {sortedGroups.length === 0 && (
             <div className="print-guide-empty-range">
               <span className="material-icons">search_off</span>
-              <p>No channels in range {fromRaw}–{toRaw}</p>
+              <p>No channel groups with numbered channels</p>
             </div>
           )}
 
           <div className="group-list">
-            {rangeFilteredGroups.map((group, index) => {
+            {sortedGroups.map((group, index) => {
               const settings = getGroupSettings(group.id);
               const info = getGroupInfo(group.id);
               const color = GROUP_COLORS[index % GROUP_COLORS.length];
+              const fromNum = parseInt(settings.fromRaw, 10);
+              const toNum = parseInt(settings.toRaw, 10);
+              const rangeError =
+                !Number.isNaN(fromNum) && !Number.isNaN(toNum) && fromNum > toNum
+                  ? '"From" must be ≤ "To"'
+                  : null;
+              const mm = groupMinMax.get(group.id);
 
               return (
                 <div
@@ -408,28 +369,68 @@ function PrintGuideModalInner({
                     <div className="group-info">
                       <span className="group-name">{group.name}</span>
                       <span className="group-details">
-                        {info.count > 0
-                          ? `${formatChannelNumber(info.first)}-${formatChannelNumber(info.last)} (${info.count} channels)`
-                          : 'No channels'}
+                        {info.rangeError
+                          ? 'Invalid range'
+                          : info.count > 0
+                            ? `${formatChannelNumber(info.first)}-${formatChannelNumber(info.last)} (${info.count} channels)`
+                            : 'No channels in range'}
                       </span>
                     </div>
                   </div>
 
-                  <div className="mode-toggle">
-                    <button
-                      className={`mode-btn ${settings.mode === 'detailed' ? 'active' : ''}`}
-                      onClick={() => setGroupMode(group.id, 'detailed')}
-                      title="Show all channels with name"
-                    >
-                      Detailed
-                    </button>
-                    <button
-                      className={`mode-btn summary ${settings.mode === 'summary' ? 'active' : ''}`}
-                      onClick={() => setGroupMode(group.id, 'summary')}
-                      title="Show only channel range"
-                    >
-                      Summary
-                    </button>
+                  <div className="group-item-controls">
+                    {/* Per-group From/To range inputs */}
+                    <div className="print-guide-group-range">
+                      <div className="print-guide-group-range-field">
+                        <label htmlFor={`pgm-from-${group.id}`}>From</label>
+                        <input
+                          id={`pgm-from-${group.id}`}
+                          type="number"
+                          min={mm?.min}
+                          max={mm?.max}
+                          value={settings.fromRaw}
+                          aria-label={`From channel for ${group.name}`}
+                          onChange={e => setGroupFrom(group.id, e.target.value)}
+                          onClick={e => e.stopPropagation()}
+                        />
+                      </div>
+                      <div className="print-guide-group-range-field">
+                        <label htmlFor={`pgm-to-${group.id}`}>To</label>
+                        <input
+                          id={`pgm-to-${group.id}`}
+                          type="number"
+                          min={mm?.min}
+                          max={mm?.max}
+                          value={settings.toRaw}
+                          aria-label={`To channel for ${group.name}`}
+                          onChange={e => setGroupTo(group.id, e.target.value)}
+                          onClick={e => e.stopPropagation()}
+                        />
+                      </div>
+                    </div>
+
+                    {rangeError && (
+                      <div className="field-error print-guide-group-range-error" role="alert">
+                        {rangeError}
+                      </div>
+                    )}
+
+                    <div className="mode-toggle">
+                      <button
+                        className={`mode-btn ${settings.mode === 'detailed' ? 'active' : ''}`}
+                        onClick={() => setGroupMode(group.id, 'detailed')}
+                        title="Show all channels with name"
+                      >
+                        Detailed
+                      </button>
+                      <button
+                        className={`mode-btn summary ${settings.mode === 'summary' ? 'active' : ''}`}
+                        onClick={() => setGroupMode(group.id, 'summary')}
+                        title="Show only channel range"
+                      >
+                        Summary
+                      </button>
+                    </div>
                   </div>
                 </div>
               );
@@ -439,16 +440,12 @@ function PrintGuideModalInner({
 
         <div className="modal-footer">
           <button className="modal-btn modal-btn-secondary" onClick={toggleAll}>
-            {allVisibleSelected ? 'Deselect All' : 'Select All'}
+            {allSelected ? 'Deselect All' : 'Select All'}
           </button>
           <button
             className="modal-btn modal-btn-primary"
             onClick={handlePrint}
-            disabled={
-              !!rangeError ||
-              rangeFilteredGroups.length === 0 ||
-              !groupSettings.some(s => s.selected && rangeFilteredGroups.some(g => g.id === s.groupId))
-            }
+            disabled={!anySelectedGroupPrintable}
           >
             <span className="material-icons">print</span>
             Print Selected
@@ -475,14 +472,13 @@ export const PrintGuideModal = memo(function PrintGuideModal(
 
 // Generate the complete HTML for the print window.
 // Exported for unit testing; not part of the public component API.
-// eslint-disable-next-line react-refresh/only-export-components -- pure function exported for unit testing; HMR handles the component export fine
+// eslint-disable-next-line react-refresh/only-export-components -- pure functions exported for unit testing; HMR handles the component export fine
 export function generatePrintHtml(
   channels: Channel[],
   sortedGroups: ChannelGroup[],
   groupSettings: GroupPrintSettings[],
   title: string,
-  rangeFrom: number,
-  rangeTo: number,
+  groupRangeMap: GroupRangeMap,
   showEmptySlots: boolean = false,
 ): string {
   const selectedGroupIds = new Set(
@@ -503,7 +499,12 @@ export function generatePrintHtml(
     const color = GROUP_COLORS[colorIndex % GROUP_COLORS.length];
     colorIndex++;
 
-    // Apply channel-number range filter before rendering
+    // Resolve per-group range
+    const groupRange = groupRangeMap[group.id];
+    const rangeFrom = groupRange?.from ?? 1;
+    const rangeTo = groupRange?.to ?? 9999;
+
+    // Apply per-group channel-number range filter before rendering
     const groupChannels = channels
       .filter(
         ch =>
@@ -535,13 +536,8 @@ export function generatePrintHtml(
       // Detailed mode: show all channels, with optional empty-slot placeholders.
       //
       // When showEmptySlots is true we walk every integer channel number from
-      // the group's first real channel to the rangeTo bound (inclusive) and
-      // emit a placeholder row for any number that has no real channel.
-      //
-      // Scope: placeholders are bounded by [group's first real ch, rangeTo] so
-      // that numbers before the group's lowest real channel aren't attributed to
-      // this group (they may belong to a different group or be genuinely empty).
-      // rangeFrom already ensures groupChannels only contains in-range channels.
+      // the group's rangeFrom to rangeTo (inclusive) and emit a placeholder row
+      // for any number that has no real channel.
       //
       // Performance cap: if the slot count exceeds MAX_EMPTY_SLOTS_PER_GROUP we
       // truncate and append a warning row rather than silently producing massive
@@ -549,7 +545,7 @@ export function generatePrintHtml(
       let channelsHtml = '';
 
       if (showEmptySlots && groupChannels.length > 0) {
-        const firstNum = groupChannels[0].channel_number!;
+        const slotStart = rangeFrom;
         const slotEnd = rangeTo;
         const realByNum = new Map(
           groupChannels
@@ -560,7 +556,7 @@ export function generatePrintHtml(
         let emptyCount = 0;
         let truncated = false;
 
-        for (let n = firstNum; n <= slotEnd; n++) {
+        for (let n = slotStart; n <= slotEnd; n++) {
           const ch = realByNum.get(n);
           if (ch) {
             const num = Number.isInteger(ch.channel_number!) ? String(ch.channel_number!) : String(ch.channel_number!);
@@ -599,13 +595,14 @@ export function generatePrintHtml(
     }
   }
 
-  // Count total channels — respects both group selection and range filter
-  const totalChannels = channels.filter(ch =>
-    selectedGroupIds.has(ch.channel_group_id ?? -1) &&
-    ch.channel_number !== null &&
-    ch.channel_number >= rangeFrom &&
-    ch.channel_number <= rangeTo
-  ).length;
+  // Count total channels — respects both group selection and per-group range filter
+  const totalChannels = channels.filter(ch => {
+    if (!selectedGroupIds.has(ch.channel_group_id ?? -1)) return false;
+    if (ch.channel_number === null) return false;
+    const groupRange = groupRangeMap[ch.channel_group_id!];
+    if (!groupRange) return false;
+    return ch.channel_number >= groupRange.from && ch.channel_number <= groupRange.to;
+  }).length;
 
   // Generate complete HTML - using same approach as Guidearr
   return `<!DOCTYPE html>


### PR DESCRIPTION
Corrects the Print Channel Guide range model per PO feedback: the range is now **per-group**, not a single global From/To.

- Each group renders its own editable **From/To** channel-number inputs, **defaulting to that group's first/last used channel** (computed per-group from loaded channels; no backend).
- `generatePrintHtml` consumes a `GroupRangeMap` — real channels + empty-slot placeholders are driven by **each group's own range** (the From bound is now fully operator-controlled).
- All the global-range machinery (`globalMin/Max`, global From/To state, clamp/blur handlers, `rangeFilteredGroups`, the global range UI block) is removed.

**PO example, test-locked:** a PPV group with only `1101–1201` assigned defaults to From=1101/To=1201 (no empty slots); editing its To to `1251` prints real `1101–1201` + empty slots `1202–1251` **for PPV only** (Sports unaffected). Both directions covered by `PO example: …` tests.

## Verification (independent)
`tsc` clean, `eslint --max-warnings 0` clean, vitest **26/26** (incl. the two PO-example tests). Version consistency at `0.17.3-0026`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)