### PR TITLE
v0.18.0-dbas: 0i2vt.8 cloud upload wiring (S3/WebDAV/GDrive)

### DIFF
--- a/backend/cloud_storage/__init__.py
+++ b/backend/cloud_storage/__init__.py
@@ -1,6 +1,6 @@
 """
 Cloud storage adapter framework for export distribution.
-Supports S3, Google Drive, OneDrive, and Dropbox.
+Supports S3, Google Drive, OneDrive, Dropbox, and WebDAV.
 """
 from cloud_storage.factory import get_adapter
 from cloud_storage.types import (

--- a/backend/cloud_storage/factory.py
+++ b/backend/cloud_storage/factory.py
@@ -16,7 +16,7 @@ def get_adapter(provider_type: str, credentials: dict) -> CloudStorageAdapter:
     """Factory function to create the appropriate cloud storage adapter.
 
     Args:
-        provider_type: One of "s3", "gdrive", "onedrive", "dropbox".
+        provider_type: One of "s3", "gdrive", "onedrive", "dropbox", "webdav".
         credentials: Provider-specific configuration dict.
 
     Returns:
@@ -38,5 +38,8 @@ def get_adapter(provider_type: str, credentials: dict) -> CloudStorageAdapter:
     elif provider_type == "dropbox":
         from cloud_storage.dropbox_adapter import DropboxAdapter
         return DropboxAdapter(credentials)
+    elif provider_type == "webdav":
+        from cloud_storage.webdav_adapter import WebDAVAdapter
+        return WebDAVAdapter(credentials)
     else:
         raise ValueError(f"Unknown cloud storage provider: {provider_type}")

--- a/backend/cloud_storage/gdrive_adapter.py
+++ b/backend/cloud_storage/gdrive_adapter.py
@@ -16,9 +16,12 @@ Security (bead 0i2vt.8):
 * **Stream from disk.** ``MediaFileUpload(..., resumable=True)`` streams the
   artifact from the on-disk path in chunks — it never reads the whole file
   into RAM (HARD AC #2).
-* **Credential masking.** Logged/surfaced error strings pass through
-  :func:`cloud_storage.upload_security.mask_secrets` so bearer tokens never
-  reach the logs (HARD AC #5).
+* **Credential masking.** Error strings surfaced via the non-logging
+  :class:`UploadResult.error` / :class:`ConnectionTestResult.message` sinks pass
+  through :func:`cloud_storage.upload_security.mask_secrets` so bearer tokens are
+  redacted; the logger itself only ever receives known-safe fields (provider,
+  filename, folder id, byte count, duration) so no credential-derived or
+  SDK-exception string reaches the logs (HARD AC #5).
 """
 import asyncio
 import json
@@ -109,11 +112,14 @@ class GDriveAdapter(CloudStorageAdapter):
             return UploadResult(success=True, remote_url=remote_url, file_size=file_size, duration_ms=duration_ms)
         except SSRFError as e:
             duration_ms = int((time.time() - start) * 1000)
-            logger.warning("[GDRIVE] Upload refused by SSRF policy: %s", mask_secrets(str(e)))
+            # Log only safe fields (provider + target folder); the masked detail
+            # is surfaced via UploadResult.error (a non-logging sink) so no
+            # credential-derived string reaches the logger.
+            logger.warning("[GDRIVE] Upload to folder %s refused by SSRF policy", self.folder_id)
             return UploadResult(success=False, error=mask_secrets(str(e)), duration_ms=duration_ms)
         except Exception as e:
             duration_ms = int((time.time() - start) * 1000)
-            logger.warning("[GDRIVE] Upload failed: %s", mask_secrets(str(e)))
+            logger.warning("[GDRIVE] Upload to folder %s failed", self.folder_id)
             return UploadResult(success=False, error=mask_secrets(str(e)), duration_ms=duration_ms)
 
     async def test_connection(self) -> ConnectionTestResult:
@@ -129,10 +135,12 @@ class GDriveAdapter(CloudStorageAdapter):
                 provider_info={"folder_id": self.folder_id, "folder_name": folder.get("name", "")},
             )
         except SSRFError as e:
-            logger.warning("[GDRIVE] Connection refused by SSRF policy: %s", mask_secrets(str(e)))
+            # Log only the safe target folder; masked detail goes to the
+            # non-logging ConnectionTestResult.message sink.
+            logger.warning("[GDRIVE] Connection to folder %s refused by SSRF policy", self.folder_id)
             return ConnectionTestResult(success=False, message=mask_secrets(str(e)))
         except Exception as e:
-            logger.warning("[GDRIVE] Connection test failed: %s", mask_secrets(str(e)))
+            logger.warning("[GDRIVE] Connection test to folder %s failed", self.folder_id)
             return ConnectionTestResult(success=False, message=mask_secrets(str(e)))
 
     async def delete(self, remote_path: str) -> bool:
@@ -152,8 +160,8 @@ class GDriveAdapter(CloudStorageAdapter):
                 )
             logger.info("[GDRIVE] Deleted %s", filename)
             return True
-        except Exception as e:
-            logger.warning("[GDRIVE] Delete failed: %s", mask_secrets(str(e)))
+        except Exception:
+            logger.warning("[GDRIVE] Delete from folder %s failed", self.folder_id)
             return False
 
     async def list_files(self, remote_path: str = "") -> list[str]:
@@ -167,6 +175,6 @@ class GDriveAdapter(CloudStorageAdapter):
                 ).execute()
             )
             return [f["name"] for f in results.get("files", [])]
-        except Exception as e:
-            logger.warning("[GDRIVE] List files failed: %s", mask_secrets(str(e)))
+        except Exception:
+            logger.warning("[GDRIVE] List files in folder %s failed", self.folder_id)
             return []

--- a/backend/cloud_storage/gdrive_adapter.py
+++ b/backend/cloud_storage/gdrive_adapter.py
@@ -1,14 +1,39 @@
 """
 Google Drive cloud storage adapter via service account.
+
+Security (bead 0i2vt.8):
+* **SSRF chokepoint (.5).** The Google Drive API endpoint host
+  (``www.googleapis.com``) is pre-resolved + denylist-validated via
+  :func:`cloud_storage.upload_security.preresolve_endpoint` before any SDK call
+  — the §9.2 row B4 option (b) "pre-resolve + validate the endpoint host before
+  the SDK call" approach. The endpoint is a fixed Google host (not
+  operator-supplied), so in practice this defends against a poisoned resolver
+  pointing googleapis.com at an internal/metadata address: such a record is
+  denied BEFORE any socket opens.
+* **Event-loop safety.** The googleapiclient is synchronous; every blocking
+  ``.execute()`` call is wrapped in :func:`asyncio.to_thread` so it runs on a
+  worker thread and never blocks the event loop (HARD AC #1).
+* **Stream from disk.** ``MediaFileUpload(..., resumable=True)`` streams the
+  artifact from the on-disk path in chunks — it never reads the whole file
+  into RAM (HARD AC #2).
+* **Credential masking.** Logged/surfaced error strings pass through
+  :func:`cloud_storage.upload_security.mask_secrets` so bearer tokens never
+  reach the logs (HARD AC #5).
 """
+import asyncio
 import json
 import logging
 import time
 from pathlib import Path
 
 from cloud_storage.types import CloudStorageAdapter, UploadResult, ConnectionTestResult
+from cloud_storage.upload_security import SSRFError, mask_secrets, preresolve_endpoint
 
 logger = logging.getLogger(__name__)
+
+# Fixed Google Drive API endpoint host — pre-validated through the .5 chokepoint
+# so a poisoned resolver pointing it at an internal address is refused.
+_GOOGLE_API_ENDPOINT = "https://www.googleapis.com/"
 
 
 class GDriveAdapter(CloudStorageAdapter):
@@ -24,9 +49,17 @@ class GDriveAdapter(CloudStorageAdapter):
         self.sa_info = json.loads(sa_json) if isinstance(sa_json, str) else sa_json
         self.folder_id = credentials["folder_id"]
 
+    def _validate_endpoint(self) -> None:
+        """Pre-resolve + denylist-validate the Google API host (.5 chokepoint).
+
+        Raises :class:`SSRFError` if the host resolves to a denied address —
+        BEFORE the Drive service / any socket is built.
+        """
+        preresolve_endpoint(_GOOGLE_API_ENDPOINT)
+
     def _get_service(self):
-        from google.oauth2 import service_account as sa_module
-        from googleapiclient.discovery import build
+        from google.oauth2 import service_account as sa_module  # ssrf-ok: endpoint pre-validated (.5)
+        from googleapiclient.discovery import build  # ssrf-ok: endpoint pre-validated (.5)
 
         creds = sa_module.Credentials.from_service_account_info(
             self.sa_info, scopes=["https://www.googleapis.com/auth/drive.file"]
@@ -36,79 +69,104 @@ class GDriveAdapter(CloudStorageAdapter):
     async def upload(self, local_path: Path, remote_path: str) -> UploadResult:
         start = time.time()
         try:
-            from googleapiclient.http import MediaFileUpload
+            self._validate_endpoint()
+            from googleapiclient.http import MediaFileUpload  # ssrf-ok: endpoint pre-validated (.5)
 
             service = self._get_service()
             filename = Path(remote_path).name
             file_size = local_path.stat().st_size
 
-            # Check if file already exists in folder
-            existing = service.files().list(
-                q=f"name='{filename}' and '{self.folder_id}' in parents and trashed=false",
-                fields="files(id)",
-            ).execute()
+            # Check if file already exists in folder (blocking → executor).
+            existing = await asyncio.to_thread(
+                lambda: service.files().list(
+                    q=f"name='{filename}' and '{self.folder_id}' in parents and trashed=false",
+                    fields="files(id)",
+                ).execute()
+            )
 
+            # resumable=True streams the artifact from the on-disk path in
+            # chunks — never a whole-file read into RAM.
             media = MediaFileUpload(str(local_path), resumable=True)
 
             if existing.get("files"):
-                # Update existing file
                 file_id = existing["files"][0]["id"]
-                result = service.files().update(
-                    fileId=file_id, media_body=media
-                ).execute()
+                result = await asyncio.to_thread(
+                    lambda: service.files().update(
+                        fileId=file_id, media_body=media
+                    ).execute()
+                )
             else:
-                # Create new file
                 metadata = {"name": filename, "parents": [self.folder_id]}
-                result = service.files().create(
-                    body=metadata, media_body=media, fields="id,webViewLink"
-                ).execute()
+                result = await asyncio.to_thread(
+                    lambda: service.files().create(
+                        body=metadata, media_body=media, fields="id,webViewLink"
+                    ).execute()
+                )
 
             duration_ms = int((time.time() - start) * 1000)
             remote_url = result.get("webViewLink", f"gdrive://{result.get('id', '')}")
             logger.info("[GDRIVE] Uploaded %s (%s bytes, %sms)", filename, file_size, duration_ms)
             return UploadResult(success=True, remote_url=remote_url, file_size=file_size, duration_ms=duration_ms)
+        except SSRFError as e:
+            duration_ms = int((time.time() - start) * 1000)
+            logger.warning("[GDRIVE] Upload refused by SSRF policy: %s", mask_secrets(str(e)))
+            return UploadResult(success=False, error=mask_secrets(str(e)), duration_ms=duration_ms)
         except Exception as e:
             duration_ms = int((time.time() - start) * 1000)
-            logger.warning("[GDRIVE] Upload failed: %s", e)
-            return UploadResult(success=False, error=str(e), duration_ms=duration_ms)
+            logger.warning("[GDRIVE] Upload failed: %s", mask_secrets(str(e)))
+            return UploadResult(success=False, error=mask_secrets(str(e)), duration_ms=duration_ms)
 
     async def test_connection(self) -> ConnectionTestResult:
         try:
+            self._validate_endpoint()
             service = self._get_service()
-            folder = service.files().get(fileId=self.folder_id, fields="id,name").execute()
+            folder = await asyncio.to_thread(
+                lambda: service.files().get(fileId=self.folder_id, fields="id,name").execute()
+            )
             return ConnectionTestResult(
                 success=True,
                 message=f"Connected to folder '{folder.get('name', self.folder_id)}'",
                 provider_info={"folder_id": self.folder_id, "folder_name": folder.get("name", "")},
             )
+        except SSRFError as e:
+            logger.warning("[GDRIVE] Connection refused by SSRF policy: %s", mask_secrets(str(e)))
+            return ConnectionTestResult(success=False, message=mask_secrets(str(e)))
         except Exception as e:
-            logger.warning("[GDRIVE] Connection test failed: %s", e)
-            return ConnectionTestResult(success=False, message=str(e))
+            logger.warning("[GDRIVE] Connection test failed: %s", mask_secrets(str(e)))
+            return ConnectionTestResult(success=False, message=mask_secrets(str(e)))
 
     async def delete(self, remote_path: str) -> bool:
         try:
+            self._validate_endpoint()
             service = self._get_service()
             filename = Path(remote_path).name
-            results = service.files().list(
-                q=f"name='{filename}' and '{self.folder_id}' in parents and trashed=false",
-                fields="files(id)",
-            ).execute()
+            results = await asyncio.to_thread(
+                lambda: service.files().list(
+                    q=f"name='{filename}' and '{self.folder_id}' in parents and trashed=false",
+                    fields="files(id)",
+                ).execute()
+            )
             for f in results.get("files", []):
-                service.files().delete(fileId=f["id"]).execute()
+                await asyncio.to_thread(
+                    lambda fid=f["id"]: service.files().delete(fileId=fid).execute()
+                )
             logger.info("[GDRIVE] Deleted %s", filename)
             return True
         except Exception as e:
-            logger.warning("[GDRIVE] Delete failed: %s", e)
+            logger.warning("[GDRIVE] Delete failed: %s", mask_secrets(str(e)))
             return False
 
     async def list_files(self, remote_path: str = "") -> list[str]:
         try:
+            self._validate_endpoint()
             service = self._get_service()
-            results = service.files().list(
-                q=f"'{self.folder_id}' in parents and trashed=false",
-                fields="files(name)",
-            ).execute()
+            results = await asyncio.to_thread(
+                lambda: service.files().list(
+                    q=f"'{self.folder_id}' in parents and trashed=false",
+                    fields="files(name)",
+                ).execute()
+            )
             return [f["name"] for f in results.get("files", [])]
         except Exception as e:
-            logger.warning("[GDRIVE] List files failed: %s", e)
+            logger.warning("[GDRIVE] List files failed: %s", mask_secrets(str(e)))
             return []

--- a/backend/cloud_storage/s3_adapter.py
+++ b/backend/cloud_storage/s3_adapter.py
@@ -111,11 +111,14 @@ class S3Adapter(CloudStorageAdapter):
             return UploadResult(success=True, remote_url=remote_url, file_size=file_size, duration_ms=duration_ms)
         except SSRFError as e:
             duration_ms = int((time.time() - start) * 1000)
-            logger.warning("[S3] Upload refused by SSRF policy: %s", mask_secrets(str(e)))
+            # Log only safe fields (provider + remote path); the masked detail
+            # is surfaced via UploadResult.error (a non-logging sink) so no
+            # credential-derived string reaches the logger.
+            logger.warning("[S3] Upload to bucket %s refused by SSRF policy", self.bucket)
             return UploadResult(success=False, error=mask_secrets(str(e)), duration_ms=duration_ms)
         except Exception as e:
             duration_ms = int((time.time() - start) * 1000)
-            logger.warning("[S3] Upload failed: %s", mask_secrets(str(e)))
+            logger.warning("[S3] Upload to bucket %s path %s failed", self.bucket, remote_path)
             return UploadResult(success=False, error=mask_secrets(str(e)), duration_ms=duration_ms)
 
     async def test_connection(self) -> ConnectionTestResult:
@@ -131,10 +134,10 @@ class S3Adapter(CloudStorageAdapter):
                 provider_info={"bucket": self.bucket, "region": region},
             )
         except SSRFError as e:
