### PR TITLE
fix(m3u-digest): offload blocking digest work off the asyncio event loop (GH #473)

### DIFF
--- a/backend/tasks/m3u_digest.py
+++ b/backend/tasks/m3u_digest.py
@@ -5,9 +5,11 @@ Scheduled task to send digest emails with M3U playlist changes.
 """
 import logging
 import re
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Optional, List, Dict
 
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
 import safe_regex
@@ -26,6 +28,35 @@ logger = logging.getLogger(__name__)
 # its own stream-name JSON blob) drove RSS to ~18.5 GiB and corrupted the SQLite
 # DB on a large deployment (GH #473). 5000 is far above any sane digest size.
 MAX_DIGEST_CHANGES = 5000
+
+
+@dataclass
+class _DigestPayload:
+    """Result of the synchronous (off-loop) digest build step.
+
+    ``_build_digest_payload`` runs the blocking work — DB load, exclude
+    filtering, and template rendering — in a worker thread and returns this
+    so ``execute()`` can do the async delivery (email/Discord) back on the
+    event loop. Either ``early_result`` is set (the run short-circuited:
+    disabled / no recipients / below threshold / no changes) and the caller
+    returns it verbatim, or the rendered content fields are populated.
+    """
+
+    # Short-circuit: when set, execute() returns this TaskResult directly.
+    early_result: Optional["TaskResult"] = None
+
+    # Rendered, ready-to-deliver content (None when early_result is set).
+    subject: Optional[str] = None
+    html_content: Optional[str] = None
+    plain_content: Optional[str] = None
+    discord_content: Optional[List[str]] = None
+
+    # Delivery context carried back to the event loop.
+    changes: List = field(default_factory=list)
+    recipients: List[str] = field(default_factory=list)
+    send_to_discord: bool = False
+    is_test: bool = False
+    since: Optional[datetime] = None
 
 
 class _FilteredChange:
@@ -136,46 +167,182 @@ class M3UDigestTask(TaskScheduler):
         """
         Execute the M3U digest task.
 
+        The heavy, loop-blocking work — the bounded SQLAlchemy load, the
+        exclude-pattern filtering loop, and the CPU-bound template rendering —
+        runs in a worker thread via ``run_in_threadpool`` (see
+        ``_build_digest_payload``). Async delivery (email via threaded smtplib,
+        Discord via aiohttp) then happens back on the event loop. This keeps a
+        heavy digest from freezing every other request (GH #473), where the
+        inline synchronous body blocked the loop for ~182s.
+
         Args:
             force: If True, send digest even if disabled or below threshold
             m3u_account_id: Optional filter for specific M3U account
         """
         started_at = datetime.utcnow()
-        db = get_session()
 
+        try:
+            self._set_progress(status="fetching_changes")
+
+            # Offload the blocking DB load + filter + render to a worker thread.
+            # The builder owns its own DB session (do NOT share a SQLAlchemy
+            # Session across threads) and returns rendered, ready-to-deliver
+            # content — or an early_result to short-circuit.
+            payload: _DigestPayload = await run_in_threadpool(
+                self._build_digest_payload, force, m3u_account_id, started_at
+            )
+
+            if payload.early_result is not None:
+                return payload.early_result
+
+            recipients = payload.recipients
+            send_to_discord = payload.send_to_discord
+            changes = payload.changes
+
+            # Track delivery results
+            email_success = False
+            discord_success = False
+            delivery_methods = []
+
+            # Send email if recipients configured
+            if recipients:
+                self._set_progress(status="sending_email")
+                email_success = await self._send_digest_email(
+                    recipients=recipients,
+                    subject=payload.subject,
+                    html_content=payload.html_content,
+                    plain_content=payload.plain_content,
+                )
+                if email_success:
+                    delivery_methods.append(f"email ({len(recipients)} recipients)")
+
+            # Send to Discord if enabled (aiohttp — already async, stays on loop)
+            if send_to_discord:
+                self._set_progress(status="sending_discord")
+                discord_success = await self._send_digest_discord(
+                    changes=changes,
+                    discord_content=payload.discord_content,
+                    is_test=payload.is_test,
+                )
+                if discord_success:
+                    delivery_methods.append("Discord")
+
+            # Check if at least one delivery succeeded
+            if email_success or discord_success:
+                # Update last digest time (only for real digests, not tests).
+                # Single-row UPDATE+commit — negligible vs the offloaded body,
+                # so it stays on the loop in its own short-lived session.
+                if changes:
+                    db = get_session()
+                    try:
+                        s = get_or_create_digest_settings(db)
+                        s.last_digest_at = datetime.utcnow()
+                        db.commit()
+                    finally:
+                        db.close()
+
+                # Build result message
+                if changes:
+                    message = f"Sent M3U digest with {len(changes)} changes via {', '.join(delivery_methods)}"
+                else:
+                    message = f"Test sent successfully via {', '.join(delivery_methods)}"
+
+                return TaskResult(
+                    success=True,
+                    message=message,
+                    started_at=started_at,
+                    completed_at=datetime.utcnow(),
+                    total_items=len(changes),
+                    success_count=len(changes),
+                    details={
+                        "changes_count": len(changes),
+                        "recipients": recipients,
+                        "discord_enabled": send_to_discord,
+                        "email_success": email_success,
+                        "discord_success": discord_success,
+                        "since": payload.since.isoformat() if changes else None,
+                        "is_test": payload.is_test,
+                    },
+                )
+            else:
+                failed_methods = []
+                if recipients and not email_success:
+                    failed_methods.append("email")
+                if send_to_discord and not discord_success:
+                    failed_methods.append("Discord")
+
+                return TaskResult(
+                    success=False,
+                    message=f"Failed to send M3U digest via {', '.join(failed_methods)}",
+                    error="All delivery methods failed",
+                    started_at=started_at,
+                    completed_at=datetime.utcnow(),
+                    total_items=len(changes),
+                )
+
+        except Exception as e:
+            logger.exception("[%s] M3U digest failed: %s", self.task_id, e)
+            return TaskResult(
+                success=False,
+                message=f"M3U digest failed: {str(e)}",
+                error=str(e),
+                started_at=started_at,
+                completed_at=datetime.utcnow(),
+            )
+
+    def _build_digest_payload(
+        self,
+        force: bool,
+        m3u_account_id: Optional[int],
+        started_at: datetime,
+    ) -> _DigestPayload:
+        """
+        Synchronous, loop-blocking digest build — run via ``run_in_threadpool``.
+
+        Owns its own DB session (a SQLAlchemy Session is NOT thread-safe and
+        must never be shared across the event loop and a worker thread). Loads
+        the bounded change set, applies settings/exclude filtering, evaluates
+        the threshold, and renders the email/Discord content. Returns a
+        ``_DigestPayload`` whose ``early_result`` short-circuits ``execute()``
+        when there is nothing to deliver, or whose rendered fields carry the
+        content for async delivery back on the event loop.
+
+        NOTE: this runs OFF the event loop, so it must not touch
+        ``self._progress`` notification scheduling or any other event-loop
+        state. ``self._set_progress`` calls stay in ``execute()``.
+        """
+        db = get_session()
         try:
             settings = get_or_create_digest_settings(db)
 
             # Check if enabled
             if not settings.enabled and not force:
-                return TaskResult(
+                return _DigestPayload(early_result=TaskResult(
                     success=True,
                     message="M3U digest is disabled",
                     started_at=started_at,
                     completed_at=datetime.utcnow(),
                     total_items=0,
-                )
+                ))
 
             # Check for at least one delivery method
             recipients = settings.get_email_recipients()
             send_to_discord = getattr(settings, 'send_to_discord', False)
 
             if not recipients and not send_to_discord:
-                return TaskResult(
+                return _DigestPayload(early_result=TaskResult(
                     success=False,
                     message="No delivery methods configured (no email recipients and Discord disabled)",
                     started_at=started_at,
                     completed_at=datetime.utcnow(),
                     total_items=0,
-                )
+                ))
 
             # Determine time range
             since = settings.last_digest_at
             if not since:
                 # First time - use frequency to determine lookback
                 since = datetime.utcnow() - get_frequency_delta(settings.frequency)
-
-            self._set_progress(status="fetching_changes")
 
             # Get changes since last digest.
             # Bounded load (MAX_DIGEST_CHANGES): the templates only show the 20
@@ -269,23 +436,23 @@ class M3UDigestTask(TaskScheduler):
                     "[%s] Only %s changes, below threshold of %s",
                     self.task_id, len(changes), settings.min_changes_threshold
                 )
-                return TaskResult(
+                return _DigestPayload(early_result=TaskResult(
                     success=True,
                     message=f"No digest sent: only {len(changes)} changes (threshold: {settings.min_changes_threshold})",
                     started_at=started_at,
                     completed_at=datetime.utcnow(),
                     total_items=len(changes),
-                )
+                ))
 
             if not changes:
                 if not force:
-                    return TaskResult(
+                    return _DigestPayload(early_result=TaskResult(
                         success=True,
                         message="No changes to report since last digest",
                         started_at=started_at,
                         completed_at=datetime.utcnow(),
                         total_items=0,
-                    )
+                    ))
                 # Force mode with no changes - send a test email
                 subject = "[ECM] M3U Digest Test - Configuration Verified"
                 html_content = """
@@ -317,99 +484,29 @@ When there are actual M3U changes to report, you will receive digest emails at t
 ---
 This is a test email from Enhanced Channel Manager.
                 """.strip()
+                discord_content = None
             else:
-                self._set_progress(status="building_digest", total=len(changes))
-
-                # Build digest content
+                # Build digest content (CPU-bound string building — off-loop).
                 template = M3UDigestTemplate()
                 show_detailed = getattr(settings, 'show_detailed_list', True)
                 html_content = template.render_html(changes, since, show_detailed_list=show_detailed)
                 plain_content = template.render_plain(changes, since, show_detailed_list=show_detailed)
                 subject = template.get_subject(changes)
-
-            # Track delivery results
-            email_success = False
-            discord_success = False
-            delivery_methods = []
-
-            # Send email if recipients configured
-            if recipients:
-                self._set_progress(status="sending_email")
-                email_success = await self._send_digest_email(
-                    recipients=recipients,
-                    subject=subject,
-                    html_content=html_content,
-                    plain_content=plain_content,
-                )
-                if email_success:
-                    delivery_methods.append(f"email ({len(recipients)} recipients)")
-
-            # Send to Discord if enabled
-            if send_to_discord:
-                self._set_progress(status="sending_discord")
-                discord_content = template.render_discord(changes, since, show_detailed_list=show_detailed) if changes else None
-                discord_success = await self._send_digest_discord(
-                    changes=changes,
-                    discord_content=discord_content,
-                    is_test=not bool(changes),
-                )
-                if discord_success:
-                    delivery_methods.append("Discord")
-
-            # Check if at least one delivery succeeded
-            if email_success or discord_success:
-                # Update last digest time (only for real digests, not tests)
-                if changes:
-                    settings.last_digest_at = datetime.utcnow()
-                    db.commit()
-
-                # Build result message
-                if changes:
-                    message = f"Sent M3U digest with {len(changes)} changes via {', '.join(delivery_methods)}"
-                else:
-                    message = f"Test sent successfully via {', '.join(delivery_methods)}"
-
-                return TaskResult(
-                    success=True,
-                    message=message,
-                    started_at=started_at,
-                    completed_at=datetime.utcnow(),
-                    total_items=len(changes),
-                    success_count=len(changes),
-                    details={
-                        "changes_count": len(changes),
-                        "recipients": recipients,
-                        "discord_enabled": send_to_discord,
-                        "email_success": email_success,
-                        "discord_success": discord_success,
-                        "since": since.isoformat() if changes else None,
-                        "is_test": not bool(changes),
-                    },
-                )
-            else:
-                failed_methods = []
-                if recipients and not email_success:
-                    failed_methods.append("email")
-                if send_to_discord and not discord_success:
-                    failed_methods.append("Discord")
-
-                return TaskResult(
-                    success=False,
-                    message=f"Failed to send M3U digest via {', '.join(failed_methods)}",
-                    error="All delivery methods failed",
-                    started_at=started_at,
-                    completed_at=datetime.utcnow(),
-                    total_items=len(changes),
+                discord_content = (
+                    template.render_discord(changes, since, show_detailed_list=show_detailed)
+                    if send_to_discord else None
                 )
 
-        except Exception as e:
-            logger.exception("[%s] M3U digest failed: %s", self.task_id, e)
-            return TaskResult(
-                success=False,
-                message=f"M3U digest failed: {str(e)}",
-                error=str(e),
-                started_at=started_at,
-                completed_at=datetime.utcnow(),
+            return _DigestPayload(
+                subject=subject,
+                html_content=html_content,
+                plain_content=plain_content,
+                discord_content=discord_content,
+                changes=changes,
+                recipients=recipients,
+                send_to_discord=send_to_discord,
+                is_test=not bool(changes),
+                since=since,
             )
         finally:
             db.close()
@@ -498,7 +595,30 @@ This is a test email from Enhanced Channel Manager.
         html_content: str,
         plain_content: str,
     ) -> bool:
-        """Send a custom email with pre-built HTML content using SMTP config dict."""
+        """Send a custom email with pre-built HTML content using SMTP config dict.
+
+        The synchronous smtplib I/O (connect / STARTTLS / login / sendmail) is
+        offloaded to a worker thread so SMTP latency cannot block the asyncio
+        event loop (GH #473).
+        """
+        return await run_in_threadpool(
+            self._send_custom_email_with_config_sync,
+            config,
+            recipients,
+            subject,
+            html_content,
+            plain_content,
+        )
+
+    def _send_custom_email_with_config_sync(
+        self,
+        config: Dict,
+        recipients: List[str],
+        subject: str,
+        html_content: str,
+        plain_content: str,
+    ) -> bool:
+        """Blocking smtplib send — runs in a worker thread, never on the loop."""
         import smtplib
         import ssl
         from email.mime.text import MIMEText

--- a/backend/tests/unit/test_m3u_digest_offload.py
+++ b/backend/tests/unit/test_m3u_digest_offload.py
@@ -1,0 +1,242 @@
+"""
+Regression tests for the M3U digest event-loop offload (GH #473).
+
+``M3UDigestTask.execute()`` is ``async def`` but used to perform long,
+synchronous, loop-blocking work inline: a blocking SQLAlchemy load, the
+Python exclude-filter loop, CPU-bound template rendering, and a blocking
+``smtplib`` send. During the GH #473 OOM run that froze the asyncio event
+loop for ~182s, stalling every other endpoint.
+
+These tests lock in that the heavy work now runs OFF the event loop:
+  1. The synchronous data-gather + filter + render runs in a worker thread
+     (``_build_digest_payload`` invoked via ``run_in_threadpool``).
+  2. The blocking ``smtplib`` send runs in a worker thread.
+  3. While ``execute()`` is running, the event loop is not blocked — a
+     concurrent coroutine still makes progress.
+
+Behavioral correctness of the digest itself (filtering, threshold, cap,
+delivery, last_digest_at) is covered by the sibling suites
+(test_m3u_digest_exclude, _safe_regex, _bounded) and test_m3u_digest.py.
+"""
+import asyncio
+import threading
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from models import M3UChangeLog, M3UDigestSettings
+
+
+class _NoCloseSession:
+    """Wrap the test session so the task's get_session().close() is a no-op.
+
+    The fixture keeps ownership of cleanup; the task opening/closing its own
+    session must not close the shared StaticPool connection underneath it.
+    """
+
+    def __init__(self, real):
+        self._real = real
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    def close(self):
+        pass
+
+
+def _make_enabled_settings(session, **overrides):
+    kwargs = dict(
+        enabled=True,
+        frequency="weekly",
+        include_group_changes=True,
+        include_stream_changes=True,
+        show_detailed_list=True,
+        min_changes_threshold=1,
+    )
+    kwargs.update(overrides)
+    settings = M3UDigestSettings(**kwargs)
+    settings.set_email_recipients(["ops@example.com"])
+    session.add(settings)
+    session.commit()
+    return settings
+
+
+def _add_change(session, i):
+    base = datetime.utcnow() - timedelta(hours=1)
+    row = M3UChangeLog(
+        m3u_account_id=1,
+        change_time=base + timedelta(seconds=i),
+        change_type="streams_added",
+        group_name=f"Group {i}",
+        count=1,
+    )
+    row.set_stream_names([f"Stream {i}"])
+    session.add(row)
+    session.commit()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_build_payload_runs_in_worker_thread(test_session):
+    """The synchronous digest builder must run off the main (event-loop) thread."""
+    from tasks import m3u_digest as digest_mod
+    from tasks.m3u_digest import M3UDigestTask
+
+    _make_enabled_settings(test_session)
+    for i in range(3):
+        _add_change(test_session, i)
+
+    recorded = {}
+    real_builder = M3UDigestTask._build_digest_payload
+
+    def _spy(self, *args, **kwargs):
+        recorded["thread_is_main"] = (
+            threading.current_thread() is threading.main_thread()
+        )
+        return real_builder(self, *args, **kwargs)
+
+    with patch.object(digest_mod, "get_session",
+                      return_value=_NoCloseSession(test_session)), \
+         patch.object(M3UDigestTask, "_build_digest_payload", new=_spy), \
+         patch.object(M3UDigestTask, "_send_digest_email",
+                      new=AsyncMock(return_value=True)):
+        task = M3UDigestTask()
+        result = await task.execute(force=True)
+
+    assert result.success is True
+    assert recorded.get("thread_is_main") is False, (
+        "_build_digest_payload ran on the main thread — the heavy digest "
+        "work is still blocking the event loop (GH #473)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_offloads_builder_via_threadpool(test_session):
+    """execute() must dispatch the heavy builder through run_in_threadpool."""
+    from tasks import m3u_digest as digest_mod
+    from tasks.m3u_digest import M3UDigestTask
+
+    _make_enabled_settings(test_session)
+    _add_change(test_session, 0)
+
+    with patch.object(digest_mod, "get_session",
+                      return_value=_NoCloseSession(test_session)), \
+         patch.object(digest_mod, "run_in_threadpool",
+                      wraps=digest_mod.run_in_threadpool) as spy_pool, \
+         patch.object(M3UDigestTask, "_send_digest_email",
+                      new=AsyncMock(return_value=True)):
+        task = M3UDigestTask()
+        result = await task.execute(force=True)
+
+    assert result.success is True
+    builder_dispatched = any(
+        getattr(call.args[0], "__name__", "") == "_build_digest_payload"
+        for call in spy_pool.call_args_list
+    )
+    assert builder_dispatched, (
+        "run_in_threadpool was not called with _build_digest_payload — "
+        "the heavy digest path is not being offloaded"
+    )
+
+
+@pytest.mark.asyncio
+async def test_event_loop_not_blocked_during_execute(test_session):
+    """A concurrent coroutine must make progress while execute() runs.
+
+    We make the builder block on a threading.Event for a beat. If the builder
+    ran inline on the event loop, the concurrent ticker could not advance until
+    the builder returned. Because it runs in a worker thread, the loop stays
+    free and the ticker advances while the builder is still parked.
+    """
+    from tasks import m3u_digest as digest_mod
+    from tasks.m3u_digest import M3UDigestTask
+
+    _make_enabled_settings(test_session)
+    _add_change(test_session, 0)
+
+    builder_entered = threading.Event()
+    release_builder = threading.Event()
+    real_builder = M3UDigestTask._build_digest_payload
+
+    def _blocking_builder(self, *args, **kwargs):
+        builder_entered.set()
+        # Park the worker thread. If this ran on the loop, the ticker below
+        # could never advance and the wait() would time out -> test fails.
+        assert release_builder.wait(timeout=5.0), "builder release timed out"
+        return real_builder(self, *args, **kwargs)
+
+    ticks = {"n": 0}
+
+    async def _ticker():
+        # Wait until the builder is parked in its worker thread, then prove the
+        # loop is alive by advancing several times before releasing it.
+        while not builder_entered.is_set():
+            await asyncio.sleep(0.001)
+        for _ in range(5):
+            ticks["n"] += 1
+            await asyncio.sleep(0.001)
+        release_builder.set()
+
+    with patch.object(digest_mod, "get_session",
+                      return_value=_NoCloseSession(test_session)), \
+         patch.object(M3UDigestTask, "_build_digest_payload",
+                      new=_blocking_builder), \
+         patch.object(M3UDigestTask, "_send_digest_email",
+                      new=AsyncMock(return_value=True)):
+        task = M3UDigestTask()
+        exec_task = asyncio.create_task(task.execute(force=True))
+        await _ticker()
+        result = await exec_task
+
+    assert result.success is True
+    assert ticks["n"] == 5, (
+        "the concurrent ticker did not advance while the digest builder was "
+        "parked — the event loop was blocked (GH #473)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_smtp_send_runs_off_event_loop(test_session):
+    """The blocking smtplib send must run in a worker thread, not on the loop."""
+    from tasks.m3u_digest import M3UDigestTask
+
+    recorded = {}
+
+    class _FakeSMTP:
+        def __init__(self, *args, **kwargs):
+            recorded["thread_is_main"] = (
+                threading.current_thread() is threading.main_thread()
+            )
+
+        def starttls(self, *a, **k):
+            pass
+
+        def login(self, *a, **k):
+            pass
+
+        def sendmail(self, *a, **k):
+            pass
+
+        def quit(self):
+            pass
+
+    task = M3UDigestTask()
+    config = {
+        "smtp_host": "smtp.example.com",
+        "smtp_port": 587,
+        "from_email": "from@example.com",
+        "from_name": "ECM",
+        "use_tls": True,
+        "use_ssl": False,
+    }
+    with patch("smtplib.SMTP", _FakeSMTP):
+        ok = await task._send_custom_email_with_config(
+            config, ["to@example.com"], "subj", "<p>html</p>", "plain"
+        )
+
+    assert ok is True
+    assert recorded.get("thread_is_main") is False, (
+        "smtplib send ran on the main thread — SMTP I/O still blocks the "
+        "event loop (GH #473)"
+    )


### PR DESCRIPTION
## Summary

Follow-up to PR #492 (the GH #473 memory fix). `M3UDigestTask.execute()` was `async def` but ran long **synchronous, loop-blocking** work with no `await` yields — DB load, exclude filtering, template rendering, and a blocking `smtplib` send. During the #473 OOM run this froze the asyncio event loop for ~182 s: every other endpoint stalled and only flushed after the digest returned. The 30 s request budget fired a 504 but did not cancel the work, so the loop stayed blocked.

Both callers hit this — the test endpoint (`POST /api/m3u/digest/test`) and the scheduled path (`task_scheduler.py:552`).

## Fix

- Extracted the synchronous build (bounded load + filtering + threshold + template rendering, plus precomputed Discord content) into `_build_digest_payload()`, which owns its **own** short-lived DB session (no Session shared across threads).
- `execute()` now runs it via `await run_in_threadpool(...)`, then does async delivery on the loop.
- Blocking `smtplib` send moved to `_send_custom_email_with_config_sync()` and offloaded via `run_in_threadpool`. Discord (aiohttp) stays on the loop.
- All observable behavior preserved: TaskResult/router shape, `force` semantics, include/exclude filtering, threshold logic, `last_digest_at` update, and the `MAX_DIGEST_CHANGES` cap from PR #492.

## Test

Full backend suite: `5300 passed, 1 skipped` (+4 over baseline). 4 new tests assert the heavy build + SMTP send run off the main thread, that `run_in_threadpool` is used, and that the loop keeps ticking during a digest. Verified independently on the branch.

Closes bead `enhancedchannelmanager-80e7b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)