### PR TITLE
fix(m3u-digest): bound digest load + drop snapshot eager-join (GH #473 OOM)

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -953,8 +953,14 @@ class M3UChangeLog(Base):
     enabled = Column(Boolean, default=False, nullable=False)  # Whether the group is enabled in the M3U
     snapshot_id = Column(Integer, ForeignKey("m3u_snapshots.id", ondelete="SET NULL"), nullable=True)
 
-    # Relationship to snapshot
-    snapshot = relationship("M3USnapshot", lazy="joined")
+    # Relationship to snapshot.
+    # lazy="select" (load-on-access), NOT "joined": M3USnapshot.groups_data is a
+    # large JSON blob (every group's full stream-name list). Every change row from
+    # a refresh shares one snapshot_id, so a joined eager load re-streams that blob
+    # once per row — an O(rows x blob) memory fanout that OOM-killed the container
+    # on the unbounded digest query (GH #473). Nothing reads .snapshot anyway
+    # (to_dict() uses the snapshot_id FK column), so on-demand loading is free here.
+    snapshot = relationship("M3USnapshot", lazy="select")
 
     __table_args__ = (
         Index("idx_m3u_change_account", m3u_account_id),

--- a/backend/tasks/m3u_digest.py
+++ b/backend/tasks/m3u_digest.py
@@ -19,6 +19,14 @@ from m3u_digest_template import M3UDigestTemplate
 
 logger = logging.getLogger(__name__)
 
+# Hard cap on how many change rows a single digest run will load into memory.
+# The email/Discord templates only render the 20 most-recent items per
+# account-and-type, so loading more than this never affects the rendered output —
+# it only risks OOM. An unbounded .all() over the change log (each row can carry
+# its own stream-name JSON blob) drove RSS to ~18.5 GiB and corrupted the SQLite
+# DB on a large deployment (GH #473). 5000 is far above any sane digest size.
+MAX_DIGEST_CHANGES = 5000
+
 
 class _FilteredChange:
     """Proxy that wraps an M3UChangeLog to override stream names/count after filtering."""
@@ -169,12 +177,28 @@ class M3UDigestTask(TaskScheduler):
 
             self._set_progress(status="fetching_changes")
 
-            # Get changes since last digest
+            # Get changes since last digest.
+            # Bounded load (MAX_DIGEST_CHANGES): the templates only show the 20
+            # newest items per account-and-type, so an unbounded .all() here is
+            # pure memory risk with no effect on the rendered digest (GH #473).
             query = db.query(M3UChangeLog).filter(M3UChangeLog.change_time >= since)
             if m3u_account_id:
                 query = query.filter(M3UChangeLog.m3u_account_id == m3u_account_id)
 
-            changes = query.order_by(M3UChangeLog.change_time.desc()).all()
+            total_changes = query.count()
+            if total_changes > MAX_DIGEST_CHANGES:
+                logger.warning(
+                    "[%s] %s changes since %s exceeds cap of %s — digest will "
+                    "summarize the %s most-recent changes only",
+                    self.task_id, total_changes, since.isoformat(),
+                    MAX_DIGEST_CHANGES, MAX_DIGEST_CHANGES,
+                )
+
+            changes = (
+                query.order_by(M3UChangeLog.change_time.desc())
+                .limit(MAX_DIGEST_CHANGES)
+                .all()
+            )
 
             # Filter by settings
             if not settings.include_group_changes:

--- a/backend/tests/unit/test_m3u_digest_bounded.py
+++ b/backend/tests/unit/test_m3u_digest_bounded.py
@@ -1,0 +1,94 @@
+"""
+Regression tests for the M3U digest memory blow-up (GH #473).
+
+A test M3U digest on a large deployment loaded the entire change log into
+memory with an unbounded ``.all()`` while ``M3UChangeLog.snapshot`` was an
+eager (``lazy="joined"``) relationship. Each change row from a refresh shares
+one snapshot whose ``groups_data`` JSON carries every group's full stream-name
+list, so the joined blob was re-streamed once per row — an O(rows x blob)
+fanout that drove RSS to ~18.5 GiB and corrupted the SQLite DB.
+
+These tests lock in the two fixes:
+  1. the snapshot relationship is load-on-access (not eager-joined), and
+  2. ``execute()`` caps how many change rows it loads (MAX_DIGEST_CHANGES).
+"""
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import inspect as sa_inspect
+
+from models import M3UChangeLog, M3UDigestSettings
+
+
+def test_snapshot_relationship_is_not_eager_joined():
+    """The snapshot relationship must be load-on-access, never eager-joined.
+
+    Eager-joining re-streams the large groups_data blob once per change row
+    sharing a snapshot — the GH #473 memory fanout. Nothing reads .snapshot
+    (to_dict() uses the snapshot_id FK column), so it must stay lazy.
+    """
+    rel = sa_inspect(M3UChangeLog).relationships["snapshot"]
+    assert rel.lazy == "select", (
+        f"M3UChangeLog.snapshot lazy={rel.lazy!r}; must be 'select' to avoid the "
+        "GH #473 joined-eager-load memory fanout"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_caps_changes_loaded(test_session):
+    """execute() must not load more than MAX_DIGEST_CHANGES rows into memory."""
+    from tasks import m3u_digest as digest_mod
+    from tasks.m3u_digest import M3UDigestTask
+
+    # Enabled settings with a recipient so the digest actually builds/sends.
+    settings = M3UDigestSettings(
+        enabled=True,
+        frequency="weekly",
+        include_group_changes=True,
+        include_stream_changes=True,
+        show_detailed_list=True,
+        min_changes_threshold=1,
+    )
+    settings.set_email_recipients(["ops@example.com"])
+    test_session.add(settings)
+    test_session.commit()
+
+    # Insert more change rows than the (patched-small) cap allows.
+    cap = 5
+    base = datetime.utcnow() - timedelta(hours=1)
+    for i in range(cap + 7):  # 12 rows, cap is 5
+        row = M3UChangeLog(
+            m3u_account_id=1,
+            change_time=base + timedelta(seconds=i),
+            change_type="streams_added",
+            group_name=f"Group {i}",
+            count=1,
+        )
+        row.set_stream_names([f"Stream {i}"])
+        test_session.add(row)
+    test_session.commit()
+
+    # get_session() inside the task returns our test session; close() is a no-op
+    # so the fixture keeps ownership of cleanup.
+    class _NoCloseSession:
+        def __init__(self, real):
+            self._real = real
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+        def close(self):
+            pass
+
+    with patch.object(digest_mod, "MAX_DIGEST_CHANGES", cap), \
+         patch.object(digest_mod, "get_session", return_value=_NoCloseSession(test_session)), \
+         patch.object(M3UDigestTask, "_send_digest_email", new=AsyncMock(return_value=True)):
+        task = M3UDigestTask()
+        result = await task.execute(force=True)
+
+    assert result.success is True
+    # total_items == len(changes loaded); must be capped, not the full 12.
+    assert result.total_items == cap, (
+        f"digest loaded {result.total_items} rows; expected cap of {cap}"
+    )


### PR DESCRIPTION
## Summary

Fixes a **third, distinct** memory failure mode in GH #473 — separate from the WAL churn (PR #474) and the auto-creation `execution_log` OOM. This one is the **test M3U digest** path (`POST /api/m3u/digest/test`), confirmed from a reporter's debug bundle + log export (ECM 0.17.4, `rule_count: 0` — auto-creation never ran).

A single test digest ran for **182 s**, drove RSS to **~18.5 GiB**, froze every other endpoint, and ended by **corrupting the SQLite DB** (`database disk image is malformed`). The traceback pins it to `tasks/m3u_digest.py:177` — the unbounded `.all()`.

## Root cause (two compounding amplifiers, same line)

1. **Unbounded load** — `execute(force=True)` loaded *every* `M3UChangeLog` row since the last digest with `.all()` and no `LIMIT`, even though the email/Discord templates only render the 20 newest items per account-and-type.
2. **Eager-join fanout** — `M3UChangeLog.snapshot` was `lazy="joined"`. `M3USnapshot.groups_data` is a JSON blob carrying every group's full stream-name list. All change rows from one refresh share one `snapshot_id`, so SQLAlchemy re-streamed that blob **once per row** → `O(rows × blob)` memory. Nothing in the codebase reads `.snapshot` (`to_dict()` uses the `snapshot_id` FK column), so the eager load was pure waste.

## Fix

- `models.py` — `M3UChangeLog.snapshot` → `lazy="select"` (load-on-access; kills the fanout, zero consumers).
- `tasks/m3u_digest.py` — cap the load at `MAX_DIGEST_CHANGES=5000` with a `WARNING` when the window exceeds it. 5000 is far above any sane digest; the rendered output is unchanged.
- Regression tests lock in both (relationship lazy-strategy + row cap).

## Test

`5296 passed, 1 skipped` (full backend suite).

## Follow-ups (not in this PR — tracked separately)

- The digest runs synchronously on the asyncio event loop; it should be offloaded so it can't freeze other requests (`exo4j`-adjacent availability concern).
- WAL-size / `PRAGMA integrity_check` backstop so a memory spike can't silently corrupt `journal.db`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)