### PR TITLE
fix(channels): bulk-commit 202+poll (bd-ggxks)

### DIFF
--- a/backend/routers/channels.py
+++ b/backend/routers/channels.py
@@ -4,6 +4,7 @@ number assignment, bulk-commit, and clear-auto-created endpoints.
 
 Extracted from main.py (Phase 2 of v0.13.0 backend refactor).
 """
+import asyncio
 import logging
 import os
 import re
@@ -14,6 +15,7 @@ from typing import Optional, Literal, Union
 
 import httpx
 from fastapi import APIRouter, HTTPException, Request, UploadFile, File, Response
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from auth import RequireAdminIfEnabled
@@ -1118,23 +1120,173 @@ def _consolidate_operations(operations: list[BulkOperation]) -> list[BulkOperati
     return consolidated
 
 
+# -----------------------------------------------------------------------------
+# Bulk-commit background jobs (bd-ggxks)
+# -----------------------------------------------------------------------------
+# Each Dispatcharr write inside a bulk commit is a sequential HTTP call
+# (~0.7s/channel for createChannel). A 441-op SiriusXM batch easily exceeds
+# the 30s ECM_REQUEST_TIMEOUT_SECONDS middleware budget, returning 504 to the
+# operator while the handler keeps running in the background. The operator
+# retries, piling duplicates into Dispatcharr.
+#
+# Architecture (matches bd-cns7j debug-bundle and bd-enfsy /auto-creation/run):
+#   POST /bulk-commit           → 202 + {job_id, status: "running"}; supervised
+#                                 background task does the work. validateOnly
+#                                 stays SYNCHRONOUS — pre-validation is fast
+#                                 and the frontend uses it for instant feedback
+#                                 before commit, where a poll round-trip would
+#                                 add latency for no gain.
+#   GET  /bulk-commit/{job_id}  → JSON status: running | failed (with error) |
+#                                 completed (with the full BulkCommitResponse
+#                                 envelope under ``result``). Completed jobs
+#                                 are evicted on first read so RAM is freed.
+#
+# Job state lives in-memory because the result envelope is small (a few KB
+# even for 1000+ ops) and the bulk commit is operator-triggered. TTL prune
+# on every new POST keeps the dict bounded if a client abandons polling.
+
+_BULK_COMMIT_JOB_TTL_SECONDS = 1800  # 30 min — matches debug-bundle TTL
+_BULK_COMMIT_BACKGROUND_TASKS: set[asyncio.Task] = set()
+
+
+class _BulkCommitJob:
+    """In-memory state for one bulk-commit run (bd-ggxks)."""
+
+    __slots__ = ("status", "created_at", "completed_at", "error", "result")
+
+    def __init__(self) -> None:
+        self.status: str = "running"  # running | completed | failed
+        self.created_at: float = time.time()
+        self.completed_at: Optional[float] = None
+        self.error: Optional[str] = None
+        self.result: Optional[dict] = None
+
+
+_BULK_COMMIT_JOBS: dict[str, _BulkCommitJob] = {}
+
+
+def _prune_old_bulk_commit_jobs() -> None:
+    """Drop bulk-commit jobs older than the TTL so the dict can't grow unbounded."""
+    cutoff = time.time() - _BULK_COMMIT_JOB_TTL_SECONDS
+    stale = [jid for jid, job in _BULK_COMMIT_JOBS.items() if job.created_at < cutoff]
+    for jid in stale:
+        _BULK_COMMIT_JOBS.pop(jid, None)
+    if stale:
+        logger.debug("[CHANNELS-BULK] Pruned %s expired bulk-commit jobs", len(stale))
+
+
 @router.post("/bulk-commit")
 async def bulk_commit_operations(request: BulkCommitRequest, _admin=RequireAdminIfEnabled):
     """
-    Process multiple channel operations in a single request. Admin only
-    (bulk operator op, bd-um30y).
+    Process multiple channel operations. Admin only (bulk operator op, bd-um30y).
 
-    This endpoint is optimized for bulk changes (1000+ operations) by:
-    - Processing all operations in a single HTTP request
-    - Tracking temp ID -> real ID mappings for newly created channels
-    - Creating groups before processing channel operations that reference them
-    - Pre-validating that referenced channels/streams exist
+    Two response shapes (bd-ggxks):
+
+    - ``validateOnly: true`` → **200 sync** with the full BulkCommitResponse.
+      Validation runs entirely against ECM-cached lookups + a single
+      Dispatcharr page fetch, so it fits comfortably inside the 30s request
+      budget and the frontend uses it for instant pre-commit feedback.
+    - ``validateOnly: false`` (default) → **202** with
+      ``{job_id, status: "running"}``. The actual work runs in a supervised
+      background task; the client polls
+      ``GET /api/channels/bulk-commit/{job_id}`` until the status is terminal
+      (``completed`` carries the full BulkCommitResponse under ``result``;
+      ``failed`` carries an ``error`` string).
 
     Options:
     - validateOnly: If true, only validate without executing
     - continueOnError: If true, continue processing even when operations fail
+    - consolidate: If true, server-side dedup of redundant ops
+    """
+    # Validate-only is fast — keep it sync so the frontend gets pre-commit
+    # feedback in one round-trip instead of POST+poll.
+    if request.validateOnly:
+        return await _run_bulk_commit(request)
 
