### PR TITLE
v0.17.6-0001: Fix auto-creation OOM + crash-loop, add created-channel cap (GH #473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+- **Auto-creation OOM-killed the container and then crash-looped on every restart (GH #473, bd-sjdsq + bd-exo4j, build 0001).** Two coupled fixes for a persistent outage. **(1) Memory (bd-sjdsq):** the engine accumulated an `execution_log` plus per-stream verbose rule/condition traces in memory for the entire run — O(streams×rules×conditions) — so RSS grew steadily until the kernel OOM-killed the process (reporter recurred even at 32 GiB). `results["execution_log"]` is now a `BoundedExecutionLog` (a `list` subclass, so every append site is governed by construction): non-dry-run runs strip the verbose per-stream trace incrementally and retain at most `MAX_AUTO_CREATION_LOG_ENTRIES` (default 500, settings-overridable) with an aggregate "…N more" summary + a `log_truncated` marker; dry-run keeps the full trace. The run now logs peak RSS and a run-size summary. **(2) Crash loop (bd-exo4j):** a kernel OOM-kill leaves the `AutoCreationExecution` row stuck `status="running"`, and scheduled M3U refresh re-fired `run_on_refresh` auto-creation unconditionally → re-OOM on every restart (doubling RAM didn't help). A startup crash-sentinel now marks orphaned `running` executions `abandoned` (before the scheduler arms) and trips a persisted circuit-breaker that **skips `run_on_refresh` auto-creation until an operator explicitly re-enables it** (`POST /api/auto-creation/reset-circuit-breaker`); a `ECM_DISABLE_RUN_ON_REFRESH=1` env var is a break-glass. Manual "Run Now" is never gated. (GH #473, bd-sjdsq, bd-exo4j, build 0001)
+
+### Added
+- **Per-run created-channel cap for auto-creation — a safety valve against runaway rules (GH #473, bd-h2xnl, build 0001).** An over-broad rule (e.g. one matching per-event PPV/event streams) could expand a lineup from ~186 to 2400+ channels in a single run, the upstream amplifier of the OOM. Auto-creation now soft-aborts a run once it would create more than `MAX_AUTO_CREATED_CHANNELS_PER_RUN` channels (default 500, settings-overridable): it stops creating further channels (already-created channels are left consistent), marks the execution `status="capped"`, and surfaces a non-silent "capped at N of M — review the rule or raise the cap" alert. (GH #473, bd-h2xnl, build 0001)
+
 ## [0.17.5] — 2026-06-16
 
 ### Security

--- a/backend/auto_creation_engine.py
+++ b/backend/auto_creation_engine.py
@@ -13,13 +13,18 @@ import asyncio
 import json
 import logging
 import re
+import resource
 from collections import defaultdict
 from datetime import datetime
 from typing import Optional
 
 import safe_regex
 import journal
-from config import get_settings
+from config import (
+    DEFAULT_MAX_AUTO_CREATED_CHANNELS_PER_RUN,
+    DEFAULT_MAX_AUTO_CREATION_LOG_ENTRIES,
+    get_settings,
+)
 from database import get_session
 from models import (
     AutoCreationRule,
@@ -43,6 +48,104 @@ from auto_creation_executor import (
 
 
 logger = logging.getLogger(__name__)
+
+
+# Keys carrying the verbose per-stream evaluation trace. Dropped from each
+# retained entry on non-dry-run so peak RSS does not scale with
+# streams×rules×conditions (bd-sjdsq). The Rule Analyzer re-evaluates rules
+# itself and does NOT read the persisted execution_log; rollback uses
+# AutoCreationSnapshot/created_entities, not the log — so dropping these is
+# safe. The retained entry still carries stream_id / stream_name and the
+# actions_executed list (which holds created channel entity_ids), so rollback
+# and the per-channel audit trail are intact.
+_VERBOSE_LOG_KEYS = ("rules_evaluated",)
+
+
+class BoundedExecutionLog(list):
+    """A list that bounds the auto-creation execution_log in memory (bd-sjdsq).
+
+    THE SINGLE CHOKEPOINT for execution_log growth. Every
+    ``results["execution_log"].append(...)`` site in the engine and the
+    executor funnels through this ``append`` — a list subclass rather than a
+    helper function so a missed call site is impossible by construction (any
+    append on the object is governed, no matter who holds the reference).
+
+    Two bounds, applied incrementally as entries arrive (NOT a final trim — the
+    reporter's docker-stats showed steady growth, so a final trim is too late):
+
+    1. Verbose-trace stripping (non-dry-run only): the per-stream
+       ``rules_evaluated`` trace — the dominant memory term — is replaced with
+       ``[]`` before the entry is retained. Dry-run keeps the full trace
+       (operator wants it for debugging and a dry-run mutates nothing).
+    2. Entry cap: at most ``cap`` entries are retained. Once the cap is hit,
+       further entries are counted but NOT stored. ``finalize()`` appends a
+       single aggregate summary entry ("…and N more") and sets a
+       ``log_truncated`` marker so the truncation is never silent.
+
+    ``cap <= 0`` disables the cap (entries still get verbose-stripped on
+    non-dry-run). Pass ``verbose=True`` for dry-run.
+    """
+
+    def __init__(self, cap: int = 0, verbose: bool = False):
+        super().__init__()
+        self._cap = cap if cap and cap > 0 else 0
+        self._verbose = verbose
+        self.retained_count = 0
+        self.truncated_count = 0
+        self.truncated = False
+        self._finalized = False
+
+    def append(self, entry):  # noqa: D102 — see class docstring
+        # Strip the verbose per-stream trace on non-dry-run runs. Mutating the
+        # dict in place is fine: it is freshly built at each call site and not
+        # referenced elsewhere after the append.
+        if not self._verbose and isinstance(entry, dict):
+            for key in _VERBOSE_LOG_KEYS:
+                if entry.get(key):
+                    entry[key] = []
+
+        if self._cap and self.retained_count >= self._cap:
+            # At cap — count it, drop it. The summary entry is emitted by
+            # finalize() so we keep peak memory flat regardless of overflow.
+            self.truncated_count += 1
+            if not self.truncated:
+                self.truncated = True
+                logger.warning(
+                    "[AUTO-CREATE] execution_log reached the retention cap (%s "
+                    "entries); further entries are summarized, not stored "
+                    "(bd-sjdsq / GH #473)",
+                    self._cap,
+                )
+            return
+
+        super().append(entry)
+        self.retained_count += 1
+
+    def finalize(self):
+        """Append the aggregate truncation summary once, if truncated."""
+        if self._finalized:
+            return
+        self._finalized = True
+        if self.truncated and self.truncated_count > 0:
+            super().append({
+                "stream_id": None,
+                "stream_name": "[AUTO-CREATE] execution log truncated",
+                "m3u_account_id": None,
+                "log_truncated": True,
+                "rules_evaluated": [],
+                "actions_executed": [{
+                    "type": "log_truncated",
+                    "description": (
+                        f"Execution log capped at {self._cap} entries; "
+                        f"{self.truncated_count} more matched-stream entries were "
+                        f"omitted to bound memory. Raise "
+                        f"max_auto_creation_log_entries in Settings to retain more."
+                    ),
+                    "success": True,
+                    "entity_id": None,
+                    "error": None,
+                }],
+            })
 
 
 class AutoCreationEngine:
@@ -198,7 +301,21 @@ class AutoCreationEngine:
         completed_at = datetime.utcnow()
         execution.completed_at = completed_at
         execution.duration_seconds = (completed_at - started_at).total_seconds()
-        execution.status = "completed"
+        # bd-h2xnl: a capped run is a distinct terminal status so the execution
+        # record (and the UI/alerts that read it) surface "capped at N of M"
+        # rather than masquerading as a clean completion. error_message carries
+        # the would-have-been M so the operator sees the full picture.
+        if results.get("capped"):
+            execution.status = "capped"
+            would = results.get("channels_created", 0) + results.get("cap_would_create", 0)
+            execution.error_message = (
+                f"Created-channel cap reached: created "
+                f"{results.get('channels_created', 0)} of ~{would} matched; "
+                f"{results.get('cap_would_create', 0)} stream(s) not processed. "
+                f"Review the rule or raise max_auto_created_channels_per_run."
+            )
+        else:
+            execution.status = "completed"
         execution.streams_evaluated = results["streams_evaluated"]
         execution.streams_matched = results["streams_matched"]
         execution.channels_created = results["channels_created"]
@@ -1384,10 +1501,29 @@ class AutoCreationEngine:
             "modified_entities": [],
             "dry_run_results": [],
             "conflicts": [],
-            "execution_log": [],
+            # bd-sjdsq: bounded in-memory execution_log. Verbose per-stream
+            # trace is stripped on non-dry-run; dry-run keeps the full trace.
+            # cap <= 0 (operator override) disables the entry cap. Every
+            # append site in the engine + executor funnels through this
+            # object's overridden .append — the single chokepoint.
+            "execution_log": BoundedExecutionLog(
+                cap=(0 if dry_run else max(0, getattr(
+                    settings, "max_auto_creation_log_entries",
+                    DEFAULT_MAX_AUTO_CREATION_LOG_ENTRIES,
+                ))),
+                verbose=dry_run,
+            ),
             "rule_match_counts": {},
             "probe_stream_ids": set(),
-            "streams_probed": 0
+            "streams_probed": 0,
+            # bd-h2xnl / bd-exo4j created-channel cap state. Resolved here so
+            # the Pass 2 soft-abort and the run summary share one value.
+            "channel_cap": max(0, getattr(
+                settings, "max_auto_created_channels_per_run",
+                DEFAULT_MAX_AUTO_CREATED_CHANNELS_PER_RUN,
+            )),
+            "capped": False,
+            "cap_would_create": 0,
         }
 
         # Track which streams have been processed by which rules
@@ -1598,7 +1734,49 @@ class AutoCreationEngine:
         # chokepoint), so it stays consistent with streams_merged no matter which
         # path produced the merge (bd-0emgo.4).
         channels_touched_ids: set = set()
-        for stream, winning_rule, losing_rules, stream_rules_log in sorted_entries:
+        # bd-h2xnl / bd-exo4j created-channel cap (shared safety valve). Checked
+        # at the TOP of each iteration — i.e. between streams, after the prior
+        # stream's actions fully completed and aggregated — so a cap trip can
+        # never leave a half-applied batch. The cap counts channels CREATED this
+        # run (results["channels_created"]); merges/updates do not count toward
+        # it (they don't drive the PPV/event blast radius). Disabled when
+        # channel_cap <= 0 or in dry-run (a dry run mutates nothing).
+        _channel_cap = results.get("channel_cap", 0)
+        _cap_active = bool(_channel_cap) and not dry_run
+        for _idx, (stream, winning_rule, losing_rules, stream_rules_log) in enumerate(sorted_entries):
+            if _cap_active and results["channels_created"] >= _channel_cap:
+                # Soft-abort: stop creating further channels, leave what we have
+                # consistent, record N-of-M for a non-silent surface.
+                remaining = len(sorted_entries) - _idx
+                results["capped"] = True
+                results["cap_would_create"] = remaining
+                logger.warning(
+                    "[AUTO-CREATE] Created-channel cap reached: %s created, "
+                    "stopping with %s matched stream(s) unprocessed (cap=%s). "
+                    "Review the rule or raise max_auto_created_channels_per_run "
+                    "(bd-h2xnl / GH #473).",
+                    results["channels_created"], remaining, _channel_cap,
+                )
+                results["execution_log"].append({
+                    "stream_id": None,
+                    "stream_name": "[AUTO-CREATE] created-channel cap reached",
+                    "m3u_account_id": None,
+                    "rules_evaluated": [],
+                    "actions_executed": [{
+                        "type": "capped",
+                        "description": (
+                            f"Auto-creation capped at {results['channels_created']} "
+                            f"channel(s); {remaining} more matched stream(s) were not "
+                            f"processed. Review the rule or raise the cap "
+                            f"(max_auto_created_channels_per_run={_channel_cap})."
+                        ),
+                        "success": True,
+                        "entity_id": None,
+                        "error": None,
+                    }],
+                })
+                break
+
             # Skip struck-out streams if the winning rule has skip_struck_streams enabled
             if getattr(winning_rule, 'skip_struck_streams', False) and stream.stream_id in self._struck_stream_ids:
                 logger.info("[AUTO-CREATE-ENGINE] Skipping struck stream %r (id=%s) for rule '%s'",
@@ -1925,6 +2103,45 @@ class AutoCreationEngine:
 
             # Clean up non-serializable set before returning
             del results["probe_stream_ids"]
+
+            # bd-sjdsq: finalize the bounded execution_log — appends the single
+            # aggregate "…and N more" summary entry if it truncated.
+            exec_log = results.get("execution_log")
+            if isinstance(exec_log, BoundedExecutionLog):
+                exec_log.finalize()
+                log_retained = exec_log.retained_count
+                log_truncated = exec_log.truncated_count
+                results["execution_log_truncated"] = exec_log.truncated
+            else:  # pragma: no cover — defensive; pipeline always sets the bounded list
+                log_retained = len(exec_log or [])
+                log_truncated = 0
+
+            # bd-sjdsq OBSERVABILITY (SRE hard requirement): a peak-RSS line and
+            # a run-size summary at completion so operators can see whether a run
+            # blew up before it OOM-kills again. INFO level, [AUTO-CREATE] prefix.
+            try:
+                # ru_maxrss is in KiB on Linux.
+                peak_rss_mib = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+                logger.info(
+                    "[AUTO-CREATE] Run peak RSS: %.1f MiB", peak_rss_mib
+                )
+            except Exception as e:  # pragma: no cover — getrusage is best-effort
+                logger.debug("[AUTO-CREATE] Could not read peak RSS: %s", e)
+            logger.info(
+                "[AUTO-CREATE] Run size summary: streams_evaluated=%s "
+                "streams_matched=%s channels_created=%s "
+                "execution_log_retained=%s execution_log_truncated=%s "
+                "capped=%s cap_would_create=%s",
+                results.get("streams_evaluated", 0),
+                results.get("streams_matched", 0),
+                results.get("channels_created", 0),
+                log_retained, log_truncated,
+                results.get("capped", False),
+                results.get("cap_would_create", 0),
+            )
+
+            # Drop the transient cap budget (not part of the API surface).
+            results.pop("channel_cap", None)
 
             return results
         finally:

--- a/backend/config.py
+++ b/backend/config.py
@@ -23,6 +23,27 @@ CONFIG_FILE = CONFIG_DIR / "settings.json"
 
 ALLOWED_URL_SCHEMES = {"http", "https"}
 
+# GH #473 OOM cluster — named, settings-overridable safety-valve defaults.
+#
+# MAX_AUTO_CREATION_LOG_ENTRIES (bd-sjdsq): hard cap on the number of
+# per-stream execution_log entries RETAINED in memory (and therefore
+# serialized to the auto_creation_executions.execution_log TEXT column) for a
+# single non-dry-run pipeline run. The dominant accumulator on a runaway run is
+# this log — it holds the full per-stream rule/condition trace — so bounding it
+# incrementally during the run is what keeps peak RSS flat regardless of how
+# many streams match. Dry-run is exempt (it mutates nothing and the operator
+# wants the full trace for debugging). Default 500.
+#
+# MAX_AUTO_CREATED_CHANNELS_PER_RUN (bd-h2xnl, shared with bd-exo4j as the
+# run-size lever): hard cap on the number of channels a single run will
+# CREATE. When a run reaches it the engine soft-aborts — it stops creating
+# further channels, leaves the already-created channels consistent, marks the
+# execution status='capped', and alerts. This is the systemic safety valve for
+# the PPV/event expansion blast radius (186 -> 2400+); it is NOT the root-cause
+# fix. Default 500.
+DEFAULT_MAX_AUTO_CREATION_LOG_ENTRIES = 500
+DEFAULT_MAX_AUTO_CREATED_CHANNELS_PER_RUN = 500
+
 
 def validate_url_scheme(url: str, field_name: str = "URL") -> None:
     """Validate that a URL uses an allowed scheme (http/https only).
@@ -218,6 +239,22 @@ class DispatcharrSettings(BaseModel):
     # M3USnapshot newest-N precedent (ADR-010 §D7).
     auto_creation_snapshot_days: int = 30  # Age window — prune snapshots older than this many days (by snapshot_time).
     auto_creation_snapshot_max: int = 50  # Count cap — keep at most this many newest snapshots; older ones pruned regardless of age.
+    # GH #473 OOM cluster safety valves (settings-overridable; module defaults
+    # in DEFAULT_MAX_* above). See those constants for the full rationale.
+    # bd-sjdsq: max per-stream execution_log entries retained in memory per
+    # non-dry-run run. Dry-run keeps the full trace. <= 0 disables the cap.
+    max_auto_creation_log_entries: int = DEFAULT_MAX_AUTO_CREATION_LOG_ENTRIES
+    # bd-h2xnl / bd-exo4j: max channels a single run will create before
+    # soft-aborting (status='capped'). <= 0 disables the cap.
+    max_auto_created_channels_per_run: int = DEFAULT_MAX_AUTO_CREATED_CHANNELS_PER_RUN
+    # bd-exo4j circuit breaker (THE breaker, persisted across restarts): when
+    # the startup crash-sentinel abandons a run left 'running' by an OOM
+    # SIGKILL, it sets this flag True. While True, run_auto_creation_after_refresh
+    # SKIPS the auto-fire chain (manual "Run Now" is NOT gated). NEVER
+    # auto-reset — the operator must deliberately clear it via
+    # POST /api/auto-creation/reset-circuit-breaker. Internal bookkeeping, not a
+    # user-facing preference.
+    auto_creation_run_on_refresh_disabled: bool = False
     # M3U change-tracking retention (bd-wehek / bd-f9gd8 DBA spike). Both tables
     # grow with every Dispatcharr upstream change (every 5-min poll if upstream
     # churns): m3u_snapshots stores ~1-10 kB groups_data JSON per row;

--- a/backend/main.py
+++ b/backend/main.py
@@ -130,7 +130,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0000",
+    version="0.17.6-0001",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/auto_creation.py
+++ b/backend/routers/auto_creation.py
@@ -1226,6 +1226,57 @@ async def run_auto_creation_rule(rule_id: int, dry_run: bool = False, _admin=Req
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+@router.get("/circuit-breaker")
+async def get_run_on_refresh_circuit_breaker():
+    """Return the run-on-refresh circuit-breaker state (bd-exo4j / GH #473).
+
+    ``disabled`` True means a previous auto-creation run was abandoned (likely
+    an OOM crash) and the startup crash-sentinel tripped the breaker, so
+    auto-creation will NOT auto-fire after M3U refresh until an operator clears
+    it via ``POST /reset-circuit-breaker``. Manual "Run Now" is never gated.
+    Lets the frontend distinguish auto-disabled from user-disabled.
+    """
+    from config import get_settings
+    settings = get_settings()
+    return {
+        "disabled": bool(getattr(settings, "auto_creation_run_on_refresh_disabled", False)),
+        "reason": "abandoned_run" if getattr(settings, "auto_creation_run_on_refresh_disabled", False) else None,
+    }
+
+
+@router.post("/reset-circuit-breaker")
+async def reset_run_on_refresh_circuit_breaker(_admin=RequireAdminIfEnabled):
+    """Clear the run-on-refresh circuit breaker (bd-exo4j / GH #473).
+
+    A DELIBERATE operator act — re-enables the post-refresh auto-fire chain
+    that the startup crash-sentinel disabled after an abandoned (OOM-killed)
+    run. The breaker NEVER auto-resets on its own, so this endpoint is the only
+    in-band recovery path. Idempotent: clearing an already-clear breaker is a
+    no-op success.
+    """
+    from config import get_settings, save_settings
+    settings = get_settings()
+    was_disabled = bool(getattr(settings, "auto_creation_run_on_refresh_disabled", False))
+    if was_disabled:
+        settings.auto_creation_run_on_refresh_disabled = False
+        save_settings(settings)
+        logger.warning(
+            "[AUTO-CREATE] Run-on-refresh circuit breaker CLEARED by operator — "
+            "auto-creation will auto-fire after M3U refresh again."
+        )
+        try:
+            journal.log_entry(
+                category="auto_creation",
+                action_type="circuit_breaker_reset",
+                entity_name="Auto-Creation",
+                description="Operator cleared the run-on-refresh circuit breaker.",
+                user_initiated=True,
+            )
+        except Exception as e:  # pragma: no cover — journal best-effort
+            logger.warning("[AUTO-CREATE] Failed to journal breaker reset: %s", e)
+    return {"success": True, "was_disabled": was_disabled, "disabled": False}
+
+
 @router.get("/executions")
 async def get_auto_creation_executions(
     limit: int = 50,

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -63,7 +63,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 
 # App version for manifest (imported at call time to avoid circular imports)
 
-APP_VERSION = "0.17.6-0000"
+APP_VERSION = "0.17.6-0001"
 
 REDACTED = "***REDACTED***"
 

--- a/backend/task_engine.py
+++ b/backend/task_engine.py
@@ -26,6 +26,98 @@ DEFAULT_CHECK_INTERVAL = 60  # Check for due tasks every 60 seconds
 MAX_CONCURRENT_TASKS = 3  # Maximum tasks running simultaneously
 
 
+def _abandon_orphaned_auto_creation_executions(session=None) -> int:
+    """bd-exo4j crash-sentinel: reconcile AutoCreationExecution rows orphaned
+    by a hard restart, and trip the circuit breaker if any were found.
+
+    A kernel OOM-kill is a SIGKILL — no Python ``finally`` runs — so an
+    in-flight auto-creation run leaves its ``AutoCreationExecution`` row at
+    ``status='running'`` forever. ``task_engine`` already reconciles stale
+    ``TaskExecution`` rows (``_cleanup_stale_executions``) but NOT
+    ``AutoCreationExecution``; this closes that gap.
+
+    Idempotent: only ``status='running'`` rows are touched (``WHERE`` filter),
+    so ``completed`` / ``failed`` / ``capped`` rows are left alone and a second
+    boot finds nothing to do. The abandoned status is the DISTINCT value
+    ``'abandoned'`` (NOT ``'failed'`` — an OOM crash is operationally different
+    from a rule that errored and we want the UI/alerts to say so).
+
+    When at least one row is abandoned we set the PERSISTED circuit-breaker
+    flag (``auto_creation_run_on_refresh_disabled=True``) so the post-refresh
+    auto-fire chain stays disabled across the restart until the operator
+    deliberately clears it. NEVER auto-resets.
+
+    MUST run before the task scheduler arms — it is called from
+    ``TaskEngine.start()`` ahead of the scheduler loop creation.
+
+    Args:
+        session: optional SQLAlchemy session (tests inject the in-memory one).
+            When None, a fresh session is opened and closed here.
+
+    Returns:
+        Count of rows transitioned 'running' -> 'abandoned'.
+    """
+    from models import AutoCreationExecution
+
+    owns_session = session is None
+    if owns_session:
+        session = get_session()
+    try:
+        abandoned_count = session.query(AutoCreationExecution).filter(
+            AutoCreationExecution.status == "running"
+        ).update({
+            "status": "abandoned",
+            "completed_at": datetime.utcnow(),
+            "error_message": (
+                "Abandoned: run was interrupted by a system restart "
+                "(likely an out-of-memory kill). See GH #473."
+            ),
+        }, synchronize_session=False)
+        session.commit()
+
+        if abandoned_count > 0:
+            logger.warning(
+                "[TASK-ENGINE] Abandoned %s orphaned auto-creation execution(s) "
+                "left 'running' by a hard restart — tripping the run-on-refresh "
+                "circuit breaker (bd-exo4j / GH #473)",
+                abandoned_count,
+            )
+            _trip_run_on_refresh_circuit_breaker()
+
+        return abandoned_count
+    except Exception as e:
+        logger.exception(
+            "[TASK-ENGINE] Failed to reconcile orphaned auto-creation executions: %s", e
+        )
+        return 0
+    finally:
+        if owns_session:
+            session.close()
+
+
+def _trip_run_on_refresh_circuit_breaker() -> None:
+    """Persist the run-on-refresh breaker flag (bd-exo4j).
+
+    Persisted in settings.json so it survives the restart that motivated the
+    breaker. Idempotent — re-tripping an already-tripped breaker is a no-op
+    write. Best-effort: a settings failure is logged but never aborts startup.
+    """
+    try:
+        from config import get_settings, save_settings
+        settings = get_settings()
+        if getattr(settings, "auto_creation_run_on_refresh_disabled", False):
+            return
+        settings.auto_creation_run_on_refresh_disabled = True
+        save_settings(settings)
+        logger.warning(
+            "[TASK-ENGINE] Run-on-refresh circuit breaker TRIPPED — auto-creation "
+            "will NOT auto-fire after M3U refresh until an operator clears it via "
+            "POST /api/auto-creation/reset-circuit-breaker."
+        )
+    except Exception as e:  # pragma: no cover — best-effort, must not block boot
+        logger.warning("[TASK-ENGINE] Failed to trip run-on-refresh circuit breaker: %s", e)
+
+
 def _task_execution_metadata_extra(task_id: str, result: TaskResult) -> dict:
     """Counter-style fields for task alerts (email/Discord), aligned with each task's UI semantics."""
     extra: dict = {}
@@ -146,8 +238,14 @@ class TaskEngine:
         logger.info("[TASK-ENGINE] Starting task execution engine")
         self._running = True
 
-        # Cleanup any stale "running" executions from previous runs
+        # Cleanup any stale "running" executions from previous runs. Runs
+        # BEFORE the scheduler loop arms (below) so a doomed auto-creation run
+        # cannot be re-fired before reconciliation.
         self._cleanup_stale_executions()
+        # bd-exo4j (GH #473): reconcile orphaned AutoCreationExecution rows the
+        # OOM SIGKILL left 'running', and trip the run-on-refresh breaker if
+        # any were found. MUST be before the scheduler loop starts.
+        _abandon_orphaned_auto_creation_executions()
 
         # Initialize registry from database
         registry = get_registry()

--- a/backend/tasks/auto_creation.py
+++ b/backend/tasks/auto_creation.py
@@ -5,14 +5,45 @@ Scheduled task to run the auto-creation pipeline, creating channels
 from streams based on configured rules.
 """
 import logging
+import os
 from datetime import datetime
 from typing import Optional
 
+import journal
+from config import get_settings
 from dispatcharr_client import get_client
 from task_scheduler import TaskScheduler, TaskResult, ScheduleConfig, ScheduleType
 from task_registry import register_task
 
 logger = logging.getLogger(__name__)
+
+
+def _run_on_refresh_suppressed() -> tuple[bool, str]:
+    """bd-exo4j: decide whether the post-refresh auto-fire chain is suppressed.
+
+    Two independent suppressors, checked at run time (the breaker scenario is a
+    container restart, so the state must be read fresh, never cached):
+
+    - ``ECM_DISABLE_RUN_ON_REFRESH`` env var (break-glass): honored regardless
+      of the persisted flag so an operator can stop the chain before the app
+      even reads settings.
+    - ``auto_creation_run_on_refresh_disabled`` persisted setting (THE
+      breaker): set True by the startup crash-sentinel when it abandons a run
+      left 'running' by an OOM SIGKILL. NEVER auto-reset — cleared only by the
+      operator via POST /api/auto-creation/reset-circuit-breaker.
+
+    Returns ``(suppressed, reason)``. ``reason`` is a short machine-stable tag
+    used in the notification/journal text.
+    """
+    env_val = (os.environ.get("ECM_DISABLE_RUN_ON_REFRESH") or "").strip().lower()
+    if env_val in ("1", "true", "yes", "on"):
+        return True, "break_glass_env"
+    try:
+        if get_settings().auto_creation_run_on_refresh_disabled:
+            return True, "circuit_breaker"
+    except Exception as e:  # pragma: no cover — settings must never block the gate
+        logger.warning("[AUTO-CREATION] Failed to read circuit-breaker flag: %s", e)
+    return False, ""
 
 
 @register_task
@@ -224,6 +255,58 @@ async def run_auto_creation_after_refresh(
     from auto_creation_engine import get_auto_creation_engine, init_auto_creation_engine
     from dispatcharr_client import get_client
 
+    # bd-exo4j THE BREAKER: a doomed run (OOM-killed, abandoned by the startup
+    # sentinel) must NOT auto-re-fire on the next scheduled refresh. Gate the
+    # auto-fire chain on the persisted breaker flag and the break-glass env var
+    # BEFORE doing any work. Manual "Run Now" goes through the router's /run
+    # endpoint, NOT this function, so it is deliberately NOT gated here.
+    suppressed, reason = _run_on_refresh_suppressed()
+    if suppressed:
+        logger.warning(
+            "[AUTO-CREATION] run_on_refresh SUPPRESSED (%s) — skipping auto-fire. "
+            "Operator must clear the circuit breaker to re-enable.",
+            reason,
+        )
+        from services.notification_service import create_notification_internal
+        if reason == "circuit_breaker":
+            msg = (
+                "Auto-creation after M3U refresh is DISABLED because a previous run "
+                "was abandoned (likely an out-of-memory crash). Review your rules, "
+                "then re-enable via POST /api/auto-creation/reset-circuit-breaker."
+            )
+        else:
+            msg = (
+                "Auto-creation after M3U refresh is suppressed by the "
+                "ECM_DISABLE_RUN_ON_REFRESH environment break-glass switch."
+            )
+        try:
+            await create_notification_internal(
+                notification_type="warning",
+                title="Auto-Creation: Skipped (run-on-refresh disabled)",
+                message=msg,
+                source="auto_creation",
+                source_id="circuit_breaker",
+                send_alerts=True,
+            )
+        except Exception as e:  # pragma: no cover — notification best-effort
+            logger.warning("[AUTO-CREATION] Failed to emit suppression notification: %s", e)
+        try:
+            journal.log_entry(
+                category="auto_creation",
+                action_type="run_on_refresh_skipped",
+                entity_name="Auto-Creation",
+                description=msg,
+                user_initiated=False,
+            )
+        except Exception as e:  # pragma: no cover — journal best-effort
+            logger.warning("[AUTO-CREATION] Failed to journal suppression: %s", e)
+        return {
+            "success": True,
+            "skipped": True,
+            "reason": reason,
+            "message": "Auto-creation run-on-refresh suppressed",
+        }
+
     # Check if any rules have run_on_refresh enabled
     session = get_session()
     try:
@@ -313,6 +396,23 @@ async def run_auto_creation_after_refresh(
             source_id="m3u_refresh",
             send_alerts=False,
         )
+
+        # bd-h2xnl: a capped run must NOT be silent. Emit a warning alert with
+        # the N-of-M so the operator knows to review the rule or raise the cap.
+        if result.get("capped"):
+            would = created + result.get("cap_would_create", 0)
+            await create_notification_internal(
+                notification_type="warning",
+                title="Auto-Creation: Capped",
+                message=(
+                    f"Auto-creation capped at {created} of ~{would} would-create "
+                    f"channels — review the rule or raise the cap "
+                    f"(max_auto_created_channels_per_run)."
+                ),
+                source="auto_creation",
+                source_id="capped",
+                send_alerts=True,
+            )
 
         return result
 

--- a/backend/tests/unit/test_auto_creation_oom_guards.py
+++ b/backend/tests/unit/test_auto_creation_oom_guards.py
@@ -1,0 +1,275 @@
+"""
+GH #473 OOM cluster — guard tests (bd-sjdsq / bd-exo4j / bd-h2xnl).
+
+Part A (bd-sjdsq): bounded in-memory execution_log.
+  - BoundedExecutionLog caps retained entries at N (not 2N) for non-dry-run.
+  - Verbose per-stream trace (rules_evaluated) is stripped for non-dry-run,
+    retained for dry-run.
+  - On truncation a marker + aggregate summary entry is present.
+
+Part B (bd-exo4j): crash-loop guard.
+  - Startup crash-sentinel marks status='running' AutoCreationExecution rows
+    'abandoned' (idempotent; leaves 'completed' rows untouched) and trips the
+    persisted circuit-breaker flag.
+  - run_auto_creation_after_refresh is SKIPPED when the flag is set, fires when
+    clear, and is suppressed by the ECM_DISABLE_RUN_ON_REFRESH break-glass env.
+
+Part C (bd-h2xnl): created-channel cap.
+  - BoundedExecutionLog/cap math is exercised in Part A; the soft-abort
+    behavior is asserted via _process_streams reaching the cap.
+"""
+import os
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from auto_creation_engine import AutoCreationEngine, BoundedExecutionLog
+
+
+# ---------------------------------------------------------------------------
+# Part A — BoundedExecutionLog
+# ---------------------------------------------------------------------------
+class TestBoundedExecutionLog:
+    def _entry(self, sid):
+        return {
+            "stream_id": sid,
+            "stream_name": f"Stream {sid}",
+            "m3u_account_id": 1,
+            "rules_evaluated": [
+                {"rule_id": 1, "rule_name": "r", "conditions": [{"x": 1}], "matched": True}
+            ],
+            "actions_executed": [{"type": "create_channel", "entity_id": sid, "success": True}],
+        }
+
+    def test_caps_retained_entries_non_dry_run(self):
+        """2*CAP appends retain exactly CAP entries (plus the summary)."""
+        cap = 10
+        log = BoundedExecutionLog(cap=cap, verbose=False)
+        for i in range(2 * cap):
+            log.append(self._entry(i))
+        log.finalize()
+        # CAP retained + 1 aggregate summary entry
+        assert log.retained_count == cap
+        assert log.truncated_count == cap
+        assert log.truncated is True
+        # The materialized list = CAP entries + 1 summary
+        assert len(log) == cap + 1
+        summary = log[-1]
+        assert summary.get("log_truncated") is True
+        assert "10 more" in summary["actions_executed"][0]["description"]
+
+    def test_no_summary_when_under_cap(self):
+        cap = 10
+        log = BoundedExecutionLog(cap=cap, verbose=False)
+        for i in range(5):
+            log.append(self._entry(i))
+        log.finalize()
+        assert log.truncated is False
+        assert len(log) == 5
+
+    def test_non_dry_run_strips_verbose_trace(self):
+        log = BoundedExecutionLog(cap=100, verbose=False)
+        log.append(self._entry(1))
+        entry = log[0]
+        # verbose rules_evaluated dropped; identity + actions retained
+        assert entry["rules_evaluated"] == []
+        assert entry["stream_id"] == 1
+        assert entry["stream_name"] == "Stream 1"
+        assert entry["actions_executed"][0]["entity_id"] == 1
+
+    def test_dry_run_retains_full_trace(self):
+        log = BoundedExecutionLog(cap=100, verbose=True)
+        log.append(self._entry(1))
+        entry = log[0]
+        assert entry["rules_evaluated"][0]["conditions"] == [{"x": 1}]
+
+    def test_cap_disabled_when_non_positive(self):
+        log = BoundedExecutionLog(cap=0, verbose=False)
+        for i in range(50):
+            log.append(self._entry(i))
+        log.finalize()
+        assert log.truncated is False
+        assert len(log) == 50
+
+
+# ---------------------------------------------------------------------------
+# Part B — crash-loop guard
+# ---------------------------------------------------------------------------
+class TestCrashSentinel:
+    def test_sentinel_marks_running_abandoned_and_trips_breaker(self, test_session):
+        from models import AutoCreationExecution
+        from task_engine import _abandon_orphaned_auto_creation_executions
+
+        running = AutoCreationExecution(
+            mode="execute", triggered_by="m3u_refresh",
+            started_at=datetime.utcnow(), status="running",
+        )
+        completed = AutoCreationExecution(
+            mode="execute", triggered_by="manual",
+            started_at=datetime.utcnow(), status="completed",
+            completed_at=datetime.utcnow(),
+        )
+        test_session.add_all([running, completed])
+        test_session.commit()
+        running_id, completed_id = running.id, completed.id
+
+        with patch("config.save_settings") as mock_save, \
+             patch("config.get_settings", return_value=MagicMock(auto_creation_run_on_refresh_disabled=False)):
+            abandoned = _abandon_orphaned_auto_creation_executions(session=test_session)
+
+        assert abandoned == 1
+        test_session.expire_all()
+        assert test_session.get(AutoCreationExecution, running_id).status == "abandoned"
+        assert test_session.get(AutoCreationExecution, running_id).completed_at is not None
+        assert test_session.get(AutoCreationExecution, completed_id).status == "completed"
+        # breaker tripped
+        mock_save.assert_called_once()
+
+    def test_sentinel_idempotent(self, test_session):
+        from models import AutoCreationExecution
+        from task_engine import _abandon_orphaned_auto_creation_executions
+
+        with patch("config.save_settings"), \
+             patch("config.get_settings", return_value=MagicMock(auto_creation_run_on_refresh_disabled=True)):
+            n = _abandon_orphaned_auto_creation_executions(session=test_session)
+        assert n == 0
+
+
+class TestRunOnRefreshBreaker:
+    @pytest.mark.asyncio
+    async def test_skipped_when_flag_set(self):
+        from tasks import auto_creation as ac
+
+        with patch.dict(os.environ, {}, clear=False), \
+             patch.object(ac, "get_settings", return_value=MagicMock(auto_creation_run_on_refresh_disabled=True)), \
+             patch("services.notification_service.create_notification_internal", new=AsyncMock()) as mock_notif, \
+             patch("journal.log_entry") as mock_journal:
+            os.environ.pop("ECM_DISABLE_RUN_ON_REFRESH", None)
+            result = await ac.run_auto_creation_after_refresh(m3u_account_ids=[1])
+
+        assert result["success"] is True
+        assert result.get("skipped") is True
+        mock_notif.assert_awaited()  # operator is told
+        mock_journal.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_break_glass_env_skips_regardless(self):
+        from tasks import auto_creation as ac
+
+        with patch.dict(os.environ, {"ECM_DISABLE_RUN_ON_REFRESH": "1"}, clear=False), \
+             patch.object(ac, "get_settings", return_value=MagicMock(auto_creation_run_on_refresh_disabled=False)):
+            result = await ac.run_auto_creation_after_refresh(m3u_account_ids=[1])
+
+        assert result.get("skipped") is True
+
+    @pytest.mark.asyncio
+    async def test_fires_when_flag_clear(self):
+        from tasks import auto_creation as ac
+
+        fake_engine = MagicMock()
+        fake_engine.run_pipeline = AsyncMock(return_value={"channels_created": 2, "streams_matched": 2, "streams_evaluated": 5})
+
+        with patch.dict(os.environ, {}, clear=False), \
+             patch.object(ac, "get_settings", return_value=MagicMock(auto_creation_run_on_refresh_disabled=False)), \
+             patch("services.notification_service.create_notification_internal", new=AsyncMock()), \
+             patch("auto_creation_engine.get_auto_creation_engine", return_value=fake_engine), \
+             patch("dispatcharr_client.get_client", return_value=MagicMock()), \
+             patch("database.get_session") as mock_sess:
+            os.environ.pop("ECM_DISABLE_RUN_ON_REFRESH", None)
+            rule = MagicMock(id=1)
+            rule.name = "R1"
+            mock_sess.return_value.query.return_value.filter.return_value.all.return_value = [rule]
+            result = await ac.run_auto_creation_after_refresh(m3u_account_ids=[1])
+
+        assert result.get("channels_created") == 2
+        fake_engine.run_pipeline.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Part C — created-channel cap soft-abort (real pipeline)
+# ---------------------------------------------------------------------------
+class TestCreatedChannelCapSoftAbort:
+    """With cap=10 and 50 would-create streams: exactly 10 created, status capped."""
+
+    def _make_engine(self):
+        from auto_creation_evaluator import StreamContext  # noqa: F401
+
+        client = MagicMock()
+        client.get_channels = AsyncMock(return_value={"count": 0, "results": []})
+        client.get_channel_groups = AsyncMock(return_value=[])
+
+        # Each create returns a distinct channel with a unique id so each
+        # counts as a NEW creation (no merge).
+        self._next_id = 1000
+
+        async def _create_channel(data):
+            self._next_id += 1
+            return {"id": self._next_id, "name": data.get("name"),
+                    "channel_number": data.get("channel_number"), "streams": data.get("streams", [])}
+
+        client.create_channel = AsyncMock(side_effect=_create_channel)
+        client.assign_channel_numbers = AsyncMock()
+        return AutoCreationEngine(client)
+
+    def _make_rule(self):
+        from models import AutoCreationRule
+        rule = AutoCreationRule()
+        rule.id = 1
+        rule.name = "Create-everything Rule"
+        rule.priority = 0
+        rule.enabled = True
+        rule.m3u_account_id = None
+        rule.target_group_id = None
+        rule.stop_on_first_match = True
+        rule.match_scope_target_group = False
+        rule.match_scope_group_id = None
+        rule.skip_struck_streams = False
+        rule.sort_field = None
+        rule.set_conditions([{"type": "always"}])
+        rule.set_actions([{"type": "create_channel", "name_template": "{stream_name}", "if_exists": "skip"}])
+        return rule
+
+    def _make_streams(self, n):
+        from auto_creation_evaluator import StreamContext
+        return [
+            StreamContext(stream_id=1000 + i, stream_name=f"Chan {i}", m3u_account_id=1)
+            for i in range(n)
+        ]
+
+    def test_cap_soft_aborts_at_ten_of_fifty(self):
+        import asyncio
+        engine = self._make_engine()
+        rule = self._make_rule()
+        streams = self._make_streams(50)
+
+        engine._load_rules = AsyncMock(return_value=[rule])
+        engine._fetch_streams = AsyncMock(return_value=streams)
+        execution = MagicMock(id=1, mode=None)
+        engine._create_execution = AsyncMock(return_value=execution)
+        engine._save_execution = AsyncMock()
+        engine._update_rule_stats = AsyncMock()
+        engine._capture_snapshot = AsyncMock()
+
+        fake_settings = MagicMock(
+            max_auto_created_channels_per_run=10,
+            max_auto_creation_log_entries=500,
+            timezone_preference="both",
+            default_channel_profile_ids=[],
+        )
+
+        with patch("auto_creation_engine.get_session", return_value=MagicMock()), \
+             patch("auto_creation_engine.get_settings", return_value=fake_settings), \
+             patch("config.get_settings", return_value=fake_settings):
+            result = asyncio.get_event_loop().run_until_complete(
+                engine.run_pipeline(dry_run=False)
+            )
+
+        assert result["channels_created"] == 10, "cap must stop creation at exactly 10"
+        assert result["capped"] is True
+        assert result["cap_would_create"] > 0
+        # Execution record marked capped (not 'completed').
+        assert execution.status == "capped"
+        assert execution.error_message and "cap" in execution.error_message.lower()
+        # client.create_channel called exactly 10 times — nothing created past the cap.
+        assert engine.client.create_channel.await_count == 10

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0000",
+  "version": "0.17.6-0001",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Three coupled fixes for **GH #473** — a persistent operator outage where auto-creation OOM-kills the container, which then crash-loops on every restart (doubling RAM didn't help).

| Bead | Fix |
|---|---|
| **sjdsq** (primary) | `results["execution_log"]` is now a `BoundedExecutionLog` (`list` subclass — every append site governed by construction). Non-dry-run strips the verbose per-stream rule/condition trace incrementally and caps retained entries at `MAX_AUTO_CREATION_LOG_ENTRIES` (default 500, settings-overridable) + aggregate summary + `log_truncated` marker; dry-run keeps the full trace. Adds peak-RSS + run-size observability lines. |
| **exo4j** | Startup crash-sentinel marks orphaned `running` `AutoCreationExecution` rows `abandoned` (before the scheduler arms) and trips a **persisted** circuit-breaker that skips `run_on_refresh` auto-creation until an operator re-enables via `POST /api/auto-creation/reset-circuit-breaker`. `ECM_DISABLE_RUN_ON_REFRESH=1` is a break-glass. Manual "Run Now" is never gated. |
| **h2xnl** (cap) | Per-run created-channel cap (`MAX_AUTO_CREATED_CHANNELS_PER_RUN`, default 500) soft-aborts a runaway run (`status="capped"`, non-silent alert) — the safety valve for the 186→2400+ PPV expansion. |

## Notes
- **No migration** — reuses existing `status`/`error_message` columns + `idx_auto_exec_status`.
- The PPV **root-cause** investigation (`h2xnl`) stays open, blocked on reporter artifacts; the cap is the safety valve.
- **Live validation:** on the dev container the sentinel found 3 genuine orphaned `running` rows (real #473 crash residue), abandoned them, and tripped the breaker — exactly as designed.

## Testing
- New `tests/unit/test_auto_creation_oom_guards.py` (11 tests): bounded-log cap/strip/dry-run, crash-sentinel abandon+trip+idempotent+leaves-completed, breaker skip/break-glass/fires-when-clear, cap soft-abort at 10-of-50 via the real pipeline.
- Full backend suite **5,351 passed, 1 skipped** (independently re-run).
- Deployed to `ecm-ecm-1`, clean restart.

## Deferred (fast-follow)
Frontend: add `abandoned`/`capped` to the executions UI (badge + circuit-breaker banner/reset button) and to the terminal-status set in `useAutoCreationExecution.ts`.

Beads: enhancedchannelmanager-sjdsq, enhancedchannelmanager-exo4j, enhancedchannelmanager-h2xnl (cap portion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)