### PR TITLE
v0.18.0-0006: Cut ECM->Dispatcharr API call volume per refresh cycle

### DIFF
--- a/backend/auto_creation_engine.py
+++ b/backend/auto_creation_engine.py
@@ -764,8 +764,13 @@ class AutoCreationEngine:
                 page = 1
                 fetched_for_account = 0
                 while True:
+                    # page_size=1000 (was 100): auto-creation runs a full
+                    # per-account stream sweep right after every M3U refresh, so
+                    # the smaller page meant ~10x the requests against Dispatcharr
+                    # for no benefit. Matches STREAM_PULL_PAGE_SIZE in the refresh
+                    # task (bd-iwfr7).
                     result = await self.client.get_streams(
-                        page=page, page_size=100, m3u_account=account_id
+                        page=page, page_size=1000, m3u_account=account_id
                     )
                     streams = result.get("results", [])
                     for stream in streams:

--- a/backend/bandwidth_tracker.py
+++ b/backend/bandwidth_tracker.py
@@ -595,6 +595,7 @@ async def resolve_active_channel_streams(
     channel_streams_cache: Optional[ChannelStreamsCache] = None,
     poll_count: int = 0,
     emit_metrics: bool = True,
+    m3u_accounts: Optional[list[dict]] = None,
 ) -> dict[str, ProviderResolution]:
     """Resolve each active channel's stream identity (id + name + provider).
 
@@ -656,6 +657,13 @@ async def resolve_active_channel_streams(
     endpoint path) the SLI line is suppressed so it doesn't drown the
     cyclic poll signal.
 
+    The ``m3u_accounts`` parameter (enhancedchannelmanager-1qmn0) lets
+    the polling hot path inject a cached accounts list (refreshed on a
+    300s TTL by ``BandwidthTracker._maybe_refresh_m3u_accounts``) so the
+    resolver no longer fetches the heavy ``/api/m3u/accounts/`` payload
+    on every poll. When None (the on-demand ``/api/stats/channels``
+    path), the list is fetched here as before.
+
     The ``channel_streams_cache`` and ``poll_count`` parameters are
     retained as no-op kwargs for back-compat with existing call sites;
     bd-gy5nd no longer issues per-channel HTTP calls so neither cache
@@ -671,17 +679,30 @@ async def resolve_active_channel_streams(
     # on Dispatcharr error we degrade to an empty list — every channel
     # falls back to bare-hostname ``provider_name`` so the operator
     # still sees a meaningful string.
-    m3u_accounts: list[dict] = []
-    try:
-        raw_accounts = await client.get_m3u_accounts()
-        if isinstance(raw_accounts, list):
-            m3u_accounts = raw_accounts
-    except Exception as e:
-        logger.debug(
-            "[STATS_V2] m3u_accounts_fetch_failed error=%s — degrading to "
-            "bare-hostname provider_name (bd-gy5nd)",
-            e,
-        )
+    # enhancedchannelmanager-1qmn0: when the caller supplies a cached
+    # accounts list (the polling hot path via
+    # ``BandwidthTracker._resolve_provider_ids``, which refreshes the
+    # snapshot on a 300s TTL) use it directly and skip the per-call
+    # fetch. When ``m3u_accounts`` is None — the on-demand
+    # ``/api/stats/channels`` endpoint path, which calls this free
+    # function outside the poll loop — fall back to fetching the list
+    # here so that code path keeps working. Degrade-to-empty-list on
+    # error is preserved either way.
+    resolved_accounts: list[dict] = []
+    if m3u_accounts is not None:
+        resolved_accounts = m3u_accounts
+    else:
+        try:
+            raw_accounts = await client.get_m3u_accounts()
+            if isinstance(raw_accounts, list):
+                resolved_accounts = raw_accounts
+        except Exception as e:
+            logger.debug(
+                "[STATS_V2] m3u_accounts_fetch_failed error=%s — degrading to "
+                "bare-hostname provider_name (bd-gy5nd)",
+                e,
+            )
+    m3u_accounts = resolved_accounts
     # Build {account_id: account_name} once for ``provider_name``
     # enrichment on the direct stream-id path.
     m3u_name_by_id: dict[int, str] = {}
@@ -1432,6 +1453,18 @@ class BandwidthTracker:
         self._ecm_channel_number_map: dict[int, str] = {}  # channel_number -> name mapping from ECM
         self._channel_map_refresh_interval = 300  # Refresh channel map every 5 minutes
         self._last_channel_map_refresh = 0.0
+        # M3U accounts snapshot cache (enhancedchannelmanager-1qmn0). The
+        # provider resolver only needs each account's id/name/server_url
+        # to build the {account_id: name} table and to URL-hostname-match
+        # providers — NOT the heavy ~734KB ``channel_groups[]`` payload.
+        # Refreshing the full accounts list every 10s poll was a likely
+        # driver of Dispatcharr's uWSGI worker memory creep, so the list
+        # is cached here and refreshed on the same 300s TTL as the
+        # channel map (time-based only — account ``updated_at`` is an
+        # unreliable refresh signal pending a Dispatcharr-side fix).
+        self._m3u_accounts_cache: list[dict] = []
+        self._m3u_accounts_refresh_interval = 300  # Refresh M3U accounts every 5 minutes
+        self._last_m3u_accounts_refresh = 0.0
         # Enhanced stats tracking (v0.11.0)
         # Maps (channel_id, ip_address) -> connection_id in UniqueClientConnection table
         self._active_connections: dict[tuple[str, str], int] = {}
@@ -1654,6 +1687,11 @@ class BandwidthTracker:
             try:
                 # Refresh channel name map periodically
                 await self._maybe_refresh_channel_map()
+                # Refresh the M3U accounts snapshot periodically
+                # (enhancedchannelmanager-1qmn0) so the provider resolver
+                # reads a cached list instead of re-fetching the heavy
+                # ``/api/m3u/accounts/`` payload every poll.
+                await self._maybe_refresh_m3u_accounts()
                 await self._collect_stats()
             except asyncio.CancelledError:
                 break
@@ -1705,6 +1743,39 @@ class BandwidthTracker:
             logger.debug("[BANDWIDTH] Refreshed channel maps: %s by UUID, %s by number", len(uuid_map), len(number_map))
         except Exception as e:
             logger.debug("[BANDWIDTH] Failed to refresh channel map: %s", e)
+
+    async def _maybe_refresh_m3u_accounts(self):
+        """Refresh the cached M3U accounts snapshot on a 300s TTL.
+
+        enhancedchannelmanager-1qmn0: the provider resolver formerly
+        fetched the full ``/api/m3u/accounts/`` payload (~734KB) on every
+        10s poll, even though it only consumes each account's
+        ``id``/``name``/``server_url``. Mirroring the
+        ``_maybe_refresh_channel_map`` throttle, the list is fetched at
+        most once per ``_m3u_accounts_refresh_interval`` and threaded into
+        ``resolve_active_channel_streams`` via ``_resolve_provider_ids``.
+
+        Best-effort: on a Dispatcharr error we debug-log and keep the
+        prior cache (which may be empty on the very first poll — the
+        resolver degrades gracefully to bare-hostname provider names).
+        Time-based only; account ``updated_at`` is not used as a refresh
+        signal (unreliable; Dispatcharr-side fix pending).
+        """
+        now = time.time()
+        if now - self._last_m3u_accounts_refresh < self._m3u_accounts_refresh_interval:
+            return
+
+        try:
+            raw_accounts = await self.client.get_m3u_accounts()
+            if isinstance(raw_accounts, list):
+                self._m3u_accounts_cache = raw_accounts
+                self._last_m3u_accounts_refresh = now
+                logger.debug(
+                    "[BANDWIDTH] Refreshed M3U accounts snapshot: %s accounts",
+                    len(raw_accounts),
+                )
+        except Exception as e:
+            logger.debug("[BANDWIDTH] Failed to refresh M3U accounts snapshot: %s", e)
 
     async def _collect_stats(self):
         """Fetch stats from Dispatcharr and update daily totals."""
@@ -2438,6 +2509,7 @@ class BandwidthTracker:
             channel_streams_cache=self._provider_cache,
             poll_count=self._poll_count,
             emit_metrics=True,
+            m3u_accounts=self._m3u_accounts_cache,
         )
 
     # ------------------------------------------------------------------

--- a/backend/dispatcharr_client.py
+++ b/backend/dispatcharr_client.py
@@ -484,39 +484,64 @@ class DispatcharrClient:
 
         Returns list of dicts: [{"name": "Group Name", "count": 42}, ...]
 
-        Optimization: Instead of fetching all streams, we get group names first,
-        then query each group with page_size=1 to get just the count from the
-        paginated response. This is much faster than loading all stream data.
+        Source (enhancedchannelmanager-05h8w): the per-group stream count
+        is read from the ``channel_groups[].stream_count`` field embedded
+        in ``GET /api/m3u/accounts/`` (the LIST view seeds a single
+        grouped COUNT per group, including disabled and zero-stream
+        groups) instead of firing one ``?channel_group_name=&page_size=1``
+        probe per group. This issues ZERO ``get_streams`` calls — just the
+        single accounts pull plus the channel-groups id→name lookup.
+
+        Semantics:
+          - ``m3u_account_id`` given → only that account's groups, and
+            groups with count == 0 are dropped.
+          - ``m3u_account_id`` None → ``stream_count`` summed per group
+            name across all accounts.
+        Sorted by name, case-insensitively.
         """
