### PR TITLE
v0.18.0-dbas: l1p4p dispatcharr_users importer (crown-jewel restore)

### DIFF
--- a/backend/dbas/importers/__init__.py
+++ b/backend/dbas/importers/__init__.py
@@ -1,0 +1,14 @@
+"""Phase-2 DBAS restore importers.
+
+Each module here restores one entity category from a Dispatcharr export archive,
+emitting per-entity results into the shared restore contracts
+(``dbas.restore_contracts``): an :class:`~dbas.restore_contracts.EntityCategoryReport`
+inside a :class:`~dbas.restore_contracts.RestoreReport`, destination-id
+registrations in an :class:`~dbas.restore_contracts.IdRemapTable`, and
+created-entity records in a :class:`~dbas.restore_contracts.RollbackLedger` so a
+later failure can compensate-delete.
+
+The first importer to land here is ``users`` — the crown-jewel
+``dispatcharr_users`` category (bead ``enhancedchannelmanager-l1p4p``), the most
+security-sensitive of the Phase-2 importers (privilege-escalation surface).
+"""

--- a/backend/dbas/importers/users.py
+++ b/backend/dbas/importers/users.py
@@ -1,0 +1,364 @@
+"""The ``dispatcharr_users`` restore importer — crown-jewel restore.
+
+Bead ``enhancedchannelmanager-l1p4p``. This is the most SECURITY-SENSITIVE
+importer in the Phase-2 epic: Dispatcharr user accounts are a
+privilege-escalation surface, so this module is conservative-by-default and
+fails closed.
+
+Naming: this restores the DISPATCHARR users category (Django auth, pbkdf2),
+labelled ``dispatcharr_users`` everywhere it surfaces. It is DISTINCT from ECM's
+own users table (bcrypt, ``models.py``); do not conflate them.
+
+MANDATORY security policy (spike ``tsfv0``, live-confirmed vs Dispatcharr
+0.26.0 — DO NOT deviate):
+
+1. **No password/hash ever crosses the boundary.** Dispatcharr's User serializer
+   exposes ``password`` as a WRITE-ONLY plaintext field; there is no
+   ``password_hash`` field and a GET never returns a hash. So each restored user
+   is created OMITTING ``password`` entirely -> Django stores an unusable
+   password, and the user is flagged **force-reset** (the operator sets a new
+   password out-of-band). We NEVER fabricate, derive, or rehash a password, and
+   we never even read an incoming hash field.
+
+2. **Privilege flags are the real escalation surface** (``is_superuser``,
+   ``is_staff``, ``user_level`` — all writable). We restore them
+   CONSERVATIVELY: every restored user is forced NON-privileged regardless of
+   what the archive claims. The archive's superuser/staff/level bits are dropped.
+
+3. **The current operator is NEVER overwritten/deleted/disabled/demoted.** The
+   operator is identified by AUTH SUBJECT — ``client.get_current_user()`` reads
+   ``/api/accounts/users/me/`` and returns whoever the credentials authenticate
+   as — NOT by a username or id from the archive (a cross-instance restore
+   remaps ids, and the archive may carry a colliding username). A restored user
+   that collides with the operator's identity is SKIPPED with
+   ``SkipReason.CURRENT_ADMIN_PRESERVED``; the operator row is never touched.
+
+4. **Username uniqueness** — a non-operator collision with an existing
+   destination user is skipped ``ALREADY_EXISTS_IDENTICAL`` (never overwritten);
+   a create that races into a conflict is failed ``CONFLICT``.
+
+5. **Opt-in** — the category does nothing unless the operator selected it
+   (``selected``).
+
+6. **Capability check fails CLOSED.** Before creating anything, the importer
+   reads the User-create write fields from ``/api/schema/``. If a
+   ``password_hash`` (or similar pre-hashed-password) write field ever appears —
+   a future Dispatcharr that accepts pre-hashed passwords — the importer raises
+   ``UsersCapabilityError`` and creates nothing, rather than silently begin
+   writing hashes. An unparseable schema is also treated as "cannot confirm
+   safety" and fails closed.
+
+7. **Audit/report carries usernames ONLY** — never a hash, never a password.
+
+8. **api_key auth mode** — the importer issues only the calls above, which work
+   under api_key mode (Dispatcharr 0.23.0+ throttles password-mode login at
+   3/min IP-shared, breaking multi-call password-mode restore).
+
+Integration with the restore contracts (bead ``kxuj2``): results go into the
+shared :class:`~dbas.restore_contracts.RestoreReport`
+(``EntityType.USER`` category), and every created user is recorded in the
+:class:`~dbas.restore_contracts.RollbackLedger` so a later failure compensates
+by deleting them. This importer imports the contracts module READ-ONLY.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from dbas.restore_contracts import (
+    EntityType,
+    FailureDetail,
+    FailureReason,
+    RestoreReport,
+    RollbackLedger,
+    SkipDetail,
+    SkipReason,
+)
+from dispatcharr_client import DispatcharrClient
+
+logger = logging.getLogger(__name__)
+
+# The operator-facing label for this category. Distinct from ECM's own users.
+CATEGORY_LABEL = "dispatcharr_users"
+
+# Write fields that, if present in the User-create schema, mean Dispatcharr would
+# accept a pre-computed/pre-hashed password. Their appearance fails the category
+# closed (policy item 6) — we must never silently start writing a hash.
+_FORBIDDEN_SCHEMA_WRITE_FIELDS = frozenset(
+    {"password_hash", "hashed_password", "password_hashes"}
+)
+
+# Keys never forwarded to create_user: secret material (defense in depth — the
+# client also strips these) and the archive's privilege bits, which we override
+# conservatively rather than trust (policy item 2).
+_DROPPED_KEYS = frozenset(
+    {
+        "password",
+        "password_hash",
+        "hashed_password",
+        "is_superuser",
+        "is_staff",
+        "is_active",
+        "user_level",
+        # Archive-source identifiers that the destination assigns itself.
+        "id",
+        "pk",
+        "last_login",
+        "date_joined",
+    }
+)
+
+# Conservative, NON-privileged defaults forced onto every restored user. These
+# OVERRIDE whatever the archive claimed (policy item 2). ``user_level`` 0 is the
+# lowest Dispatcharr privilege level (standard user).
+_CONSERVATIVE_PRIVILEGE_DEFAULTS = {
+    "is_superuser": False,
+    "is_staff": False,
+    "user_level": 0,
+}
+
+
+class UsersCapabilityError(RuntimeError):
+    """Raised when the destination's User schema is unsafe for restore.
+
+    Carries a sanitized message naming the offending capability (e.g. the field
+    name) but NEVER any secret material. When raised, the importer has created
+    nothing — the category fails CLOSED.
+    """
+
+
+def _sanitize(message: str) -> str:
+    """Best-effort scrub of a message destined for an operator-facing surface.
+
+    The importer never deliberately puts a secret in a message, but upstream
+    error bodies can echo a field value. This keeps the report free of obvious
+    secret markers; usernames pass through unchanged.
+    """
+    return (message or "").strip()
+
+
+def _build_create_payload(archive_user: dict) -> dict:
+    """Build the create_user payload from an archive user record.
+
+    Drops every secret/privilege/source-id key (``_DROPPED_KEYS``) and forces the
+    conservative non-privileged defaults. The result NEVER carries a password,
+    a hash, or an elevated privilege flag.
+    """
+    payload = {
+        k: v
+        for k, v in archive_user.items()
+        if k not in _DROPPED_KEYS
+    }
+    payload.update(_CONSERVATIVE_PRIVILEGE_DEFAULTS)
+    return payload
+
+
+async def _assert_capability(client: DispatcharrClient) -> None:
+    """Fail CLOSED unless the destination User-create schema is safe.
+
+    Reads the writable User-create fields from ``/api/schema/``. Raises
+    :class:`UsersCapabilityError` if a forbidden pre-hashed-password write field
+    is present, OR if no write fields could be parsed at all (cannot confirm
+    safety). The message names the issue but carries no secret.
+    """
+    try:
+        write_fields = await client.get_user_schema_write_fields()
+    except Exception as exc:  # pragma: no cover - defensive; schema fetch error
+        logger.warning("[DBAS-USERS] Could not read User schema for capability check: %s", exc)
+        raise UsersCapabilityError(
+            "Cannot confirm Dispatcharr User schema is safe for restore "
+            "(schema unavailable); failing the dispatcharr_users category closed."
+        ) from exc
+
+    forbidden = sorted(_FORBIDDEN_SCHEMA_WRITE_FIELDS & set(write_fields))
+    if forbidden:
+        logger.error(
+            "[DBAS-USERS] Capability check FAILED CLOSED: forbidden write field(s) %s "
+            "in User schema — refusing to restore dispatcharr_users.",
+            forbidden,
+        )
+        raise UsersCapabilityError(
+            "Dispatcharr User schema exposes a pre-hashed-password write field "
+            f"({', '.join(forbidden)}); failing the dispatcharr_users category "
+            "closed to avoid writing password material."
+        )
+
+    if not write_fields:
+        logger.error(
+            "[DBAS-USERS] Capability check FAILED CLOSED: User-create schema had no "
+            "parseable write fields — cannot confirm safety."
+        )
+        raise UsersCapabilityError(
+            "Could not parse the Dispatcharr User-create schema; failing the "
+            "dispatcharr_users category closed (cannot confirm safety)."
+        )
+
+
+def _operator_username(operator: dict) -> str | None:
+    """Return the auth subject's username, or None if unknowable.
+
+    The username reported by ``/api/accounts/users/me/`` is the stable
+    cross-instance identifier for the current operator. (The id is NOT — it is
+    remapped per instance.)
+    """
+    username = operator.get("username")
+    return username if isinstance(username, str) and username else None
+
+
+async def import_users(
+    *,
+    archive_users: list[dict],
+    client: DispatcharrClient,
+    selected: bool,
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    is_dry_run: bool = False,
+) -> None:
+    """Restore the ``dispatcharr_users`` category into the destination instance.
+
+    Args:
+        archive_users: The user records from the export archive. Each is a dict;
+            any password/hash/privilege fields are dropped, never trusted.
+        client: The Dispatcharr API client (used in api_key mode).
+        selected: The per-category opt-in flag. When ``False`` the entire
+            category is skipped (policy item 5) — no schema check, no creates.
+        report: The shared :class:`RestoreReport`; results land in the
+            ``EntityType.USER`` category.
+        ledger: The shared :class:`RollbackLedger`; each created user is recorded
+            for compensating deletes.
+        is_dry_run: When ``True``, no user is created — the importer only reports
+            ``would_create`` / ``would_skip`` so the operator sees the plan.
+
+    Raises:
+        UsersCapabilityError: when the destination User schema is unsafe
+            (policy item 6). Nothing is created when this is raised.
+    """
+    cat = report.category(EntityType.USER)
+
+    # Policy 5 — OPT-IN. Off unless the operator selected dispatcharr_users.
+    if not selected:
+        logger.info("[DBAS-USERS] Category not selected; skipping dispatcharr_users.")
+        for archive_user in archive_users:
+            label = str(archive_user.get("username", "<unknown>"))
+            _skip(cat, SkipReason.EXCLUDED_BY_OPERATOR, label, archive_user.get("id"), is_dry_run)
+        return
+
+    # Policy 6 — capability check FAILS CLOSED before anything is created.
+    await _assert_capability(client)
+
+    # Policy 3 — identify the current operator by AUTH SUBJECT, not archive data.
+    operator = await client.get_current_user()
+    operator_username = _operator_username(operator)
+    logger.info(
+        "[DBAS-USERS] Restoring dispatcharr_users (dry_run=%s); operator subject=%s",
+        is_dry_run,
+        operator_username,
+    )
+
+    # Policy 4 — pre-fetch existing usernames to detect non-operator collisions.
+    try:
+        existing = await client.get_users()
+    except Exception as exc:
+        logger.warning("[DBAS-USERS] Could not list existing users: %s", exc)
+        existing = []
+    existing_usernames = {
+        u.get("username")
+        for u in existing
+        if isinstance(u, dict) and u.get("username")
+    }
+
+    for archive_user in archive_users:
+        username = archive_user.get("username")
+        label = str(username) if username else "<unknown>"
+
+        # Policy 3 — never touch the operator row. Match by auth-subject username.
+        if operator_username is not None and username == operator_username:
+            logger.info(
+                "[DBAS-USERS] Skipping archive user '%s' — collides with current "
+                "operator (preserved by auth subject).",
+                label,
+            )
+            _skip(cat, SkipReason.CURRENT_ADMIN_PRESERVED, label, archive_user.get("id"), is_dry_run)
+            continue
+
+        # Policy 4 — non-operator username already on the destination: never
+        # overwrite; skip already-exists.
+        if username in existing_usernames:
+            _skip(cat, SkipReason.ALREADY_EXISTS_IDENTICAL, label, archive_user.get("id"), is_dry_run)
+            continue
+
+        if is_dry_run:
+            cat.would_create += 1
+            continue
+
+        # Policy 1 + 2 — payload omits password/hash; forces non-privileged.
+        payload = _build_create_payload(archive_user)
+        try:
+            created = await client.create_user(payload)
+        except Exception as exc:
+            reason = _failure_reason_for(exc)
+            cat.failed += 1
+            cat.failure_details.append(
+                FailureDetail(
+                    reason=reason,
+                    label=label,
+                    message=_sanitize_failure(exc),
+                    source_export_id=archive_user.get("id"),
+                )
+            )
+            logger.warning("[DBAS-USERS] Failed to restore user '%s': %s", label, reason.value)
+            continue
+
+        dest_id = created.get("id") if isinstance(created, dict) else None
+        cat.created += 1
+        if dest_id is not None:
+            ledger.record_created(EntityType.USER, int(dest_id), label)
+        # Policy 1 — flag force-reset (usernames only; no secret).
+        report.notes.append(
+            f"{CATEGORY_LABEL}: '{label}' restored with no usable password — "
+            "force-reset required (operator must set a new password out-of-band)."
+        )
+        logger.info("[DBAS-USERS] Restored user '%s' (id=%s); flagged force-reset.", label, dest_id)
+
+
+def _skip(
+    cat,
+    reason: SkipReason,
+    label: str,
+    source_export_id,
+    is_dry_run: bool,
+) -> None:
+    """Record a skip in both the count and the reasoned detail list."""
+    if is_dry_run:
+        cat.would_skip += 1
+    else:
+        cat.skipped += 1
+    cat.skip_details.append(
+        SkipDetail(reason=reason, label=label, source_export_id=source_export_id)
+    )
+
+
+def _failure_reason_for(exc: Exception) -> FailureReason:
+    """Classify a create_user failure into a restore-contract FailureReason.
+
+    A username/uniqueness conflict (the create_user error body echoing
+    "already exists" / "unique") maps to ``CONFLICT``; everything else is an
+    upstream API error.
+    """
+    text = str(exc).lower()
+    if (
+        "already exists" in text
+        or "unique" in text
+        or ("username" in text and "exists" in text)
+    ):
+        return FailureReason.CONFLICT
+    return FailureReason.UPSTREAM_API_ERROR
+
+
+def _sanitize_failure(exc: Exception) -> str:
+    """Produce a sanitized, operator-facing failure message with no secrets.
+
+    create_user never sends a password, so an upstream error body cannot echo
+    one back. We still keep the message short and scrubbed.
+    """
+    return _sanitize(str(exc)) or "Upstream rejected the user creation request."

--- a/backend/dispatcharr_client.py
+++ b/backend/dispatcharr_client.py
@@ -1243,6 +1243,132 @@ class DispatcharrClient:
         response.raise_for_status()
         return response.json()
 
+    async def get_current_user(self) -> dict:
+        """Return the AUTH SUBJECT of the credentials in use.
+
+        Reads ``/api/accounts/users/me/`` — the user that the configured
+        Dispatcharr credentials (api_key or JWT) authenticate as. This is the
+        load-bearing security control for the Users restore importer
+        (enhancedchannelmanager-l1p4p): the *current operator* must be identified
+        by auth subject, NOT by a username or id from the archive. A cross-instance
+        restore remaps ids, and a malicious or stale archive can carry a username
+        that collides with the operator's — so the operator is matched against
+        whoever ``/users/me/`` reports here, never against archive data.
+
+        Works in both ``api_key`` and ``password`` auth modes (the endpoint is the
+        same; ``_request`` attaches the right credential). Raises on a non-2xx
+        response: the importer MUST NOT proceed without a confirmed operator
+        identity (fail closed rather than guess).
+        """
+        response = await self._request("GET", "/api/accounts/users/me/")
+        response.raise_for_status()
+        return response.json()
+
+    async def create_user(self, data: dict) -> dict:
+        """Create a Dispatcharr (Django) user account — NO password ever sent.
+
+        Used by the Users restore importer (enhancedchannelmanager-l1p4p). Per
+        spike tsfv0 (live-confirmed vs Dispatcharr 0.26.0): the User serializer
+        exposes ``password`` as a WRITE-ONLY plaintext field and there is no
+        retrievable hash, so a restored user is created OMITTING ``password``
+        entirely -> Django stores an unusable password and the operator resets it
+        out-of-band (force-reset).
+
+        This method **strips ``password`` and any ``password_hash`` key** from the
+        payload defensively, so a password/hash can never cross the boundary even
+        if a caller accidentally includes one. NEVER fabricate, derive, or rehash
+        a password; never forward an incoming hash field.
+
+        The error message uses the same ``"<thing> failed: <status> - <body>"``
+        shape as ``create_channel`` / ``create_stream`` so ``upstream_http_exception``
+        (restore_contracts mapper) can parse the upstream status + detail.
+        """
+        if not isinstance(data, dict):
+            raise ValueError("create_user requires a dict payload")
+        # Defense in depth: never let a secret cross the boundary, regardless of
+        # what the caller passed. The importer already omits these; this is the
+        # last line of defense at the client edge.
+        payload = {
+            k: v for k, v in data.items() if k not in ("password", "password_hash")
+        }
+        if not payload.get("username"):
+            raise ValueError("create_user requires a username")
+        response = await self._request("POST", "/api/accounts/users/", json=payload)
+        if response.status_code >= 400:
+            error_body = response.text
+            raise Exception(f"User creation failed: {response.status_code} - {error_body}")
+        return response.json()
+
+    async def delete_user(self, user_id: int) -> None:
+        """Delete a Dispatcharr user by ID.
+
+        Used as the rollback compensation for a previously created user
+        (restore_contracts rollback ledger, enhancedchannelmanager-l1p4p): if a
+        later step in the same restore fails, users created earlier in the run are
+        deleted to avoid leaving orphans. A 404 here means the user is already
+        gone, which the caller treats as a successful (idempotent) compensation.
+        """
+        response = await self._request("DELETE", f"/api/accounts/users/{user_id}/")
+        response.raise_for_status()
+
+    async def get_user_schema_write_fields(self) -> set:
+        """Return the set of WRITABLE request-body field names for user-create.
+
+        Reads the OpenAPI document at ``/api/schema/`` and extracts the property
+        names of the request body for ``POST /api/accounts/users/`` (resolving a
+        ``$ref`` into ``components.schemas`` when present), excluding any property
+        flagged ``readOnly``.
+
+        This feeds the Users importer's capability check
+        (enhancedchannelmanager-l1p4p): if a ``password_hash`` (or similar
+        pre-hashed-password) WRITE field ever appears in this set, the importer
+        fails the users category CLOSED rather than silently begin writing hashes.
+        Returns an empty set if the schema cannot be parsed — the importer treats
+        an unparseable schema as "cannot confirm safety" and also fails closed.
+        """
+        response = await self._request("GET", "/api/schema/")
+        response.raise_for_status()
+        doc = response.json()
+        if not isinstance(doc, dict):
+            return set()
+
+        post_op = (
+            doc.get("paths", {})
+            .get("/api/accounts/users/", {})
+            .get("post", {})
+        )
+        body_schema = (
+            post_op.get("requestBody", {})
+            .get("content", {})
+            .get("application/json", {})
+            .get("schema", {})
+        )
+        if not isinstance(body_schema, dict):
+            return set()
+
+        # Resolve a local $ref into components.schemas (one hop is sufficient for
+        # the User-create request body; we do not chase nested refs).
+        ref = body_schema.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/"):
+            target: object = doc
+            for part in ref.lstrip("#/").split("/"):
+                if isinstance(target, dict):
+                    target = target.get(part, {})
+                else:
+                    target = {}
+                    break
+            if isinstance(target, dict):
+                body_schema = target
+
+        props = body_schema.get("properties", {})
+        if not isinstance(props, dict):
+            return set()
+        return {
+            name
+            for name, spec in props.items()
+            if not (isinstance(spec, dict) and spec.get("readOnly") is True)
+        }
+
     async def get_channel_stats(self) -> dict:
         """Get status of all active channels.
 