-    Returns a response with success status, ID mappings, and validation issues.
+    # Enqueue the actual commit as a supervised background task.
+    _prune_old_bulk_commit_jobs()
+    job_id = uuid.uuid4().hex
+    _BULK_COMMIT_JOBS[job_id] = _BulkCommitJob()
+    op_count = len(request.operations)
+
+    async def _runner() -> None:
+        job = _BULK_COMMIT_JOBS.get(job_id)
+        if job is None:
+            logger.warning("[CHANNELS-BULK] Job %s missing before start", job_id)
+            return
+        try:
+            result = await _run_bulk_commit(request)
+            job.result = result
+            job.status = "completed"
+            job.completed_at = time.time()
+            logger.info(
+                "[CHANNELS-BULK] Job %s completed: applied=%s failed=%s",
+                job_id, result.get("operationsApplied"), result.get("operationsFailed"),
+            )
+        except asyncio.CancelledError:
+            job.status = "failed"
+            job.error = "Background task cancelled"
+            job.completed_at = time.time()
+            logger.warning("[CHANNELS-BULK] Job %s cancelled", job_id)
+            raise
+        except Exception as e:  # noqa: BLE001 — supervisor must catch broadly
+            job.status = "failed"
+            job.error = f"{type(e).__name__}: {e}"
+            job.completed_at = time.time()
+            logger.exception("[CHANNELS-BULK] Job %s failed: %s", job_id, e)
+
+    task = asyncio.create_task(_runner(), name=f"bulk-commit-{job_id}")
+    _BULK_COMMIT_BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BULK_COMMIT_BACKGROUND_TASKS.discard)
+
+    logger.info("[CHANNELS-BULK] Job %s enqueued (%s operations)", job_id, op_count)
+    return JSONResponse(
+        status_code=202,
+        content={
+            "job_id": job_id,
+            "status": "running",
+            "message": (
+                f"Bulk commit started; poll /api/channels/bulk-commit/{job_id} "
+                "for status"
+            ),
+        },
+    )
+
+
+@router.get("/bulk-commit/{job_id}")
+async def get_bulk_commit_status(job_id: str):
+    """Poll a bulk-commit job (bd-ggxks).
+
+    - ``running``   → ``{job_id, status: "running"}``
+    - ``failed``    → ``{job_id, status: "failed", error}`` (job stays in the
+      dict until TTL prune so the operator can re-poll and see the error)
+    - ``completed`` → ``{job_id, status: "completed", result: <BulkCommitResponse>}``
+      and the job is evicted on read (single-shot retrieval).
+    - missing job   → 404
+    """
+    job = _BULK_COMMIT_JOBS.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Bulk commit job not found")
+    if job.status == "running":
+        return {"job_id": job_id, "status": "running"}
+    if job.status == "failed":
+        return {
+            "job_id": job_id,
+            "status": "failed",
+            "error": job.error or "unknown error",
+        }
+    # completed — drop on read so RAM is freed.
+    result = job.result or {}
+    _BULK_COMMIT_JOBS.pop(job_id, None)
+    return {"job_id": job_id, "status": "completed", "result": result}
+
+
+async def _run_bulk_commit(request: BulkCommitRequest) -> dict:
+    """Execute a bulk-commit request and return the result envelope.
+
+    Pure work function — no HTTP / endpoint awareness. Invoked synchronously by
+    POST /bulk-commit when ``validateOnly=true``, and from the supervised
+    background task dispatched by POST /bulk-commit otherwise (bd-ggxks).
     """
     client = get_client()
     batch_id = str(uuid.uuid4())[:8]

--- a/backend/tests/integration/test_normalize_channel_create.py
+++ b/backend/tests/integration/test_normalize_channel_create.py
@@ -178,9 +178,10 @@ class TestBulkCommitWithNormalize:
                     ],
                 },
             )
-            # Should accept the normalize flag without validation error
-            # May fail for other reasons (no dispatcharr connection, etc)
-            assert response.status_code in (200, 500)
+            # Non-validateOnly path returns 202 + job_id (bd-ggxks); the schema
+            # would have raised 422 BEFORE the dispatch if the normalize field
+            # were rejected, so the 202 here proves acceptance.
+            assert response.status_code in (202, 500)
 
     @pytest.mark.asyncio
     async def test_bulk_commit_createchannel_schema_includes_normalize(self, async_client):

--- a/backend/tests/routers/test_channels.py
+++ b/backend/tests/routers/test_channels.py
@@ -920,8 +920,46 @@ class TestAssignNumbers:
         mock_client.assign_channel_numbers.assert_called_once_with([1], 100)
 
 
+async def _commit_and_wait(async_client, body, *, max_polls=50):
+    """POST a bulk commit and poll until terminal, returning the result envelope.
+
+    Mirrors what the frontend client does (POST → 202 → poll). The shape
+    returned here matches the pre-bd-ggxks synchronous response body, so the
+    existing assertions on per-operation execution still apply unchanged.
+    """
+    import asyncio as _asyncio
+
+    response = await async_client.post("/api/channels/bulk-commit", json=body)
+    if response.status_code == 200:
+        # validateOnly path is still synchronous.
+        return response, response.json()
+    assert response.status_code == 202, response.text
+    job_id = response.json()["job_id"]
+    for _ in range(max_polls):
+        await _asyncio.sleep(0)
+        poll = await async_client.get(f"/api/channels/bulk-commit/{job_id}")
+        assert poll.status_code == 200, poll.text
+        payload = poll.json()
+        if payload["status"] == "completed":
+            return response, payload["result"]
+        if payload["status"] == "failed":
+            return response, payload
+    raise AssertionError(f"bulk-commit job {job_id} did not terminate in {max_polls} polls")
+
+
 class TestBulkCommit:
