### PR TITLE
v0.18.0-dbas: nav0c add create_stream + delete_stream client methods (Channels import 1/4)

### DIFF
--- a/backend/dispatcharr_client.py
+++ b/backend/dispatcharr_client.py
@@ -455,6 +455,46 @@ class DispatcharrClient:
         response.raise_for_status()
         return response.json()
 
+    async def create_stream(self, data: dict) -> dict:
+        """Create a new stream.
+
+        Used by the Channels restore importer (enhancedchannelmanager-nav0c):
+        channels carry embedded (non-standalone) streams, so restoring a channel
+        means recreating any of its streams that no matcher tier resolved to an
+        existing one.
+
+        Returns the created stream, or raises an exception with the response body
+        if creation fails. The error message uses the same
+        ``"<thing> failed: <status> - <body>"`` shape as ``create_channel`` /
+        ``create_channel_group`` so ``upstream_http_exception`` can parse the
+        upstream status + actionable detail (see restore_contracts mapper).
+        """
+        if not isinstance(data, dict):
+            raise ValueError("create_stream requires a dict payload")
+        response = await self._request(
+            "POST", "/api/channels/streams/", json=data
+        )
+        if response.status_code >= 400:
+            # Include response body in exception for better error handling
+            error_body = response.text
+            raise Exception(f"Stream creation failed: {response.status_code} - {error_body}")
+        return response.json()
+
+    async def delete_stream(self, stream_id: int) -> None:
+        """Delete a stream by ID.
+
+        Used as the rollback compensation for a previously created stream
+        (restore_contracts rollback ledger, enhancedchannelmanager-nav0c): if a
+        later step in the same restore fails, streams created earlier in the run
+        are deleted to avoid leaving orphans. A 404 here means the stream is
+        already gone, which the caller treats as a successful (idempotent)
+        compensation.
+        """
+        response = await self._request(
+            "DELETE", f"/api/channels/streams/{stream_id}/"
+        )
+        response.raise_for_status()
+
     async def get_streams_by_ids(self, ids: list[int]) -> list:
         """Get multiple streams by IDs."""
         response = await self._request(

--- a/backend/tests/unit/test_dispatcharr_client_stream_crud.py
+++ b/backend/tests/unit/test_dispatcharr_client_stream_crud.py
@@ -1,0 +1,184 @@
+"""
+Unit tests for DispatcharrClient stream create/delete helpers
+(enhancedchannelmanager-nav0c, Phase 2 Channels import 1/4).
+
+The Channels importer (0i2vt.14 + splits 4vouz/ahygg) restores channels whose
+streams are embedded (not standalone). To recreate those streams it needs a
+``create_stream`` client method, and the restore rollback ledger
+(restore_contracts kxuj2) needs a ``delete_stream`` compensation to undo a
+created stream if a later step in the same restore fails.
+
+Mocking pattern follows the existing direct-client unit tests
+(test_dispatcharr_client_group_filter.py): construct a real ``DispatcharrClient``
+and ``patch.object(client, "_request", AsyncMock(...))`` so the helper's
+endpoint, payload, return parsing, and error handling are exercised without a
+live HTTP round-trip.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+from config import DispatcharrSettings
+from dispatcharr_client import DispatcharrClient
+
+
+def _response(status_code: int, json_body=None, text: str = ""):
+    resp = AsyncMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json = lambda: json_body if json_body is not None else {}
+    resp.text = text
+
+    def _raise_for_status():
+        if status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"HTTP {status_code}", request=None, response=resp
+            )
+
+    resp.raise_for_status = _raise_for_status
+    return resp
+
+
+def _make_client():
+    settings = DispatcharrSettings(
+        url="http://dispatcharr:8000",
+        auth_method="password",
+        username="admin",
+        password="secret",
+    )
+    return DispatcharrClient(settings)
+
+
+# ---------------------------------------------------------------------------
+# create_stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_stream_posts_to_streams_endpoint_and_returns_created():
+    """create_stream POSTs the payload to /api/channels/streams/ and returns
+    the parsed created-stream body."""
+    client = _make_client()
+    try:
+        created = {"id": 555, "name": "ESPN HD", "url": "http://p/espn.ts"}
+        request_mock = AsyncMock(return_value=_response(201, created))
+        data = {
+            "name": "ESPN HD",
+            "url": "http://p/espn.ts",
+            "m3u_account": 7,
+        }
+
+        with patch.object(client, "_request", request_mock):
+            result = await client.create_stream(data)
+
+        assert result == created
+        method, path = request_mock.await_args.args
+        assert method == "POST"
+        assert path == "/api/channels/streams/"
+        assert request_mock.await_args.kwargs["json"] == data
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_stream_accepts_200_status():
+    """Some DRF endpoints return 200 rather than 201 on create; both are
+    treated as success (the helper keys off status >= 400 for failure, matching
+    create_channel/create_channel_group)."""
+    client = _make_client()
+    try:
+        created = {"id": 1, "name": "S"}
+        request_mock = AsyncMock(return_value=_response(200, created))
+        with patch.object(client, "_request", request_mock):
+            result = await client.create_stream({"name": "S"})
+        assert result == created
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_stream_raises_with_status_and_body_on_4xx():
+    """A 4xx upstream response raises an Exception whose message matches the
+    '<thing> failed: <status> - <body>' shape that upstream_http_exception
+    (restore_contracts mapper) parses to surface the actionable detail."""
+    client = _make_client()
+    try:
+        body = '{"url": ["This field is required."]}'
+        request_mock = AsyncMock(return_value=_response(400, text=body))
+        with patch.object(client, "_request", request_mock):
+            with pytest.raises(Exception) as exc_info:
+                await client.create_stream({"name": "no-url"})
+
+        msg = str(exc_info.value)
+        assert "Stream creation failed" in msg
+        assert "400" in msg
+        assert body in msg
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_stream_raises_on_5xx():
+    """A 5xx upstream response also raises (created stream not returned)."""
+    client = _make_client()
+    try:
+        request_mock = AsyncMock(return_value=_response(503, text="upstream down"))
+        with patch.object(client, "_request", request_mock):
+            with pytest.raises(Exception) as exc_info:
+                await client.create_stream({"name": "x"})
+        assert "503" in str(exc_info.value)
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_stream_rejects_non_dict_payload():
+    """Input validation: create_stream requires a dict payload; a non-dict
+    (e.g. None, list) raises before any HTTP request is issued."""
+    client = _make_client()
+    try:
+        request_mock = AsyncMock(return_value=_response(201, {"id": 1}))
+        with patch.object(client, "_request", request_mock):
+            with pytest.raises(ValueError):
+                await client.create_stream(None)  # type: ignore[arg-type]
+            with pytest.raises(ValueError):
+                await client.create_stream([{"name": "x"}])  # type: ignore[arg-type]
+        request_mock.assert_not_awaited()
+    finally:
+        await client._client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# delete_stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_stream_issues_delete_to_id_endpoint():
+    """delete_stream DELETEs /api/channels/streams/{id}/ and returns None."""
+    client = _make_client()
+    try:
+        request_mock = AsyncMock(return_value=_response(204))
+        with patch.object(client, "_request", request_mock):
+            result = await client.delete_stream(555)
+
+        assert result is None
+        method, path = request_mock.await_args.args
+        assert method == "DELETE"
+        assert path == "/api/channels/streams/555/"
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_delete_stream_raises_on_error_status():
+    """delete_stream surfaces an upstream error via raise_for_status (matches
+    delete_channel/delete_channel_group convention)."""
+    client = _make_client()
+    try:
+        request_mock = AsyncMock(return_value=_response(500, text="boom"))
+        with patch.object(client, "_request", request_mock):
+            with pytest.raises(httpx.HTTPStatusError):
+                await client.delete_stream(999)
+    finally:
+        await client._client.aclose()


### PR DESCRIPTION
## Bead
enhancedchannelmanager-nav0c — Phase 2 Channels A: add the Dispatcharr client stream methods the Channels importer needs (split 1/4 of 0i2vt.14).

## Verify-then-size result
Already present: get_streams, get_stream, update_stream, get_streams_by_ids, get_channel_streams, get_stream_groups(_with_counts), and update_profile_channel (profile reattach, for 4vouz).
Added: `create_stream` (POST /api/channels/streams/) and `delete_stream` (DELETE /api/channels/streams/{id}/).

`delete_stream` added beyond the literal "create_stream minimum" because the kxuj2 restore contracts define a per-entity rollback ledger — a created-then-failed restore would otherwise orphan streams with no compensation path. Method raises on 404 (matching delete_channel); 404-as-idempotent-success is the rollback caller's job per the contract.

## Conventions
`create_stream` mirrors create_channel/create_channel_group exactly (manual >=400 check raising the precise "Stream creation failed: <status> - <body>" shape the restore error-mapper parses). No new re.* calls.

## Tests
7 tests in backend/tests/unit/test_dispatcharr_client_stream_crud.py. Full backend suite green locally (5567 passed, 5 pre-existing SSRF skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)