-            logger.warning("[S3] Connection refused by SSRF policy: %s", mask_secrets(str(e)))
+            logger.warning("[S3] Connection to bucket %s refused by SSRF policy", self.bucket)
             return ConnectionTestResult(success=False, message=mask_secrets(str(e)))
         except Exception as e:
-            logger.warning("[S3] Connection test failed: %s", mask_secrets(str(e)))
+            logger.warning("[S3] Connection test to bucket %s failed", self.bucket)
             return ConnectionTestResult(success=False, message=mask_secrets(str(e)))
 
     async def delete(self, remote_path: str) -> bool:
@@ -144,8 +147,8 @@ class S3Adapter(CloudStorageAdapter):
             await asyncio.to_thread(client.delete_object, Bucket=self.bucket, Key=remote_path)
             logger.info("[S3] Deleted %s from %s", remote_path, self.bucket)
             return True
-        except Exception as e:
-            logger.warning("[S3] Delete failed: %s", mask_secrets(str(e)))
+        except Exception:
+            logger.warning("[S3] Delete of %s from bucket %s failed", remote_path, self.bucket)
             return False
 
     async def list_files(self, remote_path: str = "") -> list[str]:
@@ -156,6 +159,6 @@ class S3Adapter(CloudStorageAdapter):
                 client.list_objects_v2, Bucket=self.bucket, Prefix=remote_path
             )
             return [obj["Key"] for obj in response.get("Contents", [])]
-        except Exception as e:
-            logger.warning("[S3] List files failed: %s", mask_secrets(str(e)))
+        except Exception:
+            logger.warning("[S3] List files under prefix %s in bucket %s failed", remote_path, self.bucket)
             return []

--- a/backend/cloud_storage/s3_adapter.py
+++ b/backend/cloud_storage/s3_adapter.py
@@ -1,18 +1,41 @@
 """
 S3-compatible cloud storage adapter.
 Supports AWS S3, MinIO, and Backblaze B2.
+
+Security (bead 0i2vt.8):
+* **SSRF chokepoint (.5).** A custom ``endpoint_url`` (MinIO/B2/self-hosted) is
+  pre-resolved + denylist-validated via
+  :func:`cloud_storage.upload_security.preresolve_endpoint` BEFORE the boto3
+  client is constructed — the §9.2 row B4 option (b) "pre-resolve + validate the
+  endpoint host before the SDK call" approach. A custom endpoint pointed at
+  ``169.254.169.254`` (the cloud-metadata endpoint) raises
+  :class:`security.ssrf.SSRFError` before any socket opens. AWS's own regional
+  endpoints (no custom ``endpoint_url``) are public AWS infrastructure and are
+  not operator-influenceable, so they are not pre-resolved.
+* **Event-loop safety.** boto3 is synchronous; every blocking SDK call
+  (``upload_file``, ``head_bucket`` …) is wrapped in :func:`asyncio.to_thread`
+  so it runs on a worker thread, never blocking the event loop (HARD AC #1).
+* **Stream from disk.** ``upload_file`` streams the artifact from the on-disk
+  path — it never reads the whole file into RAM (HARD AC #2).
+* **Credential masking.** Logged/surfaced error strings are passed through
+  :func:`cloud_storage.upload_security.mask_secrets` so access keys, secret
+  keys, and X-Amz-Signature query strings never reach the logs (HARD AC #5).
 """
+import asyncio
 import logging
 import time
 from pathlib import Path
 
 from cloud_storage.types import CloudStorageAdapter, UploadResult, ConnectionTestResult
+from cloud_storage.upload_security import SSRFError, mask_secrets, preresolve_endpoint
 
 logger = logging.getLogger(__name__)
 
 CONTENT_TYPES = {
     ".m3u": "audio/x-mpegurl",
     ".xml": "application/xml",
+    ".zip": "application/zip",
+    ".sha256": "text/plain",
 }
 
 
@@ -36,8 +59,18 @@ class S3Adapter(CloudStorageAdapter):
         self.endpoint_url = credentials.get("endpoint_url") or None
         self.region = credentials.get("region") or "us-east-1"
 
+    def _validate_endpoint(self) -> None:
+        """Pre-resolve + denylist-validate a custom endpoint (.5 chokepoint).
+
+        No-op for the default AWS endpoint (no operator-supplied URL). Raises
+        :class:`SSRFError` if a custom endpoint host is denied — BEFORE the
+        boto3 client is built (so before any socket opens).
+        """
+        if self.endpoint_url:
+            preresolve_endpoint(self.endpoint_url)
+
     def _get_client(self):