-    """Tests for POST /api/channels/bulk-commit."""
+    """Tests for POST /api/channels/bulk-commit (202+poll, bd-ggxks)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_jobs(self):
+        # Each test starts with an empty job dict so state never leaks across
+        # tests (the dict is module-level by design so the in-memory job
+        # lookup survives between requests within a single process).
+        from routers import channels as router_module
+
+        router_module._BULK_COMMIT_JOBS.clear()
+        yield
+        router_module._BULK_COMMIT_JOBS.clear()
 
     @pytest.mark.asyncio
     async def test_empty_operations(self, async_client):
@@ -930,18 +968,15 @@ class TestBulkCommit:
 
         with patch("routers.channels.get_client", return_value=mock_client), \
              patch("routers.channels.journal"):
-            response = await async_client.post("/api/channels/bulk-commit", json={
-                "operations": [],
-            })
+            response, data = await _commit_and_wait(async_client, {"operations": []})
 
-        assert response.status_code == 200
-        data = response.json()
+        assert response.status_code == 202
         assert data["success"] is True
         assert data["operationsApplied"] == 0
 
     @pytest.mark.asyncio
     async def test_validate_only(self, async_client):
-        """Returns validation results without executing."""
+        """Returns validation results synchronously without executing."""
         mock_client = AsyncMock()
         mock_client.get_channels.return_value = {"results": [], "count": 0, "next": None}
         mock_client.get_streams.return_value = {"results": [], "count": 0, "next": None}
@@ -955,9 +990,9 @@ class TestBulkCommit:
                 "validateOnly": True,
             })
 
+        # Validate-only stays sync — single round-trip, no job_id envelope.
         assert response.status_code == 200
         data = response.json()
-        # Validate-only doesn't execute operations
         assert data["operationsApplied"] == 0
 
     @pytest.mark.asyncio
@@ -974,14 +1009,13 @@ class TestBulkCommit:
 
         with patch("routers.channels.get_client", return_value=mock_client), \
              patch("routers.channels.journal"):
-            response = await async_client.post("/api/channels/bulk-commit", json={
+            response, data = await _commit_and_wait(async_client, {
                 "operations": [
                     {"type": "deleteChannel", "channelId": 1},
                 ],
             })
 
-        assert response.status_code == 200
-        data = response.json()
+        assert response.status_code == 202
         assert data["success"] is True
 
     @pytest.mark.asyncio
@@ -1004,15 +1038,14 @@ class TestBulkCommit:
 
         with patch("routers.channels.get_client", return_value=mock_client), \
              patch("routers.channels.journal"):
-            response = await async_client.post("/api/channels/bulk-commit", json={
+            response, data = await _commit_and_wait(async_client, {
                 "operations": [
                     {"type": "reorderChannelStreams", "channelId": 1,
                      "streamIds": [5003, 5001, 5002]},
                 ],
             })
 
-        assert response.status_code == 200
-        data = response.json()
+        assert response.status_code == 202
         assert data["success"] is True
         assert data["operationsApplied"] == 1
         assert data["operationsFailed"] == 0
@@ -1043,7 +1076,7 @@ class TestBulkCommit:
 
         with patch("routers.channels.get_client", return_value=mock_client), \
              patch("routers.channels.journal"):
-            response = await async_client.post("/api/channels/bulk-commit", json={
+            response, data = await _commit_and_wait(async_client, {
                 "operations": [
                     # Omits 5001 -> would detach it under replace-semantics.
                     {"type": "reorderChannelStreams", "channelId": 1,
@@ -1052,8 +1085,7 @@ class TestBulkCommit:
                 "continueOnError": True,
             })
 
-        assert response.status_code == 200
-        data = response.json()
+        assert response.status_code == 202
         # The lossy op is rejected: reported as an error, not applied.
         assert data["operationsApplied"] == 0
         assert data["operationsFailed"] == 1
@@ -1065,6 +1097,237 @@ class TestBulkCommit:
             assert written.get("streams") != [5002]
         # Strongest assertion: no replace happened at all for this channel.
         mock_client.update_channel.assert_not_awaited()
+
+
+class TestBulkCommitAsync:
+    """Tests for the 202+poll lifecycle of POST /api/channels/bulk-commit
+    and its sibling GET /api/channels/bulk-commit/{job_id} (bd-ggxks).
+
+    The bulk commit was previously synchronous and bounded by the 30s
+    ECM_REQUEST_TIMEOUT_SECONDS middleware budget. On a 441-channel SiriusXM
+    batch the timeout fired mid-flight, returning 504 to the operator while
+    the handler kept running — duplicates piled up across retries. The new
+    pattern returns 202 + job_id immediately so a slow batch can never hit
+    the request-budget cliff.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_jobs(self):
+        from routers import channels as router_module
+
+        router_module._BULK_COMMIT_JOBS.clear()
+        yield
+        router_module._BULK_COMMIT_JOBS.clear()
+
+    @pytest.mark.asyncio
+    async def test_post_returns_202_with_job_id_and_running_status(self, async_client):
+        """A non-validateOnly POST immediately returns 202 + {job_id, status}."""
+        import asyncio as _asyncio
+
+        mock_client = AsyncMock()
+        gate = _asyncio.Event()
+
+        async def slow_run(req):
+            await gate.wait()
+            return {
+                "success": True,
+                "operationsApplied": 0,
+                "operationsFailed": 0,
+                "errors": [],
+                "tempIdMap": {},
+                "groupIdMap": {},
+            }
+
+        try:
+            with patch("routers.channels.get_client", return_value=mock_client), \
+                 patch("routers.channels._run_bulk_commit", side_effect=slow_run):
+                response = await async_client.post(
+                    "/api/channels/bulk-commit", json={"operations": []}
+                )
+                assert response.status_code == 202
+                body = response.json()
+                assert body["job_id"]
+                assert body["status"] == "running"
+
+                # Job is registered as still running before the worker finishes.
+                from routers.channels import _BULK_COMMIT_JOBS
+                assert body["job_id"] in _BULK_COMMIT_JOBS
+                assert _BULK_COMMIT_JOBS[body["job_id"]].status == "running"
+        finally:
+            gate.set()
+            for _ in range(20):
+                await _asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_get_while_running_returns_running_status(self, async_client):
+        """GET /{job_id} reports running until the worker finishes."""
+        import asyncio as _asyncio
+
+        mock_client = AsyncMock()
+        gate = _asyncio.Event()
+
+        async def slow_run(req):
+            await gate.wait()
+            return {
+                "success": True,
+                "operationsApplied": 0,
+                "operationsFailed": 0,
+                "errors": [],
+                "tempIdMap": {},
+                "groupIdMap": {},
+            }
+
+        try:
+            with patch("routers.channels.get_client", return_value=mock_client), \
+                 patch("routers.channels._run_bulk_commit", side_effect=slow_run):
+                enqueue = await async_client.post(
+                    "/api/channels/bulk-commit", json={"operations": []}
+                )
+                job_id = enqueue.json()["job_id"]
+
+                poll = await async_client.get(f"/api/channels/bulk-commit/{job_id}")
+                assert poll.status_code == 200
+                body = poll.json()
+                assert body["job_id"] == job_id
+                assert body["status"] == "running"
+                # Running poll envelope must NOT leak a result yet.
+                assert "result" not in body
+        finally:
+            gate.set()
+            for _ in range(20):
+                await _asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_get_after_completion_returns_result_and_evicts_job(self, async_client):
+        """Once the worker completes, GET returns the full BulkCommitResponse
+        and the job row is dropped from the dict (single-shot retrieval)."""
+        import asyncio as _asyncio
+
+        mock_client = AsyncMock()
+
+        async def fast_run(req):
+            return {
+                "success": True,
+                "operationsApplied": 3,
+                "operationsFailed": 0,
+                "errors": [],
+                "tempIdMap": {-1: 100, -2: 101},
+                "groupIdMap": {},
+            }
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels._run_bulk_commit", side_effect=fast_run):
+            enqueue = await async_client.post(
+                "/api/channels/bulk-commit", json={"operations": []}
+            )
+            job_id = enqueue.json()["job_id"]
+            for _ in range(50):
+                await _asyncio.sleep(0)
+
+            poll = await async_client.get(f"/api/channels/bulk-commit/{job_id}")
+            assert poll.status_code == 200
+            body = poll.json()
+            assert body["status"] == "completed"
+            assert body["result"]["operationsApplied"] == 3
+            assert body["result"]["tempIdMap"] == {"-1": 100, "-2": 101}
+
+            # Second GET of the same job returns 404 — the job was evicted
+            # so RAM stays bounded for short-lived ops.
+            from routers.channels import _BULK_COMMIT_JOBS
+            assert job_id not in _BULK_COMMIT_JOBS
+            second = await async_client.get(f"/api/channels/bulk-commit/{job_id}")
+            assert second.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_failed_job_returns_failed_status(self, async_client):
+        """A worker that raises is marked failed and exposed via GET status."""
+        import asyncio as _asyncio
+
+        mock_client = AsyncMock()
+
+        async def boom(req):
+            raise RuntimeError("dispatcharr unreachable")
+
+        with patch("routers.channels.get_client", return_value=mock_client), \
+             patch("routers.channels._run_bulk_commit", side_effect=boom):
+            enqueue = await async_client.post(
+                "/api/channels/bulk-commit", json={"operations": []}
+            )
+            job_id = enqueue.json()["job_id"]
+            for _ in range(50):
+                await _asyncio.sleep(0)
+
+            poll = await async_client.get(f"/api/channels/bulk-commit/{job_id}")
+            assert poll.status_code == 200
+            body = poll.json()
+            assert body["status"] == "failed"
+            assert "dispatcharr unreachable" in body["error"]
+            # Failed jobs stay in the dict until TTL prune so the operator
+            # can re-poll and read the error (matches debug-bundle pattern).
+            from routers.channels import _BULK_COMMIT_JOBS
+            assert job_id in _BULK_COMMIT_JOBS
+
+    @pytest.mark.asyncio
+    async def test_get_unknown_job_id_returns_404(self, async_client):
+        response = await async_client.get("/api/channels/bulk-commit/does-not-exist")
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_post_returns_within_timeout_budget(self, async_client):
+        """The handler itself must return fast — a slow worker must never
+        block the enqueue path. The whole point of bd-ggxks is to make
+        bulk-commit not synchronous on large batches."""
+        import asyncio as _asyncio
+        import time as _time
+
+        mock_client = AsyncMock()
+        gate = _asyncio.Event()
+
+        async def slow_run(req):
+            await gate.wait()
+            return {
+                "success": True,
+                "operationsApplied": 0,
+                "operationsFailed": 0,
+                "errors": [],
+                "tempIdMap": {},
+                "groupIdMap": {},
+            }
+
+        try:
+            with patch("routers.channels.get_client", return_value=mock_client), \
+                 patch("routers.channels._run_bulk_commit", side_effect=slow_run):
+                start = _time.monotonic()
+                response = await async_client.post(
+                    "/api/channels/bulk-commit", json={"operations": []}
+                )
+                elapsed = _time.monotonic() - start
+
+            assert response.status_code == 202
+            assert elapsed < 5.0, (
+                f"enqueue took {elapsed:.2f}s — handler is not async-enqueuing"
+            )
+        finally:
+            gate.set()
+            for _ in range(20):
+                await _asyncio.sleep(0)
+
+    def test_prune_drops_expired_jobs(self):
+        """_prune_old_bulk_commit_jobs evicts jobs older than the TTL."""
+        from routers import channels as router_module
+
+        old = router_module._BulkCommitJob()
+        old.created_at = (
+            router_module.time.time() - (router_module._BULK_COMMIT_JOB_TTL_SECONDS + 60)
+        )
+        fresh = router_module._BulkCommitJob()
+        router_module._BULK_COMMIT_JOBS["old"] = old
+        router_module._BULK_COMMIT_JOBS["fresh"] = fresh
+
+        router_module._prune_old_bulk_commit_jobs()
+
+        assert "old" not in router_module._BULK_COMMIT_JOBS
+        assert "fresh" in router_module._BULK_COMMIT_JOBS
 
 
 class TestClearAutoCreated:

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for API service.
  */