-        # First, get all group names (fast)
-        group_names = await self.get_stream_groups()
+        # id→name map for channel groups (channel_groups[] carries the
+        # numeric channel_group id, not the name).
+        channel_groups = await self.get_channel_groups()
+        name_by_id: dict = {}
+        for group in channel_groups:
+            group_id = group.get("id")
+            group_name = group.get("name")
+            if group_id is not None and group_name:
+                name_by_id[group_id] = group_name
 
-        # For each group, query with page_size=1 to get just the count
-        async def get_group_count(group_name: str) -> dict:
-            try:
-                params = {"channel_group_name": group_name, "page_size": 1}
-                if m3u_account_id is not None:
-                    params["m3u_account"] = m3u_account_id
-                response = await self._request(
-                    "GET",
-                    "/api/channels/streams/",
-                    params=params
-                )
-                response.raise_for_status()
-                data = response.json()
-                return {"name": group_name, "count": data.get("count", 0)}
-            except Exception:
-                return {"name": group_name, "count": 0}
+        accounts = await self.get_m3u_accounts()
 
-        # Fetch counts concurrently for all groups
-        results = await asyncio.gather(*[get_group_count(name) for name in group_names])
+        counts_by_name: dict = {}
+        missing_count_seen = False
+        for account in accounts:
+            if m3u_account_id is not None and account.get("id") != m3u_account_id:
+                continue
+            for acg in account.get("channel_groups", []):
+                group_id = acg.get("channel_group")
+                group_name = name_by_id.get(group_id)
+                if not group_name:
+                    continue
+                if "stream_count" not in acg:
+                    missing_count_seen = True
+                    stream_count = 0
+                else:
+                    stream_count = acg.get("stream_count") or 0
+                counts_by_name[group_name] = counts_by_name.get(group_name, 0) + stream_count
 
-        # Filter out groups with 0 streams when filtering by provider
-        results = list(results)
+        if missing_count_seen:
+            logger.warning(
+                "[DISPATCHARR] get_stream_groups_with_counts: one or more "
+                "channel_groups[] entries lacked a stream_count field; "
+                "treated as 0 (no probing fallback)"
+            )
+
+        results = [{"name": name, "count": count} for name, count in counts_by_name.items()]
+
+        # When filtering by provider, drop groups with 0 streams (matches
+        # the prior probe-based behaviour).
         if m3u_account_id is not None:
             results = [r for r in results if r["count"] > 0]
 
-        # Sort by name
         results.sort(key=lambda x: x["name"].lower())
 
         return results

--- a/backend/m3u_change_detector.py
+++ b/backend/m3u_change_detector.py
@@ -136,6 +136,13 @@ class M3UChangeDetector:
         for group in groups_data:
             group_copy = dict(group)
             group_name = group.get("name")
+            # enhancedchannelmanager-05h8w: persist the authoritative
+            # ``is_stale`` flag (from /api/m3u/accounts/ channel_groups[])
+            # into the snapshot's groups_data JSON blob. Defaulted to
+            # False so legacy current_groups dicts that predate the field
+            # still serialize cleanly. Old persisted snapshots that lack
+            # the key are handled at read time (callers default to False).
+            group_copy["is_stale"] = group.get("is_stale", False)
             if stream_names_by_group and group_name in stream_names_by_group:
                 group_copy["stream_names"] = stream_names_by_group[group_name]
                 groups_with_names += 1

--- a/backend/main.py
+++ b/backend/main.py
@@ -130,7 +130,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.0-0005",
+    version="0.18.0-0006",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.18.0-0005"
+APP_VERSION = "0.18.0-0006"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/tasks/m3u_refresh.py
+++ b/backend/tasks/m3u_refresh.py
@@ -18,11 +18,96 @@ logger = logging.getLogger(__name__)
 POLL_INTERVAL_SECONDS = 5  # How often to check if refresh is complete
 MAX_WAIT_SECONDS = 300  # Maximum time to wait (5 minutes)
 
+# Page size for the bulk stream pull used to build per-group counts/names.
+# Larger pages mean fewer round-trips and a lower burst RPM against Dispatcharr's
+# uWSGI workers (each request costs a COUNT(*) + auth/middleware pass regardless
+# of size). 1000 keeps response sizes/memory modest while halving the pulls vs
+# 500; going much higher risks request timeouts on the largest accounts (bd-iwfr7).
+STREAM_PULL_PAGE_SIZE = 1000
+# Maximum number of stream names captured per group for the snapshot diff.
+MAX_STREAM_NAMES = 500
+
+
+async def get_streams_grouped(
+    api_client,
+    account_id: int,
+    group_lookup: Dict[int, str],
+    enabled_group_names: set,
+) -> tuple[Dict[str, int], Dict[str, list]]:
+    """Pull ALL streams for an M3U account in a single paginated loop and group
+    them client-side by channel group name.
+
+    This replaces both the per-group count probes (one
+    ``GET /api/channels/streams/?page_size=1`` per group) and the per-group
+    paged pulls with a SINGLE paginated ``get_streams(m3u_account=...)`` loop —
+    mirroring the proven pattern in ``auto_creation_engine._fetch_streams``.
+
+    Dispatcharr returns ``channel_group`` as a numeric ID; we resolve it to a
+    name via ``group_lookup`` (built from ``get_channel_groups()``).
+
+    Args:
+        api_client: Dispatcharr client.
+        account_id: M3U account ID to pull streams for.
+        group_lookup: {channel_group_id: group_name} for ALL channel groups.
+        enabled_group_names: Set of group names that are enabled for this
+            account. Stream NAMES are only captured for these groups (parity
+            with the prior behavior); COUNTS are captured for every group.
+
+    Returns:
+        (stream_count_lookup, stream_names_by_group)
+          - stream_count_lookup: {group_name: count} for every group with >=1
+            stream (enabled or not).
+          - stream_names_by_group: {group_name: [names]} for ENABLED groups
+            only, capped at MAX_STREAM_NAMES per group.
+    """
+    stream_count_lookup: Dict[str, int] = {}
+    stream_names_by_group: Dict[str, list] = {}
+
+    page = 1
+    fetched = 0
+    page_count = 0
+    while True:
+        response = await api_client.get_streams(
+            page=page,
+            page_size=STREAM_PULL_PAGE_SIZE,
+            m3u_account=account_id,
+        )
+        page_count += 1
+        results = response.get("results", [])
+        for stream in results:
+            group_id = stream.get("channel_group")
+            group_name = group_lookup.get(group_id)
+            if not group_name:
+                # Stream belongs to a group we don't have a name for; skip it
+                # (parity with prior code, which only counted known groups).
+                continue
+            stream_count_lookup[group_name] = stream_count_lookup.get(group_name, 0) + 1
+            # Capture names only for enabled groups, capped per group.
+            if group_name in enabled_group_names:
+                names = stream_names_by_group.setdefault(group_name, [])
+                if len(names) < MAX_STREAM_NAMES:
+                    names.append(stream.get("name", ""))
+
+        fetched += len(results)
+        total = response.get("count", 0)
+        if fetched >= total or not results:
+            break
+        page += 1
+
+    logger.debug(
+        "[M3U-CHANGE] Bulk stream pull for account %s: %s streams over %s page(s), "
+        "%s groups with streams, %s enabled groups with names",
+        account_id, fetched, page_count, len(stream_count_lookup), len(stream_names_by_group),
+    )
+    return stream_count_lookup, stream_names_by_group
+
 
 async def capture_m3u_changes(
     account_id: int,
     account_name: str,
     dispatcharr_updated_at: Optional[str] = None,
+    account_data: Optional[Dict] = None,
+    all_channel_groups: Optional[list] = None,
 ) -> Optional[Dict]:
     """
     Capture M3U state changes after a refresh.
@@ -40,6 +125,11 @@ async def capture_m3u_changes(
         account_id: The M3U account ID
         account_name: The account name (for logging)
         dispatcharr_updated_at: Dispatcharr's updated_at timestamp (for change monitoring)
+        account_data: Pre-fetched M3U account dict (from get_m3u_account). When
+            None, it is fetched here. Lets a caller that already has the account
+            (e.g. the refresh task) avoid a redundant fetch.
+        all_channel_groups: Pre-fetched list of all channel groups (from
+            get_channel_groups). When None, it is fetched here. Same rationale.
 
     Returns the change set dict if changes were detected, None otherwise.
     """