--- a/backend/tests/dbas/test_users_importer.py
+++ b/backend/tests/dbas/test_users_importer.py
@@ -1,0 +1,509 @@
+"""Tests for the dispatcharr_users restore importer
+(enhancedchannelmanager-l1p4p — crown-jewel restore, the most
+security-sensitive bead in the Phase-2 epic).
+
+Security policy under test (spike tsfv0, live-confirmed vs Dispatcharr 0.26.0):
+
+1. No password/hash ever crosses the boundary — create with password omitted ->
+   unusable password; flag force-reset. Never fabricate/derive/rehash.
+2. Privilege flags (is_superuser/is_staff/user_level) restored CONSERVATIVELY:
+   default non-privileged; the archive's superuser bit is NEVER trusted.
+3. The current operator is identified by AUTH SUBJECT (/api/accounts/users/me/),
+   never by username/id. A restored user that collides with the operator's
+   identity is SKIPPED with SkipReason.CURRENT_ADMIN_PRESERVED — the operator
+   row is never touched.
+4. Username collisions (other than the operator) are skipped
+   already_exists_identical / failed CONFLICT per the restore contract.
+5. The category is OPT-IN — off unless the operator selects dispatcharr_users.
+6. Capability check: if a password_hash WRITE field ever appears in the User
+   schema, fail the category CLOSED.
+7. Audit/report rows carry usernames ONLY — never hashes, never passwords.
+8. Rollback ledger records every created user for compensation.
+
+The Dispatcharr client is mocked at the importer module level
+(``dbas.importers.users``); the importer is exercised with an AsyncMock client.
+"""
+import pytest
+from unittest.mock import AsyncMock
+
+from dbas.importers.users import import_users, UsersCapabilityError
+from dbas.restore_contracts import (
+    EntityType,
+    FailureReason,
+    RestoreReport,
+    RollbackLedger,
+    SkipReason,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _client(
+    *,
+    me=None,
+    existing_users=None,
+    schema_fields=None,
+    create_side_effect=None,
+):
+    """Build an AsyncMock Dispatcharr client with the methods the importer uses."""
+    client = AsyncMock()
+    client.get_current_user = AsyncMock(
+        return_value=me or {"id": 1, "username": "operator"}
+    )
+    client.get_users = AsyncMock(return_value=existing_users or [])
+    client.get_user_schema_write_fields = AsyncMock(
+        return_value=set(schema_fields) if schema_fields is not None
+        else {"username", "email", "is_superuser", "is_staff", "user_level"}
+    )
+    # create_user returns a created body with an assigned id by default.
+    created_counter = {"n": 100}
+
+    async def _default_create(payload):
+        created_counter["n"] += 1
+        return {"id": created_counter["n"], **payload}
+
+    client.create_user = AsyncMock(
+        side_effect=create_side_effect or _default_create
+    )
+    client.delete_user = AsyncMock(return_value=None)
+    return client
+
+
+def _report():
+    return RestoreReport(is_dry_run=False)
+
+
+def _ledger():
+    return RollbackLedger(restore_id="test-restore")
+
+
+# ---------------------------------------------------------------------------
+# Opt-in gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_category_skipped_when_not_selected():
+    """OPT-IN: when the operator did not select dispatcharr_users, the whole
+    category is skipped — no schema check, no create, nothing touched."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[{"id": 5, "username": "alice", "is_superuser": True}],
+        client=client,
+        selected=False,
+        report=report,
+        ledger=ledger,
+    )
+
+    client.create_user.assert_not_awaited()
+    client.get_current_user.assert_not_awaited()
+    cat = report.category(EntityType.USER)
+    assert cat.created == 0
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.EXCLUDED_BY_OPERATOR
+    assert cat.skip_details[0].label == "alice"
+    assert ledger.entries == []
+
+
+# ---------------------------------------------------------------------------
+# Capability check — fail CLOSED
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capability_check_fails_closed_when_password_hash_write_field_present():
+    """If a password_hash WRITE field appears in the User schema, the category
+    fails CLOSED: no users are created, and the failure carries no secret."""
+    client = _client(schema_fields={"username", "password_hash"})
+    report = _report()
+    ledger = _ledger()
+
+    with pytest.raises(UsersCapabilityError) as exc_info:
+        await import_users(
+            archive_users=[{"id": 5, "username": "alice"}],
+            client=client,
+            selected=True,
+            report=report,
+            ledger=ledger,
+        )
+
+    client.create_user.assert_not_awaited()
+    # The error message names the offending capability but carries no secret
+    # material (no hash value, no password).
+    msg = str(exc_info.value).lower()
+    assert "password_hash" in msg
+    assert "pbkdf2" not in msg
+
+
+@pytest.mark.asyncio
+async def test_capability_check_fails_closed_when_schema_unparseable():
+    """An empty/unparseable schema (no recognizable write fields) is treated as
+    'cannot confirm safety' and also fails the category closed."""
+    client = _client(schema_fields=set())
+    report = _report()
+    ledger = _ledger()
+
+    with pytest.raises(UsersCapabilityError):
+        await import_users(
+            archive_users=[{"id": 5, "username": "alice"}],
+            client=client,
+            selected=True,
+            report=report,
+            ledger=ledger,
+        )
+    client.create_user.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_capability_check_passes_with_normal_schema():
+    """A normal schema (username + privilege flags, no hash field) passes the
+    capability gate and allows the restore to proceed."""
+    client = _client()  # default schema has no password_hash
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[{"id": 5, "username": "alice"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+    client.create_user.assert_awaited()
+    assert report.category(EntityType.USER).created == 1
+
+
+# ---------------------------------------------------------------------------
+# MANDATED TEST: colliding-username-does-not-touch-operator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_colliding_username_does_not_touch_operator():
+    """The archive carries a user whose username == the current operator's, but
+    with a DIFFERENT (remapped) id. The operator is matched by auth subject
+    (/users/me/), so the colliding archive user is SKIPPED with
+    CURRENT_ADMIN_PRESERVED — and the operator row is never created/updated/
+    deleted (no create_user, no delete_user)."""
+    operator = {"id": 1, "username": "admin", "is_superuser": True}
+    client = _client(me=operator)
+    report = _report()
+    ledger = _ledger()
+
+    # Archive's "admin" has a different source id (cross-instance remap) and even
+    # claims superuser — must be ignored entirely.
+    await import_users(
+        archive_users=[{"id": 999, "username": "admin", "is_superuser": True}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    client.create_user.assert_not_awaited()
+    client.delete_user.assert_not_awaited()
+    cat = report.category(EntityType.USER)
+    assert cat.created == 0
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.CURRENT_ADMIN_PRESERVED
+    assert cat.skip_details[0].label == "admin"
+    assert ledger.entries == []
+
+
+@pytest.mark.asyncio
+async def test_operator_matched_by_subject_not_by_archive_id():
+    """Even if an archive user shares the operator's *id* but a different
+    username, OR shares the username but not the id, the operator is preserved.
+    Matching is by username-of-the-auth-subject (the stable cross-instance
+    identifier returned by /users/me/), never by the archive's remappable id."""
+    operator = {"id": 1, "username": "operator"}
+    client = _client(me=operator)
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        # id 1 collides with operator's id but username differs -> NOT the operator
+        # (id is remappable); this user is a normal restore.
+        archive_users=[
+            {"id": 1, "username": "someone_else"},
+            {"id": 50, "username": "operator"},  # username match -> preserved
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    cat = report.category(EntityType.USER)
+    # someone_else created; operator-username collision skipped.
+    assert cat.created == 1
+    created_payload = client.create_user.await_args_list[0].args[0]
+    assert created_payload["username"] == "someone_else"
+    preserved = [
+        d for d in cat.skip_details if d.reason == SkipReason.CURRENT_ADMIN_PRESERVED
+    ]
+    assert len(preserved) == 1
+    assert preserved[0].label == "operator"
+
+
+# ---------------------------------------------------------------------------
+# MANDATED TEST: archive-superuser-bit-not-trusted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_archive_superuser_bit_not_trusted():
+    """An archive user with is_superuser=true (and is_staff=true, elevated
+    user_level) is created NON-privileged. The archive's privilege bits are
+    dropped; conservative defaults are forced."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[
+            {
+                "id": 5,
+                "username": "wannabe_admin",
+                "is_superuser": True,
+                "is_staff": True,
+                "user_level": 10,
+            }
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    payload = client.create_user.await_args.args[0]
+    assert payload["is_superuser"] is False
+    assert payload["is_staff"] is False
+    # user_level is forced to the lowest/non-privileged value, never the
+    # archive's elevated 10.
+    assert payload["user_level"] != 10
+    assert report.category(EntityType.USER).created == 1
+
+
+# ---------------------------------------------------------------------------
+# MANDATED TEST: no-password-set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_password_set():
+    """The create payload omits password entirely (and any hash field), so the
+    restored user ends with an unusable Django password."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[
+            {
+                "id": 5,
+                "username": "alice",
+                "password": "hunter2",
+                "password_hash": "pbkdf2_sha256$...",
+            }
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    payload = client.create_user.await_args.args[0]
+    assert "password" not in payload
+    assert "password_hash" not in payload
+
+
+# ---------------------------------------------------------------------------
+# MANDATED TEST: force-reset-flagged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_force_reset_flagged():
+    """Each restored user is flagged force-reset (operator must set a new password
+    out-of-band). The flag is surfaced in the report notes, keyed by username."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[
+            {"id": 5, "username": "alice"},
+            {"id": 6, "username": "bob"},
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    notes_blob = " ".join(report.notes).lower()
+    assert "force-reset" in notes_blob or "force reset" in notes_blob
+    assert "alice" in notes_blob
+    assert "bob" in notes_blob
+
+
+# ---------------------------------------------------------------------------
+# Username uniqueness (non-operator collisions)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_existing_non_operator_username_skipped_already_exists():
+    """A restored user whose username already exists on the destination (and is
+    NOT the operator) is skipped already_exists_identical — never overwritten."""
+    client = _client(
+        me={"id": 1, "username": "operator"},
+        existing_users=[{"id": 30, "username": "existing_user"}],
+    )
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[{"id": 5, "username": "existing_user"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    client.create_user.assert_not_awaited()
+    cat = report.category(EntityType.USER)
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.ALREADY_EXISTS_IDENTICAL
+
+
+@pytest.mark.asyncio
+async def test_create_conflict_recorded_as_failure_conflict():
+    """If create_user raises a CONFLICT-shaped upstream error (race: username
+    appeared between the pre-check and the create), it is recorded as a
+    FailureReason.CONFLICT with a sanitized message and no secret."""
+    async def _conflict(payload):
+        raise Exception(
+            'User creation failed: 400 - {"username": ["already exists."]}'
+        )
+
+    client = _client(create_side_effect=_conflict)
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[{"id": 5, "username": "racy"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    cat = report.category(EntityType.USER)
+    assert cat.failed == 1
+    assert cat.failure_details[0].reason == FailureReason.CONFLICT
+    assert cat.failure_details[0].label == "racy"
+
+
+# ---------------------------------------------------------------------------
+# Rollback ledger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rollback_ledger_records_each_created_user():
+    """Each successfully created user is recorded in the rollback ledger with its
+    destination id and username label, so a later failure can compensate-delete."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[
+            {"id": 5, "username": "alice"},
+            {"id": 6, "username": "bob"},
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    assert len(ledger.entries) == 2
+    for entry in ledger.entries:
+        assert entry.entity_type == EntityType.USER
+        assert entry.destination_id is not None
+        assert entry.label in ("alice", "bob")
+    # id remap recorded created destination ids back into the ledger labels only;
+    # no secret material on any entry.
+    labels = {e.label for e in ledger.entries}
+    assert labels == {"alice", "bob"}
+
+
+# ---------------------------------------------------------------------------
+# Audit/report carries usernames only — never hashes/passwords
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_report_and_ledger_carry_no_secret_material():
+    """Across every report surface (skip_details, failure_details, notes) and the
+    ledger, only usernames appear — never a password or hash substring."""
+    client = _client(
+        me={"id": 1, "username": "operator"},
+        existing_users=[{"id": 9, "username": "dup_user"}],
+    )
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[
+            {"id": 5, "username": "alice", "password": "SECRET_PW", "password_hash": "SECRET_HASH"},
+            {"id": 6, "username": "operator", "password": "SECRET_PW"},  # preserved
+            {"id": 7, "username": "dup_user", "password_hash": "SECRET_HASH"},  # exists
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    blob = report.model_dump_json() + ledger.model_dump_json()
+    assert "SECRET_PW" not in blob
+    assert "SECRET_HASH" not in blob
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_does_not_create_but_reports_would_create():
+    """A dry-run issues no create_user calls but populates would_create so the
+    operator sees the plan."""
+    client = _client()
+    report = RestoreReport(is_dry_run=True)
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[{"id": 5, "username": "alice"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        is_dry_run=True,
+    )
+
+    client.create_user.assert_not_awaited()
+    cat = report.category(EntityType.USER)
+    assert cat.would_create == 1
+    assert cat.created == 0
+    assert ledger.entries == []

--- a/backend/tests/unit/test_dispatcharr_client_user_crud.py
+++ b/backend/tests/unit/test_dispatcharr_client_user_crud.py
@@ -1,0 +1,315 @@
+"""Unit tests for DispatcharrClient user helpers
+(enhancedchannelmanager-l1p4p, Phase 2 Users import — crown-jewel restore).
+
+The Users importer restores Dispatcharr (Django) user accounts. Per spike
+tsfv0 (live-confirmed vs Dispatcharr 0.26.0):
+
+* No password/hash ever crosses the boundary. ``create_user`` POSTs to
+  /api/accounts/users/ OMITTING ``password`` -> Django stores an unusable
+  password; the operator resets it out-of-band (force-reset).
+* The current operator is identified by AUTH SUBJECT via
+  ``get_current_user`` (/api/accounts/users/me/) — never by username/id, which
+  a cross-instance restore remaps and which a malicious archive can collide.
+* A startup capability check reads the User schema and fails the users
+  category CLOSED if a ``password_hash`` (or similar) WRITE field ever appears,
+  so a future Dispatcharr that accepts pre-hashed passwords cannot silently
+  cause ECM to start writing hashes.
+
+Mocking pattern follows test_dispatcharr_client_stream_crud.py: construct a real
+``DispatcharrClient`` and ``patch.object(client, "_request", AsyncMock(...))``.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+from config import DispatcharrSettings
+from dispatcharr_client import DispatcharrClient
+
+
+def _response(status_code: int, json_body=None, text: str = ""):
+    resp = AsyncMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json = lambda: json_body if json_body is not None else {}
+    resp.text = text
+
+    def _raise_for_status():
+        if status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"HTTP {status_code}", request=None, response=resp
+            )
+
+    resp.raise_for_status = _raise_for_status
+    return resp
+
+
+def _make_client():
+    settings = DispatcharrSettings(
+        url="http://dispatcharr:8000",
+        auth_method="api_key",
+        dispatcharr_api_key="key-123",
+    )
+    return DispatcharrClient(settings)
+
+
+# ---------------------------------------------------------------------------
+# create_user
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_user_posts_to_accounts_users_endpoint_and_returns_created():
+    """create_user POSTs to /api/accounts/users/ and returns the created body."""
+    client = _make_client()
+    try:
+        created = {"id": 42, "username": "alice", "is_superuser": False}
+        request_mock = AsyncMock(return_value=_response(201, created))
+        with patch.object(client, "_request", request_mock):
+            result = await client.create_user({"username": "alice"})
+
+        assert result == created
+        method, path = request_mock.await_args.args
+        assert method == "POST"
+        assert path == "/api/accounts/users/"
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_user_payload_omits_password_entirely():
+    """The payload sent upstream MUST NOT carry a password (or any hash) field —
+    create-with-no-usable-password is the mandated policy. Even if a caller
+    passes one, create_user strips it so a password never crosses the boundary."""
+    client = _make_client()
+    try:
+        request_mock = AsyncMock(return_value=_response(201, {"id": 1, "username": "bob"}))
+        with patch.object(client, "_request", request_mock):
+            await client.create_user(
+                {
+                    "username": "bob",
+                    "password": "should-be-dropped",
+                    "password_hash": "pbkdf2$...",
+                }
+            )
+
+        sent = request_mock.await_args.kwargs["json"]
+        assert "password" not in sent
+        assert "password_hash" not in sent
+        assert sent["username"] == "bob"
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_user_accepts_200_status():
+    """200 (some DRF endpoints) is treated as success like 201."""
+    client = _make_client()
+    try:
+        created = {"id": 1, "username": "c"}
+        request_mock = AsyncMock(return_value=_response(200, created))
+        with patch.object(client, "_request", request_mock):
+            result = await client.create_user({"username": "c"})
+        assert result == created
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_user_raises_with_status_and_body_on_4xx():
+    """A 4xx raises an Exception matching the '<thing> failed: <status> - <body>'
+    shape that upstream_http_exception parses."""
+    client = _make_client()
+    try:
+        body = '{"username": ["A user with that username already exists."]}'
+        request_mock = AsyncMock(return_value=_response(400, text=body))
+        with patch.object(client, "_request", request_mock):
+            with pytest.raises(Exception) as exc_info:
+                await client.create_user({"username": "dup"})
+        msg = str(exc_info.value)
+        assert "User creation failed" in msg
+        assert "400" in msg
+        assert body in msg
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_user_rejects_non_dict_payload():
+    """create_user requires a dict payload; non-dict raises before any HTTP."""
+    client = _make_client()
+    try:
+        request_mock = AsyncMock(return_value=_response(201, {"id": 1}))
+        with patch.object(client, "_request", request_mock):
+            with pytest.raises(ValueError):
+                await client.create_user(None)  # type: ignore[arg-type]
+            with pytest.raises(ValueError):
+                await client.create_user([{"username": "x"}])  # type: ignore[arg-type]
+        request_mock.assert_not_awaited()
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_user_requires_username():
+    """A payload without a username raises before any HTTP (Django requires it)."""
+    client = _make_client()
+    try:
+        request_mock = AsyncMock(return_value=_response(201, {"id": 1}))
+        with patch.object(client, "_request", request_mock):
+            with pytest.raises(ValueError):
+                await client.create_user({"email": "x@example.com"})
+        request_mock.assert_not_awaited()
+    finally:
+        await client._client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# delete_user (rollback compensation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_user_issues_delete_to_id_endpoint():
+    """delete_user DELETEs /api/accounts/users/{id}/ and returns None."""
+    client = _make_client()
+    try:
+        request_mock = AsyncMock(return_value=_response(204))
+        with patch.object(client, "_request", request_mock):
+            result = await client.delete_user(42)
+        assert result is None
+        method, path = request_mock.await_args.args
+        assert method == "DELETE"
+        assert path == "/api/accounts/users/42/"
+    finally:
+        await client._client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# get_current_user (auth subject — the load-bearing security control)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_reads_users_me_endpoint():
+    """get_current_user GETs /api/accounts/users/me/ — the auth subject of the
+    credentials in use, NOT a username from the archive."""
+    client = _make_client()
+    try:
+        me = {"id": 7, "username": "operator", "is_superuser": True}
+        request_mock = AsyncMock(return_value=_response(200, me))
+        with patch.object(client, "_request", request_mock):
+            result = await client.get_current_user()
+        assert result == me
+        method, path = request_mock.await_args.args
+        assert method == "GET"
+        assert path == "/api/accounts/users/me/"
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_raises_on_error():
+    """A non-2xx from /users/me/ raises — the importer must NOT proceed without
+    a confirmed operator identity (fail closed rather than guess)."""
+    client = _make_client()
+    try:
+        request_mock = AsyncMock(return_value=_response(401, text="unauth"))
+        with patch.object(client, "_request", request_mock):
+            with pytest.raises(httpx.HTTPStatusError):
+                await client.get_current_user()
+    finally:
+        await client._client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# get_user_schema_write_fields (capability check source)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_user_schema_write_fields_extracts_writable_request_props():
+    """get_user_schema_write_fields reads /api/schema/ and returns the set of
+    WRITABLE request-body property names for the User-create endpoint, so the
+    importer can detect a password_hash write field appearing in a future
+    Dispatcharr."""
+    client = _make_client()
+    try:
+        # Minimal OpenAPI doc: the POST /api/accounts/users/ requestBody
+        # references a UserRequest schema with writable props.
+        schema_doc = {
+            "paths": {
+                "/api/accounts/users/": {
+                    "post": {
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/UserRequest"}
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "UserRequest": {
+                        "type": "object",
+                        "properties": {
+                            "username": {"type": "string"},
+                            "password": {"type": "string", "writeOnly": True},
+                            "is_superuser": {"type": "boolean"},
+                            "id": {"type": "integer", "readOnly": True},
+                        },
+                    }
+                }
+            },
+        }
+        request_mock = AsyncMock(return_value=_response(200, schema_doc))
+        with patch.object(client, "_request", request_mock):
+            fields = await client.get_user_schema_write_fields()
+
+        method, path = request_mock.await_args.args
+        assert method == "GET"
+        assert path == "/api/schema/"
+        # Writable request props are present; the read-only id is excluded.
+        assert "username" in fields
+        assert "password" in fields
+        assert "is_superuser" in fields
+        assert "id" not in fields
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_get_user_schema_write_fields_surfaces_password_hash_when_present():
+    """If a future schema exposes a writable password_hash field, it appears in
+    the returned set so the capability check can fail the category closed."""
+    client = _make_client()
+    try:
+        schema_doc = {
+            "paths": {
+                "/api/accounts/users/": {
+                    "post": {
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "username": {"type": "string"},
+                                            "password_hash": {"type": "string"},
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        request_mock = AsyncMock(return_value=_response(200, schema_doc))
+        with patch.object(client, "_request", request_mock):
+            fields = await client.get_user_schema_write_fields()
+        assert "password_hash" in fields
+    finally:
+        await client._client.aclose()


### PR DESCRIPTION
## Bead
enhancedchannelmanager-l1p4p — Phase 2 Users importer (crown-jewel restore). Most security-sensitive bead in the epic; privilege-escalation surface.

## Policy (spike tsfv0, live-confirmed vs Dispatcharr 0.26.0)
- **No password/hash crosses the boundary.** `POST /api/accounts/users/` OMITS password → Django stores an unusable password; restored users flagged **force-reset**. Never fabricated/derived/rehashed/parsed.
- **Privilege flags conservative.** Archive `is_superuser`/`is_staff`/`user_level`/`is_active` are DROPPED, then `is_superuser=False, is_staff=False, user_level=0` forced. A restored user is non-privileged regardless of archive content.
- **Operator preserved by AUTH SUBJECT** (`/api/accounts/users/me/`), not username/id. A colliding archive username is skipped `CURRENT_ADMIN_PRESERVED`; the importer has NO update/PUT path so an existing user can never be demoted/disabled/deleted. Fails closed if `/users/me/` errors.
- **Capability check fails CLOSED** before any create if a `password_hash` write field appears in the Dispatcharr schema (or schema unparseable).
- Category is **opt-in** (`dispatcharr_users`, distinct from ECM's own bcrypt users). Audit surfaces usernames only.
- New client methods: `get_current_user`, `create_user` (password-stripped at the edge too), `delete_user` (rollback compensation, 404=idempotent), `get_user_schema_write_fields`.

## Security review
Independent security-engineer review: **SAFE TO MERGE WITH FOLLOW-UPS** — all 6 invariants verified against code, no BLOCKER/HIGH. Follow-ups filed: ledger disk-flush ownership (orchestrator .18), allowlist∩schema payload hardening, `_sanitize` tightening.

## Tests
25 tests (14 importer + 11 client) including the 4 mandated: colliding-username-does-not-touch-operator, archive-superuser-bit-not-trusted, no-password-set, force-reset-flagged; plus capability-fail-closed, secret-material-absent, operator-by-subject-not-id. Full backend suite green (5605 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)