-import { describe, it, expect, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { server } from '../test/mocks/server';
 import { http, HttpResponse } from 'msw';
 import {
@@ -11,6 +11,7 @@ import {
   removeStreamFromChannel,
   reorderChannelStreams,
   deleteChannel,
+  bulkCommit,
   getChannelMergeCandidates,
   // Compute sort
   computeSort,
@@ -289,6 +290,133 @@ describe('API Service', () => {
       );
 
       await expect(deleteChannel(999)).rejects.toThrow('Channel not found');
+    });
+  });
+
+  describe('bulkCommit (bd-ggxks 202+poll)', () => {
+    // Speed-up: the api client sleeps 750ms between polls. Stubbing
+    // setTimeout makes each await synchronous so the tests still cover the
+    // running→completed transition without taking seconds per case.
+    beforeEach(() => {
+      vi.stubGlobal(
+        'setTimeout',
+        ((fn: () => void) => {
+          fn();
+          return 0;
+        }) as unknown as typeof setTimeout
+      );
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('validateOnly path: synchronous POST returns the response body untouched', async () => {
+      let getCallCount = 0;
+      server.use(
+        http.post('/api/channels/bulk-commit', async ({ request }) => {
+          const body = (await request.json()) as { validateOnly?: boolean };
+          expect(body.validateOnly).toBe(true);
+          return HttpResponse.json(
+            {
+              success: true,
+              operationsApplied: 0,
+              operationsFailed: 0,
+              errors: [],
+              tempIdMap: {},
+              groupIdMap: {},
+              validationPassed: true,
+              validationIssues: [],
+            },
+            { status: 200 }
+          );
+        }),
+        http.get('/api/channels/bulk-commit/:jobId', () => {
+          getCallCount++;
+          return HttpResponse.json({ status: 'running' });
+        })
+      );
+
+      const result = await bulkCommit({ operations: [], validateOnly: true });
+
+      expect(result.success).toBe(true);
+      expect(result.validationPassed).toBe(true);
+      // Sync path must never poll — that's the whole point of keeping it sync.
+      expect(getCallCount).toBe(0);
+    });
+
+    it('async path: 202 enqueue then polls GET until completed, returns result', async () => {
+      let postCallCount = 0;
+      const pollResponses = [
+        { status: 'running' },
+        { status: 'running' },
+        {
+          status: 'completed',
+          result: {
+            success: true,
+            operationsApplied: 3,
+            operationsFailed: 0,
+            errors: [],
+            tempIdMap: { '-1': 100 },
+            groupIdMap: {},
+          },
+        },
+      ];
+      let pollIdx = 0;
+
+      server.use(
+        http.post('/api/channels/bulk-commit', () => {
+          postCallCount++;
+          return HttpResponse.json(
+            { job_id: 'abc123', status: 'running' },
+            { status: 202 }
+          );
+        }),
+        http.get('/api/channels/bulk-commit/:jobId', ({ params }) => {
+          expect(params.jobId).toBe('abc123');
+          const body = pollResponses[Math.min(pollIdx, pollResponses.length - 1)];
+          pollIdx += 1;
+          return HttpResponse.json({ job_id: 'abc123', ...body });
+        })
+      );
+
+      const result = await bulkCommit({
+        operations: [
+          {
+            type: 'createChannel',
+            tempId: -1,
+            name: 'SiriusXM Hits 1',
+          },
+        ],
+      });
+
+      expect(postCallCount).toBe(1);
+      // Loop ran until "completed" — three polls drained from the array.
+      expect(pollIdx).toBe(3);
+      expect(result.success).toBe(true);
+      expect(result.operationsApplied).toBe(3);
+      expect(result.tempIdMap).toEqual({ '-1': 100 });
+    });
+
+    it('async path: failed status raises with the backend error message', async () => {
+      server.use(
+        http.post('/api/channels/bulk-commit', () =>
+          HttpResponse.json({ job_id: 'fail', status: 'running' }, { status: 202 })
+        ),
+        http.get('/api/channels/bulk-commit/:jobId', () =>
+          HttpResponse.json({
+            job_id: 'fail',
+            status: 'failed',
+            error: 'dispatcharr unreachable',
+          })
+        )
+      );
+
+      await expect(
+        bulkCommit({
+          operations: [{ type: 'createChannel', tempId: -1, name: 'X' }],
+        })
+      ).rejects.toThrow(/dispatcharr unreachable/);
     });
   });
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -433,15 +433,67 @@ export interface BulkCommitResponse {
   validationPassed?: boolean;
 }
 
+// 202+poll envelope for the async bulk-commit path (bd-ggxks). validateOnly
+// stays synchronous on the backend, so this typing applies only to the
+// non-validateOnly POST + the subsequent status polls.
+
+interface BulkCommitJobAccepted {
+  job_id: string;
+  status: 'running';
+  message?: string;
+}
+
+type BulkCommitJobStatus =
+  | { job_id: string; status: 'running' }
+  | { job_id: string; status: 'failed'; error: string }
+  | { job_id: string; status: 'completed'; result: BulkCommitResponse };
+
+const BULK_COMMIT_POLL_INTERVAL_MS = 750;
+// Hard ceiling well above the backend's 30-min job TTL — a job that genuinely
+// hangs longer than this needs operator attention, not silent waiting.
+const BULK_COMMIT_POLL_MAX_DURATION_MS = 60 * 60 * 1000;
+
+async function pollBulkCommitJob(jobId: string): Promise<BulkCommitResponse> {
+  const started = Date.now();
+  while (Date.now() - started < BULK_COMMIT_POLL_MAX_DURATION_MS) {
+    const status = await fetchJson<BulkCommitJobStatus>(
+      `${API_BASE}/channels/bulk-commit/${encodeURIComponent(jobId)}`,
+    );
+    if (status.status === 'completed') {
+      return status.result;
+    }
+    if (status.status === 'failed') {
+      throw new Error(`Bulk commit failed: ${status.error}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, BULK_COMMIT_POLL_INTERVAL_MS));
+  }
+  throw new Error(`Bulk commit polling exceeded ${BULK_COMMIT_POLL_MAX_DURATION_MS / 1000}s`);
+}
+
 /**
- * Commit multiple channel operations in a single request.
- * This is much more efficient than making individual API calls for 1000+ operations.
+ * Commit multiple channel operations.
+ *
+ * Two paths (bd-ggxks):
+ * - validateOnly: synchronous POST returning the full response in one round-trip.
+ *   Used by useEditMode.validate() for instant pre-commit feedback.
+ * - default (validateOnly=false): POST returns 202 + {job_id}; this function
+ *   polls GET /api/channels/bulk-commit/{job_id} until the job terminates,
+ *   so callers still receive the same BulkCommitResponse on success and a
+ *   thrown Error on failure. The hop is invisible to existing callers.
  */
 export async function bulkCommit(request: BulkCommitRequest): Promise<BulkCommitResponse> {
-  return fetchJson(`${API_BASE}/channels/bulk-commit`, {
+  if (request.validateOnly) {
+    return fetchJson(`${API_BASE}/channels/bulk-commit`, {
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
+  }
+
+  const accepted = await fetchJson<BulkCommitJobAccepted>(`${API_BASE}/channels/bulk-commit`, {
     method: 'POST',
     body: JSON.stringify(request),
   });
+  return pollBulkCommitJob(accepted.job_id);
 }
 
 // Stream-to-channel deduplication (ADR-008 / bd-1v4ht epic) ----------------

--- a/mcp-server/tests/test_lq38l_channel_safety.py
+++ b/mcp-server/tests/test_lq38l_channel_safety.py
@@ -251,11 +251,17 @@ class TestBuildChannelLineupCreatedOnly:
             {"id": 555, "name": "MCPTEST Lineup ESPN", "channel_number": 901, "streams": []},
         ]
 
-        async def post_side_effect(path, **kwargs):
-            if path == "/api/channels/bulk-commit":
-                # tempId -1 -> realId 555 (the only channel this call created)
+        # bd-ggxks: bulk-commit moved to 202+poll. The lineup builder now
+        # routes through tools.channels._bulk_commit_with_wait, which calls
+        # client.call_endpoint(..., "/api/channels/bulk-commit") and may poll
+        # client.get("/api/channels/bulk-commit/{job_id}") until completed.
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            if endpoint.path == "/api/channels/bulk-commit":
+                # tempId -1 -> realId 555 (the only channel this call created).
+                # Returning the BulkCommitResponse shape directly emulates the
+                # synchronous fast-path (the helper unwraps 202 envelopes too,
+                # but the sync return value is the cleanest mock surface).
                 return {"success": True, "tempIdMap": {"-1": 555}}
-            # add-stream: nothing matched in this scenario
             return {}
 
         async def get_side_effect(path, **kwargs):
@@ -266,7 +272,7 @@ class TestBuildChannelLineupCreatedOnly:
             return {}
 
         client = AsyncMock()
-        client.post.side_effect = post_side_effect
+        client.call_endpoint.side_effect = call_endpoint_side_effect
         client.get.side_effect = get_side_effect
 
         with patch("tools.channels.get_ecm_client", return_value=client):
@@ -300,9 +306,9 @@ class TestBuildChannelLineupCreatedOnly:
             {"id": 700, "name": "New One", "channel_number": 700, "streams": []},
         ]
 
-        async def post_side_effect(path, **kwargs):
-            if path == "/api/channels/bulk-commit":
-                return {"success": True}  # no tempIdMap
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            if endpoint.path == "/api/channels/bulk-commit":
+                return {"success": True}  # no tempIdMap — fallback path
             return {}
 
         async def get_side_effect(path, **kwargs):
@@ -313,7 +319,7 @@ class TestBuildChannelLineupCreatedOnly:
             return {}
 
         client = AsyncMock()
-        client.post.side_effect = post_side_effect
+        client.call_endpoint.side_effect = call_endpoint_side_effect
         client.get.side_effect = get_side_effect
 
         with patch("tools.channels.get_ecm_client", return_value=client):

--- a/mcp-server/tests/test_tools.py
+++ b/mcp-server/tests/test_tools.py
@@ -572,6 +572,96 @@ class TestBulkCommitChannelsErrorDetail:
         assert "channelId" in text
 
 
+class TestBulkCommitWithWaitPolling:
+    """The bd-ggxks 202+poll helper unwraps the job envelope so callers see
+    the BulkCommitResponse shape regardless of which path the backend took.
+
+    Three cases exercised: validateOnly sync (no job_id), async run that
+    transitions running→completed, and async run that lands on failed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sync_validate_only_response_passed_through(self, monkeypatch):
+        """When the backend returns a BulkCommitResponse inline (validateOnly
+        path), the helper returns it untouched — no extra polls fired."""
+        from tools import channels as tools_channels
+
+        client = AsyncMock()
+        client.call_endpoint.return_value = {
+            "success": True,
+            "operationsApplied": 0,
+            "validationPassed": True,
+        }
+
+        result = await tools_channels._bulk_commit_with_wait(
+            client, {"operations": [], "validateOnly": True}
+        )
+
+        assert result["success"] is True
+        # No status polls — the sync path skips the GET entirely.
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_job_polls_until_completed(self, monkeypatch):
+        """A 202 + running status drives the helper to GET until completed,
+        and the helper returns the unwrapped result."""
+        from tools import channels as tools_channels
+
+        # Make sleep effectively a no-op so the test doesn't take seconds.
+        monkeypatch.setattr(tools_channels, "_BULK_COMMIT_POLL_INTERVAL_S", 0)
+
+        client = AsyncMock()
+        client.call_endpoint.return_value = {
+            "job_id": "abc", "status": "running",
+            "message": "queued",
+        }
+        # Two running polls before completion so we prove the loop runs.
+        completed_result = {
+            "success": True,
+            "operationsApplied": 3,
+            "tempIdMap": {"-1": 100},
+        }
+        client.get.side_effect = [
+            {"job_id": "abc", "status": "running"},
+            {"job_id": "abc", "status": "running"},
+            {"job_id": "abc", "status": "completed", "result": completed_result},
+        ]
+
+        result = await tools_channels._bulk_commit_with_wait(
+            client, {"operations": []}
+        )
+
+        assert result == completed_result
+        # POST once, GET three times.
+        assert client.call_endpoint.await_count == 1
+        assert client.get.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_async_job_failure_raises_with_error_message(self, monkeypatch):
+        """A failed terminal status surfaces as a RuntimeError carrying the
+        backend's error message so the tool's outer except can format it."""
+        from tools import channels as tools_channels
+
+        monkeypatch.setattr(tools_channels, "_BULK_COMMIT_POLL_INTERVAL_S", 0)
+
+        client = AsyncMock()
+        client.call_endpoint.return_value = {
+            "job_id": "abc", "status": "running",
+        }
+        client.get.return_value = {
+            "job_id": "abc",
+            "status": "failed",
+            "error": "dispatcharr exploded",
+        }
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await tools_channels._bulk_commit_with_wait(
+                client, {"operations": []}
+            )
+
+        assert "dispatcharr exploded" in str(exc_info.value)
+
+
 class TestECMClientHTTPErrorDetail:
     """ECMClient.post surfaces the response body's detail on HTTPStatusError (bd-mjtxn / GH #224)."""
 

--- a/mcp-server/tools/channels.py
+++ b/mcp-server/tools/channels.py
@@ -1,4 +1,5 @@
 """Channel management tools."""
+import asyncio
 import logging
 
 from mcp.server.fastmcp import FastMCP
@@ -7,6 +8,47 @@ from _endpoint_contracts import ENDPOINTS
 from ecm_client import get_ecm_client
 
 logger = logging.getLogger(__name__)
+
+# bd-ggxks: bulk-commit moved to a 202+poll contract. validateOnly stays
+# synchronous (200 with the BulkCommitResponse body); every other call now
+# returns 202 + {job_id, status: "running"} and the client must poll
+# GET /api/channels/bulk-commit/{job_id} until terminal.
+_BULK_COMMIT_POLL_INTERVAL_S = 1.0
+_BULK_COMMIT_POLL_MAX_WAIT_S = 1800.0  # 30 min — matches backend job TTL
+
+
+async def _bulk_commit_with_wait(client, payload: dict) -> dict:
+    """POST /api/channels/bulk-commit and unwrap the 202+poll envelope (bd-ggxks).
+
+    Returns a BulkCommitResponse-shaped dict for both the sync (validateOnly)
+    and async paths so callers can stay agnostic. Raises on poll timeout or
+    backend-reported failure.
+    """
+    response = await client.call_endpoint(
+        ENDPOINTS["channels_bulk_commit"], body=payload
+    )
+    if not isinstance(response, dict) or response.get("status") != "running":
+        return response if isinstance(response, dict) else {}
+
+    job_id = response.get("job_id")
+    if not job_id:
+        raise RuntimeError("Bulk commit returned 202 without a job_id")
+
+    deadline = asyncio.get_event_loop().time() + _BULK_COMMIT_POLL_MAX_WAIT_S
+    while asyncio.get_event_loop().time() < deadline:
+        status = await client.get(f"/api/channels/bulk-commit/{job_id}")  # contract-exempt: status-poll for bd-ggxks
+        if not isinstance(status, dict):
+            raise RuntimeError(f"Bulk commit poll returned non-dict: {type(status).__name__}")
+        if status.get("status") == "completed":
+            return status.get("result") or {}
+        if status.get("status") == "failed":
+            raise RuntimeError(
+                f"Bulk commit failed: {status.get('error', 'unknown error')}"
+            )
+        await asyncio.sleep(_BULK_COMMIT_POLL_INTERVAL_S)
+    raise TimeoutError(
+        f"Bulk commit {job_id} did not terminate within {_BULK_COMMIT_POLL_MAX_WAIT_S}s"
+    )
 
 
 def _fmt_channel_number(value) -> str:
@@ -942,7 +984,9 @@ def register(mcp: FastMCP):
                 "validateOnly": validate_only,
                 "continueOnError": continue_on_error,
             }
-            result = await client.call_endpoint(ENDPOINTS["channels_bulk_commit"], body=payload)
+            # bd-ggxks: helper handles both the validateOnly sync path and
+            # the default 202+poll path so this site keeps a single shape.
+            result = await _bulk_commit_with_wait(client, payload)
             success = result.get("success", False)
             # Per-operation result list is available at result["errors"] but not
             # surfaced in the response below — the operator gets aggregate status,
@@ -1074,7 +1118,10 @@ def register(mcp: FastMCP):
                     "channelNumber": ch["number"],
                     "groupId": group_id,
                 })
-            bulk_result = await client.post("/api/channels/bulk-commit", json_data={  # contract-exempt: see above
+            # bd-ggxks: route through the 202+poll helper so a slow batch
+            # (the lineup builder commits everything in one go) never
+            # surfaces the bare 202 envelope as "missing success".
+            bulk_result = await _bulk_commit_with_wait(client, {
                 "operations": operations,
                 "continueOnError": True,
             })


### PR DESCRIPTION
## Summary

- POST `/api/channels/bulk-commit` was synchronous and pinned behind the 30s `ECM_REQUEST_TIMEOUT_SECONDS` middleware. A 441-op SiriusXM batch (~6 min of sequential Dispatcharr POSTs) caused the middleware to fire 504 mid-flight while the handler kept running, and operators retried — piling duplicates into Dispatcharr (root-cause for the gateway-timeout report investigated under bd-ggxks).
- Refactored bulk-commit to the same 202+poll pattern bd-cns7j (debug-bundle) and bd-enfsy (`/auto-creation/run`) already use: POST returns `202 + {job_id}`; clients poll `GET /api/channels/bulk-commit/{job_id}` until terminal. `validateOnly` stays synchronous because it's fast and the frontend uses it for instant pre-commit feedback.
- Frontend `bulkCommit()` and MCP `bulk_commit_channels` / `build_channel_lineup` updated to drive the new POST → poll loop transparently; their public shapes are unchanged so all existing callers keep working.

## Test plan

- [x] Backend: 5,203 tests pass (97 channels-router tests, all green; new `TestBulkCommitAsync` covers 202 lifecycle, running/failed/completed transitions, 404 on missing job, single-shot eviction, TTL prune, fast-enqueue contract).
- [x] Frontend: 1,555 tests pass including 3 new `bulkCommit` cases for validateOnly sync, async poll→completed, and async poll→failed.
- [x] MCP: 370 tests pass including new `_bulk_commit_with_wait` helper coverage and updated `build_channel_lineup` mocks.
- [x] typecheck (`tsc --noEmit`) + ESLint clean on touched frontend files.
- [x] Deployed to `ecm-ecm-1`; container restarted cleanly with no router-registration or import errors in startup logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)