### PR TITLE
Post-renumber: dev to 0.17.6-0000 (v0.18.0 → v0.17.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-## [0.18.0] — 2026-06-16
+## [0.17.5] — 2026-06-16
 
 ### Security
 - **Bumped dependencies to clear known CVEs flagged by the release security scans (bd-3hgrf, build 0008).** The main-targeting CI security scans (`pip-audit`, `npm audit`) — which dev-targeting PRs skip — flagged 16 backend CVEs and a frontend high that had gone latent. Backend: `aiohttp` 3.14.0→3.14.1 (8 CVEs, CVE-2026-54273..54280), `python-multipart` 0.0.27→0.0.32 (3 CVEs), `starlette` 1.0.1→1.3.1 (4 CVEs, CVE-2026-48818/48817/54283/54282 — FastAPI 0.136.1's unbounded `starlette>=0.46.0` pin already permits it, so no FastAPI bump was needed), and `cryptography` 46.0.7→49.0.0 (GHSA-537c-gmf6-5ccf). Frontend: `vite` 8.0.10→8.0.16 (GHSA-fx2h-pf6j-xcff `server.fs.deny` bypass) plus transitive patch bumps via non-`--force` `npm audit fix` (no major bumps). `pip-audit` and `npm audit --audit-level=high` now both report zero; full backend (5340 passed) and frontend (1573 passed) suites stayed green against the bumped versions. (bd-3hgrf, build 0008)

--- a/backend/main.py
+++ b/backend/main.py
@@ -130,7 +130,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.1-0000",
+    version="0.17.6-0000",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.18.1-0000"
+APP_VERSION = "0.17.6-0000"
 
 REDACTED = "***REDACTED***"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.1-0000",
+  "version": "0.17.6-0000",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Aligns `dev` with the v0.18.0→v0.17.5 renumber: reopens the build counter at **0.17.6-0000** and renames the released CHANGELOG section heading `[0.18.0]`→`[0.17.5]`. `0.18.0` is reserved for the DBAS epic (bd-0i2vt). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)