### PR TITLE
v0.17.4-0001: bulk-commit 202+poll (bd-ggxks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+- **`POST /api/channels/bulk-commit` returned 504 mid-flight on large batches while the handler kept running, producing duplicates on retry (bd-ggxks, build 0001).** The endpoint was synchronous and pinned behind the 30s `ECM_REQUEST_TIMEOUT_SECONDS` middleware. A 441-op SiriusXM batch (~6 min of sequential Dispatcharr POSTs) caused the middleware to fire `504 Gateway Timeout` to the operator while the handler kept running in the background; the operator retried, each retry committed another ~30 partial channels, and Dispatcharr accumulated duplicates. Fix: bulk-commit now follows the bd-cns7j / bd-enfsy 202+poll pattern. Non-`validateOnly` `POST /api/channels/bulk-commit` returns `202 + {job_id, status: "running"}` immediately and dispatches a supervised background task; clients poll `GET /api/channels/bulk-commit/{job_id}` until the status is terminal (`completed` with the full `BulkCommitResponse` under `result`, or `failed` with an `error` message). `validateOnly` stays synchronous (200 with the response body inline) because pre-commit validation is fast and the frontend uses it for instant feedback. Frontend `bulkCommit()` and the MCP `bulk_commit_channels` / `build_channel_lineup` tools drive the new POST→poll loop transparently — their public shapes are unchanged so all three `useEditMode` call sites and existing MCP consumers keep working. Job state is in-memory with a 30-min TTL prune on every new POST; completed jobs are evicted on first read so RAM stays bounded; failed jobs persist until the TTL so operators can re-poll the error message. (bd-ggxks, build 0001)
+
 ## [0.17.3] — 2026-05-25
 
 ### Removed

--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.4-0000",
+    version="0.17.4-0001",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.4-0000"
+APP_VERSION = "0.17.4-0001"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.4-0000",
+  "version": "0.17.4-0001",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Bumps the three version touchpoints to `0.17.4-0001`: `frontend/package.json`, `backend/routers/backup.py` `APP_VERSION`, `backend/main.py` FastAPI `version=` kwarg. CI version-consistency gate passes.
- Adds the `[Unreleased]` CHANGELOG entry for the bd-ggxks bulk-commit fix that shipped in PR #463.

## Test plan

- [x] `python scripts/check_version_consistency.py` — all 3 touchpoints match `0.17.4-0001`.
- [x] No code changes outside version literals + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)