@@ -49,50 +139,38 @@ async def capture_m3u_changes(
     api_client = get_client()
 
     try:
-        # Get the M3U account - channel_groups contains ALL groups from this M3U source
-        account_data = await api_client.get_m3u_account(account_id)
+        # Get the M3U account - channel_groups contains ALL groups from this M3U source.
+        # Prefer caller-supplied data to avoid redundant fetches within a refresh run;
+        # fall back to fetching when called standalone (e.g. from the change monitor).
+        if account_data is None:
+            account_data = await api_client.get_m3u_account(account_id)
         account_channel_groups = account_data.get("channel_groups", [])
 
         # Get all channel groups to build ID -> name mapping
-        all_channel_groups = await api_client.get_channel_groups()
+        if all_channel_groups is None:
+            all_channel_groups = await api_client.get_channel_groups()
         group_lookup = {
             g["id"]: g["name"]
             for g in all_channel_groups
         }
 
-        # Get actual stream counts (only available for enabled groups with imported streams)
-        stream_counts = await api_client.get_stream_groups_with_counts(m3u_account_id=account_id)
-        stream_count_lookup = {
-            g["name"]: g["count"]
-            for g in stream_counts
-        }
-
-        # Build list of enabled group names to fetch stream names for
-        enabled_group_names = []
+        # Build set of enabled group names (stream names are only captured for these).
+        enabled_group_names = set()
         for acg in account_channel_groups:
             group_id = acg.get("channel_group")
             if group_id and group_id in group_lookup and acg.get("enabled", False):
-                enabled_group_names.append(group_lookup[group_id])
+                enabled_group_names.add(group_lookup[group_id])
 
-        # Fetch stream names for enabled groups (limit to first 50 per group)
-        stream_names_by_group = {}
-        MAX_STREAM_NAMES = 500
-        logger.info("[M3U-CHANGE] Fetching stream names for %s enabled groups: %s%s", len(enabled_group_names), enabled_group_names[:5], "..." if len(enabled_group_names) > 5 else "")
-        for group_name in enabled_group_names:
-            try:
-                streams_response = await api_client.get_streams(
-                    page=1,
-                    page_size=MAX_STREAM_NAMES,
-                    channel_group_name=group_name,
-                    m3u_account=account_id,
-                )
-                results = streams_response.get("results", [])
-                stream_names = [s.get("name", "") for s in results]
-                logger.debug("[M3U-CHANGE] Group '%s': got %s streams, %s names", group_name, len(results), len(stream_names))
-                if stream_names:
-                    stream_names_by_group[group_name] = stream_names
-            except Exception as e:
-                logger.warning("[M3U-CHANGE] Could not fetch streams for group '%s': %s", group_name, e)
+        # Single bulk paginated pull replaces BOTH the per-group count probes
+        # (get_stream_groups_with_counts) AND the per-group get_streams loop.
+        # Counts come from every group; names only for enabled groups (capped).
+        logger.info(
+            "[M3U-CHANGE] Bulk-pulling streams for account %s (%s): %s enabled groups",
+            account_id, account_name, len(enabled_group_names),
+        )
+        stream_count_lookup, stream_names_by_group = await get_streams_grouped(
+            api_client, account_id, group_lookup, enabled_group_names
+        )
 
         logger.info("[M3U-CHANGE] Captured stream names for %s groups", len(stream_names_by_group))
 
@@ -104,13 +182,21 @@ async def capture_m3u_changes(
             group_id = acg.get("channel_group")
             if group_id and group_id in group_lookup:
                 group_name = group_lookup[group_id]
-                # Get stream count if available (only for enabled groups), otherwise 0
+                # Get stream count if available (only for enabled groups), otherwise 0.
+                # NOTE (enhancedchannelmanager-05h8w): stream_count MUST stay
+                # sourced from the post-refresh bulk pull (stream_count_lookup
+                # from get_streams_grouped). The start-of-run accounts list is
+                # PRE-refresh (stale counts) and detail-endpoint count seeding
+                # is unconfirmed — only ``enabled``/``is_stale`` are taken from
+                # channel_groups[], which are authoritative.
                 stream_count = stream_count_lookup.get(group_name, 0)
                 enabled = acg.get("enabled", False)
+                is_stale = acg.get("is_stale", False)
                 current_groups.append({
                     "name": group_name,
                     "stream_count": stream_count,
                     "enabled": enabled,
+                    "is_stale": is_stale,
                 })
                 total_streams += stream_count
 
@@ -237,6 +323,20 @@ class M3URefreshTask(TaskScheduler):
                 status="refreshing",
             )
 
+            # Fetch the channel-group list ONCE for the whole run instead of
+            # re-fetching it inside capture_m3u_changes per account. Channel
+            # groups are a slow-changing read; group membership relevant to the
+            # diff comes from each account's own channel_groups (fetched fresh
+            # per account below), so a single list snapshot here is safe.
+            try:
+                all_channel_groups = await client.get_channel_groups()
+            except Exception as e:
+                logger.warning(
+                    "[%s] Could not pre-fetch channel groups, capture will fetch per-account: %s",
+                    self.task_id, e,
+                )
+                all_channel_groups = None
+
             # Refresh each account
             success_count = 0
             failed_count = 0
@@ -262,10 +362,23 @@ class M3URefreshTask(TaskScheduler):
                     logger.info("[%s] Triggering M3U refresh for: %s", self.task_id, account_name)
                     await client.refresh_m3u_account(account_id)
 
-                    # Poll until refresh completes or timeout
+                    # Poll until refresh completes or timeout.
+                    #
+                    # Track WHY we stopped polling so we can gate the expensive
+                    # capture sweep:
+                    #   - timestamp_moved=True  -> positive evidence of a content
+                    #     change; capture.
+                    #   - assumed_complete=True -> the 30s fallback fired because
+                    #     Dispatcharr exposed no usable timestamp; we have NO
+                    #     definitive "no change" signal, so we MUST still capture.
+                    #   - neither -> timestamp existed and never moved == definitive
+                    #     no-change; skip the sweep.
                     self._set_progress(current_item=f"Waiting for {account_name} to complete...")
                     refresh_complete = False
                     wait_start = datetime.utcnow()
+                    timestamp_moved = False
+                    assumed_complete = False
+                    latest_updated = initial_updated
 
                     while not refresh_complete and not self._cancel_requested:
                         elapsed = (datetime.utcnow() - wait_start).total_seconds()
@@ -278,20 +391,53 @@ class M3URefreshTask(TaskScheduler):
                         # Check if account has been updated
                         current_account = await client.get_m3u_account(account_id)
                         current_updated = current_account.get("updated_at") or current_account.get("last_refresh")
+                        latest_updated = current_updated
 
                         if current_updated and current_updated != initial_updated:
                             refresh_complete = True
+                            timestamp_moved = True
                             wait_duration = (datetime.utcnow() - wait_start).total_seconds()
                             logger.info("[%s] %s refresh complete in %.1fs", self.task_id, account_name, wait_duration)
                         elif elapsed > 30:
                             # After 30 seconds, assume refresh is complete if no timestamp field
-                            # (Dispatcharr might not have updated_at on M3U accounts)
+                            # (Dispatcharr might not have updated_at on M3U accounts).
+                            # This is the UNCERTAIN path: no usable timestamp means we
+                            # cannot prove "no change", so capture must still run.
+                            assumed_complete = True
                             logger.info("[%s] %s - assuming complete after %.0fs", self.task_id, account_name, elapsed)
                             break
 
-                    # Capture M3U changes after successful refresh
-                    self._set_progress(current_item=f"Capturing changes for {account_name}...")
-                    await capture_m3u_changes(account_id, account_name)
+                    # Gate the expensive capture sweep on POSITIVE evidence of a
+                    # change. CRITICAL: never skip when uncertain. We only skip
+                    # when the timestamp existed and definitively did NOT move
+                    # (timestamp_moved is False AND we did not fall back to the
+                    # "assume complete" path AND we saw a real timestamp). Any
+                    # other case (moved, or no usable timestamp signal) captures.
+                    have_definitive_no_change = (
+                        not timestamp_moved
+                        and not assumed_complete
+                        and latest_updated is not None
+                    )
+                    if have_definitive_no_change:
+                        logger.info(
+                            "[%s] %s: updated_at unchanged (%s) - skipping capture sweep",
+                            self.task_id, account_name, latest_updated,
+                        )
+                    else:
+                        # Capture M3U changes after refresh. Pass the freshly
+                        # fetched account + the run-level channel-group list to
+                        # avoid redundant fetches inside capture_m3u_changes.
+                        self._set_progress(current_item=f"Capturing changes for {account_name}...")
+                        capture_account_data = (
+                            current_account if timestamp_moved or assumed_complete else None
+                        )
+                        await capture_m3u_changes(
+                            account_id,
+                            account_name,
+                            dispatcharr_updated_at=latest_updated,
+                            account_data=capture_account_data,
+                            all_channel_groups=all_channel_groups,
+                        )
 
                     success_count += 1
                     refreshed.append(account_name)

--- a/backend/tests/unit/test_bandwidth_tracker_m3u_accounts_cache.py
+++ b/backend/tests/unit/test_bandwidth_tracker_m3u_accounts_cache.py
@@ -1,0 +1,191 @@
+"""Tests for enhancedchannelmanager-1qmn0 — decouple the heavy
+``/api/m3u/accounts/`` fetch from the 10s bandwidth poll.
+
+The provider resolver only needs each account's ``id``/``name``/
+``server_url`` to build the {account_id: name} table and to URL-hostname
+match providers — NOT the ~734KB ``channel_groups[]`` payload. Fetching
+the full accounts list every poll was a likely driver of Dispatcharr
+uWSGI worker memory creep, so ``BandwidthTracker`` now caches the list
+and refreshes it on a 300s TTL (mirroring ``_maybe_refresh_channel_map``)
+and threads the cached snapshot into ``resolve_active_channel_streams``.
+
+These tests pin two contracts:
+
+* ``_maybe_refresh_m3u_accounts`` fetches at most once per TTL window and
+  re-fetches after the TTL boundary elapses.
+* ``resolve_active_channel_streams`` uses a passed-in ``m3u_accounts``
+  list WITHOUT calling ``client.get_m3u_accounts`` and falls back to a
+  fetch when ``m3u_accounts`` is None (the on-demand endpoint path).
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bandwidth_tracker import BandwidthTracker, resolve_active_channel_streams
+
+
+def _make_tracker():
+    client = AsyncMock()
+    return BandwidthTracker(client, poll_interval=10), client
+
+
+@pytest.mark.asyncio
+async def test_refresh_fetches_once_within_ttl_window():
+    """Multiple ``_maybe_refresh_m3u_accounts`` calls inside one TTL
+    window fetch the accounts list from Dispatcharr exactly once."""
+    tracker, client = _make_tracker()
+    client.get_m3u_accounts = AsyncMock(
+        return_value=[{"id": 1, "name": "A", "server_url": "http://a/list.m3u"}]
+    )
+
+    # Pin time to a fixed instant well past the 0.0 init so the first
+    # call refreshes, and every subsequent call within the window is a
+    # no-op.
+    with patch("bandwidth_tracker.time.time", return_value=1000.0):
+        await tracker._maybe_refresh_m3u_accounts()
+        await tracker._maybe_refresh_m3u_accounts()
+        await tracker._maybe_refresh_m3u_accounts()
+
+    assert client.get_m3u_accounts.await_count == 1
+    assert tracker._m3u_accounts_cache == [
+        {"id": 1, "name": "A", "server_url": "http://a/list.m3u"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refresh_refetches_after_ttl_boundary():
+    """Advancing ``time.time`` past the 300s TTL boundary triggers a
+    second fetch; calls before the boundary do not."""
+    tracker, client = _make_tracker()
+    client.get_m3u_accounts = AsyncMock(
+        side_effect=[
+            [{"id": 1, "name": "first"}],
+            [{"id": 2, "name": "second"}],
+        ]
+    )
+
+    # First refresh at t=1000.
+    with patch("bandwidth_tracker.time.time", return_value=1000.0):
+        await tracker._maybe_refresh_m3u_accounts()
+    assert client.get_m3u_accounts.await_count == 1
+
+    # Still inside the 300s window — no refetch.
+    with patch("bandwidth_tracker.time.time", return_value=1000.0 + 299):
+        await tracker._maybe_refresh_m3u_accounts()
+    assert client.get_m3u_accounts.await_count == 1
+    assert tracker._m3u_accounts_cache == [{"id": 1, "name": "first"}]
+
+    # Past the boundary — refetch and replace the cache.
+    with patch("bandwidth_tracker.time.time", return_value=1000.0 + 301):
+        await tracker._maybe_refresh_m3u_accounts()
+    assert client.get_m3u_accounts.await_count == 2
+    assert tracker._m3u_accounts_cache == [{"id": 2, "name": "second"}]
+
+
+@pytest.mark.asyncio
+async def test_refresh_keeps_prior_cache_on_error():
+    """A Dispatcharr error during refresh is best-effort: the prior
+    cache is retained and the TTL timestamp is NOT advanced (so the next
+    poll retries)."""
+    tracker, client = _make_tracker()
+    tracker._m3u_accounts_cache = [{"id": 9, "name": "prior"}]
+    client.get_m3u_accounts = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with patch("bandwidth_tracker.time.time", return_value=1000.0):
+        await tracker._maybe_refresh_m3u_accounts()
+
+    assert tracker._m3u_accounts_cache == [{"id": 9, "name": "prior"}]
+    assert tracker._last_m3u_accounts_refresh == 0.0
+
+
+@pytest.mark.asyncio
+async def test_resolver_uses_passed_in_accounts_without_fetch():
+    """When ``m3u_accounts`` is supplied, the resolver never calls
+    ``client.get_m3u_accounts`` and uses the provided list for provider
+    enrichment / hostname matching."""
+    client = AsyncMock()
+    client.get_m3u_accounts = AsyncMock(return_value=[])
+
+    snapshot = [
+        {
+            "channel_uuid": "u1",
+            "stream_id": None,
+            "url": "https://infinity.gives/live/85796.ts",
+        }
+    ]
+    accounts = [
+        {"id": 6, "name": "Infinity TV", "server_url": "https://infinity.gives/list.m3u"}
+    ]
+
+    result = await resolve_active_channel_streams(
+        client,
+        snapshot,
+        emit_metrics=False,
+        m3u_accounts=accounts,
+    )
+
+    client.get_m3u_accounts.assert_not_awaited()
+    # Hostname match resolved the provider name from the passed-in list.
+    assert result["u1"].provider_name == "Infinity TV"
+    assert result["u1"].provider_id == 6
+
+
+@pytest.mark.asyncio
+async def test_resolver_falls_back_to_fetch_when_accounts_none():
+    """When ``m3u_accounts`` is None (the on-demand endpoint path), the
+    resolver fetches the accounts list itself — preserving that code
+    path."""
+    client = AsyncMock()
+    client.get_m3u_accounts = AsyncMock(
+        return_value=[
+            {"id": 6, "name": "Infinity TV", "server_url": "https://infinity.gives/x.m3u"}
+        ]
+    )
+
+    snapshot = [
+        {
+            "channel_uuid": "u1",
+            "stream_id": None,
+            "url": "https://infinity.gives/live/85796.ts",
+        }
+    ]
+
+    result = await resolve_active_channel_streams(
+        client,
+        snapshot,
+        emit_metrics=False,
+        m3u_accounts=None,
+    )
+
+    client.get_m3u_accounts.assert_awaited_once()
+    assert result["u1"].provider_name == "Infinity TV"
+    assert result["u1"].provider_id == 6
+
+
+@pytest.mark.asyncio
+async def test_resolver_empty_passed_list_degrades_to_bare_hostname():
+    """An empty passed-in list (cache not yet warmed) degrades to the
+    bare-hostname provider_name without fetching."""
+    client = AsyncMock()
+    client.get_m3u_accounts = AsyncMock(return_value=[])
+
+    snapshot = [
+        {
+            "channel_uuid": "u1",
+            "stream_id": None,
+            "url": "https://infinity.gives/live/85796.ts",
+        }
+    ]
+
+    result = await resolve_active_channel_streams(
+        client,
+        snapshot,
+        emit_metrics=False,
+        m3u_accounts=[],
+    )
+
+    client.get_m3u_accounts.assert_not_awaited()
+    assert result["u1"].provider_name == "infinity.gives"
+    assert result["u1"].provider_id is None

--- a/backend/tests/unit/test_bandwidth_tracker_session_telemetry.py
+++ b/backend/tests/unit/test_bandwidth_tracker_session_telemetry.py
@@ -185,7 +185,15 @@ async def _drive_two_polls(tracker, mock_client, first_payload, second_payload):
     byte delta and the ``_active_connections`` map is populated (the first
     poll opens connections, the second poll counts as ``still_active`` and
     is what the telemetry helper observes).
+
+    enhancedchannelmanager-1qmn0: the provider resolver no longer fetches
+    ``/api/m3u/accounts/`` inside ``_collect_stats``; the tracker caches
+    the accounts list and refreshes it on a 300s TTL via
+    ``_maybe_refresh_m3u_accounts`` (called from ``_poll_loop`` in
+    production). Prime that cache here so the resolver sees the configured
+    accounts, mirroring the real poll loop.
     """
+    await tracker._maybe_refresh_m3u_accounts()
     mock_client.get_channel_stats.return_value = {"channels": [first_payload]}
     await tracker._collect_stats()
     mock_client.get_channel_stats.return_value = {"channels": [second_payload]}
@@ -1484,17 +1492,21 @@ async def test_resolver_url_hostname_match_zero_per_channel_http_calls(
     mock_client,
 ):
     """bd-gy5nd contract: the URL-hostname-match fallback issues ZERO
-    per-channel HTTP calls — it consults the once-per-poll M3U
-    accounts list in memory. Replaces the bd-5g7kx per-channel-streams
-    cache test (which existed because that fallback did one HTTP call
-    per channel and needed cache layers to avoid blowing the
-    Dispatcharr budget). bd-gy5nd issues one ``get_m3u_accounts`` call
-    per poll regardless of how many channels need the hostname match.
+    per-channel HTTP calls — it consults the cached M3U accounts list in
+    memory. Replaces the bd-5g7kx per-channel-streams cache test (which
+    existed because that fallback did one HTTP call per channel and
+    needed cache layers to avoid blowing the Dispatcharr budget).
+
+    enhancedchannelmanager-1qmn0: the accounts list is now refreshed on
+    the tracker's 300s TTL (primed once here) rather than fetched inside
+    each poll, so two polls within one TTL window issue exactly ONE
+    ``get_m3u_accounts`` call regardless of how many channels need the
+    hostname match.
 
     Two channels with different uuids both fall through to the
     hostname-match path; assert ``get_channel_streams`` is never
     called (the broken endpoint) and ``get_m3u_accounts`` is called
-    exactly once per poll.
+    once for the TTL-window refresh.
     """
     channel_uuid_a = "uuid-a"
     channel_uuid_b = "uuid-b"
@@ -1539,6 +1551,10 @@ async def test_resolver_url_hostname_match_zero_per_channel_http_calls(
         url=active_url,
     )
 
+    # enhancedchannelmanager-1qmn0: prime the TTL-gated accounts cache
+    # (what _poll_loop does in production) so the resolver reads the
+    # cached snapshot instead of fetching per poll.
+    await tracker._maybe_refresh_m3u_accounts()
     mock_client.get_channel_stats.return_value = {
         "channels": [ch_a_first, ch_b_first]
     }
@@ -1553,24 +1569,29 @@ async def test_resolver_url_hostname_match_zero_per_channel_http_calls(
         "get_channel_streams must not be called with proxy-session UUIDs — "
         "the endpoint returns SPA HTML for that identifier shape"
     )
-    # One M3U accounts fetch per poll, regardless of channel count.
-    assert mock_client.get_m3u_accounts.call_count == 2, (
-        "expected one get_m3u_accounts call per poll (2 polls = 2 calls), got %d"
+    # enhancedchannelmanager-1qmn0: one M3U accounts fetch for the TTL
+    # window (the primed refresh), regardless of poll/channel count.
+    assert mock_client.get_m3u_accounts.call_count == 1, (
+        "expected one get_m3u_accounts call for the TTL window, got %d"
         % mock_client.get_m3u_accounts.call_count
     )
 
 
 @pytest.mark.asyncio
-async def test_resolver_url_hostname_match_per_poll_fetch(
+async def test_resolver_url_hostname_match_uses_ttl_cached_accounts(
     patched_session_local,
     seed_synthetic_user,
     tracker,
     mock_client,
 ):
-    """bd-gy5nd: the M3U accounts list is fetched once per poll (not
-    cached cross-poll). The polling cycle is 10s so freshness is built
-    in — a freshly-added M3U account becomes visible to the resolver
-    on the next poll without bespoke invalidation logic.
+    """enhancedchannelmanager-1qmn0: the M3U accounts list is NO LONGER
+    fetched inside the resolver on every poll. It is refreshed on the
+    tracker's 300s TTL (``_maybe_refresh_m3u_accounts``, primed here once
+    via ``_drive_two_polls``) and the resolver reads the cached snapshot.
+    Two polls within one TTL window therefore issue exactly ONE
+    ``get_m3u_accounts`` call, and the provider still resolves from the
+    cache. (Was bd-gy5nd's ``per_poll_fetch``; 1qmn0 inverts the per-poll
+    contract to eliminate the ~734KB-per-poll fetch.)
     """
     channel_uuid = "stable-channel"
     active_url = "https://infinity.gives/live/mot/16118141/85796.ts"
@@ -1598,8 +1619,9 @@ async def test_resolver_url_hostname_match_per_poll_fetch(
 
     await _drive_two_polls(tracker, mock_client, first, second)
 
-    # 2 polls = 2 get_m3u_accounts calls. No per-channel HTTP fan-out.
-    assert mock_client.get_m3u_accounts.call_count == 2
+    # 2 polls within one TTL window = ONE get_m3u_accounts call (the
+    # primed refresh). No per-channel HTTP fan-out.
+    assert mock_client.get_m3u_accounts.call_count == 1
     assert mock_client.get_channel_streams.call_count == 0
 
     session = patched_session_local()
@@ -1869,6 +1891,10 @@ async def test_resolver_three_paths_resolve_in_one_poll(
         ),
     ]
 
+    # enhancedchannelmanager-1qmn0: prime the TTL-gated accounts cache so
+    # the URL-hostname-match path (ch-fallback) reads the configured
+    # accounts from the cache instead of a per-poll fetch.
+    await tracker._maybe_refresh_m3u_accounts()
     mock_client.get_channel_stats.return_value = {"channels": poll1}
     await tracker._collect_stats()
     mock_client.get_channel_stats.return_value = {"channels": poll2}

--- a/backend/tests/unit/test_dispatcharr_client_group_filter.py
+++ b/backend/tests/unit/test_dispatcharr_client_group_filter.py
@@ -207,3 +207,128 @@ async def test_get_streams_m3u_account_none_omits_param():
         assert "m3u_account" not in params
     finally:
         await client._client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# enhancedchannelmanager-05h8w: get_stream_groups_with_counts reads
+# channel_groups[].stream_count from /api/m3u/accounts/ — ZERO per-group
+# probes.
+# ---------------------------------------------------------------------------
+
+_MIXED_ACCOUNTS = [
+    {
+        "id": 1,
+        "name": "Provider A",
+        "channel_groups": [
+            {"channel_group": 10, "enabled": True, "stream_count": 50},
+            {"channel_group": 20, "enabled": False, "stream_count": 0},   # disabled, zero
+            {"channel_group": 30, "enabled": True, "stream_count": 7},
+        ],
+    },
+    {
+        "id": 2,
+        "name": "Provider B",
+        "channel_groups": [
+            {"channel_group": 10, "enabled": True, "stream_count": 12},   # same group, other account
+            {"channel_group": 40, "enabled": True, "stream_count": 3},
+        ],
+    },
+]
+
+_GROUP_NAMES = [
+    {"id": 10, "name": "Sports"},
+    {"id": 20, "name": "Radio"},
+    {"id": 30, "name": "Movies"},
+    {"id": 40, "name": "News"},
+]
+
+
+@pytest.mark.asyncio
+async def test_group_counts_issues_zero_stream_probes():
+    """get_stream_groups_with_counts must NEVER call get_streams — it
+    reads counts from channel_groups[].stream_count."""
+    client = _make_client()
+    try:
+        get_streams_mock = AsyncMock(
+            side_effect=AssertionError("probing path must not be used")
+        )
+        with patch.object(client, "get_channel_groups", AsyncMock(return_value=_GROUP_NAMES)), \
+             patch.object(client, "get_m3u_accounts", AsyncMock(return_value=_MIXED_ACCOUNTS)), \
+             patch.object(client, "get_streams", get_streams_mock):
+            await client.get_stream_groups_with_counts()
+        get_streams_mock.assert_not_called()
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_group_counts_none_sums_across_accounts_sorted():
+    """m3u_account_id None → sum stream_count per group name across all
+    accounts, sorted case-insensitively, zero-count groups retained."""
+    client = _make_client()
+    try:
+        with patch.object(client, "get_channel_groups", AsyncMock(return_value=_GROUP_NAMES)), \
+             patch.object(client, "get_m3u_accounts", AsyncMock(return_value=_MIXED_ACCOUNTS)):
+            result = await client.get_stream_groups_with_counts()
+
+        # Sports = 50 + 12; Movies = 7; News = 3; Radio = 0 (retained, no filter).
+        assert result == [
+            {"name": "Movies", "count": 7},
+            {"name": "News", "count": 3},
+            {"name": "Radio", "count": 0},
+            {"name": "Sports", "count": 62},
+        ]
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_group_counts_account_filter_drops_zero_count():
+    """m3u_account_id given → only that account's groups, with count==0
+    dropped (matches prior probe-based semantics)."""
+    client = _make_client()
+    try:
+        with patch.object(client, "get_channel_groups", AsyncMock(return_value=_GROUP_NAMES)), \
+             patch.object(client, "get_m3u_accounts", AsyncMock(return_value=_MIXED_ACCOUNTS)):
+            result = await client.get_stream_groups_with_counts(m3u_account_id=1)
+
+        # Account 1 only: Sports=50, Radio=0 (dropped), Movies=7.
+        assert result == [
+            {"name": "Movies", "count": 7},
+            {"name": "Sports", "count": 50},
+        ]
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_group_counts_missing_stream_count_treated_as_zero():
+    """A channel_groups[] entry lacking stream_count is treated as 0 —
+    never falls back to probing."""
+    client = _make_client()
+    try:
+        accounts = [
+            {
+                "id": 1,
+                "name": "A",
+                "channel_groups": [
+                    {"channel_group": 10, "enabled": True},  # no stream_count
+                    {"channel_group": 30, "enabled": True, "stream_count": 7},
+                ],
+            }
+        ]
+        get_streams_mock = AsyncMock(
+            side_effect=AssertionError("probing path must not be used")
+        )
+        with patch.object(client, "get_channel_groups", AsyncMock(return_value=_GROUP_NAMES)), \
+             patch.object(client, "get_m3u_accounts", AsyncMock(return_value=accounts)), \
+             patch.object(client, "get_streams", get_streams_mock):
+            result = await client.get_stream_groups_with_counts()
+
+        get_streams_mock.assert_not_called()
+        assert result == [
+            {"name": "Movies", "count": 7},
+            {"name": "Sports", "count": 0},
+        ]
+    finally:
+        await client._client.aclose()

--- a/backend/tests/unit/test_m3u_change_detector.py
+++ b/backend/tests/unit/test_m3u_change_detector.py
@@ -205,6 +205,57 @@ class TestM3UChangeDetector:
         assert len(stored_data["groups"]) == 2
         assert stored_data["groups"][0]["name"] == "Sports"
 
+    def test_create_snapshot_persists_is_stale(self, test_session):
+        """enhancedchannelmanager-05h8w: the authoritative ``is_stale``
+        flag from /api/m3u/accounts/ channel_groups[] survives the
+        groups_data JSON round-trip."""
+        detector = M3UChangeDetector(test_session)
+        groups_data = [
+            {"name": "Sports", "stream_count": 50, "enabled": True, "is_stale": True},
+            {"name": "Movies", "stream_count": 100, "enabled": False, "is_stale": False},
+        ]
+
+        snapshot = detector.create_snapshot(
+            m3u_account_id=1,
+            groups_data=groups_data,
+            total_streams=150,
+        )
+
+        stored = {g["name"]: g for g in snapshot.get_groups_data()["groups"]}
+        assert stored["Sports"]["is_stale"] is True
+        assert stored["Movies"]["is_stale"] is False
+
+    def test_create_snapshot_is_stale_defaults_false(self, test_session):
+        """Legacy current_groups dicts that predate the ``is_stale``
+        field serialize with is_stale defaulting to False."""
+        detector = M3UChangeDetector(test_session)
+        groups_data = [{"name": "Sports", "stream_count": 50, "enabled": True}]
+
+        snapshot = detector.create_snapshot(
+            m3u_account_id=1,
+            groups_data=groups_data,
+            total_streams=50,
+        )
+
+        stored = snapshot.get_groups_data()["groups"]
+        assert stored[0]["is_stale"] is False
+
+    def test_legacy_groups_data_without_is_stale_reads_default_false(self, test_session):
+        """An old persisted snapshot whose groups_data JSON lacks the
+        ``is_stale`` key still parses; callers default to False."""
+        from models import M3USnapshot
+
+        snapshot = M3USnapshot(m3u_account_id=1, total_streams=10)
+        # Simulate a pre-05h8w blob with no is_stale key.
+        snapshot.set_groups_data({"groups": [{"name": "Sports", "stream_count": 10, "enabled": True}]})
+        test_session.add(snapshot)
+        test_session.commit()
+        test_session.refresh(snapshot)
+
+        group = snapshot.get_groups_data()["groups"][0]
+        assert "is_stale" not in group
+        assert group.get("is_stale", False) is False
+
     def test_create_snapshot_with_dispatcharr_timestamp(self, test_session):
         """Test creating snapshot with Dispatcharr's updated_at timestamp."""
         detector = M3UChangeDetector(test_session)

--- a/backend/tests/unit/test_m3u_refresh_api_volume.py
+++ b/backend/tests/unit/test_m3u_refresh_api_volume.py
@@ -1,0 +1,411 @@
+"""
+Unit tests for M3U refresh API-call-volume optimizations (bead iwfr7).
+
+Covers:
+- get_streams_grouped: single bulk paginated pull replaces per-group probes,
+  with correct client-side counting, enabled-only name capture, and the
+  per-group name cap.
+- M3URefreshTask.execute() gating: skip the capture sweep on a definitive
+  "no change" (timestamp existed and never moved), but NEVER skip when the
+  signal is uncertain (timestamp moved, or no usable timestamp -> fallback).
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tasks.m3u_refresh import (
+    get_streams_grouped,
+    capture_m3u_changes,
+    M3URefreshTask,
+    MAX_STREAM_NAMES,
+    STREAM_PULL_PAGE_SIZE,
+)
+
+
+def _paged_streams(rows, page_size=STREAM_PULL_PAGE_SIZE):
+    """Build a fake get_streams side_effect that paginates `rows` like Dispatcharr.
+
+    Returns an async callable matching api_client.get_streams(page=, page_size=, ...).
+    """
+    total = len(rows)
+
+    async def _get_streams(page=1, page_size=page_size, **kwargs):
+        start = (page - 1) * page_size
+        end = start + page_size
+        return {"count": total, "results": rows[start:end]}
+
+    return _get_streams
+
+
+@pytest.mark.asyncio
+async def test_get_streams_grouped_counts_and_names():
+    """Counts cover all groups; names captured only for enabled groups."""
+    # group_lookup: id -> name. 3 groups, one disabled (Movies).
+    group_lookup = {1: "Sports", 2: "News", 3: "Movies"}
+    enabled = {"Sports", "News"}  # Movies disabled
+
+    rows = (
+        [{"channel_group": 1, "name": f"Sports {i}"} for i in range(3)]
+        + [{"channel_group": 2, "name": f"News {i}"} for i in range(2)]
+        + [{"channel_group": 3, "name": f"Movie {i}"} for i in range(4)]
+    )
+
+    client = MagicMock()
+    client.get_streams = AsyncMock(side_effect=_paged_streams(rows))
+
+    counts, names = await get_streams_grouped(client, 7, group_lookup, enabled)
+
+    # Counts: every group with streams, enabled or not.
+    assert counts == {"Sports": 3, "News": 2, "Movies": 4}
+    # Names: only enabled groups.
+    assert set(names.keys()) == {"Sports", "News"}
+    assert names["Sports"] == ["Sports 0", "Sports 1", "Sports 2"]
+    assert names["News"] == ["News 0", "News 1"]
+    assert "Movies" not in names
+
+
+@pytest.mark.asyncio
+async def test_get_streams_grouped_is_single_paginated_pull_not_per_group():
+    """One paginated loop, NOT one call per group: 9 rows / page_size>9 == 1 call."""
+    group_lookup = {1: "A", 2: "B", 3: "C"}
+    enabled = {"A", "B", "C"}
+    rows = [{"channel_group": (i % 3) + 1, "name": f"s{i}"} for i in range(9)]
+
+    client = MagicMock()
+    client.get_streams = AsyncMock(side_effect=_paged_streams(rows))
+
+    await get_streams_grouped(client, 1, group_lookup, enabled)
+
+    # All 9 rows fit in one page (page_size=500), so exactly ONE get_streams call.
+    assert client.get_streams.call_count == 1
+    # And it must NOT be a per-group call (no channel_group_name filter).
+    _, kwargs = client.get_streams.call_args
+    assert "channel_group_name" not in kwargs
+    assert kwargs["m3u_account"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_streams_grouped_paginates_when_over_page_size():
+    """A group with > page_size streams is pulled across multiple pages and the
+    name list is capped at MAX_STREAM_NAMES."""
+    group_lookup = {1: "Big"}
+    enabled = {"Big"}
+    n = STREAM_PULL_PAGE_SIZE + 250  # forces a second page
+    rows = [{"channel_group": 1, "name": f"s{i}"} for i in range(n)]
+
+    client = MagicMock()
+    client.get_streams = AsyncMock(side_effect=_paged_streams(rows))
+
+    counts, names = await get_streams_grouped(client, 1, group_lookup, enabled)
+
+    # Count reflects ALL rows.
+    assert counts["Big"] == n
+    # Two pages were needed.
+    assert client.get_streams.call_count == 2
+    # Names capped at MAX_STREAM_NAMES.
+    assert len(names["Big"]) == MAX_STREAM_NAMES
+
+
+@pytest.mark.asyncio
+async def test_get_streams_grouped_skips_unknown_group_ids():
+    """Streams whose channel_group isn't in group_lookup are ignored (parity)."""
+    group_lookup = {1: "Known"}
+    enabled = {"Known"}
+    rows = [
+        {"channel_group": 1, "name": "a"},
+        {"channel_group": 999, "name": "orphan"},  # unknown group id
+    ]
+    client = MagicMock()
+    client.get_streams = AsyncMock(side_effect=_paged_streams(rows))
+
+    counts, names = await get_streams_grouped(client, 1, group_lookup, enabled)
+
+    assert counts == {"Known": 1}
+    assert names == {"Known": ["a"]}
+
+
+@pytest.mark.asyncio
+async def test_capture_m3u_changes_uses_bulk_pull_not_count_probes():
+    """capture_m3u_changes must NOT call get_stream_groups_with_counts and must
+    issue a bounded number of get_streams calls (one paginated loop)."""
+    account_data = {
+        "channel_groups": [
+            {"channel_group": 1, "enabled": True},
+            {"channel_group": 2, "enabled": False},
+        ]
+    }
+    all_groups = [{"id": 1, "name": "Sports"}, {"id": 2, "name": "Movies"}]
+    rows = (
+        [{"channel_group": 1, "name": f"sp{i}"} for i in range(3)]
+        + [{"channel_group": 2, "name": f"mv{i}"} for i in range(5)]
+    )
+
+    client = MagicMock()
+    client.get_streams = AsyncMock(side_effect=_paged_streams(rows))
+    client.get_stream_groups_with_counts = AsyncMock(
+        side_effect=AssertionError("count-probe path must not be used")
+    )
+
+    detector = MagicMock()
+    change_set = MagicMock()
+    change_set.has_changes = False
+    detector.detect_changes.return_value = change_set
+
+    fake_db = MagicMock()
+
+    with patch("tasks.m3u_refresh.get_client", return_value=client), \
+         patch("database.get_session", return_value=fake_db), \
+         patch("m3u_change_detector.M3UChangeDetector", return_value=detector):
+        await capture_m3u_changes(
+            account_id=7,
+            account_name="Prov",
+            account_data=account_data,
+            all_channel_groups=all_groups,
+        )
+
+    # No count-probe call happened (AsyncMock side_effect would have raised).
+    client.get_stream_groups_with_counts.assert_not_called()
+    # Single paginated pull (8 rows < page_size) == 1 get_streams call.
+    assert client.get_streams.call_count == 1
+
+    # Contract to detect_changes: counts for ALL groups, names for ENABLED only.
+    _, kwargs = detector.detect_changes.call_args
+    groups = {g["name"]: g for g in kwargs["current_groups"]}
+    assert groups["Sports"]["stream_count"] == 3
+    assert groups["Movies"]["stream_count"] == 5
+    assert kwargs["current_total_streams"] == 8
+    assert set(kwargs["stream_names_by_group"].keys()) == {"Sports"}
+
+
+@pytest.mark.asyncio
+async def test_capture_m3u_changes_captures_is_stale_and_enabled_from_channel_groups():
+    """enhancedchannelmanager-05h8w: capture_m3u_changes pulls the
+    authoritative ``enabled`` + ``is_stale`` flags from channel_groups[]
+    into current_groups, while stream_count stays sourced from the
+    post-refresh bulk pull (NOT from channel_groups[])."""
+    account_data = {
+        "channel_groups": [
+            # channel_groups[] carries a stream_count that MUST be ignored
+            # for the count field (bulk pull is authoritative) but enabled
+            # + is_stale ARE taken from here.
+            {"channel_group": 1, "enabled": True, "is_stale": False, "stream_count": 999},
+            {"channel_group": 2, "enabled": False, "is_stale": True, "stream_count": 999},
+        ]
+    }
+    all_groups = [{"id": 1, "name": "Sports"}, {"id": 2, "name": "Movies"}]
+    rows = (
+        [{"channel_group": 1, "name": f"sp{i}"} for i in range(3)]
+        + [{"channel_group": 2, "name": f"mv{i}"} for i in range(5)]
+    )
+
+    client = MagicMock()
+    client.get_streams = AsyncMock(side_effect=_paged_streams(rows))
+
+    detector = MagicMock()
+    change_set = MagicMock()
+    change_set.has_changes = False
+    detector.detect_changes.return_value = change_set
+
+    with patch("tasks.m3u_refresh.get_client", return_value=client), \
+         patch("database.get_session", return_value=MagicMock()), \
+         patch("m3u_change_detector.M3UChangeDetector", return_value=detector):
+        await capture_m3u_changes(
+            account_id=7,
+            account_name="Prov",
+            account_data=account_data,
+            all_channel_groups=all_groups,
+        )
+
+    _, kwargs = detector.detect_changes.call_args
+    groups = {g["name"]: g for g in kwargs["current_groups"]}
+    # enabled + is_stale come from channel_groups[].
+    assert groups["Sports"]["enabled"] is True
+    assert groups["Sports"]["is_stale"] is False
+    assert groups["Movies"]["enabled"] is False
+    assert groups["Movies"]["is_stale"] is True
+    # stream_count stays from the bulk pull, NOT channel_groups[].stream_count (999).
+    assert groups["Sports"]["stream_count"] == 3
+    assert groups["Movies"]["stream_count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_capture_m3u_changes_is_stale_defaults_false_when_absent():
+    """channel_groups[] entries without an is_stale key default to
+    False (backward compatible with older Dispatcharr payloads)."""
+    account_data = {"channel_groups": [{"channel_group": 1, "enabled": True}]}
+    all_groups = [{"id": 1, "name": "Sports"}]
+    rows = [{"channel_group": 1, "name": "sp0"}]
+
+    client = MagicMock()
+    client.get_streams = AsyncMock(side_effect=_paged_streams(rows))
+
+    detector = MagicMock()
+    change_set = MagicMock()
+    change_set.has_changes = False
+    detector.detect_changes.return_value = change_set
+
+    with patch("tasks.m3u_refresh.get_client", return_value=client), \
+         patch("database.get_session", return_value=MagicMock()), \
+         patch("m3u_change_detector.M3UChangeDetector", return_value=detector):
+        await capture_m3u_changes(
+            account_id=7,
+            account_name="Prov",
+            account_data=account_data,
+            all_channel_groups=all_groups,
+        )
+
+    _, kwargs = detector.detect_changes.call_args
+    groups = {g["name"]: g for g in kwargs["current_groups"]}
+    assert groups["Sports"]["is_stale"] is False
+
+
+@pytest.mark.asyncio
+async def test_capture_m3u_changes_fetches_when_no_prefetch_given():
+    """When called standalone (change monitor path) it fetches account + groups."""
+    client = MagicMock()
+    client.get_m3u_account = AsyncMock(return_value={"channel_groups": []})
+    client.get_channel_groups = AsyncMock(return_value=[])
+    client.get_streams = AsyncMock(side_effect=_paged_streams([]))
+
+    detector = MagicMock()
+    cs = MagicMock()
+    cs.has_changes = False
+    detector.detect_changes.return_value = cs
+
+    with patch("tasks.m3u_refresh.get_client", return_value=client), \
+         patch("database.get_session", return_value=MagicMock()), \
+         patch("m3u_change_detector.M3UChangeDetector", return_value=detector):
+        await capture_m3u_changes(account_id=3, account_name="Standalone")
+
+    client.get_m3u_account.assert_awaited_once_with(3)
+    client.get_channel_groups.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: execute() gating on a real change.
+# ---------------------------------------------------------------------------
+
+def _make_task():
+    task = M3URefreshTask()
+    task.account_ids = []
+    task.skip_inactive = True
+    return task
+
+
+async def _run_execute_with_timestamps(initial_ts, polled_ts):
+    """Run execute() against one account whose updated_at goes initial -> polled.
+
+    Returns (capture_mock, captured_kwargs_or_None).
+    """
+    account = {"id": 1, "name": "Prov", "is_active": True}
+
+    client = MagicMock()
+    client.get_m3u_accounts = AsyncMock(return_value=[account])
+    client.get_channel_groups = AsyncMock(return_value=[{"id": 1, "name": "G"}])
+    client.refresh_m3u_account = AsyncMock(return_value=None)
+
+    # get_m3u_account: first call (initial) then poll call (polled).
+    client.get_m3u_account = AsyncMock(side_effect=[
+        {"id": 1, "updated_at": initial_ts, "channel_groups": []},
+        {"id": 1, "updated_at": polled_ts, "channel_groups": []},
+    ])
+
+    capture = AsyncMock(return_value=None)
+
+    # Patch sleep so the poll loop runs instantly. Drive "elapsed" so the 30s
+    # fallback only triggers when we want it to (after the timestamp check).
+    with patch("tasks.m3u_refresh.get_client", return_value=client), \
+         patch("tasks.m3u_refresh.capture_m3u_changes", capture), \
+         patch("tasks.m3u_refresh.POLL_INTERVAL_SECONDS", 0), \
+         patch("tasks.m3u_refresh.asyncio.sleep", new=AsyncMock(return_value=None)), \
+         patch("tasks.auto_creation.run_auto_creation_after_refresh",
+               new=AsyncMock(return_value={})):
+        task = _make_task()
+        await task.execute()
+
+    captured_kwargs = capture.call_args.kwargs if capture.called else None
+    return capture, captured_kwargs
+
+
+@pytest.mark.asyncio
+async def test_execute_captures_when_timestamp_moved():
+    """Positive change evidence (updated_at moved) -> capture runs."""
+    capture, kwargs = await _run_execute_with_timestamps("2026-01-01T00:00:00Z",
+                                                          "2026-01-02T00:00:00Z")
+    assert capture.called
+    # Gating passes the observed (moved) timestamp down for the snapshot.
+    assert kwargs["dispatcharr_updated_at"] == "2026-01-02T00:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_execute_skips_when_timestamp_definitively_unchanged():
+    """Definitive no-change (timestamp existed and never moved) -> skip capture.
+
+    The poll loop sees the same non-null timestamp and eventually times out
+    (we shorten MAX_WAIT so it ends fast). No fallback, real timestamp, no move
+    == definitive no-change.
+    """
+    account = {"id": 1, "name": "Prov", "is_active": True}
+    ts = "2026-01-01T00:00:00Z"
+
+    client = MagicMock()
+    client.get_m3u_accounts = AsyncMock(return_value=[account])
+    client.get_channel_groups = AsyncMock(return_value=[{"id": 1, "name": "G"}])
+    client.refresh_m3u_account = AsyncMock(return_value=None)
+    client.get_m3u_account = AsyncMock(return_value={
+        "id": 1, "updated_at": ts, "channel_groups": []
+    })
+
+    capture = AsyncMock(return_value=None)
+
+    # MAX_WAIT_SECONDS tiny so the unchanged-timestamp loop terminates via
+    # timeout without ever hitting the 30s "assume complete" fallback.
+    with patch("tasks.m3u_refresh.get_client", return_value=client), \
+         patch("tasks.m3u_refresh.capture_m3u_changes", capture), \
+         patch("tasks.m3u_refresh.POLL_INTERVAL_SECONDS", 0), \
+         patch("tasks.m3u_refresh.MAX_WAIT_SECONDS", 0), \
+         patch("tasks.m3u_refresh.asyncio.sleep", new=AsyncMock(return_value=None)), \
+         patch("tasks.auto_creation.run_auto_creation_after_refresh",
+               new=AsyncMock(return_value={})):
+        task = _make_task()
+        await task.execute()
+
+    capture.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_captures_when_no_usable_timestamp_uncertain():
+    """No usable timestamp -> the 30s fallback fires -> uncertain -> MUST capture.
+
+    Never skip when uncertain: an account with no updated_at/last_refresh gives
+    no definitive no-change signal, so capture has to run.
+    """
+    account = {"id": 1, "name": "Prov", "is_active": True}
+
+    client = MagicMock()
+    client.get_m3u_accounts = AsyncMock(return_value=[account])
+    client.get_channel_groups = AsyncMock(return_value=[{"id": 1, "name": "G"}])
+    client.refresh_m3u_account = AsyncMock(return_value=None)
+    # No updated_at / last_refresh anywhere -> latest_updated stays None.
+    client.get_m3u_account = AsyncMock(return_value={"id": 1, "channel_groups": []})
+
+    capture = AsyncMock(return_value=None)
+
+    # Need elapsed > 30 to trip the fallback. We can't fast-forward wall clock,
+    # so patch the fallback threshold path by making elapsed large: patch
+    # datetime in the module is heavy; instead rely on the fact that with no
+    # timestamp the loop only exits via the >30s fallback OR timeout, and either
+    # way latest_updated is None => uncertain => capture. Force a quick timeout.
+    with patch("tasks.m3u_refresh.get_client", return_value=client), \
+         patch("tasks.m3u_refresh.capture_m3u_changes", capture), \
+         patch("tasks.m3u_refresh.POLL_INTERVAL_SECONDS", 0), \
+         patch("tasks.m3u_refresh.MAX_WAIT_SECONDS", 0), \
+         patch("tasks.m3u_refresh.asyncio.sleep", new=AsyncMock(return_value=None)), \
+         patch("tasks.auto_creation.run_auto_creation_after_refresh",
+               new=AsyncMock(return_value={})):
+        task = _make_task()
+        await task.execute()
+
+    # latest_updated is None -> have_definitive_no_change is False -> capture.
+    capture.assert_called()
+    assert capture.call_args.kwargs["dispatcharr_updated_at"] is None

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.0-0005",
+  "version": "0.18.0-0006",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Three connected optimizations of ECM's API call pattern against the Dispatcharr backend, each validated from the Dispatcharr side (nginx access logs + live DB queries).

| Bead | Change |
|---|---|
| **iwfr7** | `capture_m3u_changes` replaces ~1,000 per-group `page_size=1` count probes + per-group paged pulls with ONE bulk per-account `get_streams` loop grouped client-side; `page_size` 500→1000; auto-creation sweep `page_size` 100→1000; capture sweep gated on positive change evidence. |
| **05h8w** | `get_stream_groups_with_counts` reads `channel_groups[].stream_count` from `get_m3u_accounts()` instead of one `?channel_group_name=` probe per group — **zero per-group probes** (also fixes the UI count callers). Authoritative `is_stale` + `enabled` captured from `channel_groups[]` into the snapshot JSON (no migration; legacy snapshots default `is_stale=False`). |
| **1qmn0** | `BandwidthTracker` no longer fetches the ~734 KB `/api/m3u/accounts/` payload every 10s poll — caches the snapshot on a 300s TTL (mirrors `_maybe_refresh_channel_map`), threaded into the provider resolver. On-demand `/api/stats/channels` path keeps its fallback fetch. |

## Impact
- Per-cycle `GET /api/channels/streams/` collapses from **~2,283 → a few dozen**.
- The continuous **734 KB/10s heartbeat** on `/api/m3u/accounts/` (likely driver of Dispatcharr's uWSGI worker memory creep) is **eliminated** (~5.2/min → ~0.2/min).

## Correctness notes
- Refresh-task `stream_count` intentionally stays sourced from the post-refresh bulk pull (the start-of-run accounts list is pre-refresh; detail-endpoint count-seeding is unconfirmed). Only `enabled`/`is_stale` come from `channel_groups[]`.
- Capture sweep never skips when the change signal is uncertain (never miss a real provider change).
- Provider-name labels reflect a new/renamed M3U account within the 300s TTL.

## Testing
- Full backend suite **5,339 passed, 1 skipped** (independently re-run).
- New tests: bulk-pull grouping + sweep gating, zero-probe `get_stream_groups_with_counts`, `is_stale` round-trip + backward-compat, TTL-cached accounts (once-per-window + fallback).
- Deployed to `ecm-ecm-1` and smoke-verified (clean startup; live zero-probe confirmation).

Beads: enhancedchannelmanager-iwfr7, enhancedchannelmanager-05h8w, enhancedchannelmanager-1qmn0

🤖 Generated with [Claude Code](https://claude.com/claude-code)