### PR TITLE
v0.18.0-0007: Fix Streams pane showing empty/disabled groups on first load

### DIFF
--- a/backend/dispatcharr_client.py
+++ b/backend/dispatcharr_client.py
@@ -493,10 +493,14 @@ class DispatcharrClient:
         single accounts pull plus the channel-groups id→name lookup.
 
         Semantics:
-          - ``m3u_account_id`` given → only that account's groups, and
-            groups with count == 0 are dropped.
+          - ``m3u_account_id`` given → only that account's groups.
           - ``m3u_account_id`` None → ``stream_count`` summed per group
             name across all accounts.
+          - In BOTH cases, groups with count == 0 are dropped. This
+            faithfully restores the pre-05h8w "only groups that have
+            streams" universe (enhancedchannelmanager-rmyn7): the
+            all-accounts Streams pane must not surface empty/disabled
+            groups on first load.
         Sorted by name, case-insensitively.
         """
         # id→name map for channel groups (channel_groups[] carries the
@@ -537,10 +541,11 @@ class DispatcharrClient:
 
         results = [{"name": name, "count": count} for name, count in counts_by_name.items()]
 
-        # When filtering by provider, drop groups with 0 streams (matches
-        # the prior probe-based behaviour).
-        if m3u_account_id is not None:
-            results = [r for r in results if r["count"] > 0]
+        # Drop groups with 0 streams in all cases (matches the prior
+        # probe-based behaviour, where the group universe came from groups
+        # that actually had streams). Applies to both the provider-filtered
+        # and the all-accounts paths (enhancedchannelmanager-rmyn7).
+        results = [r for r in results if r["count"] > 0]
 
         results.sort(key=lambda x: x["name"].lower())
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -130,7 +130,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.0-0006",
+    version="0.18.0-0007",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.18.0-0006"
+APP_VERSION = "0.18.0-0007"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/tests/unit/test_dispatcharr_client_group_filter.py
+++ b/backend/tests/unit/test_dispatcharr_client_group_filter.py
@@ -264,20 +264,47 @@ async def test_group_counts_issues_zero_stream_probes():
 @pytest.mark.asyncio
 async def test_group_counts_none_sums_across_accounts_sorted():
     """m3u_account_id None → sum stream_count per group name across all
-    accounts, sorted case-insensitively, zero-count groups retained."""
+    accounts, sorted case-insensitively, zero-count groups dropped.
+
+    The count==0 drop is UNCONDITIONAL (enhancedchannelmanager-rmyn7): it
+    applies to the all-accounts case too, faithfully restoring the
+    pre-05h8w "only groups that have streams" universe. Radio sums to 0
+    across all accounts, so it must be absent."""
     client = _make_client()
     try:
         with patch.object(client, "get_channel_groups", AsyncMock(return_value=_GROUP_NAMES)), \
              patch.object(client, "get_m3u_accounts", AsyncMock(return_value=_MIXED_ACCOUNTS)):
             result = await client.get_stream_groups_with_counts()
 
-        # Sports = 50 + 12; Movies = 7; News = 3; Radio = 0 (retained, no filter).
+        # Sports = 50 + 12; Movies = 7; News = 3; Radio = 0 (dropped).
         assert result == [
             {"name": "Movies", "count": 7},
             {"name": "News", "count": 3},
-            {"name": "Radio", "count": 0},
             {"name": "Sports", "count": 62},
         ]
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_group_counts_none_drops_zero_count_groups():
+    """Regression (enhancedchannelmanager-rmyn7): the all-accounts
+    (m3u_account_id None) result must NOT contain a group whose summed
+    stream_count is 0.
+
+    05h8w only dropped count==0 groups in the provider-filtered branch, so
+    the unfiltered first load of the Channel Manager Streams pane began
+    showing empty/disabled groups (Radio here, disabled & zero). This test
+    fails on the 05h8w code (Radio present) and passes on the fix."""
+    client = _make_client()
+    try:
+        with patch.object(client, "get_channel_groups", AsyncMock(return_value=_GROUP_NAMES)), \
+             patch.object(client, "get_m3u_accounts", AsyncMock(return_value=_MIXED_ACCOUNTS)):
+            result = await client.get_stream_groups_with_counts()
+
+        names = [r["name"] for r in result]
+        assert "Radio" not in names
+        assert all(r["count"] > 0 for r in result)
     finally:
         await client._client.aclose()
 
@@ -304,7 +331,9 @@ async def test_group_counts_account_filter_drops_zero_count():
 @pytest.mark.asyncio
 async def test_group_counts_missing_stream_count_treated_as_zero():
     """A channel_groups[] entry lacking stream_count is treated as 0 —
-    never falls back to probing."""
+    never falls back to probing. A group that only sums to 0 (because its
+    sole entry lacked stream_count) is then dropped by the unconditional
+    count==0 filter (enhancedchannelmanager-rmyn7)."""
     client = _make_client()
     try:
         accounts = [
@@ -312,7 +341,7 @@ async def test_group_counts_missing_stream_count_treated_as_zero():
                 "id": 1,
                 "name": "A",
                 "channel_groups": [
-                    {"channel_group": 10, "enabled": True},  # no stream_count
+                    {"channel_group": 10, "enabled": True},  # no stream_count → 0
                     {"channel_group": 30, "enabled": True, "stream_count": 7},
                 ],
             }
@@ -325,10 +354,11 @@ async def test_group_counts_missing_stream_count_treated_as_zero():
              patch.object(client, "get_streams", get_streams_mock):
             result = await client.get_stream_groups_with_counts()
 
+        # Missing stream_count is treated as 0 (no probe), and the resulting
+        # zero-count Sports group is dropped. Movies (count=7) remains.
         get_streams_mock.assert_not_called()
         assert result == [
             {"name": "Movies", "count": 7},
-            {"name": "Sports", "count": 0},
         ]
     finally:
         await client._client.aclose()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.0-0006",
+  "version": "0.18.0-0007",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Regression fix for a defect introduced by **enhancedchannelmanager-05h8w** (PR #497).

`get_stream_groups_with_counts` now reads `channel_groups[].stream_count` from `/api/m3u/accounts/`, which includes disabled and zero-stream groups. The `count == 0` drop was applied **only** in the provider-filtered branch — so the all-accounts (`m3u_account_id is None`) path, which the Channel Manager **Streams pane hits on first load** before any provider filter, surfaced empty/disabled groups. (The pre-05h8w group universe came from `/api/channels/streams/groups/`, which only lists groups that actually have streams, so empty groups never appeared.)

User-reported symptom: empty groups showed in the Streams pane on first load only; selecting a provider filter "fixed" it (that path already dropped zero-count groups).

## Fix
Make the `count > 0` drop **unconditional** — applied in both the None and provider-filtered paths. Restores the prior behavior: only enabled/populated groups appear.

## Testing
- Full backend suite **5,340 passed, 1 skipped** (independently re-run).
- New regression test `test_group_counts_none_drops_zero_count_groups` — confirmed to fail on the old code, pass on the fix. The test that encoded the buggy "keep zero-count" expectation was corrected; the zero-probe guarantee (`get_streams` never called) is untouched.
- Deployed to `ecm-ecm-1`, clean restart; live smoke: unfiltered call returns 26 groups, all `count > 0`.

Bead: enhancedchannelmanager-rmyn7

🤖 Generated with [Claude Code](https://claude.com/claude-code)