### PR TITLE
fix(database): SQLite startup integrity check + WAL-growth backstop (GH #473)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -33,6 +33,44 @@ _SessionLocal = None
 # informative without spamming once-per-connection lines.
 _pragma_logged = False
 
+# --- WAL-growth backstop (bd-12hxn / GH #473) ----------------------------
+# The startup ``_wal_checkpoint_truncate`` (bd-ej995 / GH #274) only bounds the
+# WAL at boot. DURING a long run the passive auto-checkpoint that SQLite would
+# normally fire every ``wal_autocheckpoint`` pages gets STARVED whenever a
+# reader (e.g. the stats poller) holds a read transaction across the checkpoint
+# window — exactly the GH #274 pinned-reader pathology — so the -wal can grow
+# without bound until the next restart truncates it. Under the GH #473 memory
+# spike that unbounded growth compounds the disk/swap pressure that corrupted
+# journal.db.
+#
+# We bound it per-connection with two cheap PRAGMA levers (no new background
+# task lifecycle to own/test):
+#
+#   * ``journal_size_limit`` caps how many bytes of WAL are RETAINED after a
+#     checkpoint reclaims it. Without a limit SQLite keeps the WAL file at its
+#     high-water mark (it only ever truncates on an explicit TRUNCATE
+#     checkpoint), so a single growth spike leaves the file large for the rest
+#     of the run. With the limit, an ordinary auto-checkpoint shrinks the file
+#     back to the cap. This does NOT fight the boot TRUNCATE checkpoint —
+#     TRUNCATE still takes the WAL to zero; the limit only governs the retained
+#     size of incremental checkpoints during the run.
+#   * ``wal_autocheckpoint`` sets the page threshold at which a committing
+#     connection attempts a PASSIVE checkpoint. SQLite's default is 1000 pages
+#     (~4 MB at the default 4 KB page size). We keep that default frequency —
+#     lowering it would checkpoint more often (more contention with readers),
+#     raising it would let the WAL run further between checkpoints. 1000 is a
+#     well-tuned default; we set it explicitly so the value is visible and
+#     can't drift if a future SQLite changes its default.
+#
+# 64 MiB cap: comfortably above normal steady-state WAL (a few MB), well below
+# the 1.4 GB GH #274 incident and the multi-GB pressure of GH #473. A reader
+# that pins the WAL can still let it grow past the cap transiently (the cap is
+# enforced at checkpoint time, and a pinned reader blocks the checkpoint) — but
+# the moment the reader releases, the next checkpoint reclaims back to the cap
+# instead of leaving the file at its spike high-water mark.
+WAL_JOURNAL_SIZE_LIMIT_BYTES = 64 * 1024 * 1024  # 64 MiB
+WAL_AUTOCHECKPOINT_PAGES = 1000  # SQLite default; set explicitly for visibility
+
 
 @event.listens_for(Engine, "connect")
 def _set_sqlite_pragmas(dbapi_connection, connection_record):
@@ -89,13 +127,29 @@ def _set_sqlite_pragmas(dbapi_connection, connection_record):
             if row is not None:
                 resulting_mode = row[0]
 
+            # WAL-growth backstop (bd-12hxn / GH #473). Only meaningful for
+            # file-backed WAL databases — in-memory DBs have no WAL file to
+            # bound. ``journal_size_limit`` returns the previous limit; we do
+            # not act on it. Setting these per-connection (rather than once on
+            # the main connection) ensures every pooled/probe/task connection
+            # shares the same checkpoint policy.
+            cursor.execute(
+                "PRAGMA journal_size_limit=%d" % WAL_JOURNAL_SIZE_LIMIT_BYTES
+            )
+            cursor.execute(
+                "PRAGMA wal_autocheckpoint=%d" % WAL_AUTOCHECKPOINT_PAGES
+            )
+
         cursor.execute("PRAGMA synchronous=NORMAL")
         cursor.execute("PRAGMA foreign_keys=ON")
 
         if not _pragma_logged:
             logger.info(
-                "[DATABASE] SQLite PRAGMAs applied: journal_mode=%s synchronous=NORMAL foreign_keys=ON (memory=%s)",
+                "[DATABASE] SQLite PRAGMAs applied: journal_mode=%s synchronous=NORMAL "
+                "foreign_keys=ON journal_size_limit=%d wal_autocheckpoint=%d (memory=%s)",
                 resulting_mode or "memory",
+                WAL_JOURNAL_SIZE_LIMIT_BYTES,
+                WAL_AUTOCHECKPOINT_PAGES,
                 is_memory,
             )
             _pragma_logged = True
@@ -220,6 +274,114 @@ def _wal_checkpoint_truncate(engine) -> None:
         logger.warning(
             "[DATABASE] WAL checkpoint failed (non-fatal): %s", e
         )
+
+
+def _integrity_check(engine) -> None:
+    """Run ``PRAGMA quick_check`` against the journal DB and loud-fail on damage.
+
+    bd-12hxn / GH #473: an M3U digest OOM'd the container (~18.5 GiB) and, under
+    the memory/swap pressure, CORRUPTED the on-disk SQLite DB — the run died
+    with ``sqlite3.DatabaseError: database disk image is malformed`` raised from
+    a ``fetchall`` mid-request. That is a DATA-LOSS class outcome, not just an
+    availability one, and it surfaced at a random read instead of at boot. This
+    check moves detection to the front door: corruption is caught BEFORE
+    migrations or ``create_all`` touch a malformed file (which can deepen the
+    damage), and surfaced LOUDLY with operator guidance instead of as a cryptic
+    mid-request 500.
+
+    quick_check vs integrity_check — we use ``quick_check`` deliberately:
+
+    * A full ``PRAGMA integrity_check`` walks every index and cross-checks every
+      b-tree against its table — on a multi-GB DB that can take many seconds to
+      minutes. That is the SAME Docker health-check ``start_period`` risk the
+      WAL-truncate comment documents (GH #274): a slow boot step marks the
+      container unhealthy and blocks ecm-mcp.
+    * ``quick_check`` skips the expensive index-vs-table cross-verification but
+      STILL detects the malformed-page / corrupt-b-tree class — exactly the
+      "database disk image is malformed" failure GH #473 hit. It is dramatically
+      cheaper and bounded enough to run on every boot. The cheaper check catching
+      the actual incident's failure mode is the right trade for a boot-path guard.
+
+    Placement (init_db): after the engine is created and after
+    ``_wal_checkpoint_truncate`` (so the check sees the post-truncate main-file
+    state), but BEFORE ``_bootstrap_alembic`` / ``create_all`` /
+    ``_assert_schema_matches_models`` — corruption must be caught before
+    migrations try to write to a malformed file.
+
+    In-memory DBs (tests, ``sqlite:///:memory:``) and fresh installs (no file
+    yet) are skipped: ``quick_check`` on an empty/absent DB returns ``ok``
+    trivially, but skipping the in-memory path keeps the main test suite (which
+    runs thousands of in-memory engines) free of an unnecessary per-init scan.
+
+    On a non-'ok' result we follow the bd-zaaey loud-fail philosophy already in
+    this file (re-raise on boot problems rather than running for days on a
+    silently-broken DB): log a ``[DATABASE]`` ERROR with actionable recovery
+    guidance and raise ``RuntimeError`` so boot fails visibly.
+
+    Raises:
+        RuntimeError: when ``quick_check`` reports anything other than ``ok``.
+    """
+    # Skip in-memory engines — no on-disk file to corrupt, and the main test
+    # suite spins up thousands of them. Detect the same way the PRAGMA listener
+    # does: an in-memory DB's main entry in ``PRAGMA database_list`` has an
+    # empty ``file`` column.
+    try:
+        with engine.connect() as conn:
+            db_list = conn.execute(text("PRAGMA database_list")).fetchall()
+            # rows like (seq, name, file). Main DB is first; empty file = memory.
+            if db_list and len(db_list[0]) >= 3 and not db_list[0][2]:
+                logger.debug(
+                    "[DATABASE] Skipping integrity check for in-memory database"
+                )
+                return
+
+            # PRAGMA quick_check returns one row ``('ok',)`` on success, or one
+            # or more rows describing problems on failure. ``scalar`` reads the
+            # first row's first column, which is ``ok`` iff the DB is clean.
+            result = conn.execute(text("PRAGMA quick_check")).scalar()
+    except Exception as e:
+        # A raw "database disk image is malformed" can also surface as an
+        # exception from the PRAGMA itself rather than a non-'ok' row. Treat
+        # that identically — loud-fail with guidance.
+        logger.error(
+            "[DATABASE] SQLite integrity check could not run against %s: %s. "
+            "This often indicates a corrupted or unreadable database file. "
+            "Recovery: stop the container, back up %s (and its -wal/-shm "
+            "siblings) BEFORE any repair attempt, then restore journal.db from "
+            "a known-good backup, or attempt `sqlite3 journal.db \".recover\"` "
+            "into a fresh file. Run `PRAGMA integrity_check` for a full report.",
+            JOURNAL_DB_FILE,
+            e,
+            JOURNAL_DB_FILE,
+        )
+        raise RuntimeError(
+            "SQLite integrity check failed to run — journal.db may be corrupted "
+            f"or unreadable: {e}. Back up the DB and restore from a known-good "
+            "backup (or `.recover`) before restarting."
+        ) from e
+
+    if result != "ok":
+        logger.error(
+            "[DATABASE] SQLite integrity check FAILED for %s: quick_check "
+            "returned %r (expected 'ok'). The on-disk database is corrupted — "
+            "this is a data-integrity failure, not a transient error, and was "
+            "the GH #473 outcome of a memory/swap spike damaging the DB. "
+            "Recovery: stop the container, back up %s (and its -wal/-shm "
+            "siblings) BEFORE any repair, then restore journal.db from a "
+            "known-good backup, or attempt `sqlite3 journal.db \".recover\"` "
+            "into a fresh file. Run `PRAGMA integrity_check` (the full, slower "
+            "check) for a complete corruption report.",
+            JOURNAL_DB_FILE,
+            result,
+            JOURNAL_DB_FILE,
+        )
+        raise RuntimeError(
+            "SQLite integrity check failed — journal.db is corrupted "
+            f"(quick_check returned {result!r}). Restore from a known-good "
+            "backup or `.recover` the database before restarting."
+        )
+
+    logger.info("[DATABASE] SQLite integrity check passed (quick_check=ok)")
 
 
 def _bootstrap_alembic(engine) -> None:
@@ -548,6 +710,16 @@ def init_db() -> None:
         # before _bootstrap_alembic / _assert_schema_matches_models so the
         # migration path sees the post-truncate state.
         _wal_checkpoint_truncate(_engine)
+
+        # bd-12hxn / GH #473: verify the on-disk DB is not corrupted BEFORE any
+        # migration or create_all touches it. Runs after the WAL truncate (so it
+        # checks the post-truncate main file) but before _bootstrap_alembic so a
+        # malformed file fails the boot loudly with operator guidance instead of
+        # corrupting further or surfacing as a cryptic mid-request 500. Uses the
+        # cheap quick_check (not full integrity_check) to avoid the GH #274
+        # health-check start_period risk on large DBs. No-op for in-memory test
+        # DBs and fresh installs.
+        _integrity_check(_engine)
 
         # Import models to register them with Base
         from models import JournalEntry, BandwidthDaily, ChannelWatchStats, HiddenChannelGroup, StreamStats, ScheduledTask, TaskSchedule, TaskExecution, Notification, AlertMethod, TagGroup, Tag, NormalizationRuleGroup, NormalizationRule, User, UserSession, PasswordResetToken, UserIdentity, AutoCreationRule, AutoCreationExecution, AutoCreationConflict, FFmpegProfile, DummyEPGProfile, DummyEPGChannelAssignment, LookupTable, PendingMerge, PendingMergeJournal  # noqa: F401

--- a/backend/tests/unit/test_database_integrity_check.py
+++ b/backend/tests/unit/test_database_integrity_check.py
@@ -1,0 +1,229 @@
+"""Tests for the startup SQLite integrity check + WAL-growth backstop.
+
+bd-12hxn / GH #473: a memory/swap spike corrupted the on-disk journal.db
+("database disk image is malformed", raised from a mid-request fetchall). The
+fix adds:
+
+* ``database._integrity_check`` — a ``PRAGMA quick_check`` run during boot that
+  loud-fails (raises with operator guidance) on a corrupted file, BEFORE
+  migrations touch it. In-memory and fresh DBs are skipped/trivially-ok.
+* A per-connection WAL-growth backstop (``journal_size_limit`` +
+  ``wal_autocheckpoint``) so the -wal can't grow without bound during a long
+  run.
+
+These tests cover the healthy-pass path, the corruption-raises path (both real
+corruption and a patched non-'ok' result), in-memory skip, and that the WAL
+PRAGMA backstop values are actually applied on a new file-backed connection.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import StaticPool
+
+import database
+
+
+def _make_file_engine(db_file: Path):
+    """A file-backed SQLite engine matching production settings."""
+    return create_engine(
+        f"sqlite:///{db_file}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+
+
+# --- Part A: integrity check ------------------------------------------------
+
+
+def test_integrity_check_passes_on_healthy_db(tmp_path):
+    """A valid DB with real b-tree content must pass quick_check and not raise."""
+    db_file = tmp_path / "healthy.db"
+    engine = _make_file_engine(db_file)
+    try:
+        # Use a self-contained table (no model constraint coupling) so the test
+        # exercises quick_check against real, populated b-trees.
+        with engine.begin() as conn:
+            conn.execute(text("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)"))
+            for i in range(50):
+                conn.execute(
+                    text("INSERT INTO t (v) VALUES (:v)"), {"v": f"row-{i}"}
+                )
+        # Should complete silently (no raise).
+        database._integrity_check(engine)
+    finally:
+        engine.dispose()
+
+
+def test_integrity_check_skips_in_memory_db():
+    """In-memory engines have no on-disk file — the check must no-op, not raise."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+    try:
+        database.Base.metadata.create_all(bind=engine)
+        # Must return without raising and without running quick_check.
+        database._integrity_check(engine)
+    finally:
+        engine.dispose()
+
+
+def test_integrity_check_raises_on_non_ok_result(tmp_path):
+    """A non-'ok' quick_check result must raise RuntimeError with guidance.
+
+    Simulate corruption by intercepting connection execution: the
+    ``database_list`` probe reports a real file (so the in-memory skip does NOT
+    fire), and the ``quick_check`` reports a damaged page.
+    """
+    db_file = tmp_path / "patched.db"
+    engine = _make_file_engine(db_file)
+    try:
+        database.Base.metadata.create_all(bind=engine)
+
+        real_connect = engine.connect
+
+        def make_result(sql: str):
+            result = MagicMock()
+            if "database_list" in sql:
+                result.fetchall.return_value = [(0, "main", str(db_file))]
+            elif "quick_check" in sql:
+                result.scalar.return_value = (
+                    "*** in database main ***\nPage 5: btree corrupt"
+                )
+            return result
+
+        def fake_connect(*args, **kwargs):
+            conn = real_connect(*args, **kwargs)
+            original_execute = conn.execute
+            conn.execute = lambda stmt, *a, **k: (  # type: ignore[assignment]
+                make_result(str(stmt))
+                if ("database_list" in str(stmt) or "quick_check" in str(stmt))
+                else original_execute(stmt, *a, **k)
+            )
+            return conn
+
+        with patch.object(engine, "connect", side_effect=fake_connect):
+            with pytest.raises(RuntimeError, match="integrity check failed"):
+                database._integrity_check(engine)
+    finally:
+        engine.dispose()
+
+
+def test_integrity_check_raises_on_real_corruption(tmp_path):
+    """A genuinely corrupted DB file must be detected and raise.
+
+    We build a valid DB, then overwrite interior pages with garbage while
+    leaving the 16-byte SQLite header intact, so the file still opens as a
+    SQLite DB but quick_check finds malformed b-tree pages.
+    """
+    db_file = tmp_path / "corrupt.db"
+    engine = _make_file_engine(db_file)
+    try:
+        # Self-contained table; insert enough rows to span multiple pages so
+        # corrupting page bodies actually damages b-tree content.
+        with engine.begin() as conn:
+            conn.execute(text("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)"))
+            for i in range(500):
+                conn.execute(
+                    text("INSERT INTO t (v) VALUES (:v)"), {"v": "x" * 200}
+                )
+    finally:
+        engine.dispose()
+
+    # Corrupt the file: keep the first SQLite page header (first 100 bytes,
+    # which includes the 16-byte magic string) but garble the rest of the file.
+    data = bytearray(db_file.read_bytes())
+    for offset in range(100, len(data)):
+        data[offset] = 0xFF
+    db_file.write_bytes(bytes(data))
+
+    engine2 = _make_file_engine(db_file)
+    try:
+        with pytest.raises(RuntimeError):
+            database._integrity_check(engine2)
+    finally:
+        engine2.dispose()
+
+
+def test_init_db_aborts_on_corruption(tmp_path, monkeypatch):
+    """init_db must abort (raise) when the integrity check fails, before
+    migrations run — the corruption must not be silently passed to create_all.
+    """
+    db_file = tmp_path / "journal.db"
+
+    # Point the module's DB file + config dir at our temp path so init_db uses
+    # them and does not touch the real config directory.
+    monkeypatch.setattr(database, "JOURNAL_DB_FILE", db_file)
+    monkeypatch.setattr(database, "CONFIG_DIR", tmp_path)
+
+    # Make the integrity check fail; assert bootstrap is never reached.
+    bootstrap_called = {"hit": False}
+
+    def fake_integrity(engine):
+        raise RuntimeError("integrity check failed — journal.db is corrupted (simulated)")
+
+    def fake_bootstrap(engine):
+        bootstrap_called["hit"] = True
+
+    monkeypatch.setattr(database, "_integrity_check", fake_integrity)
+    monkeypatch.setattr(database, "_bootstrap_alembic", fake_bootstrap)
+
+    with pytest.raises(RuntimeError, match="integrity check failed"):
+        database.init_db()
+
+    assert bootstrap_called["hit"] is False, (
+        "Bootstrap/migrations must NOT run after a failed integrity check — "
+        "the whole point is to catch corruption before touching the file."
+    )
+
+
+# --- Part B: WAL-growth backstop -------------------------------------------
+
+
+def test_wal_journal_size_limit_applied_on_new_connection(tmp_path):
+    """A new file-backed connection must have journal_size_limit set to the cap."""
+    db_file = tmp_path / "wal_limit.db"
+    engine = _make_file_engine(db_file)
+    try:
+        with engine.connect() as conn:
+            limit = conn.execute(text("PRAGMA journal_size_limit")).scalar()
+        assert limit == database.WAL_JOURNAL_SIZE_LIMIT_BYTES, (
+            f"Expected journal_size_limit={database.WAL_JOURNAL_SIZE_LIMIT_BYTES}, "
+            f"got {limit!r}. The WAL-growth backstop must bound retained WAL size."
+        )
+    finally:
+        engine.dispose()
+
+
+def test_wal_autocheckpoint_applied_on_new_connection(tmp_path):
+    """A new file-backed connection must have wal_autocheckpoint set."""
+    db_file = tmp_path / "wal_autockpt.db"
+    engine = _make_file_engine(db_file)
+    try:
+        with engine.connect() as conn:
+            pages = conn.execute(text("PRAGMA wal_autocheckpoint")).scalar()
+        assert pages == database.WAL_AUTOCHECKPOINT_PAGES, (
+            f"Expected wal_autocheckpoint={database.WAL_AUTOCHECKPOINT_PAGES}, "
+            f"got {pages!r}."
+        )
+    finally:
+        engine.dispose()
+
+
+def test_wal_backstop_constants_are_sane():
+    """Guard the constants against accidental regression to unbounded/zero."""
+    # 64 MiB default — comfortably above steady state, well below incident size.
+    assert database.WAL_JOURNAL_SIZE_LIMIT_BYTES == 64 * 1024 * 1024
+    # journal_size_limit must be positive — 0 would force the WAL to truncate to
+    # zero on every checkpoint (churn), -1 would mean "no limit" (the bug).
+    assert database.WAL_JOURNAL_SIZE_LIMIT_BYTES > 0
+    # wal_autocheckpoint must be positive — 0 disables auto-checkpoint entirely,
+    # which would let the WAL grow unbounded (the opposite of the fix).
+    assert database.WAL_AUTOCHECKPOINT_PAGES > 0


### PR DESCRIPTION
## Summary

Durability backstop for GH #473. The test-digest OOM didn't just crash the container — under memory/swap pressure it **corrupted `journal.db`** (`sqlite3.DatabaseError: database disk image is malformed`, raised from a `fetchall`). The memory leak is fixed (PR #492) and the loop-blocking is offloaded (PR #493); this PR ensures a future spike can't silently corrupt the DB and that corruption surfaces **loudly at boot** instead of mid-request.

## Part A — Startup integrity check (detect + loud fail)

- New `_integrity_check(engine)` runs `PRAGMA quick_check` in `init_db()`, placed after the existing `_wal_checkpoint_truncate()` but **before** Alembic bootstrap / `create_all` / schema-assert — so a malformed file is caught before migrations touch it.
- **`quick_check` over `integrity_check`:** a full `integrity_check` walks every index/b-tree cross-check and can take minutes on a multi-GB DB — the same Docker health-check `start_period` risk documented for the WAL truncate (GH #274). `quick_check` still detects the malformed-page class that caused #473, far cheaper.
- In-memory/test DBs are skipped (same `PRAGMA database_list` empty-`file` detection the existing PRAGMA listener uses), so fresh installs and the in-memory test engines don't pay for a scan.
- On a non-`ok` result (or PRAGMA exception): logs a `[DATABASE]` ERROR with actionable recovery guidance (back up `journal.db`+`-wal`/`-shm`, restore from backup or `.recover`) and **raises** — consistent with the existing bd-zaaey loud-fail-on-boot philosophy.

## Part B — WAL-growth backstop

Added to the per-connection PRAGMA listener (alongside `journal_mode=WAL`):
- **`journal_size_limit = 64 MiB`** — caps WAL bytes retained after incremental checkpoints, so a growth spike can't pin the `-wal` at its high-water mark for the rest of a run. Startup `_wal_checkpoint_truncate` (TRUNCATE → 0) is unaffected.
- **`wal_autocheckpoint = 1000`** (SQLite default, set explicitly for visibility/drift-protection).

PRAGMA tuning was chosen over a background checkpoint task — no new task lifecycle to own.

## Test

Full backend suite: `5304 passed, 1 skipped` (+8 new tests). Independently re-verified the integrity + all DB/startup/migration tests on the branch: `303 passed`. New tests cover healthy boot, in-memory skip, simulated + real on-disk corruption, boot-abort-on-corruption, and the WAL PRAGMA values applied on a new connection.

Closes bead `enhancedchannelmanager-12hxn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)