-        import boto3
+        import boto3  # ssrf-ok: endpoint pre-validated via preresolve_endpoint (.5)
         kwargs = {
             "service_name": "s3",
             "aws_access_key_id": self.access_key,
@@ -51,11 +84,18 @@ class S3Adapter(CloudStorageAdapter):
     async def upload(self, local_path: Path, remote_path: str) -> UploadResult:
         start = time.time()
         try:
+            # SSRF guard FIRST — refuse a denied custom endpoint before any
+            # client/socket is created.
+            self._validate_endpoint()
             client = self._get_client()
             content_type = CONTENT_TYPES.get(local_path.suffix, "application/octet-stream")
             file_size = local_path.stat().st_size
 
-            client.upload_file(
+            # Executor-wrap the blocking boto3 upload — boto3 streams the file
+            # from the path (no whole-file read), and to_thread keeps the call
+            # off the event loop.
+            await asyncio.to_thread(
+                client.upload_file,
                 str(local_path),
                 self.bucket,
                 remote_path,
@@ -69,41 +109,53 @@ class S3Adapter(CloudStorageAdapter):
 
             logger.info("[S3] Uploaded %s to %s (%s bytes, %sms)", local_path.name, remote_path, file_size, duration_ms)
             return UploadResult(success=True, remote_url=remote_url, file_size=file_size, duration_ms=duration_ms)
+        except SSRFError as e:
+            duration_ms = int((time.time() - start) * 1000)
+            logger.warning("[S3] Upload refused by SSRF policy: %s", mask_secrets(str(e)))
+            return UploadResult(success=False, error=mask_secrets(str(e)), duration_ms=duration_ms)
         except Exception as e:
             duration_ms = int((time.time() - start) * 1000)
-            logger.warning("[S3] Upload failed: %s", e)
-            return UploadResult(success=False, error=str(e), duration_ms=duration_ms)
+            logger.warning("[S3] Upload failed: %s", mask_secrets(str(e)))
+            return UploadResult(success=False, error=mask_secrets(str(e)), duration_ms=duration_ms)
 
     async def test_connection(self) -> ConnectionTestResult:
         try:
+            self._validate_endpoint()
             client = self._get_client()
-            client.head_bucket(Bucket=self.bucket)
-            location = client.get_bucket_location(Bucket=self.bucket)
+            await asyncio.to_thread(client.head_bucket, Bucket=self.bucket)
+            location = await asyncio.to_thread(client.get_bucket_location, Bucket=self.bucket)
             region = location.get("LocationConstraint") or "us-east-1"
             return ConnectionTestResult(
                 success=True,
                 message=f"Connected to bucket '{self.bucket}'",
                 provider_info={"bucket": self.bucket, "region": region},
             )
+        except SSRFError as e:
+            logger.warning("[S3] Connection refused by SSRF policy: %s", mask_secrets(str(e)))
+            return ConnectionTestResult(success=False, message=mask_secrets(str(e)))
         except Exception as e:
-            logger.warning("[S3] Connection test failed: %s", e)
-            return ConnectionTestResult(success=False, message=str(e))
+            logger.warning("[S3] Connection test failed: %s", mask_secrets(str(e)))
+            return ConnectionTestResult(success=False, message=mask_secrets(str(e)))
 
     async def delete(self, remote_path: str) -> bool:
         try:
+            self._validate_endpoint()
             client = self._get_client()
-            client.delete_object(Bucket=self.bucket, Key=remote_path)
+            await asyncio.to_thread(client.delete_object, Bucket=self.bucket, Key=remote_path)
             logger.info("[S3] Deleted %s from %s", remote_path, self.bucket)
             return True
         except Exception as e:
-            logger.warning("[S3] Delete failed: %s", e)
+            logger.warning("[S3] Delete failed: %s", mask_secrets(str(e)))
             return False
 
     async def list_files(self, remote_path: str = "") -> list[str]:
         try:
+            self._validate_endpoint()
             client = self._get_client()
-            response = client.list_objects_v2(Bucket=self.bucket, Prefix=remote_path)
+            response = await asyncio.to_thread(
+                client.list_objects_v2, Bucket=self.bucket, Prefix=remote_path
+            )
             return [obj["Key"] for obj in response.get("Contents", [])]
         except Exception as e:
-            logger.warning("[S3] List files failed: %s", e)
+            logger.warning("[S3] List files failed: %s", mask_secrets(str(e)))
             return []

--- a/backend/cloud_storage/upload_security.py
+++ b/backend/cloud_storage/upload_security.py
@@ -1,0 +1,213 @@
+"""Shared SSRF + credential-masking helpers for cloud-upload adapters.
+
+Bead ``enhancedchannelmanager-0i2vt.8``. Every outbound DBAS upload routes
+through the :mod:`security.ssrf` chokepoint built by ``.5``. This module is the
+adapter-facing glue that makes that routing uniform across the three shipping
+adapters (S3, GDrive, WebDAV) and centralises two cross-cutting security
+controls the grooming HARD ACs mandate:
+
+1. **SSRF refusal BEFORE a socket opens.** :func:`preresolve_endpoint` runs the
+   ``.5`` validator (``validate_outbound_url``) on the operator-supplied endpoint
+   URL and raises :class:`security.ssrf.SSRFError` *before* the adapter ever
+   constructs an SDK client or opens an httpx connection. For the SDK-based
+   adapters (boto3 S3, Google Drive) this is the documented §9.2 row B4 option
+   (b) "pre-resolve + denylist-validate the endpoint host before the SDK call"
+   approach — the SDK then does its own DNS, but the host has already been
+   validated (the residual rebinding window is documented in §9.5).
+
+   For the httpx-based WebDAV adapter, :func:`pinned_async_client` goes further:
+   it connects by the *validated IP* (resolve-then-connect-by-IP) so there is no
+   second DNS lookup between validate and connect.
+
+2. **Credential masking in ALL outbound/log lines.** :func:`mask_secrets`
+   redacts Authorization headers, bearer tokens, S3 access-key/secret-key
+   material, and S3 signed-URL query strings (``X-Amz-Signature`` /
+   ``X-Amz-Credential``) from any string before it is logged or surfaced. The
+   masking patterns are PRECOMPILED MODULE CONSTANTS (Semgrep
+   ``no-bare-re-on-dynamic-pattern`` — never compile a regex from a runtime
+   value in the hot path).
+"""
+from __future__ import annotations
+
+import logging
+import re
+import ssl
+
+from security.ssrf import (  # noqa: F401 — re-exported for adapter convenience
+    SSRFError,
+    ResolvedTarget,
+    get_ssrf_mode,
+    validate_outbound_url,
+)
+
+logger = logging.getLogger(__name__)
+
+# Per-upload timeout (seconds) scoped across validated-resolve + connect +
+# transfer (HARD AC #6). Generous enough for a multi-hundred-MB artifact on a
+# slow uplink, bounded so a black-holed destination cannot hang the task loop.
+UPLOAD_TIMEOUT_SECONDS = 300.0
+
+# ---------------------------------------------------------------------------
+# Credential masking — PRECOMPILED module constants (Semgrep-safe).
+# ---------------------------------------------------------------------------
+# Each pattern is compiled ONCE at import. The masking function only ever calls
+# ``.sub`` on these constants — it never builds a pattern from a runtime value.
+#
+# Order matters: the more specific signed-URL params are masked before the
+# generic key/secret sweeps so the replacement text is stable.
+_MASK = "***REDACTED***"
+
+# Authorization: Bearer <token>  /  Authorization: AWS4-HMAC-SHA256 ...
+# Capture the whole header value (scheme + token), stopping at a quote, comma,
+# or brace so a serialized header dict masks the value but keeps the structure.
+_AUTH_HEADER_RE = re.compile(
+    r"(?i)(authorization\s*[:=]\s*)(['\"]?)([^'\",}]+)",
+)
+# Standalone "Bearer <token>" (e.g. inside a serialized header dict).
+_BEARER_RE = re.compile(r"(?i)(bearer\s+)([A-Za-z0-9._\-]+)")
+
+# S3 signed-URL query params — the signature itself and the credential scope.
+_AMZ_SIGNATURE_RE = re.compile(r"(?i)(X-Amz-Signature=)([A-Za-z0-9%]+)")
+_AMZ_CREDENTIAL_RE = re.compile(r"(?i)(X-Amz-Credential=)([^&\s'\"]+)")
+_AMZ_SECURITY_TOKEN_RE = re.compile(r"(?i)(X-Amz-Security-Token=)([^&\s'\"]+)")
+
+# AWS access key IDs (AKIA…/ASIA… 16+ alnum) and secret-key-shaped material in
+# key=value or key: value form (access_key_id / secret_access_key / aws_secret…).
+_AWS_AKID_RE = re.compile(r"\b((?:AKIA|ASIA)[A-Z0-9]{8,})\b")
+_SECRET_KV_RE = re.compile(
+    r"(?i)((?:secret_access_key|aws_secret_access_key|access_key_id|"
+    r"client_secret|access_token|secret|password|passwd|api_key)"
+    r"\s*[:=]\s*)(['\"]?)([^'\"\s,}&]+)",
+)
+
+# Order is significant — signed-URL params and KV pairs first, then the broad
+# token sweeps, so a value matched by an earlier rule is not double-processed
+# into an unstable form.
+_MASK_RULES = (
+    _AMZ_SIGNATURE_RE,
+    _AMZ_CREDENTIAL_RE,
+    _AMZ_SECURITY_TOKEN_RE,
+    _SECRET_KV_RE,
+    _AUTH_HEADER_RE,
+    _BEARER_RE,
+    _AWS_AKID_RE,
+)
+
+
+def mask_secrets(text: str) -> str:
+    """Redact credential material from ``text`` for safe logging/surfacing.
+
+    Masks Authorization headers, bearer tokens, AWS access keys (AKIA/ASIA),
+    secret/token key=value pairs, and S3 signed-URL params (X-Amz-Signature,
+    X-Amz-Credential, X-Amz-Security-Token). Never raises — masking is a
+    best-effort safety net on the logging path, so a malformed input returns
+    the original string rather than blowing up a log call.
+
+    The patterns are precompiled module constants; this function only calls
+    ``.sub`` on them.
+    """
+    if not text:
+        return text
+    try:
+        out = text
+        for rule in _MASK_RULES:
+            if rule is _AWS_AKID_RE:
+                out = rule.sub(_MASK, out)
+            elif rule in (_AUTH_HEADER_RE, _SECRET_KV_RE):
+                # Keep the header/key name + any opening quote; redact the value.
+                out = rule.sub(lambda m: m.group(1) + (m.group(2) or "") + _MASK, out)
+            else:
+                out = rule.sub(lambda m: m.group(1) + _MASK, out)
+        return out
+    except Exception:  # pragma: no cover — masking must never break logging
+        return _MASK
+
+
+# ---------------------------------------------------------------------------
+# SSRF pre-resolution (SDK adapters: boto3 / GDrive).
+# ---------------------------------------------------------------------------
+def preresolve_endpoint(url: str, mode=None) -> ResolvedTarget:
+    """Validate an operator-supplied endpoint URL through the .5 chokepoint.
+
+    Raises :class:`SSRFError` BEFORE any socket is opened if the URL's host (or
+    any resolved A/AAAA record) is on the always-on denylist (incl. the
+    ``169.254.169.254`` cloud-metadata endpoint) or disallowed by the active
+    SSRF mode. This is the SDK-adapter SSRF guard: the boto3 / GDrive client is
+    constructed ONLY after this returns successfully.
+
+    Args:
+        url: the endpoint URL (S3 endpoint_url, WebDAV base URL, etc.).
+        mode: optional override; defaults to the persisted global SSRF mode.
+
+    Returns:
+        A validated :class:`ResolvedTarget` (validated IP + preserved host).
+
+    Raises:
+        SSRFError: the host/any record is denied (fail-closed).
+    """
+    if mode is None:
+        mode = get_ssrf_mode()
+    return validate_outbound_url(url, mode)
+
+
+# ---------------------------------------------------------------------------
+# httpx resolve-then-connect-by-IP transport (WebDAV adapter).
+# ---------------------------------------------------------------------------
+def pinned_async_client(
+    target: ResolvedTarget,
+    *,
+    verify: bool = True,
+    timeout: float = UPLOAD_TIMEOUT_SECONDS,
+):
+    """Build an httpx ``AsyncClient`` that CONNECTS to the validated IP.
+
+    Resolve-then-connect-by-IP (§9.4 item 3): the client connects to
+    ``target.ip`` (no second DNS lookup — closes the DNS-rebinding window) while
+    presenting ``target.hostname`` for TLS SNI + the ``Host:`` header. Redirects
+    are disabled (``follow_redirects=False``) so a 3xx to an internal address
+    cannot bypass the validator — the WebDAV PUT/DELETE verbs do not legitimately
+    redirect, and re-validation of a redirect chain is out of scope for .8.
+
+    Args:
+        target: the validated target from :func:`preresolve_endpoint`.
+        verify: TLS verification. Default True; the per-target ``insecure``
+            flag wires False here (and the caller writes the insecure audit row).
+        timeout: per-upload timeout in seconds (connect + read + write + pool).
+    """
+    import httpx  # ssrf-ok: connects to the .5-validated IP via a pinned transport
+
+    # The adapter builds request URLs against ``target.ip`` (see
+    # :func:`pinned_request_url`) so the socket goes to the validated IP — there
+    # is no second DNS lookup, closing the rebinding window. The TLS SNI +
+    # ``Host:`` header (carrying the original hostname) are supplied per-request
+    # by the adapter via request extensions / headers. Redirects are disabled so
+    # a 3xx to an internal address cannot bypass the validator.
+    return httpx.AsyncClient(
+        verify=_ssl_context(verify),
+        timeout=httpx.Timeout(timeout, connect=min(30.0, timeout)),
+        follow_redirects=False,
+    )
+
+
+def _ssl_context(verify: bool):
+    """Return an SSL context (verify=True) or False (skip verification)."""
+    if not verify:
+        return False
+    return ssl.create_default_context()
+
+
+def pinned_request_url(target: ResolvedTarget, path: str, query: str = "") -> str:
+    """Build a request URL that connects by the validated IP.
+
+    The scheme + validated IP + port form the authority (so the socket goes to
+    the IP, not a re-resolved host); ``path`` (and optional ``query``) come from
+    the original request. The caller MUST send ``Host: target.host_header`` and
+    use ``target.hostname`` for SNI so TLS + vhost routing still work.
+    """
+    ip = target.ip
+    # Bracket IPv6 literals for the authority component.
+    host = f"[{ip}]" if ip.version == 6 else str(ip)
+    base = f"{target.scheme}://{host}:{target.port}"
+    if not path.startswith("/"):
+        path = "/" + path
+    return f"{base}{path}{('?' + query) if query else ''}"

--- a/backend/cloud_storage/upload_security.py
+++ b/backend/cloud_storage/upload_security.py
@@ -33,12 +33,27 @@ import logging
 import re
 import ssl
 
-from security.ssrf import (  # noqa: F401 — re-exported for adapter convenience
+from security.ssrf import (
     SSRFError,
     ResolvedTarget,
     get_ssrf_mode,
     validate_outbound_url,
 )
+
+# Re-exported for adapter convenience: the S3/GDrive/WebDAV adapters import
+# ``SSRFError`` from this module rather than reaching into ``security.ssrf``.
+# Declaring it in ``__all__`` marks it as an intentional public re-export so it
+# is not reported as an unused import (CodeQL ``py/unused-import`` honours
+# ``__all__`` membership; this is the §B re-export, not dead code).
+__all__ = [
+    "SSRFError",
+    "ResolvedTarget",
+    "UPLOAD_TIMEOUT_SECONDS",
+    "mask_secrets",
+    "preresolve_endpoint",
+    "pinned_async_client",
+    "pinned_request_url",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -75,9 +90,7 @@ _AMZ_SECURITY_TOKEN_RE = re.compile(r"(?i)(X-Amz-Security-Token=)([^&\s'\"]+)")
 # key=value or key: value form (access_key_id / secret_access_key / aws_secret…).
 _AWS_AKID_RE = re.compile(r"\b((?:AKIA|ASIA)[A-Z0-9]{8,})\b")
 _SECRET_KV_RE = re.compile(
-    r"(?i)((?:secret_access_key|aws_secret_access_key|access_key_id|"
-    r"client_secret|access_token|secret|password|passwd|api_key)"
-    r"\s*[:=]\s*)(['\"]?)([^'\"\s,}&]+)",
+    r"(?i)((?:secret_access_key|aws_secret_access_key|access_key_id|client_secret|access_token|secret|password|passwd|api_key)\s*[:=]\s*)(['\"]?)([^'\"\s,}&]+)",
 )
 
 # Order is significant — signed-URL params and KV pairs first, then the broad

--- a/backend/cloud_storage/webdav_adapter.py
+++ b/backend/cloud_storage/webdav_adapter.py
@@ -135,9 +135,12 @@ class WebDAVAdapter(CloudStorageAdapter):
                 resp.raise_for_status()
 
             duration_ms = int((time.time() - start) * 1000)
+            # Log only safe fields (filename, byte count, duration, validated
+            # host). The display URL — which can carry credential-bearing query
+            # material — is returned via UploadResult.remote_url, never logged.
             logger.info(
-                "[WEBDAV] Uploaded %s to %s (%s bytes, %sms)",
-                local_path.name, mask_secrets(display_url), file_size, duration_ms,
+                "[WEBDAV] Uploaded %s to host %s (%s bytes, %sms)",
+                local_path.name, target.hostname, file_size, duration_ms,
             )
             return UploadResult(
                 success=True, remote_url=display_url, file_size=file_size,
@@ -145,11 +148,13 @@ class WebDAVAdapter(CloudStorageAdapter):
             )
         except SSRFError as e:
             duration_ms = int((time.time() - start) * 1000)
-            logger.warning("[WEBDAV] Upload refused by SSRF policy: %s", mask_secrets(str(e)))
+            # Masked detail goes only to UploadResult.error (non-logging sink);
+            # the logger gets generic safe text so no sensitive source reaches it.
+            logger.warning("[WEBDAV] Upload of %s refused by SSRF policy", local_path.name)
             return UploadResult(success=False, error=mask_secrets(str(e)), duration_ms=duration_ms)
         except Exception as e:
             duration_ms = int((time.time() - start) * 1000)
-            logger.warning("[WEBDAV] Upload failed: %s", mask_secrets(str(e)))
+            logger.warning("[WEBDAV] Upload of %s failed", local_path.name)
             return UploadResult(success=False, error=mask_secrets(str(e)), duration_ms=duration_ms)
 
     async def test_connection(self) -> ConnectionTestResult:
@@ -170,10 +175,10 @@ class WebDAVAdapter(CloudStorageAdapter):
                 provider_info={"host": target.hostname},
             )
         except SSRFError as e:
-            logger.warning("[WEBDAV] Connection refused by SSRF policy: %s", mask_secrets(str(e)))
+            logger.warning("[WEBDAV] Connection refused by SSRF policy")
             return ConnectionTestResult(success=False, message=mask_secrets(str(e)))
         except Exception as e:
-            logger.warning("[WEBDAV] Connection test failed: %s", mask_secrets(str(e)))
+            logger.warning("[WEBDAV] Connection test failed")
             return ConnectionTestResult(success=False, message=mask_secrets(str(e)))
 
     async def delete(self, remote_path: str) -> bool:
@@ -187,8 +192,8 @@ class WebDAVAdapter(CloudStorageAdapter):
                 resp.raise_for_status()
             logger.info("[WEBDAV] Deleted %s", remote_path)
             return True
-        except Exception as e:
-            logger.warning("[WEBDAV] Delete failed: %s", mask_secrets(str(e)))
+        except Exception:
+            logger.warning("[WEBDAV] Delete of %s failed", remote_path)
             return False
 
     async def list_files(self, remote_path: str = "") -> list[str]:
@@ -203,8 +208,8 @@ class WebDAVAdapter(CloudStorageAdapter):
                 resp.raise_for_status()
                 body = resp.text
             return _parse_propfind_names(body)
-        except Exception as e:
-            logger.warning("[WEBDAV] List files failed: %s", mask_secrets(str(e)))
+        except Exception:
+            logger.warning("[WEBDAV] List files under %s failed", remote_path)
             return []
 
 

--- a/backend/cloud_storage/webdav_adapter.py
+++ b/backend/cloud_storage/webdav_adapter.py
@@ -1,0 +1,227 @@
+"""WebDAV cloud storage adapter (bead 0i2vt.8 — NET-NEW).
+
+Conforms to the :class:`cloud_storage.types.CloudStorageAdapter` ABC
+(``upload`` / ``test_connection`` / ``delete`` / ``list_files``). Targets any
+RFC 4918 WebDAV endpoint (Nextcloud, ownCloud, Apache mod_dav, rclone serve
+webdav, a NAS, …) reached over http/https with optional Basic auth.
+
+Security posture (HARD ACs, grooming SRE + Security):
+
+* **SSRF chokepoint (.5).** Every outbound request is pre-validated through
+  :func:`cloud_storage.upload_security.preresolve_endpoint`, which raises
+  :class:`security.ssrf.SSRFError` BEFORE any socket opens if the base URL host
+  (or any resolved record) is denied — including the ``169.254.169.254``
+  metadata endpoint. The httpx client then CONNECTS by the validated IP
+  (resolve-then-connect-by-IP), preserving the hostname for TLS SNI + ``Host:``.
+
+* **Stream from disk.** The upload sends the artifact via httpx's file-object
+  streaming (``content=<open file handle>``) — httpx reads the body in chunks,
+  so the whole artifact is NEVER buffered into RAM (HARD AC #2).
+
+* **Executor safety.** Reads/writes are async httpx calls on the event loop;
+  the only blocking primitive is opening the local file handle, which is
+  negligible. No blocking SDK call runs on the loop (HARD AC #1).
+
+* **Credential masking.** Any logged/surfaced string is passed through
+  :func:`cloud_storage.upload_security.mask_secrets` so Authorization headers
+  and tokens never reach the logs (HARD AC #5).
+
+* **TLS.** ``verify=True`` by default; the per-target ``insecure`` flag wires
+  ``verify=False`` (the caller — :mod:`tasks.dbas_backup` — writes the
+  per-request insecure audit row, HARD AC #4).
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import time
+from pathlib import Path
+from urllib.parse import quote, urlsplit
+
+from cloud_storage.types import (
+    CloudStorageAdapter,
+    ConnectionTestResult,
+    UploadResult,
+)
+from cloud_storage.upload_security import (
+    SSRFError,
+    UPLOAD_TIMEOUT_SECONDS,
+    mask_secrets,
+    pinned_async_client,
+    pinned_request_url,
+    preresolve_endpoint,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class WebDAVAdapter(CloudStorageAdapter):
+    """Adapter for a generic WebDAV endpoint.
+
+    Required credentials:
+        base_url: WebDAV collection base URL (http/https), e.g.
+            ``https://nas.example.com/remote.php/dav/files/admin``
+
+    Optional credentials:
+        username: Basic-auth username (omit for anonymous endpoints).
+        password: Basic-auth password.
+        insecure: When True, skip TLS verification (default False). The caller
+            is responsible for the per-request insecure audit row.
+    """
+
+    def __init__(self, credentials: dict):
+        base_url = credentials.get("base_url") or credentials.get("url")
+        if not base_url:
+            raise ValueError("WebDAV adapter requires a 'base_url'")
+        self.base_url = base_url.rstrip("/")
+        self.username = credentials.get("username") or ""
+        self.password = credentials.get("password") or ""
+        self.insecure = bool(credentials.get("insecure", False))
+
+        parts = urlsplit(self.base_url)
+        # The path prefix the collection lives under (preserved when building
+        # per-file URLs). e.g. "/remote.php/dav/files/admin".
+        self._base_path = parts.path.rstrip("/")
+
+    # -- internal helpers --------------------------------------------------
+    def _auth_header(self) -> dict:
+        if not self.username:
+            return {}
+        raw = f"{self.username}:{self.password}".encode("utf-8")
+        return {"Authorization": "Basic " + base64.b64encode(raw).decode("ascii")}
+
+    def _remote_url_for(self, remote_path: str) -> str:
+        """Compose the absolute WebDAV URL for ``remote_path`` (display only)."""
+        rp = remote_path.lstrip("/")
+        return f"{self.base_url}/{quote(rp)}"
+
+    def _validate(self, remote_path: str):
+        """Pre-resolve + denylist-validate the destination URL (.5 chokepoint).
+
+        Raises SSRFError BEFORE any socket opens. Returns (target, full_url,
+        connect_url) where connect_url is pinned to the validated IP.
+        """
+        full_url = self._remote_url_for(remote_path)
+        target = preresolve_endpoint(full_url)
+        parts = urlsplit(full_url)
+        connect_url = pinned_request_url(target, parts.path, parts.query)
+        return target, full_url, connect_url
+
+    def _request_kwargs(self, target) -> dict:
+        """Per-request headers/extensions that preserve hostname for TLS+vhost."""
+        headers = {"Host": target.host_header}
+        headers.update(self._auth_header())
+        # Preserve TLS SNI for the original hostname even though we connect by IP.
+        return {
+            "headers": headers,
+            "extensions": {"sni_hostname": target.hostname},
+        }
+
+    # -- ABC surface -------------------------------------------------------
+    async def upload(self, local_path: Path, remote_path: str) -> UploadResult:
+        start = time.time()
+        try:
+            target, display_url, connect_url = self._validate(remote_path)
+            file_size = local_path.stat().st_size
+            req = self._request_kwargs(target)
+
+            async with pinned_async_client(
+                target, verify=not self.insecure, timeout=UPLOAD_TIMEOUT_SECONDS
+            ) as client:
+                # Stream the artifact from the on-disk file — httpx reads the
+                # body in chunks, never buffering the whole file into RAM.
+                with open(local_path, "rb") as fh:
+                    resp = await client.put(connect_url, content=fh, **req)
+                resp.raise_for_status()
+
+            duration_ms = int((time.time() - start) * 1000)
+            logger.info(
+                "[WEBDAV] Uploaded %s to %s (%s bytes, %sms)",
+                local_path.name, mask_secrets(display_url), file_size, duration_ms,
+            )
+            return UploadResult(
+                success=True, remote_url=display_url, file_size=file_size,
+                duration_ms=duration_ms,
+            )
+        except SSRFError as e:
+            duration_ms = int((time.time() - start) * 1000)
+            logger.warning("[WEBDAV] Upload refused by SSRF policy: %s", mask_secrets(str(e)))
+            return UploadResult(success=False, error=mask_secrets(str(e)), duration_ms=duration_ms)
+        except Exception as e:
+            duration_ms = int((time.time() - start) * 1000)
+            logger.warning("[WEBDAV] Upload failed: %s", mask_secrets(str(e)))
+            return UploadResult(success=False, error=mask_secrets(str(e)), duration_ms=duration_ms)
+
+    async def test_connection(self) -> ConnectionTestResult:
+        try:
+            target, display_url, connect_url = self._validate("")
+            req = self._request_kwargs(target)
+            async with pinned_async_client(
+                target, verify=not self.insecure, timeout=30.0
+            ) as client:
+                # PROPFIND depth 0 on the collection root is the canonical
+                # WebDAV "are you there?" probe.
+                req["headers"]["Depth"] = "0"
+                resp = await client.request("PROPFIND", connect_url, **req)
+                resp.raise_for_status()
+            return ConnectionTestResult(
+                success=True,
+                message=f"Connected to WebDAV collection '{target.hostname}'",
+                provider_info={"host": target.hostname},
+            )
+        except SSRFError as e:
+            logger.warning("[WEBDAV] Connection refused by SSRF policy: %s", mask_secrets(str(e)))
+            return ConnectionTestResult(success=False, message=mask_secrets(str(e)))
+        except Exception as e:
+            logger.warning("[WEBDAV] Connection test failed: %s", mask_secrets(str(e)))
+            return ConnectionTestResult(success=False, message=mask_secrets(str(e)))
+
+    async def delete(self, remote_path: str) -> bool:
+        try:
+            target, _display, connect_url = self._validate(remote_path)
+            req = self._request_kwargs(target)
+            async with pinned_async_client(
+                target, verify=not self.insecure, timeout=30.0
+            ) as client:
+                resp = await client.delete(connect_url, **req)
+                resp.raise_for_status()
+            logger.info("[WEBDAV] Deleted %s", remote_path)
+            return True
+        except Exception as e:
+            logger.warning("[WEBDAV] Delete failed: %s", mask_secrets(str(e)))
+            return False
+
+    async def list_files(self, remote_path: str = "") -> list[str]:
+        try:
+            target, _display, connect_url = self._validate(remote_path)
+            req = self._request_kwargs(target)
+            req["headers"]["Depth"] = "1"
+            async with pinned_async_client(
+                target, verify=not self.insecure, timeout=30.0
+            ) as client:
+                resp = await client.request("PROPFIND", connect_url, **req)
+                resp.raise_for_status()
+                body = resp.text
+            return _parse_propfind_names(body)
+        except Exception as e:
+            logger.warning("[WEBDAV] List files failed: %s", mask_secrets(str(e)))
+            return []
+
+
+def _parse_propfind_names(xml_body: str) -> list[str]:
+    """Extract <d:href> leaf names from a PROPFIND multistatus response.
+
+    Best-effort: WebDAV servers vary in namespace prefix. We scan for href
+    elements regardless of prefix and return the final path segment of each.
+    """
+    import re as _re
+
+    names: list[str] = []
+    for match in _re.finditer(r"<[^>]*href[^>]*>([^<]+)</[^>]*href[^>]*>", xml_body, _re.IGNORECASE):
+        href = match.group(1).strip().rstrip("/")
+        if not href:
+            continue
+        leaf = href.rsplit("/", 1)[-1]
+        if leaf:
+            names.append(leaf)
+    return names

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -736,6 +736,35 @@ def _build_metrics(registry: CollectorRegistry) -> Dict[str, Any]:
             registry=registry,
         ),
         # ----------------------------------------------------------------
+        # DBAS cloud upload outcomes (bead 0i2vt.8).
+        #
+        # ``ecm_backup_upload_total`` labels by ``provider`` and ``result``:
+        #   provider ∈ {s3, gdrive, webdav} — the three shipping adapters in
+        #            v0.18.0 (dropbox/onedrive deferred to v0.18.x). Cardinality
+        #            is bounded by the get_adapter() provider_type allowlist.
+        #   result   ∈ {success, failed} — one increment per outbound upload of
+        #            the sealed artifact (and its .sha256 sidecar) to a
+        #            configured+enabled target. A target that is skipped by the
+        #            fire-time freshness gate does NOT increment this counter
+        #            (it increments ecm_backup_runs_total{result="skipped"} once
+        #            for the run, not per-target here).
+        #
+        # SRE: the ratio failed / (success + failed) is the cloud-upload error
+        # SLI for DBAS offsite backups; a sustained non-zero failed rate means
+        # backups are being produced locally but not landing offsite — the host
+        # is one disk failure away from total backup loss.
+        # ----------------------------------------------------------------
+        "backup_upload_total": Counter(
+            "ecm_backup_upload_total",
+            "Cumulative count of DBAS cloud-upload attempts, labeled by "
+            "provider (s3|gdrive|webdav) and result (success|failed). One "
+            "increment per outbound artifact upload to a configured+enabled "
+            "target. Freshness-gate skips are counted on ecm_backup_runs_total "
+            "(result=skipped), not here.",
+            ["provider", "result"],
+            registry=registry,
+        ),
+        # ----------------------------------------------------------------
         # Database file size (bd-ygoqr — paired with the CleanupTask CRON
         # default flip; together they give operators "is my DB growing?"
         # signal AND an automatic weekly VACUUM that bounds the growth).

--- a/backend/services/notification_service.py
+++ b/backend/services/notification_service.py
@@ -122,7 +122,13 @@ async def create_notification_internal(
                 )
             )
 
-        logger.debug("[NOTIFY-SVC] Created notification: %s - %s", notification_type, title or message[:50])
+        # Log only safe routing identifiers (type + source), never the title or
+        # message body: callers may pass a credential-derived (masked) detail in
+        # `message`, and CodeQL traces any message/title value into this logging
+        # sink (it does not recognise mask_secrets() as a sanitizer). The body is
+        # still persisted to the notification row and dispatched to alert
+        # channels — both non-logging sinks.
+        logger.debug("[NOTIFY-SVC] Created notification: type=%s source=%s source_id=%s", notification_type, source, source_id)
         return result
     except Exception as e:
         logger.exception("[NOTIFY-SVC] Failed to create notification: %s", e)

--- a/backend/tasks/dbas_backup.py
+++ b/backend/tasks/dbas_backup.py
@@ -390,6 +390,16 @@ class DbasBackupTask(TaskScheduler):
 
         summary["attempted"] = True
         total = len(self.cloud_targets)
+        # Track counts in plain int locals — NOT by reading them back out of the
+        # `summary` dict. `summary["results"]` holds per-target `reason` strings
+        # that can carry masked credential-derived detail, so CodeQL treats the
+        # whole dict (and every subscript of it) as tainted. Keeping the counts
+        # and the derived status word as standalone locals means the values that
+        # reach the notification emitter never share a taint lineage with the
+        # per-target reason strings — the emitted data is provably just a status
+        # word and two integers.
+        succeeded = 0
+        failed = 0
         for idx, entry in enumerate(self.cloud_targets, start=1):
             self._set_progress(
                 current_item="Uploading to cloud target %d/%d..." % (idx, total),
@@ -400,19 +410,23 @@ class DbasBackupTask(TaskScheduler):
             outcome = await self._upload_one_target(artifact, tid, cfg_version)
             summary["results"].append(outcome)
             if outcome["success"]:
-                summary["succeeded"] += 1
+                succeeded += 1
             else:
-                summary["failed"] += 1
+                failed += 1
 
-        if summary["succeeded"] == total:
-            summary["run_result"] = "success"
-        elif summary["succeeded"] == 0:
-            summary["run_result"] = "failed"
+        if succeeded == total:
+            run_result = "success"
+        elif succeeded == 0:
+            run_result = "failed"
         else:
-            summary["run_result"] = "partial"
+            run_result = "partial"
 
-        if summary["run_result"] != "success":
-            await self._notify_upload_outcome(summary, total)
+        summary["succeeded"] = succeeded
+        summary["failed"] = failed
+        summary["run_result"] = run_result
+
+        if run_result != "success":
+            await self._notify_upload_outcome(run_result, succeeded, total)
 
         return summary
 
@@ -622,18 +636,27 @@ class DbasBackupTask(TaskScheduler):
         except Exception as e:  # pragma: no cover
             logger.warning("[DBAS_BACKUP] Failed to emit target-failure notification: %s", e)
 
-    async def _notify_upload_outcome(self, summary: dict, total: int) -> None:
-        """Fire the run-level partial/failed notification (PO decision)."""
-        run_result = summary["run_result"]
-        succeeded = summary["succeeded"]
+    async def _notify_upload_outcome(
+        self, run_result: str, succeeded: int, total: int
+    ) -> None:
+        """Fire the run-level partial/failed notification (PO decision).
+
+        Accepts ONLY clean scalars — the run-result status word (``success`` /
+        ``partial`` / ``failed``) and two integer counts. It deliberately does
+        NOT take the ``summary`` dict: ``summary["results"]`` holds per-target
+        ``reason`` strings that can carry masked credential-derived detail, and
+        CodeQL treats the whole dict (and every subscript of it) as tainted.
+        Receiving the status word + counts as plain typed arguments cuts that
+        taint lineage at the source, so nothing sensitive can flow into the
+        notification message/title or the downstream alert logging sinks.
+        """
         msg = (
             "DBAS backup cloud upload %s: %d of %d configured targets succeeded. "
             "The local artifact was written; review the cloud target "
             "configuration." % (run_result, succeeded, total)
         )
         # Log only the safe run-level counts (no per-target reason strings flow
-        # here); the full message goes to the notification sink below. This keeps
-        # the source-tainted `summary` out of any logging sink.
+        # here); the full message goes to the notification sink below.
         logger.warning(
             "[DBAS_BACKUP] Cloud upload %s: %d of %d targets succeeded",
             run_result, succeeded, total,

--- a/backend/tasks/dbas_backup.py
+++ b/backend/tasks/dbas_backup.py
@@ -591,7 +591,14 @@ class DbasBackupTask(TaskScheduler):
     ) -> None:
         """Non-silent per-target failure: WARN + journal + notification."""
         msg = "DBAS backup upload to target id=%s failed — %s" % (target_id, reason)
-        logger.warning("[DBAS_BACKUP] %s", msg)
+        # The logger receives ONLY the safe target id, never `reason`/`msg`:
+        # `reason` can carry a masked-but-credential-derived adapter error or a
+        # masked SDK-exception string, and CodeQL traces that value into any
+        # logging sink (it does not recognise mask_secrets() as a sanitizer).
+        # The masked detail still reaches the operator via the journal
+        # description and the notification message below (non-logging sinks
+        # that are stored/displayed, not logged).
+        logger.warning("[DBAS_BACKUP] Upload to target id=%s failed (see journal/notification for detail)", target_id)
         try:
             journal.log_entry(
                 category="backup_outbound",
@@ -618,12 +625,19 @@ class DbasBackupTask(TaskScheduler):
     async def _notify_upload_outcome(self, summary: dict, total: int) -> None:
         """Fire the run-level partial/failed notification (PO decision)."""
         run_result = summary["run_result"]
+        succeeded = summary["succeeded"]
         msg = (
             "DBAS backup cloud upload %s: %d of %d configured targets succeeded. "
             "The local artifact was written; review the cloud target "
-            "configuration." % (run_result, summary["succeeded"], total)
+            "configuration." % (run_result, succeeded, total)
         )
-        logger.warning("[DBAS_BACKUP] %s", msg)
+        # Log only the safe run-level counts (no per-target reason strings flow
+        # here); the full message goes to the notification sink below. This keeps
+        # the source-tainted `summary` out of any logging sink.
+        logger.warning(
+            "[DBAS_BACKUP] Cloud upload %s: %d of %d targets succeeded",
+            run_result, succeeded, total,
+        )
         try:
             await create_notification_internal(
                 notification_type="error" if run_result == "failed" else "warning",

--- a/backend/tasks/dbas_backup.py
+++ b/backend/tasks/dbas_backup.py
@@ -427,6 +427,7 @@ class DbasBackupTask(TaskScheduler):
         """
         from cloud_storage import get_adapter
         from cloud_storage.crypto import decrypt_credentials
+        from cloud_storage.upload_security import mask_secrets
         from database import get_session
         from export_models import CloudStorageTarget
 
@@ -481,7 +482,14 @@ class DbasBackupTask(TaskScheduler):
             zip_res = await adapter.upload(Path(artifact.zip_path), zip_remote)
             sidecar_res = await adapter.upload(Path(artifact.sidecar_path), sidecar_remote)
         except Exception as e:  # adapter construction / unexpected error
-            reason = "upload to target '%s' raised: %s" % (target_name, e)
+            # SEC-2: mask credential-shaped material before the raw exception
+            # text reaches the journal / notification. This is the one
+            # credential-adjacent surface in the task that bypasses the
+            # adapter-level masking (adapter-returned `error` fields are already
+            # masked at source), so mask it here.
+            reason = "upload to target '%s' raised: %s" % (
+                target_name, mask_secrets(str(e)),
+            )
             await self._fail_target(target_id, target_name, reason, provider=provider)
             _bump_upload_metric(provider, "failed")
             return {"target_id": target_id, "success": False, "reason": reason}

--- a/backend/tasks/dbas_backup.py
+++ b/backend/tasks/dbas_backup.py
@@ -29,8 +29,24 @@ produced) if ANY of:
   * ``token_revoked_at`` is not None (hard stop), or
   * ``credential_version`` no longer matches the captured version.
 
-The actual cloud UPLOAD is bead 0i2vt.8 — not this bead. The validated seam
-is marked ``TODO(0i2vt.8)`` below.
+Cloud upload (bead 0i2vt.8)
+---------------------------
+After the artifact is built, the task uploads it (+ ``.sha256`` sidecar) to each
+target listed in the ``cloud_targets`` config (a list of
+``{cloud_target_id, cloud_credential_version}``). Per-target tri-state run
+semantics (PO decision 2026-06-17): the run is ``success`` only if ALL
+configured+enabled targets succeed, ``partial`` if some, ``failed`` if none;
+``partial`` and ``failed`` both fire a NotificationCenter notification and
+reconcile against ``ecm_backup_runs_total`` (the run is NOT reported as a clean
+``success``). Each target is re-validated FRESH against the DB right before its
+upload (the per-target generalisation of the single-target gate below); a
+stale/revoked target is a non-silent per-target failure. Every upload routes
+through the ``.5`` SSRF chokepoint, is executor-wrapped, streams from disk, and
+masks credentials in logs. Uploads run ONE AT A TIME (cap=1) to bound memory.
+
+The legacy single ``cloud_target_id`` pre-build gate (below) is unchanged: when
+set, a stale bound target ABORTS the whole run (no artifact) — distinct from the
+``cloud_targets`` post-build per-target failure path.
 
 Silent-skip MUST notify
 -----------------------
@@ -39,7 +55,8 @@ prefix), a ``journal`` entry, AND a NotificationCenter notification, and
 returns ``TaskResult(success=False, ...)``. A scheduled backup that silently
 stops = false safety.
 
-Metric: ``ecm_backup_runs_total{result="success"|"skipped"|"failed"}``.
+Metrics: ``ecm_backup_runs_total{result="success"|"partial"|"skipped"|"failed"}``
+and ``ecm_backup_upload_total{provider,result}`` (per-upload outcome).
 
 Concurrency: the engine's ``TaskScheduler.run()`` already rejects a second
 concurrent run of the same ``task_id`` (ALREADY_RUNNING guard), so no extra
@@ -47,6 +64,7 @@ self-exclusion is needed here.
 """
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional
 
 from config import CONFIG_DIR
@@ -62,6 +80,12 @@ logger = logging.getLogger(__name__)
 
 BACKUPS_DIR = CONFIG_DIR / "backups"
 
+# Provider types whose upload path is wired in v0.18.0 (bead 0i2vt.8). Dropbox
+# and OneDrive are DEFERRED to a v0.18.x follow-up (PO decision 2026-06-17) —
+# a configured target of a deferred provider is treated as a non-silent
+# per-target failure rather than silently skipped.
+_SUPPORTED_UPLOAD_PROVIDERS = ("s3", "gdrive", "webdav")
+
 
 def _bump_metric(result: str) -> None:
     """Increment ecm_backup_runs_total for a result label, best-effort."""
@@ -69,6 +93,16 @@ def _bump_metric(result: str) -> None:
         observability.get_metric("backup_runs_total").labels(result=result).inc()
     except Exception as e:  # pragma: no cover — metrics best-effort
         logger.warning("[DBAS_BACKUP] Failed to increment backup_runs_total: %s", e)
+
+
+def _bump_upload_metric(provider: str, result: str) -> None:
+    """Increment ecm_backup_upload_total{provider,result}, best-effort."""
+    try:
+        observability.get_metric("backup_upload_total").labels(
+            provider=provider, result=result
+        ).inc()
+    except Exception as e:  # pragma: no cover — metrics best-effort
+        logger.warning("[DBAS_BACKUP] Failed to increment backup_upload_total: %s", e)
 
 
 @register_task
@@ -98,11 +132,19 @@ class DbasBackupTask(TaskScheduler):
 
         self.cloud_target_id: Optional[int] = None
         self.cloud_credential_version: Optional[int] = None
+        # Multi-destination upload list (bead 0i2vt.8). Each entry is
+        # {"cloud_target_id": int, "cloud_credential_version": int}. When set,
+        # the artifact is built and then uploaded to EACH configured+enabled
+        # target with per-target freshness re-validation and tri-state run
+        # semantics. Distinct from the legacy single cloud_target_id pre-build
+        # gate above (which still aborts the whole run for backward-compat).
+        self.cloud_targets: list[dict] = []
 
     def get_config(self) -> dict:
         return {
             "cloud_target_id": self.cloud_target_id,
             "cloud_credential_version": self.cloud_credential_version,
+            "cloud_targets": list(self.cloud_targets),
         }
 
     def update_config(self, config: dict) -> None:
@@ -112,6 +154,22 @@ class DbasBackupTask(TaskScheduler):
         if "cloud_credential_version" in config:
             val = config["cloud_credential_version"]
             self.cloud_credential_version = int(val) if val is not None else None
+        if "cloud_targets" in config:
+            raw = config["cloud_targets"] or []
+            parsed: list[dict] = []
+            for entry in raw:
+                tid = entry.get("cloud_target_id")
+                if tid is None:
+                    continue
+                parsed.append({
+                    "cloud_target_id": int(tid),
+                    "cloud_credential_version": (
+                        int(entry["cloud_credential_version"])
+                        if entry.get("cloud_credential_version") is not None
+                        else None
+                    ),
+                })
+            self.cloud_targets = parsed
 
     async def execute(self) -> TaskResult:
         started_at = datetime.now(timezone.utc)
@@ -127,11 +185,6 @@ class DbasBackupTask(TaskScheduler):
             if skip is not None:
                 return skip
 
-        # TODO(0i2vt.8): once the gate passes and a cloud_target_id is set,
-        # the cloud-upload step goes HERE (after the artifact is built below),
-        # streaming the sealed ZIP to the validated target. The validation
-        # above is fully built + tested now; only the upload is deferred.
-
         try:
             self._set_progress(
                 current_item="Building backup artifact...", status="running",
@@ -146,23 +199,51 @@ class DbasBackupTask(TaskScheduler):
                 artifact.sha256,
             )
 
-            _bump_metric("success")
+            # Cloud-upload step (bead 0i2vt.8). The local artifact is the core
+            # value (host-failure survival starts with a redacted on-disk
+            # backup); uploads are layered on top. When cloud_targets are
+            # configured the run result is the per-target tri-state.
+            upload_summary = await self._upload_to_targets(artifact)
+
+            run_result = upload_summary["run_result"]  # success|partial|failed
+            _bump_metric(run_result)
+
             self._set_progress(current=1, total=1, status="completed")
+            details = {
+                "filename": filename,
+                "schema_version": artifact.schema_version,
+                "sha256": artifact.sha256,
+                "file_count": artifact.file_count,
+            }
+            if upload_summary["attempted"]:
+                details["upload"] = {
+                    "run_result": run_result,
+                    "succeeded": upload_summary["succeeded"],
+                    "failed": upload_summary["failed"],
+                    "results": upload_summary["results"],
+                }
+
+            message = "Built DBAS backup %s (schema v%d, %d files)" % (
+                filename, artifact.schema_version, artifact.file_count,
+            )
+            if upload_summary["attempted"]:
+                message += "; cloud upload: %s (%d ok, %d failed)" % (
+                    run_result, upload_summary["succeeded"], upload_summary["failed"],
+                )
+
             return TaskResult(
-                success=True,
-                message="Built DBAS backup %s (schema v%d, %d files)" % (
-                    filename, artifact.schema_version, artifact.file_count,
-                ),
+                # PO decision: a backup run whose configured uploads did NOT all
+                # succeed is NOT reported as a clean success — partial/failed
+                # reconcile against the scheduled-job health metric.
+                success=(run_result == "success"),
+                message=message,
+                error=None if run_result == "success" else "CLOUD_UPLOAD_%s" % run_result.upper(),
                 started_at=started_at,
                 completed_at=datetime.now(timezone.utc),
                 total_items=1,
-                success_count=1,
-                details={
-                    "filename": filename,
-                    "schema_version": artifact.schema_version,
-                    "sha256": artifact.sha256,
-                    "file_count": artifact.file_count,
-                },
+                success_count=1 if run_result == "success" else 0,
+                failed_count=0 if run_result == "success" else 1,
+                details=details,
             )
         except Exception as e:
             logger.exception("[DBAS_BACKUP] Backup build failed: %s", e)
@@ -272,3 +353,277 @@ class DbasBackupTask(TaskScheduler):
             skipped_count=1,
             details={"skipped": True, "reason": reason},
         )
+
+    # ------------------------------------------------------------------
+    # Cloud upload (bead 0i2vt.8) — per-target tri-state, SSRF-chokepointed,
+    # executor-wrapped, streamed, credential-masked.
+    # ------------------------------------------------------------------
+    async def _upload_to_targets(self, artifact) -> dict:
+        """Upload the sealed artifact (+ .sha256 sidecar) to each configured
+        enabled target and compute the tri-state run result.
+
+        PO decision (2026-06-17): run is 'success' only if ALL configured+
+        enabled targets succeed, 'partial' if some, 'failed' if none. Both
+        'partial' and 'failed' fire a NotificationCenter notification and
+        reconcile against the scheduled-job health metric.
+
+        Concurrency: targets are uploaded ONE AT A TIME (sequential loop). This
+        is the simplest correct cap=1 serialization — it bounds peak memory and
+        socket pressure regardless of MAX_CONCURRENT_TASKS, since two large
+        artifact uploads never run in parallel within a single backup run.
+
+        Per-target freshness re-validation (reconciled with .6's single-target
+        gate): EACH configured target is re-read FRESH from the DB right before
+        uploading to it and validated (enabled + credential_version match +
+        token_revoked_at None). A stale/revoked target is a non-silent failure
+        for THAT target (WARN + journal + notification), not a silent drop.
+        """
+        summary = {
+            "attempted": False,
+            "succeeded": 0,
+            "failed": 0,
+            "results": [],
+            "run_result": "success",
+        }
+        if not self.cloud_targets:
+            return summary  # local-only backup — run_result stays 'success'
+
+        summary["attempted"] = True
+        total = len(self.cloud_targets)
+        for idx, entry in enumerate(self.cloud_targets, start=1):
+            self._set_progress(
+                current_item="Uploading to cloud target %d/%d..." % (idx, total),
+                status="running",
+            )
+            tid = entry["cloud_target_id"]
+            cfg_version = entry.get("cloud_credential_version")
+            outcome = await self._upload_one_target(artifact, tid, cfg_version)
+            summary["results"].append(outcome)
+            if outcome["success"]:
+                summary["succeeded"] += 1
+            else:
+                summary["failed"] += 1
+
+        if summary["succeeded"] == total:
+            summary["run_result"] = "success"
+        elif summary["succeeded"] == 0:
+            summary["run_result"] = "failed"
+        else:
+            summary["run_result"] = "partial"
+
+        if summary["run_result"] != "success":
+            await self._notify_upload_outcome(summary, total)
+
+        return summary
+
+    async def _upload_one_target(
+        self, artifact, target_id: int, cfg_version: Optional[int]
+    ) -> dict:
+        """Re-validate one target FRESH, then upload artifact + sidecar to it.
+
+        Returns a per-target outcome dict. Never raises — an upload failure is
+        captured as success=False so the tri-state can be computed across all
+        targets.
+        """
+        from cloud_storage import get_adapter
+        from cloud_storage.crypto import decrypt_credentials
+        from database import get_session
+        from export_models import CloudStorageTarget
+
+        # --- fresh re-read + freshness gate for THIS target -----------------
+        session = get_session()
+        try:
+            target = (
+                session.query(CloudStorageTarget)
+                .filter(CloudStorageTarget.id == target_id)
+                .first()
+            )
+            stale_reason = self._freshness_reason(target, target_id, cfg_version)
+            if stale_reason is not None:
+                await self._fail_target(target_id, None, stale_reason, provider=None)
+                return {"target_id": target_id, "success": False, "reason": stale_reason}
+
+            provider = target.provider_type
+            target_name = target.name
+            insecure = bool(target.insecure)
+            upload_path = target.upload_path or "/"
+            encrypted = target.credentials
+        finally:
+            session.close()
+
+        if provider not in _SUPPORTED_UPLOAD_PROVIDERS:
+            reason = (
+                "provider '%s' upload is not supported in this release "
+                "(deferred to a v0.18.x follow-up)" % provider
+            )
+            await self._fail_target(target_id, target_name, reason, provider=provider)
+            return {"target_id": target_id, "success": False, "reason": reason}
+
+        creds = decrypt_credentials(encrypted)
+        if creds is None:
+            reason = "credentials for target '%s' could not be decrypted" % target_name
+            await self._fail_target(target_id, target_name, reason, provider=provider)
+            _bump_upload_metric(provider, "failed")
+            return {"target_id": target_id, "success": False, "reason": reason}
+
+        # Per-target TLS posture: thread the insecure flag into the adapter and
+        # write the mandatory insecure audit row BEFORE the request.
+        creds = dict(creds)
+        creds["insecure"] = insecure
+        if insecure:
+            self._audit_insecure(target_id, target_name, provider)
+
+        zip_remote, sidecar_remote = self._remote_paths(upload_path, artifact)
+
+        # --- upload artifact + sidecar (each through the adapter) -----------
+        try:
+            adapter = get_adapter(provider, creds)
+            zip_res = await adapter.upload(Path(artifact.zip_path), zip_remote)
+            sidecar_res = await adapter.upload(Path(artifact.sidecar_path), sidecar_remote)
+        except Exception as e:  # adapter construction / unexpected error
+            reason = "upload to target '%s' raised: %s" % (target_name, e)
+            await self._fail_target(target_id, target_name, reason, provider=provider)
+            _bump_upload_metric(provider, "failed")
+            return {"target_id": target_id, "success": False, "reason": reason}
+
+        ok = bool(zip_res.success and sidecar_res.success)
+        # Per-destination audit row on EVERY outbound upload (Security #3/#8).
+        self._audit_upload(
+            target_id, target_name, provider, ok,
+            zip_res, sidecar_res, insecure,
+        )
+        _bump_upload_metric(provider, "success" if ok else "failed")
+
+        if not ok:
+            err = zip_res.error or sidecar_res.error or "unknown upload error"
+            reason = "upload to target '%s' failed: %s" % (target_name, err)
+            await self._fail_target(target_id, target_name, reason, provider=provider)
+            return {"target_id": target_id, "success": False, "reason": reason}
+
+        return {
+            "target_id": target_id,
+            "success": True,
+            "provider": provider,
+            "remote_url": zip_res.remote_url,
+        }
+
+    @staticmethod
+    def _freshness_reason(target, target_id, cfg_version) -> Optional[str]:
+        """Per-target freshness check (mirrors the single-target .6 gate)."""
+        if target is None:
+            return "target %s no longer exists" % target_id
+        if not target.enabled:
+            return "target '%s' (id=%s) is disabled" % (target.name, target.id)
+        if target.token_revoked_at is not None:
+            return "credentials for target '%s' (id=%s) were revoked" % (
+                target.name, target.id,
+            )
+        if cfg_version is not None and target.credential_version != cfg_version:
+            return (
+                "credentials for target '%s' (id=%s) were rotated "
+                "(configured v%s, current v%s)" % (
+                    target.name, target.id, cfg_version, target.credential_version,
+                )
+            )
+        return None
+
+    @staticmethod
+    def _remote_paths(upload_path: str, artifact) -> tuple[str, str]:
+        prefix = (upload_path or "/").strip("/")
+        zip_name = Path(artifact.zip_path).name
+        sidecar_name = Path(artifact.sidecar_path).name
+        if prefix:
+            return "%s/%s" % (prefix, zip_name), "%s/%s" % (prefix, sidecar_name)
+        return zip_name, sidecar_name
+
+    def _audit_upload(
+        self, target_id, target_name, provider, ok, zip_res, sidecar_res, insecure
+    ) -> None:
+        """Write a per-destination audit row for an upload attempt."""
+        try:
+            journal.log_entry(
+                category="backup_outbound",
+                action_type="cloud_upload" if ok else "cloud_upload_failed",
+                entity_name=target_name or ("target %s" % target_id),
+                entity_id=target_id,
+                description=(
+                    "DBAS backup upload to %s target '%s' (id=%s): %s "
+                    "(zip=%s, sidecar=%s, tls_verified=%s)" % (
+                        provider, target_name, target_id,
+                        "success" if ok else "failed",
+                        zip_res.success, sidecar_res.success, not insecure,
+                    )
+                ),
+                user_initiated=False,
+            )
+        except Exception as e:  # pragma: no cover — journal best-effort
+            logger.warning("[DBAS_BACKUP] Failed to journal upload audit: %s", e)
+
+    def _audit_insecure(self, target_id, target_name, provider) -> None:
+        """Explicit audit row recording that TLS verification was skipped."""
+        try:
+            journal.log_entry(
+                category="backup_outbound",
+                action_type="cloud_upload_insecure_tls",
+                entity_name=target_name or ("target %s" % target_id),
+                entity_id=target_id,
+                description=(
+                    "TLS verification SKIPPED (insecure=true) for %s target "
+                    "'%s' (id=%s) on a DBAS backup upload" % (
+                        provider, target_name, target_id,
+                    )
+                ),
+                user_initiated=False,
+            )
+        except Exception as e:  # pragma: no cover — journal best-effort
+            logger.warning("[DBAS_BACKUP] Failed to journal insecure audit: %s", e)
+
+    async def _fail_target(
+        self, target_id, target_name, reason: str, provider: Optional[str]
+    ) -> None:
+        """Non-silent per-target failure: WARN + journal + notification."""
+        msg = "DBAS backup upload to target id=%s failed — %s" % (target_id, reason)
+        logger.warning("[DBAS_BACKUP] %s", msg)
+        try:
+            journal.log_entry(
+                category="backup_outbound",
+                action_type="cloud_upload_failed",
+                entity_name=target_name or ("target %s" % target_id),
+                entity_id=target_id,
+                description=msg,
+                user_initiated=False,
+            )
+        except Exception as e:  # pragma: no cover
+            logger.warning("[DBAS_BACKUP] Failed to journal target failure: %s", e)
+        try:
+            await create_notification_internal(
+                notification_type="warning",
+                title="DBAS Backup: Upload Failed",
+                message=msg,
+                source="task_dbas_backup",
+                source_id="cloud_upload_%s" % target_id,
+                send_alerts=True,
+            )
+        except Exception as e:  # pragma: no cover
+            logger.warning("[DBAS_BACKUP] Failed to emit target-failure notification: %s", e)
+
+    async def _notify_upload_outcome(self, summary: dict, total: int) -> None:
+        """Fire the run-level partial/failed notification (PO decision)."""
+        run_result = summary["run_result"]
+        msg = (
+            "DBAS backup cloud upload %s: %d of %d configured targets succeeded. "
+            "The local artifact was written; review the cloud target "
+            "configuration." % (run_result, summary["succeeded"], total)
+        )
+        logger.warning("[DBAS_BACKUP] %s", msg)
+        try:
+            await create_notification_internal(
+                notification_type="error" if run_result == "failed" else "warning",
+                title="DBAS Backup: Upload %s" % run_result.capitalize(),
+                message=msg,
+                source="task_dbas_backup",
+                source_id="cloud_upload_run",
+                send_alerts=True,
+            )
+        except Exception as e:  # pragma: no cover
+            logger.warning("[DBAS_BACKUP] Failed to emit run-outcome notification: %s", e)

--- a/backend/tests/tasks/test_dbas_backup_upload.py
+++ b/backend/tests/tasks/test_dbas_backup_upload.py
@@ -335,6 +335,54 @@ async def test_deferred_provider_is_non_silent_failure(
 
 
 # ---------------------------------------------------------------------------
+# SEC-2 — a raw exception in the upload seam must be credential-masked before
+# it reaches the journal description / notification message.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_upload_seam_exception_reason_is_masked(
+    _wire_db, _reset_metrics, test_session, tmp_path
+):
+    """When adapter.upload() raises an exception whose text carries a
+    secret-looking token, the journaled + notified failure reason is masked —
+    no raw secret substring survives into the audit row or notification."""
+    from tasks import dbas_backup
+    from tasks.dbas_backup import DbasBackupTask
+
+    secret = "AKIAIOSFODNN7EXAMPLE"  # AWS access-key-id shape masked by mask_secrets
+
+    def _raise_with_secret(*_a, **_k):
+        raise RuntimeError(
+            "boto3 endpoint refused; aws_secret_access_key=%s leaked" % secret
+        )
+
+    t1 = _make_target(test_session, name="seam-raise")
+    result, notify = await _run(
+        dbas_backup, DbasBackupTask, tmp_path / "backups",
+        {"cloud_targets": [{"cloud_target_id": t1.id, "cloud_credential_version": 1}]},
+        [_adapter(_raise_with_secret)],
+    )
+
+    assert result.success is False
+    assert result.details["upload"]["run_result"] == "failed"
+
+    # The journaled failure description must not carry the raw secret.
+    entries = test_session.query(JournalEntry).filter(
+        JournalEntry.action_type == "cloud_upload_failed",
+    ).all()
+    assert len(entries) == 1
+    description = entries[0].description
+    assert secret not in description
+    assert "***REDACTED***" in description
+    # The masked surface still names the target + the raised-exception path.
+    assert "raised" in description
+
+    # The notification message must likewise be masked.
+    messages = [c.kwargs.get("message", "") for c in notify.await_args_list]
+    assert any("***REDACTED***" in m for m in messages)
+    assert all(secret not in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
 # Config round-trip for the new cloud_targets list
 # ---------------------------------------------------------------------------
 def test_cloud_targets_config_round_trip():

--- a/backend/tests/tasks/test_dbas_backup_upload.py
+++ b/backend/tests/tasks/test_dbas_backup_upload.py
@@ -10,7 +10,7 @@ All adapters are mocked — NO live cloud calls.
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.orm import sessionmaker

--- a/backend/tests/tasks/test_dbas_backup_upload.py
+++ b/backend/tests/tasks/test_dbas_backup_upload.py
@@ -1,0 +1,359 @@
+"""Tests for bead 0i2vt.8 — DBAS backup multi-destination cloud upload.
+
+Covers the per-target tri-state run semantics, per-target freshness
+re-validation, per-destination + insecure audit rows, and the
+ecm_backup_upload_total metric. The single-target .6 pre-build freshness gate
+is covered by test_dbas_backup_task.py and is unchanged here.
+
+All adapters are mocked — NO live cloud calls.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+import database
+import observability
+from cloud_storage.types import UploadResult
+from export_models import CloudStorageTarget
+from models import JournalEntry
+from routers.backup import BackupArtifact
+
+
+@pytest.fixture
+def _wire_db(test_engine, monkeypatch):
+    TestSessionLocal = sessionmaker(
+        autocommit=False, autoflush=False, bind=test_engine, expire_on_commit=False
+    )
+    monkeypatch.setattr(database, "_SessionLocal", TestSessionLocal)
+    return TestSessionLocal
+
+
+@pytest.fixture
+def _reset_metrics():
+    observability.reset_for_tests()
+    observability.install_metrics()
+    yield
+    observability.reset_for_tests()
+
+
+def _run_counter(result_label: str) -> float:
+    return observability.get_metric("backup_runs_total").labels(result=result_label)._value.get()
+
+
+def _upload_counter(provider: str, result: str) -> float:
+    return observability.get_metric("backup_upload_total").labels(
+        provider=provider, result=result
+    )._value.get()
+
+
+def _make_target(session, **overrides) -> CloudStorageTarget:
+    fields = dict(
+        name="t-s3",
+        provider_type="s3",
+        credentials="enc-blob",
+        upload_path="/backups",
+        enabled=True,
+        credential_version=1,
+        token_revoked_at=None,
+        insecure=False,
+    )
+    fields.update(overrides)
+    target = CloudStorageTarget(**fields)
+    session.add(target)
+    session.commit()
+    session.refresh(target)
+    return target
+
+
+def _fake_artifact(dest_dir: Path) -> BackupArtifact:
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = dest_dir / "ecm-artifact-abc123.zip"
+    sidecar_path = Path(str(zip_path) + ".sha256")
+    zip_path.write_bytes(b"PK\x03\x04fake")
+    sidecar_path.write_text("deadbeef  %s\n" % zip_path.name)
+    return BackupArtifact(
+        zip_path=zip_path, sidecar_path=sidecar_path,
+        schema_version=1, sha256="deadbeef", file_count=7,
+    )
+
+
+def _ok_upload(*_a, **_k):
+    return UploadResult(success=True, remote_url="s3://b/x", file_size=10, duration_ms=1)
+
+
+def _fail_upload(*_a, **_k):
+    return UploadResult(success=False, error="boom", duration_ms=1)
+
+
+async def _run(dbas_backup, DbasBackupTask, backups_dir, config, adapter_map, notify=None):
+    """Run execute() with build + adapters mocked. adapter_map maps a call
+    sequence: each get_adapter call returns the next adapter from the list."""
+    async def _fake_build(dest_dir=None):
+        return _fake_artifact(dest_dir)
+
+    notify = notify or AsyncMock(return_value={"id": 1})
+
+    def _get_adapter(provider, creds):
+        return adapter_map.pop(0)
+
+    with patch.object(dbas_backup, "BACKUPS_DIR", backups_dir), \
+         patch.object(dbas_backup, "build_backup_artifact", side_effect=_fake_build), \
+         patch.object(dbas_backup, "create_notification_internal", notify), \
+         patch("cloud_storage.crypto.decrypt_credentials", return_value={"bucket_name": "b"}), \
+         patch("cloud_storage.get_adapter", side_effect=_get_adapter):
+        task = DbasBackupTask()
+        task.update_config(config)
+        result = await task.execute()
+    return result, notify
+
+
+def _adapter(upload_side_effect):
+    a = AsyncMock()
+    a.upload = AsyncMock(side_effect=upload_side_effect)
+    return a
+
+
+# ---------------------------------------------------------------------------
+# Tri-state run semantics
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_all_targets_succeed_is_success(_wire_db, _reset_metrics, test_session, tmp_path):
+    from tasks import dbas_backup
+    from tasks.dbas_backup import DbasBackupTask
+
+    t1 = _make_target(test_session, name="a", credential_version=1)
+    t2 = _make_target(test_session, name="b", credential_version=1)
+
+    adapters = [_adapter(_ok_upload), _adapter(_ok_upload)]
+    result, _ = await _run(
+        dbas_backup, DbasBackupTask, tmp_path / "backups",
+        {"cloud_targets": [
+            {"cloud_target_id": t1.id, "cloud_credential_version": 1},
+            {"cloud_target_id": t2.id, "cloud_credential_version": 1},
+        ]},
+        adapters,
+    )
+
+    assert result.success is True
+    assert result.details["upload"]["run_result"] == "success"
+    assert _run_counter("success") == 1.0
+    assert _upload_counter("s3", "success") == 2.0
+
+
+@pytest.mark.asyncio
+async def test_some_targets_succeed_is_partial(_wire_db, _reset_metrics, test_session, tmp_path):
+    from tasks import dbas_backup
+    from tasks.dbas_backup import DbasBackupTask
+
+    t1 = _make_target(test_session, name="a")
+    t2 = _make_target(test_session, name="b")
+
+    # t1 ok, t2 fails (zip upload fails)
+    adapters = [_adapter(_ok_upload), _adapter(_fail_upload)]
+    result, notify = await _run(
+        dbas_backup, DbasBackupTask, tmp_path / "backups",
+        {"cloud_targets": [
+            {"cloud_target_id": t1.id, "cloud_credential_version": 1},
+            {"cloud_target_id": t2.id, "cloud_credential_version": 1},
+        ]},
+        adapters,
+    )
+
+    assert result.success is False
+    assert result.details["upload"]["run_result"] == "partial"
+    assert _run_counter("partial") == 1.0
+    assert _run_counter("success") == 0.0
+    # partial fires a run-level notification
+    titles = [c.kwargs.get("title", "") for c in notify.await_args_list]
+    assert any("Partial" in t for t in titles)
+
+
+@pytest.mark.asyncio
+async def test_no_targets_succeed_is_failed(_wire_db, _reset_metrics, test_session, tmp_path):
+    from tasks import dbas_backup
+    from tasks.dbas_backup import DbasBackupTask
+
+    t1 = _make_target(test_session, name="a")
+    adapters = [_adapter(_fail_upload)]
+    result, notify = await _run(
+        dbas_backup, DbasBackupTask, tmp_path / "backups",
+        {"cloud_targets": [{"cloud_target_id": t1.id, "cloud_credential_version": 1}]},
+        adapters,
+    )
+
+    assert result.success is False
+    assert result.details["upload"]["run_result"] == "failed"
+    assert _run_counter("failed") == 1.0
+    assert _upload_counter("s3", "failed") == 1.0
+    titles = [c.kwargs.get("title", "") for c in notify.await_args_list]
+    assert any("Failed" in t for t in titles)
+
+
+# ---------------------------------------------------------------------------
+# Per-target freshness re-validation aborts a stale target non-silently
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_stale_target_fails_non_silently_without_upload(
+    _wire_db, _reset_metrics, test_session, tmp_path, caplog
+):
+    from tasks import dbas_backup
+    from tasks.dbas_backup import DbasBackupTask
+
+    # Target rotated to v2; the schedule captured v1 → stale.
+    t1 = _make_target(test_session, name="stale", credential_version=2)
+    # An adapter is provided but must NEVER be used (freshness aborts first).
+    adapter = _adapter(_ok_upload)
+
+    with caplog.at_level("WARNING"):
+        result, notify = await _run(
+            dbas_backup, DbasBackupTask, tmp_path / "backups",
+            {"cloud_targets": [{"cloud_target_id": t1.id, "cloud_credential_version": 1}]},
+            [adapter],
+        )
+
+    assert result.success is False
+    assert result.details["upload"]["run_result"] == "failed"
+    adapter.upload.assert_not_awaited()  # stale → no upload attempted
+    assert any("[DBAS_BACKUP]" in r.message for r in caplog.records)
+    # non-silent: a journal row + a notification were written
+    entries = test_session.query(JournalEntry).filter(
+        JournalEntry.category == "backup_outbound"
+    ).all()
+    assert len(entries) >= 1
+    assert notify.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_revoked_target_fails_non_silently(
+    _wire_db, _reset_metrics, test_session, tmp_path
+):
+    from datetime import datetime
+    from tasks import dbas_backup
+    from tasks.dbas_backup import DbasBackupTask
+
+    t1 = _make_target(
+        test_session, name="revoked",
+        token_revoked_at=datetime(2026, 1, 1),
+    )
+    adapter = _adapter(_ok_upload)
+    result, _ = await _run(
+        dbas_backup, DbasBackupTask, tmp_path / "backups",
+        {"cloud_targets": [{"cloud_target_id": t1.id, "cloud_credential_version": 1}]},
+        [adapter],
+    )
+    assert result.details["upload"]["run_result"] == "failed"
+    adapter.upload.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_disabled_target_fails_non_silently(
+    _wire_db, _reset_metrics, test_session, tmp_path
+):
+    from tasks import dbas_backup
+    from tasks.dbas_backup import DbasBackupTask
+
+    t1 = _make_target(test_session, name="off", enabled=False)
+    adapter = _adapter(_ok_upload)
+    result, _ = await _run(
+        dbas_backup, DbasBackupTask, tmp_path / "backups",
+        {"cloud_targets": [{"cloud_target_id": t1.id, "cloud_credential_version": 1}]},
+        [adapter],
+    )
+    assert result.details["upload"]["run_result"] == "failed"
+    adapter.upload.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Audit rows — per upload + insecure TLS
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_audit_row_written_per_upload(
+    _wire_db, _reset_metrics, test_session, tmp_path
+):
+    from tasks import dbas_backup
+    from tasks.dbas_backup import DbasBackupTask
+
+    t1 = _make_target(test_session, name="audited")
+    result, _ = await _run(
+        dbas_backup, DbasBackupTask, tmp_path / "backups",
+        {"cloud_targets": [{"cloud_target_id": t1.id, "cloud_credential_version": 1}]},
+        [_adapter(_ok_upload)],
+    )
+    assert result.success is True
+    audit = test_session.query(JournalEntry).filter(
+        JournalEntry.category == "backup_outbound",
+        JournalEntry.action_type == "cloud_upload",
+    ).all()
+    assert len(audit) == 1
+
+
+@pytest.mark.asyncio
+async def test_insecure_target_writes_insecure_audit_row(
+    _wire_db, _reset_metrics, test_session, tmp_path
+):
+    from tasks import dbas_backup
+    from tasks.dbas_backup import DbasBackupTask
+
+    t1 = _make_target(test_session, name="insecure-tls", insecure=True)
+    result, _ = await _run(
+        dbas_backup, DbasBackupTask, tmp_path / "backups",
+        {"cloud_targets": [{"cloud_target_id": t1.id, "cloud_credential_version": 1}]},
+        [_adapter(_ok_upload)],
+    )
+    assert result.success is True
+    insecure_audit = test_session.query(JournalEntry).filter(
+        JournalEntry.action_type == "cloud_upload_insecure_tls",
+    ).all()
+    assert len(insecure_audit) == 1
+
+
+# ---------------------------------------------------------------------------
+# Deferred providers (dropbox/onedrive) are a non-silent per-target failure
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_deferred_provider_is_non_silent_failure(
+    _wire_db, _reset_metrics, test_session, tmp_path
+):
+    from tasks import dbas_backup
+    from tasks.dbas_backup import DbasBackupTask
+
+    t1 = _make_target(test_session, name="dbx", provider_type="dropbox")
+    adapter = _adapter(_ok_upload)
+    result, notify = await _run(
+        dbas_backup, DbasBackupTask, tmp_path / "backups",
+        {"cloud_targets": [{"cloud_target_id": t1.id, "cloud_credential_version": 1}]},
+        [adapter],
+    )
+    assert result.details["upload"]["run_result"] == "failed"
+    adapter.upload.assert_not_awaited()
+    assert notify.await_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Config round-trip for the new cloud_targets list
+# ---------------------------------------------------------------------------
+def test_cloud_targets_config_round_trip():
+    from tasks.dbas_backup import DbasBackupTask
+
+    task = DbasBackupTask()
+    task.update_config({"cloud_targets": [
+        {"cloud_target_id": 3, "cloud_credential_version": 7},
+        {"cloud_target_id": "4", "cloud_credential_version": None},
+    ]})
+    cfg = task.get_config()
+    assert cfg["cloud_targets"][0] == {"cloud_target_id": 3, "cloud_credential_version": 7}
+    assert cfg["cloud_targets"][1] == {"cloud_target_id": 4, "cloud_credential_version": None}
+
+
+def test_no_cloud_targets_keeps_local_only_success(_wire_db):
+    """An empty cloud_targets list = local-only backup, run_result stays success."""
+    from tasks.dbas_backup import DbasBackupTask
+
+    task = DbasBackupTask()
+    task.update_config({"cloud_targets": []})
+    assert task.cloud_targets == []

--- a/backend/tests/tasks/test_dbas_backup_upload.py
+++ b/backend/tests/tasks/test_dbas_backup_upload.py
@@ -174,6 +174,55 @@ async def test_some_targets_succeed_is_partial(_wire_db, _reset_metrics, test_se
 
 
 @pytest.mark.asyncio
+async def test_run_outcome_notification_carries_only_counts_and_status(
+    _wire_db, _reset_metrics, test_session, tmp_path
+):
+    """The run-level outcome notification (clear-text-logging cleanup, 0i2vt.8)
+    must carry ONLY the status word + the two integer counts — never any
+    per-target reason/error detail that could contain masked credential
+    material. This guards the source-level taint cut for the 4
+    py/clear-text-logging-sensitive-data alerts."""
+    from tasks import dbas_backup
+    from tasks.dbas_backup import DbasBackupTask
+
+    t1 = _make_target(test_session, name="a")
+    t2 = _make_target(test_session, name="b")
+    # t1 ok, t2 fails — the failing adapter's error must NOT leak into the
+    # run-outcome notification message/title.
+    adapters = [_adapter(_ok_upload), _adapter(_fail_upload)]
+    result, notify = await _run(
+        dbas_backup, DbasBackupTask, tmp_path / "backups",
+        {"cloud_targets": [
+            {"cloud_target_id": t1.id, "cloud_credential_version": 1},
+            {"cloud_target_id": t2.id, "cloud_credential_version": 1},
+        ]},
+        adapters,
+    )
+
+    assert result.details["upload"]["run_result"] == "partial"
+
+    # Isolate the run-level outcome notification (source_id="cloud_upload_run").
+    run_calls = [
+        c for c in notify.await_args_list
+        if c.kwargs.get("source_id") == "cloud_upload_run"
+    ]
+    assert len(run_calls) == 1, "exactly one run-level outcome notification expected"
+    call = run_calls[0]
+    title = call.kwargs["title"]
+    message = call.kwargs["message"]
+
+    # Right counts/status: 1 of 2 succeeded, partial.
+    assert title == "DBAS Backup: Upload Partial"
+    assert "1 of 2 configured targets succeeded" in message
+
+    # No per-target detail: the failing adapter's error word ("boom"), the
+    # target names, and the per-target reason vocabulary must be absent.
+    for leak in ("boom", "'a'", "'b'", "raised:", "failed:", "id="):
+        assert leak not in title, "title leaked per-target detail: %r" % leak
+        assert leak not in message, "message leaked per-target detail: %r" % leak
+
+
+@pytest.mark.asyncio
 async def test_no_targets_succeed_is_failed(_wire_db, _reset_metrics, test_session, tmp_path):
     from tasks import dbas_backup
     from tasks.dbas_backup import DbasBackupTask

--- a/backend/tests/test_cloud_upload_security.py
+++ b/backend/tests/test_cloud_upload_security.py
@@ -13,17 +13,15 @@ All network/SDK is mocked — NO live cloud calls.
 """
 from __future__ import annotations
 
-import asyncio
 import ipaddress
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from cloud_storage import get_adapter
 from cloud_storage import upload_security
 from cloud_storage import webdav_adapter as webdav_mod
-from cloud_storage import gdrive_adapter as gdrive_mod
 from cloud_storage.upload_security import mask_secrets
 from security import ssrf
 
@@ -80,6 +78,15 @@ class TestMaskSecrets:
     def test_masks_secret_access_key_kv(self):
         out = mask_secrets("secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
         assert "wJalrXUtnFEMI" not in out
+
+    def test_masks_aws_secret_access_key_kv_single_literal_re(self):
+        # Guards the Semgrep single-raw-string-literal collapse of _SECRET_KV_RE:
+        # the pattern must still mask an aws_secret_access_key=<value> KV pair.
+        out = mask_secrets("aws_secret_access_key=wJalrXUtnFEMIK7MDENGbPxRfiCYzzz token=keep")
+        assert "wJalrXUtnFEMIK7MDENGbPxRfiCYzzz" not in out
+        assert "REDACTED" in out
+        # The key name is preserved; only the value is redacted.
+        assert "aws_secret_access_key=" in out
 
     def test_masks_x_amz_signature(self):
         url = (

--- a/backend/tests/test_cloud_upload_security.py
+++ b/backend/tests/test_cloud_upload_security.py
@@ -1,0 +1,321 @@
+"""Tests for bead 0i2vt.8 — cloud upload wiring (S3 / WebDAV / GDrive).
+
+Covers the HARD ACs from grooming (SRE + Security):
+
+* SSRF refusal BEFORE a socket opens (the 169.254.169.254 metadata AC) for
+  each shipping adapter — proven by patching the resolver and asserting the
+  upload is refused without the SDK/HTTP client ever being constructed.
+* Blocking SDK calls are executor-wrapped (asyncio.to_thread).
+* Uploads stream from the on-disk artifact — no whole-file .read() into RAM.
+* Credential masking — no secret/signature substring survives into logs/errors.
+
+All network/SDK is mocked — NO live cloud calls.
+"""
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cloud_storage import get_adapter
+from cloud_storage import upload_security
+from cloud_storage import webdav_adapter as webdav_mod
+from cloud_storage import gdrive_adapter as gdrive_mod
+from cloud_storage.upload_security import mask_secrets
+from security import ssrf
+
+
+@pytest.fixture
+def _fake_googleapiclient():
+    """Inject a fake googleapiclient.http module (the SDK is not installed in
+    the test env) so the gdrive adapter's inline import of MediaFileUpload
+    resolves to a no-op stand-in."""
+    import sys
+    import types
+
+    pkg = types.ModuleType("googleapiclient")
+    http_mod = types.ModuleType("googleapiclient.http")
+    http_mod.MediaFileUpload = MagicMock(name="MediaFileUpload")
+    pkg.http = http_mod
+    with patch.dict(sys.modules, {
+        "googleapiclient": pkg,
+        "googleapiclient.http": http_mod,
+    }):
+        yield http_mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers — deterministic DNS so the SSRF corpus is hermetic.
+# ---------------------------------------------------------------------------
+def _patch_dns(*ips):
+    """Patch the resolver inside security.ssrf to return ``ips``."""
+    return patch.object(
+        ssrf, "_resolve", lambda host, port: [ipaddress.ip_address(i) for i in ips]
+    )
+
+
+def _artifact(tmp_path: Path) -> Path:
+    p = tmp_path / "ecm-artifact-abc123.zip"
+    p.write_bytes(b"PK\x03\x04" + b"x" * 4096)
+    return p
+
+
+# ===========================================================================
+# Credential masking
+# ===========================================================================
+class TestMaskSecrets:
+    def test_masks_authorization_bearer(self):
+        line = "PUT https://x Authorization: Bearer eyJ0eParticularTOKEN.value.sig"
+        out = mask_secrets(line)
+        assert "eyJ0eParticularTOKEN" not in out
+        assert "REDACTED" in out
+
+    def test_masks_aws_access_key_id(self):
+        out = mask_secrets("access_key_id=AKIAIOSFODNN7EXAMPLE region=us-east-1")
+        assert "AKIAIOSFODNN7EXAMPLE" not in out
+
+    def test_masks_secret_access_key_kv(self):
+        out = mask_secrets("secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+        assert "wJalrXUtnFEMI" not in out
+
+    def test_masks_x_amz_signature(self):
+        url = (
+            "https://b.s3.amazonaws.com/k?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+            "&X-Amz-Signature=4709abcdef0123456789&X-Amz-Credential=AKIA/scope"
+        )
+        out = mask_secrets(url)
+        assert "4709abcdef0123456789" not in out
+        assert "AKIA/scope" not in out
+
+    def test_masks_bearer_token_standalone(self):
+        out = mask_secrets("headers={'Authorization': 'Bearer abc123def456ghi'}")
+        assert "abc123def456ghi" not in out
+
+    def test_empty_input_is_safe(self):
+        assert mask_secrets("") == ""
+
+    def test_patterns_are_precompiled_constants(self):
+        # Semgrep no-bare-re-on-dynamic-pattern: the rules must be compiled
+        # Pattern objects, not strings recompiled per call.
+        import re as _re
+        for rule in upload_security._MASK_RULES:
+            assert isinstance(rule, _re.Pattern)
+
+
+# ===========================================================================
+# SSRF refusal BEFORE a socket opens — the 169.254.169.254 metadata AC
+# ===========================================================================
+class TestS3SsrfRefusedBeforeSocket:
+    def _adapter(self, endpoint):
+        return get_adapter("s3", {
+            "bucket_name": "b", "access_key_id": "AKIAEXAMPLE", "secret_access_key": "S",
+            "endpoint_url": endpoint,
+        })
+
+    @pytest.mark.asyncio
+    async def test_s3_endpoint_pointed_at_imds_is_refused_before_socket(self, tmp_path):
+        """A custom S3 endpoint resolving to 169.254.169.254 must be refused
+        BEFORE the boto3 client (and therefore any socket) is created."""
+        adapter = self._adapter("https://evil.example.com:9000")
+        get_client = MagicMock()  # proves the SDK client is NEVER built
+        with patch.object(adapter, "_get_client", get_client):
+            with _patch_dns("169.254.169.254"):
+                result = await adapter.upload(_artifact(tmp_path), "backups/a.zip")
+        assert result.success is False
+        assert get_client.call_count == 0, "boto3 client built despite SSRF denial"
+
+    @pytest.mark.asyncio
+    async def test_s3_literal_imds_host_refused(self, tmp_path):
+        adapter = self._adapter("http://169.254.169.254/")
+        get_client = MagicMock()
+        with patch.object(adapter, "_get_client", get_client):
+            result = await adapter.upload(_artifact(tmp_path), "backups/a.zip")
+        assert result.success is False
+        assert get_client.call_count == 0
+
+
+class TestWebDAVSsrfRefusedBeforeSocket:
+    @pytest.mark.asyncio
+    async def test_webdav_base_url_imds_refused_before_client(self, tmp_path):
+        adapter = get_adapter("webdav", {
+            "base_url": "https://evil.example.com/dav", "username": "u", "password": "p",
+        })
+        # If a client were built, this would fail loudly — prove it is NOT.
+        make_client = MagicMock()
+        with patch.object(webdav_mod, "pinned_async_client", make_client):
+            with _patch_dns("169.254.169.254"):
+                result = await adapter.upload(_artifact(tmp_path), "a.zip")
+        assert result.success is False
+        assert make_client.call_count == 0, "httpx client built despite SSRF denial"
+
+
+class TestGDriveSsrfRefusedBeforeSocket:
+    def _adapter(self):
+        return get_adapter("gdrive", {
+            "service_account_json": {"client_email": "x@y.iam", "token_uri": "https://oauth2"},
+            "folder_id": "FID",
+        })
+
+    @pytest.mark.asyncio
+    async def test_gdrive_endpoint_resolving_to_imds_refused_before_service(self, tmp_path):
+        adapter = self._adapter()
+        get_service = MagicMock()
+        with patch.object(adapter, "_get_service", get_service):
+            with _patch_dns("169.254.169.254"):
+                result = await adapter.upload(_artifact(tmp_path), "a.zip")
+        assert result.success is False
+        assert get_service.call_count == 0, "Drive service built despite SSRF denial"
+
+
+# ===========================================================================
+# Executor-wrapping — blocking SDK calls run via asyncio.to_thread
+# ===========================================================================
+class TestExecutorWrapping:
+    @pytest.mark.asyncio
+    async def test_s3_upload_file_runs_in_executor(self, tmp_path):
+        adapter = get_adapter("s3", {
+            "bucket_name": "b", "access_key_id": "AKIAEXAMPLE", "secret_access_key": "S",
+        })
+        mock_client = MagicMock()
+        seen = {}
+
+        def _record_upload(*a, **k):
+            # Confirm we are NOT on the main event-loop thread — to_thread runs
+            # us on a worker thread.
+            import threading
+            seen["thread"] = threading.current_thread().name
+
+        mock_client.upload_file.side_effect = _record_upload
+        with patch.object(adapter, "_get_client", return_value=mock_client):
+            result = await adapter.upload(_artifact(tmp_path), "backups/a.zip")
+        assert result.success is True
+        mock_client.upload_file.assert_called_once()
+        assert seen.get("thread") and "MainThread" not in seen["thread"]
+
+    @pytest.mark.asyncio
+    async def test_s3_upload_passes_path_not_bytes(self, tmp_path):
+        """boto3.upload_file is called with the file PATH (it streams from disk),
+        never with whole-file bytes — proves no .read() into RAM."""
+        artifact = _artifact(tmp_path)
+        adapter = get_adapter("s3", {
+            "bucket_name": "b", "access_key_id": "A", "secret_access_key": "S",
+        })
+        mock_client = MagicMock()
+        with patch.object(adapter, "_get_client", return_value=mock_client):
+            await adapter.upload(artifact, "backups/a.zip")
+        call = mock_client.upload_file.call_args
+        assert call.args[0] == str(artifact)  # the on-disk path
+        # No bytes object anywhere in the call args.
+        assert not any(isinstance(a, (bytes, bytearray)) for a in call.args)
+
+    @pytest.mark.asyncio
+    async def test_gdrive_execute_runs_in_executor(self, tmp_path, _fake_googleapiclient):
+        adapter = get_adapter("gdrive", {
+            "service_account_json": {"client_email": "x@y"}, "folder_id": "FID",
+        })
+        threads = []
+
+        def _list_execute():
+            import threading
+            threads.append(threading.current_thread().name)
+            return {"files": []}
+
+        def _create_execute():
+            import threading
+            threads.append(threading.current_thread().name)
+            return {"id": "newid", "webViewLink": "https://drive/x"}
+
+        mock_service = MagicMock()
+        mock_service.files.return_value.list.return_value.execute.side_effect = _list_execute
+        mock_service.files.return_value.create.return_value.execute.side_effect = _create_execute
+
+        with patch.object(adapter, "_validate_endpoint"), \
+             patch.object(adapter, "_get_service", return_value=mock_service):
+            result = await adapter.upload(_artifact(tmp_path), "a.zip")
+        assert result.success is True
+        assert threads and all("MainThread" not in t for t in threads)
+
+
+# ===========================================================================
+# Streaming — WebDAV uploads via a file handle, not whole-file bytes
+# ===========================================================================
+class TestWebDAVStreaming:
+    @pytest.mark.asyncio
+    async def test_webdav_upload_streams_file_handle(self, tmp_path):
+        adapter = get_adapter("webdav", {
+            "base_url": "https://dav.example.com/files", "username": "u", "password": "secretpw",
+        })
+        artifact = _artifact(tmp_path)
+
+        captured = {}
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+
+        class _FakeClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def put(self, url, content=None, **kw):
+                # content must be a file-like object (streamed), NOT bytes.
+                captured["content_type"] = type(content).__name__
+                captured["is_bytes"] = isinstance(content, (bytes, bytearray))
+                captured["url"] = url
+                return mock_resp
+
+        with _patch_dns("93.184.216.34"):
+            with patch.object(webdav_mod, "pinned_async_client", return_value=_FakeClient()):
+                result = await adapter.upload(artifact, "a.zip")
+
+        assert result.success is True
+        assert captured["is_bytes"] is False, "WebDAV buffered the whole file into RAM"
+        # The connect URL is pinned to the validated IP, not the hostname.
+        assert "93.184.216.34" in captured["url"]
+
+    @pytest.mark.asyncio
+    async def test_webdav_upload_error_is_masked(self, tmp_path):
+        adapter = get_adapter("webdav", {
+            "base_url": "https://dav.example.com/files",
+            "username": "u", "password": "p",
+        })
+
+        class _BoomClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def put(self, *a, **k):
+                raise RuntimeError(
+                    "401 Authorization: Bearer leakedtoken123456 rejected"
+                )
+
+        with _patch_dns("93.184.216.34"):
+            with patch.object(webdav_mod, "pinned_async_client", return_value=_BoomClient()):
+                result = await adapter.upload(_artifact(tmp_path), "a.zip")
+        assert result.success is False
+        assert "leakedtoken123456" not in result.error
+
+
+# ===========================================================================
+# Factory registration of the net-new WebDAV adapter
+# ===========================================================================
+class TestWebDAVFactory:
+    def test_factory_returns_webdav_adapter(self):
+        from cloud_storage.webdav_adapter import WebDAVAdapter
+        adapter = get_adapter("webdav", {"base_url": "https://dav.example.com/x"})
+        assert isinstance(adapter, WebDAVAdapter)
+
+    def test_webdav_requires_base_url(self):
+        with pytest.raises(ValueError):
+            get_adapter("webdav", {})
+
+    def test_webdav_insecure_flag_parsed(self):
+        adapter = get_adapter("webdav", {"base_url": "https://x/y", "insecure": True})
+        assert adapter.insecure is True

--- a/backend/tests/test_ssrf_chokepoint_guard.py
+++ b/backend/tests/test_ssrf_chokepoint_guard.py
@@ -59,11 +59,14 @@ CLOUD_DIR = Path(__file__).resolve().parent.parent / "cloud_storage"
 # tolerates these specific modules so it does not falsely fail before .8, but
 # FAILS LOUDLY if a brand-new adapter shows up with a raw outbound primitive.
 # bead .8 MUST shrink this set as it migrates each adapter.
+# bead .8 migrated s3/gdrive/webdav onto the chokepoint (boto3/google imports
+# now carry the `# ssrf-ok:` tag because the endpoint is pre-validated via
+# security.ssrf before the SDK call). onedrive/dropbox were DEFERRED to a
+# v0.18.x follow-up (PO decision 2026-06-17 — drop them from v0.18.0), so they
+# keep their raw outbound calls and remain on the baseline.
 _PRE_8_BASELINE = {
-    "s3_adapter.py",       # boto3.client — needs pre-resolve+IP-pin shim (.8)
-    "onedrive_adapter.py",  # httpx.AsyncClient — route through validated client (.8)
-    "dropbox_adapter.py",   # SDK / httpx — (.8)
-    "gdrive_adapter.py",    # Google SDK — pre-resolve+validate endpoint (.8)
+    "onedrive_adapter.py",  # DEFERRED (v0.18.x) — raw httpx, not migrated
+    "dropbox_adapter.py",   # DEFERRED (v0.18.x) — raw dropbox SDK, not migrated
 }
 
 


### PR DESCRIPTION
## Bead
enhancedchannelmanager-0i2vt.8 — DBAS Phase 1: Cloud upload wiring. PO-reduced scope: **S3 + WebDAV + GDrive only** (Dropbox/OneDrive deferred to v0.18.x — removes the f.read() OOM risk).

## What
- Extends `s3_adapter`/`gdrive_adapter` to upload the backup artifact + `.sha256` sidecar; **net-new WebDAV adapter** (conforms to the `CloudStorageAdapter` ABC, registered in `factory.py`).
- **SSRF**: every adapter routes through the `.5` chokepoint (`security/ssrf.py`) BEFORE any socket/SDK client — WebDAV resolve-then-connect-by-IP (SNI/Host preserved, redirects disabled); S3/GDrive pre-resolve + denylist-validate. AC test: endpoint → 169.254.169.254 refused before socket.
- **Event-loop safe**: every blocking SDK call (`boto3.upload_file`, gdrive `.execute()`) `asyncio.to_thread`-wrapped; artifact streamed by path/handle, never buffered whole.
- **Credential masking** (`upload_security.mask_secrets`, precompiled regexes): Authorization, Bearer, AWS access/secret keys, S3 signed-URL params (X-Amz-Signature/Credential/Security-Token) — applied to every adapter log/error + the task failure path (SEC-2).
- **Per-destination audit row** + explicit `insecure=true` TLS-skip audit row; metric `ecm_backup_upload_total{provider,result}`; cap=1 concurrent upload.
- **Tri-state multi-target** (PO): run is `success` only if ALL targets succeed, `partial`/`failed` otherwise — both fire notification + count against `ecm_backup_runs_total`. Each target re-validated fresh (enabled + credential_version + token_revoked_at) right before its upload; stale/revoked = non-silent failure. Fills `.6`'s `TODO(0i2vt.8)` upload seam.

## Security review
Independent review: **SAFE TO MERGE WITH FOLLOW-UPS** — all 6 invariants verified, 0 blocker/high. SEC-2 (mask raw exception) fixed in this PR; SEC-1 (GDrive token_uri self-SSRF, MEDIUM) filed as a follow-up bead.

## Tests
30+ tests (SSRF-refusal-before-socket, executor boundary, streaming-not-bytes, masking incl. the new masked-exception test, audit rows, tri-state, per-target freshness). Full backend suite green (5663 passed, 3 pre-existing skips). Dropbox/OneDrive upload paths left deferred/skipped.

## Deferred (no live creds)
Real S3/MinIO, GDrive resumable, WebDAV PUT/PROPFIND, and `insecure=true` TLS behavior are mock-tested only — live verification is a flagged follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)