### PR TITLE
Post-release: promote CHANGELOG to [0.17.3], reopen dev counter (0.17.4-0000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.17.3] — 2026-05-25
+
 ### Removed
 - **Retired MCP OAuth 2.1 feature fully removed from the codebase (bead jir0m, bd-9axgc).** The MCP OAuth 2.1 "Custom Connector" offering — already disabled by PO decision in bd-9axgc because it required public-internet exposure the operator did not want — is now deleted, not just dormant. Removed: the backend OAuth Authorization Server (`routers/oauth_mcp.py`, `routers/oauth_discovery.py`, `auth/oauth_provider.py`, `auth/oauth_store.py`, `auth/oauth_clients.py`, `auth/oauth_rate_limit.py`, `auth/oauth_discovery.py`), the MCP-server OAuth bits (`oauth_discovery.py` and the `verify_oauth_token` HS256 verifier in `oauth_rs.py`), the OAuth config fields/helpers (`mcp_oauth_signing_secret`, `oauth_allow_insecure`, `get_or_create_oauth_signing_secret`, and the MCP-server `get_signing_key*` / `get_oauth_allow_insecure` / `OAUTH_ISSUER` helpers), the frontend consent UI (`OAuthConsentPage`) and OAuth grant/consent API functions, and ~60 OAuth-only tests. **The supported MCP authentication method is unchanged: the static `?api_key=` path.** The security-critical CD1 no-fail-cascade guard is preserved — `looks_like_jwt` still rejects any JWT-shaped Bearer with 401 so it can never fall through to the static-key compare. ADR-009 and `docs/security/threat_model_mcp_oauth.md` are retained (marked Superseded) for decision history. ([bead jir0m], bd-9axgc)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.3-0027",
+    version="0.17.4-0000",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.3-0027"
+APP_VERSION = "0.17.4-0000"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.3-0027",
+  "version": "0.17.4-0000",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Back-syncs `dev` after the **v0.17.3** release cut (tagged `v0.17.3` on `main`, commit 3e829bb4).

- Promotes CHANGELOG `[Unreleased]` → `[0.17.3] — 2026-05-25` (matches main; fresh empty `[Unreleased]` retained)
- Reopens the dev build counter `0.17.3-0027` → `0.17.4-0000` across the 3 version touchpoints

No code changes. (`dev` is protected, so the standard post-cut back-merge is delivered via this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)