### PR TITLE
v0.18.0-dbas: 4vouz channels importer -- channel create + profile reattach (Channels import 2/4)

### DIFF
--- a/backend/dbas/importers/__init__.py
+++ b/backend/dbas/importers/__init__.py
@@ -11,4 +11,16 @@ later failure can compensate-delete.
 The first importer to land here is ``users`` — the crown-jewel
 ``dispatcharr_users`` category (bead ``enhancedchannelmanager-l1p4p``), the most
 security-sensitive of the Phase-2 importers (privilege-escalation surface).
+
+``channels`` (bead ``enhancedchannelmanager-4vouz``) restores the CHANNEL
+category: it creates each archived channel row (remapping its FK references
+through the :class:`~dbas.restore_contracts.IdRemapTable`) and reattaches each
+channel to its archived channel-profile memberships. It leaves a clean seam where
+bead ``0i2vt.14`` integrates the stream matcher + custom-stream fallback to
+attach streams — this importer never matches or attaches a stream.
 """
+
+from dbas.importers.channels import import_channels
+from dbas.importers.users import import_users
+
+__all__ = ["import_channels", "import_users"]

--- a/backend/dbas/importers/channels.py
+++ b/backend/dbas/importers/channels.py
@@ -1,0 +1,408 @@
+"""The channels restore importer — channel-row create + profile reattach.
+
+Bead ``enhancedchannelmanager-4vouz`` (split 2/4 of the ``0i2vt.14`` channels
+importer epic). This module restores the CHANNEL entity category from a
+Dispatcharr export archive: it creates each archived channel row and reattaches
+each channel to its archived channel-profile memberships.
+
+SCOPE — TIGHT. This importer does channel-row create + profile membership
+reattach ONLY. It deliberately leaves a clean SEAM where bead ``0i2vt.14``
+integrates the stream matcher (``al6e3``) + ``create_stream`` (``nav0c``) +
+custom-stream fallback (``ahygg``) to match and attach an archived channel's
+streams. This importer NEVER matches a stream, NEVER attaches a stream, and
+strips any embedded ``streams`` payload from the create. Stream attachment is
+explicitly out of scope.
+
+FK remapping (the load-bearing correctness control). A Dispatcharr export records
+each entity's id *as it was on the source instance*; on restore the destination
+assigns its own ids. FK reference fields on a channel therefore point at SOURCE
+ids and MUST be rewritten to DESTINATION ids (via the shared
+:class:`~dbas.restore_contracts.IdRemapTable`, populated by the groups/profiles
+importer ``0i2vt.12``) before the create is sent — or the channel is skipped
+``DEPENDENCY_UNRESOLVED`` rather than sent upstream with a stale archive id.
+
+The channel FK fields and how each is handled:
+
+* ``channel_group_id`` -> :data:`EntityType.CHANNEL_GROUP` — REMAPPED. Resolved
+  through the IdRemapTable; unresolved => channel skipped DEPENDENCY_UNRESOLVED.
+* ``stream_profile_id`` -> :data:`EntityType.STREAM_PROFILE` — REMAPPED. Same
+  treatment.
+* ``logo_id`` / ``epg_data_id`` -> NO EntityType in the restore contract. Logos
+  and EPG data are owned by separate beads (logos: ``.15`` / ``.19``, surfaced
+  via :attr:`RestoreReport.logo_misses`); there is no id namespace in the remap
+  to resolve them. Sending the stale archive id would dangle a reference, so
+  these fields are DROPPED from the create payload. (A later logo/epg bead
+  reattaches them; this importer must not invent or forward a stale id.)
+
+Channel-profile membership reattach. Channels belong to channel profiles. After a
+channel is created, each archived membership is reattached via
+``client.update_profile_channel(dest_profile_id, dest_channel_id, {"enabled": ...})``.
+The destination profile id is resolved through the IdRemapTable
+(:data:`EntityType.CHANNEL_PROFILE`, populated by ``0i2vt.12``). If the profile
+is NOT in the remap (the channel-profiles importer did not run, or did not
+restore that profile), the membership is handled as ``DEPENDENCY_UNRESOLVED`` and
+recorded under the :data:`EntityType.CHANNEL_PROFILE` category — never crashing,
+never guessing a profile id.
+
+Collision taxonomy. A channel whose ``(name, channel_number)`` already exists on
+the destination is skipped ``ALREADY_EXISTS_IDENTICAL`` (never overwritten); its
+source id is still remapped to the existing destination id so a later profile
+reattach can resolve it. A create that races into an upstream uniqueness conflict
+is failed ``CONFLICT``.
+
+Opt-in. The category does nothing unless the operator selected it (``selected``).
+
+Integration with the restore contracts (bead ``kxuj2``): results land in the
+shared :class:`~dbas.restore_contracts.RestoreReport`
+(:data:`EntityType.CHANNEL` category, plus :data:`EntityType.CHANNEL_PROFILE` for
+unresolved memberships), created channels register source->dest in the
+:class:`~dbas.restore_contracts.IdRemapTable`, and every created channel is
+recorded in the :class:`~dbas.restore_contracts.RollbackLedger` so a later
+failure compensates by deleting it. This importer imports the contracts module
+READ-ONLY.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from dbas.restore_contracts import (
+    EntityType,
+    FailureDetail,
+    FailureReason,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+    SkipDetail,
+    SkipReason,
+)
+from dispatcharr_client import DispatcharrClient
+
+logger = logging.getLogger(__name__)
+
+# Channel FK fields whose ids reference another entity that the restore remaps.
+# Maps the archive field name -> the EntityType namespace to resolve it through.
+# These are the ONLY FK fields the contract can remap (the others — logo_id,
+# epg_data_id — have no EntityType and are dropped, see _NON_REMAPPABLE_FK_KEYS).
+_REMAPPABLE_FK_FIELDS = {
+    "channel_group_id": EntityType.CHANNEL_GROUP,
+    "stream_profile_id": EntityType.STREAM_PROFILE,
+}
+
+# FK fields that reference an entity NOT in the restore-contract id namespace.
+# Logos / EPG data are owned by separate beads (logos: .15 / .19). There is no
+# remap to rewrite their ids, so we DROP them rather than forward a stale archive
+# id that would dangle. A later logo/epg bead reattaches them.
+_NON_REMAPPABLE_FK_KEYS = frozenset({"logo_id", "epg_data_id"})
+
+# Archive-source identifiers the destination assigns itself, never forwarded.
+_SOURCE_ID_KEYS = frozenset({"id", "pk"})
+
+# Embedded/derived keys that are NOT part of a channel create payload. ``streams``
+# is the stream-attachment SEAM owned by bead 0i2vt.14 — this importer strips it
+# and never attaches a stream. ``profile_memberships`` is consumed separately by
+# the profile-reattach step (post-create), not sent in the create body. Other
+# read-only/derived fields a GET echoes back are dropped defensively.
+_NON_CREATE_KEYS = frozenset(
+    {
+        "streams",
+        "profile_memberships",
+        "channelprofilemembership_set",
+        "stream_count",
+        "stats",
+    }
+)
+
+# All keys dropped before issuing the create. The remappable FK fields are not in
+# this set — they are rewritten in-place to destination ids (or the channel is
+# skipped if unresolvable) rather than dropped.
+_DROPPED_CREATE_KEYS = (
+    _SOURCE_ID_KEYS | _NON_REMAPPABLE_FK_KEYS | _NON_CREATE_KEYS
+)
+
+
+def _channel_label(archive_channel: dict) -> str:
+    """Operator-facing identifier for a channel — its name, never a secret."""
+    name = archive_channel.get("name")
+    return str(name) if name else "<unknown>"
+
+
+def _build_create_payload(archive_channel: dict, remap: IdRemapTable) -> dict:
+    """Build the create_channel payload, rewriting remappable FK ids to dest ids.
+
+    Returns the payload on success, or ``None`` if a remappable FK reference could
+    not be resolved through ``remap`` (the channel must then be skipped
+    ``DEPENDENCY_UNRESOLVED`` rather than created with a stale archive id).
+
+    Drops the archive's source id, the non-remappable FK fields (logo/epg, owned
+    by other beads), and the embedded/derived non-create keys (notably the
+    ``streams`` seam owned by bead 0i2vt.14).
+    """
+    payload = {
+        k: v for k, v in archive_channel.items() if k not in _DROPPED_CREATE_KEYS
+    }
+    for field, entity_type in _REMAPPABLE_FK_FIELDS.items():
+        source_id = archive_channel.get(field)
+        if source_id is None:
+            continue
+        dest_id = remap.resolve(entity_type, int(source_id))
+        if dest_id is None:
+            return None
+        payload[field] = dest_id
+    return payload
+
+
+def _existing_channel_key(channel: dict) -> tuple:
+    """Identity key for an existing destination channel: (name, channel_number).
+
+    A restored channel that matches an existing one on this key is a no-op
+    (ALREADY_EXISTS_IDENTICAL); ``channel_number`` may be absent on either side.
+    """
+    return (channel.get("name"), channel.get("channel_number"))
+
+
+def _failure_reason_for(exc: Exception) -> FailureReason:
+    """Classify a create_channel failure into a restore-contract FailureReason.
+
+    A name/number uniqueness conflict (the error body echoing "already exists" /
+    "unique") maps to ``CONFLICT``; everything else is an upstream API error.
+    """
+    text = str(exc).lower()
+    if "already exists" in text or "unique" in text or "conflict" in text:
+        return FailureReason.CONFLICT
+    return FailureReason.UPSTREAM_API_ERROR
+
+
+def _sanitize_failure(exc: Exception) -> str:
+    """Produce a sanitized, operator-facing failure message (no raw traces)."""
+    return (str(exc) or "").strip() or "Upstream rejected the channel creation request."
+
+
+async def import_channels(
+    *,
+    archive_channels: list[dict],
+    client: DispatcharrClient,
+    selected: bool,
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    remap: IdRemapTable,
+    is_dry_run: bool = False,
+) -> None:
+    """Restore the CHANNEL category: create channel rows + reattach profiles.
+
+    Args:
+        archive_channels: The channel records from the export archive. Each is a
+            dict; the archive's source id, non-remappable FK fields, and embedded
+            stream payload are dropped/handled per the module docstring.
+        client: The Dispatcharr API client.
+        selected: The per-category opt-in flag. When ``False`` the entire category
+            is skipped (no creates) — every channel recorded EXCLUDED_BY_OPERATOR.
+        report: The shared :class:`RestoreReport`; channel results land in the
+            ``EntityType.CHANNEL`` category, unresolved profile memberships in
+            ``EntityType.CHANNEL_PROFILE``.
+        ledger: The shared :class:`RollbackLedger`; each created channel is
+            recorded for compensating deletes.
+        remap: The shared :class:`IdRemapTable`. READ to resolve channel FK
+            references (channel_group / stream_profile) and channel-profile ids;
+            WRITTEN with each created channel's source->dest id (under
+            ``EntityType.CHANNEL``) so the stream-attachment bead and the profile
+            reattach can resolve channels.
+        is_dry_run: When ``True``, nothing is created or reattached — the importer
+            only reports ``would_create`` / ``would_skip`` so the operator sees
+            the plan.
+    """
+    cat = report.category(EntityType.CHANNEL)
+
+    # OPT-IN. Off unless the operator selected the channels category.
+    if not selected:
+        logger.info("[DBAS-CHANNELS] Category not selected; skipping channels.")
+        for archive_channel in archive_channels:
+            _skip(
+                cat,
+                SkipReason.EXCLUDED_BY_OPERATOR,
+                _channel_label(archive_channel),
+                archive_channel.get("id"),
+                is_dry_run,
+            )
+        return
+
+    logger.info(
+        "[DBAS-CHANNELS] Restoring channels (dry_run=%s); %d archived channel(s).",
+        is_dry_run,
+        len(archive_channels),
+    )
+
+    # Pre-fetch existing channels to detect (name, channel_number) collisions.
+    existing_by_key: dict[tuple, dict] = {}
+    try:
+        existing = await client.get_channels(page_size=1000)
+        results = existing.get("results", []) if isinstance(existing, dict) else existing
+        for ch in results or []:
+            if isinstance(ch, dict):
+                existing_by_key[_existing_channel_key(ch)] = ch
+    except Exception as exc:
+        logger.warning("[DBAS-CHANNELS] Could not list existing channels: %s", exc)
+
+    # Channels created/resolved this run, paired with their archive record, so the
+    # profile-reattach pass (post-create) can resolve each channel's dest id.
+    # Each tuple: (archive_channel, destination_channel_id).
+    reattach_queue: list[tuple[dict, int]] = []
+
+    for archive_channel in archive_channels:
+        label = _channel_label(archive_channel)
+        source_id = archive_channel.get("id")
+
+        # Collision: an identical (name, number) already on the destination.
+        existing = existing_by_key.get(_existing_channel_key(archive_channel))
+        if existing is not None:
+            _skip(cat, SkipReason.ALREADY_EXISTS_IDENTICAL, label, source_id, is_dry_run)
+            # Still remap source -> existing dest id so a later profile reattach
+            # (and the stream-attachment bead) can resolve this channel.
+            existing_id = existing.get("id")
+            if source_id is not None and existing_id is not None:
+                remap.add(EntityType.CHANNEL, int(source_id), int(existing_id))
+                if not is_dry_run:
+                    reattach_queue.append((archive_channel, int(existing_id)))
+            continue
+
+        # FK remap: rewrite remappable FK ids; unresolved => DEPENDENCY_UNRESOLVED.
+        payload = _build_create_payload(archive_channel, remap)
+        if payload is None:
+            logger.info(
+                "[DBAS-CHANNELS] Channel '%s' skipped — an FK dependency is "
+                "unresolved (not yet restored).",
+                label,
+            )
+            _skip(cat, SkipReason.DEPENDENCY_UNRESOLVED, label, source_id, is_dry_run)
+            continue
+
+        if is_dry_run:
+            cat.would_create += 1
+            continue
+
+        try:
+            created = await client.create_channel(payload)
+        except Exception as exc:
+            reason = _failure_reason_for(exc)
+            cat.failed += 1
+            cat.failure_details.append(
+                FailureDetail(
+                    reason=reason,
+                    label=label,
+                    message=_sanitize_failure(exc),
+                    source_export_id=source_id,
+                )
+            )
+            logger.warning(
+                "[DBAS-CHANNELS] Failed to restore channel '%s': %s", label, reason.value
+            )
+            continue
+
+        dest_id = created.get("id") if isinstance(created, dict) else None
+        cat.created += 1
+        if dest_id is not None:
+            dest_id = int(dest_id)
+            if source_id is not None:
+                remap.add(EntityType.CHANNEL, int(source_id), dest_id)
+            ledger.record_created(EntityType.CHANNEL, dest_id, label)
+            reattach_queue.append((archive_channel, dest_id))
+        logger.info("[DBAS-CHANNELS] Restored channel '%s' (id=%s).", label, dest_id)
+
+    # Profile reattach pass — runs AFTER all channels are created so every channel
+    # has a destination id. Dry-run reattaches nothing.
+    if not is_dry_run:
+        await _reattach_profiles(reattach_queue, client=client, report=report, remap=remap)
+
+
+async def _reattach_profiles(
+    reattach_queue: list[tuple[dict, int]],
+    *,
+    client: DispatcharrClient,
+    report: RestoreReport,
+    remap: IdRemapTable,
+) -> None:
+    """Reattach each restored channel to its archived channel-profile memberships.
+
+    For each membership, resolve the destination profile id through the
+    IdRemapTable (``EntityType.CHANNEL_PROFILE``). An unresolved profile is
+    recorded ``DEPENDENCY_UNRESOLVED`` under the CHANNEL_PROFILE category and the
+    membership is NOT applied (no guessed id). A reattach upstream error is
+    recorded ``UPSTREAM_API_ERROR``.
+    """
+    prof_cat = report.category(EntityType.CHANNEL_PROFILE)
+    for archive_channel, dest_channel_id in reattach_queue:
+        label = _channel_label(archive_channel)
+        for membership in _profile_memberships(archive_channel):
+            source_profile_id = membership.get("profile_id")
+            if source_profile_id is None:
+                continue
+            dest_profile_id = remap.resolve(
+                EntityType.CHANNEL_PROFILE, int(source_profile_id)
+            )
+            if dest_profile_id is None:
+                logger.info(
+                    "[DBAS-CHANNELS] Channel '%s' profile membership skipped — "
+                    "profile (source id %s) not in remap (dependency unresolved).",
+                    label,
+                    source_profile_id,
+                )
+                prof_cat.skipped += 1
+                prof_cat.skip_details.append(
+                    SkipDetail(
+                        reason=SkipReason.DEPENDENCY_UNRESOLVED,
+                        label=label,
+                        source_export_id=int(source_profile_id),
+                    )
+                )
+                continue
+            enabled = bool(membership.get("enabled", True))
+            try:
+                await client.update_profile_channel(
+                    dest_profile_id, dest_channel_id, {"enabled": enabled}
+                )
+            except Exception as exc:
+                prof_cat.failed += 1
+                prof_cat.failure_details.append(
+                    FailureDetail(
+                        reason=FailureReason.UPSTREAM_API_ERROR,
+                        label=label,
+                        message=_sanitize_failure(exc),
+                        source_export_id=int(source_profile_id),
+                    )
+                )
+                logger.warning(
+                    "[DBAS-CHANNELS] Failed to reattach channel '%s' to profile "
+                    "(dest id %s): %s",
+                    label,
+                    dest_profile_id,
+                    exc,
+                )
+
+
+def _profile_memberships(archive_channel: dict) -> list[dict]:
+    """Extract the channel's archived profile memberships as a list of dicts.
+
+    Accepts the canonical ``profile_memberships`` list (``{profile_id, enabled}``
+    records). Returns an empty list when the archive carries no memberships.
+    """
+    memberships = archive_channel.get("profile_memberships")
+    if not isinstance(memberships, list):
+        return []
+    return [m for m in memberships if isinstance(m, dict)]
+
+
+def _skip(
+    cat,
+    reason: SkipReason,
+    label: str,
+    source_export_id,
+    is_dry_run: bool,
+) -> None:
+    """Record a skip in both the count and the reasoned detail list."""
+    if is_dry_run:
+        cat.would_skip += 1
+    else:
+        cat.skipped += 1
+    cat.skip_details.append(
+        SkipDetail(reason=reason, label=label, source_export_id=source_export_id)
+    )

--- a/backend/tests/dbas/test_channels_importer.py
+++ b/backend/tests/dbas/test_channels_importer.py
@@ -1,0 +1,606 @@
+"""Tests for the channels restore importer
+(enhancedchannelmanager-4vouz — split 2/4 of 0i2vt.14).
+
+Scope under test (TIGHT — channel-row create + profile membership reattach):
+
+1. Create channels. For each archived channel, strip archive-only / non-writable
+   keys (id/pk and the FK-id fields that are remapped) and create via
+   ``client.create_channel``. Register source->dest in the IdRemapTable under
+   EntityType.CHANNEL and record each create in the RollbackLedger.
+2. FK remapping. ``channel_group_id`` and ``stream_profile_id`` are FK references
+   to other entities (EntityType.CHANNEL_GROUP / STREAM_PROFILE produced by bead
+   .12). They are resolved through the IdRemapTable to a destination id before
+   create. If a referenced FK is NOT in the remap, the channel is skipped
+   DEPENDENCY_UNRESOLVED (never sent upstream with a stale archive id).
+3. Profile reattach. After channels are created, each restored channel is
+   reattached to its archived channel-profile memberships via
+   ``client.update_profile_channel``. The destination profile id is resolved
+   through the IdRemapTable (EntityType.CHANNEL_PROFILE). A profile not in the
+   remap is skipped DEPENDENCY_UNRESOLVED (dependency not yet restored) — never
+   crashes, never guesses a profile id.
+4. Opt-in: nothing happens unless the operator selected the category.
+5. Dry-run: no creates, no ledger entries; reports would_create.
+6. Name/number collision taxonomy: an existing identical channel is skipped
+   ALREADY_EXISTS_IDENTICAL; a create that races into a conflict is failed
+   CONFLICT.
+
+OUT OF SCOPE (other beads): stream matching/attaching (0i2vt.14 + al6e3 + nav0c),
+custom-stream fallback synthesis (ahygg). This importer leaves a clean seam where
+.14 attaches streams — it never matches or attaches a stream.
+
+The Dispatcharr client is mocked at the importer module level
+(``dbas.importers.channels``); the importer is exercised with an AsyncMock client.
+"""
+import pytest
+from unittest.mock import AsyncMock
+
+from dbas.importers.channels import import_channels
+from dbas.restore_contracts import (
+    EntityType,
+    FailureReason,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+    SkipReason,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _client(*, existing_channels=None, profiles=None, create_side_effect=None):
+    """Build an AsyncMock Dispatcharr client with the methods the importer uses."""
+    client = AsyncMock()
+    client.get_channels = AsyncMock(
+        return_value={"results": existing_channels or [], "count": len(existing_channels or [])}
+    )
+    client.get_channel_profiles = AsyncMock(return_value=profiles or [])
+    created_counter = {"n": 500}
+
+    async def _default_create(payload):
+        created_counter["n"] += 1
+        return {"id": created_counter["n"], **payload}
+
+    client.create_channel = AsyncMock(side_effect=create_side_effect or _default_create)
+    client.update_profile_channel = AsyncMock(return_value={"success": True})
+    client.delete_channel = AsyncMock(return_value=None)
+    return client
+
+
+def _report(is_dry_run=False):
+    return RestoreReport(is_dry_run=is_dry_run)
+
+
+def _ledger():
+    return RollbackLedger(restore_id="test-restore")
+
+
+def _remap(**kwargs):
+    """Build an IdRemapTable pre-seeded with the given mappings.
+
+    Each kwarg is an EntityType-value name -> {src: dest} dict, e.g.
+    ``_remap(channel_group={10: 110}, channel_profile={1: 101})``.
+    """
+    table = IdRemapTable()
+    name_to_type = {
+        "channel_group": EntityType.CHANNEL_GROUP,
+        "stream_profile": EntityType.STREAM_PROFILE,
+        "channel_profile": EntityType.CHANNEL_PROFILE,
+    }
+    for name, mapping in kwargs.items():
+        for src, dest in mapping.items():
+            table.add(name_to_type[name], src, dest)
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Opt-in gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_category_skipped_when_not_selected():
+    """OPT-IN: when the operator did not select the channels category, nothing is
+    created — every archived channel is recorded EXCLUDED_BY_OPERATOR."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channels(
+        archive_channels=[{"id": 5, "name": "CNN", "channel_number": 1}],
+        client=client,
+        selected=False,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    client.create_channel.assert_not_awaited()
+    cat = report.category(EntityType.CHANNEL)
+    assert cat.created == 0
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.EXCLUDED_BY_OPERATOR
+    assert cat.skip_details[0].label == "CNN"
+    assert ledger.entries == []
+    # remap not mutated
+    assert remap.resolve(EntityType.CHANNEL, 5) is None
+
+
+# ---------------------------------------------------------------------------
+# Channel create happy path — remap + ledger recorded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_channel_create_happy_path_records_remap_and_ledger():
+    """A clean channel create registers source->dest in the IdRemapTable under
+    EntityType.CHANNEL and records the create in the RollbackLedger."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channels(
+        archive_channels=[{"id": 5, "name": "CNN", "channel_number": 1}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = report.category(EntityType.CHANNEL)
+    assert cat.created == 1
+    # remap: source export id 5 -> assigned destination id 501
+    dest_id = remap.resolve(EntityType.CHANNEL, 5)
+    assert dest_id == 501
+    # ledger recorded the created channel for compensation
+    assert len(ledger.entries) == 1
+    entry = ledger.entries[0]
+    assert entry.entity_type == EntityType.CHANNEL
+    assert entry.destination_id == 501
+    assert entry.label == "CNN"
+
+
+@pytest.mark.asyncio
+async def test_create_payload_strips_source_id_keys():
+    """The create payload never carries the archive's id/pk — the destination
+    assigns its own id."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channels(
+        archive_channels=[{"id": 5, "pk": 5, "name": "CNN"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    payload = client.create_channel.await_args.args[0]
+    assert "id" not in payload
+    assert "pk" not in payload
+    assert payload["name"] == "CNN"
+
+
+# ---------------------------------------------------------------------------
+# FK remapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fk_remap_resolves_channel_group_and_stream_profile():
+    """The channel's channel_group_id and stream_profile_id FK references are
+    rewritten from source ids to destination ids via the IdRemapTable before
+    the create is sent — never the stale archive ids."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    # source group 10 -> dest 110; source stream profile 7 -> dest 207
+    remap = _remap(channel_group={10: 110}, stream_profile={7: 207})
+
+    await import_channels(
+        archive_channels=[
+            {
+                "id": 5,
+                "name": "CNN",
+                "channel_group_id": 10,
+                "stream_profile_id": 7,
+            }
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    payload = client.create_channel.await_args.args[0]
+    assert payload["channel_group_id"] == 110
+    assert payload["stream_profile_id"] == 207
+    assert report.category(EntityType.CHANNEL).created == 1
+
+
+@pytest.mark.asyncio
+async def test_fk_target_missing_skips_dependency_unresolved_no_stale_id():
+    """When a channel's FK target (channel_group) is NOT in the remap, the channel
+    is skipped DEPENDENCY_UNRESOLVED — and NO create is issued, so the stale
+    archive id is never sent upstream."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()  # empty — group 10 not resolvable
+
+    await import_channels(
+        archive_channels=[
+            {"id": 5, "name": "CNN", "channel_group_id": 10}
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    client.create_channel.assert_not_awaited()
+    cat = report.category(EntityType.CHANNEL)
+    assert cat.created == 0
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.DEPENDENCY_UNRESOLVED
+    assert cat.skip_details[0].label == "CNN"
+    # no ledger entry, no remap entry for the unresolved channel
+    assert ledger.entries == []
+    assert remap.resolve(EntityType.CHANNEL, 5) is None
+
+
+@pytest.mark.asyncio
+async def test_non_remappable_fk_fields_dropped_not_sent_stale():
+    """logo_id and epg_data_id have no EntityType in the remap contract (logos are
+    owned by beads .15/.19). They are DROPPED rather than sent with a stale
+    archive id — the create payload carries neither."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channels(
+        archive_channels=[
+            {"id": 5, "name": "CNN", "logo_id": 99, "epg_data_id": 42}
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    payload = client.create_channel.await_args.args[0]
+    assert "logo_id" not in payload
+    assert "epg_data_id" not in payload
+    assert report.category(EntityType.CHANNEL).created == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_fields_not_attached_seam_for_dot14():
+    """SCOPE SEAM: this importer creates the channel row only — it does NOT match
+    or attach streams. Any embedded stream payload is stripped from the create and
+    never forwarded to a stream-add call (bead 0i2vt.14 owns attachment)."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channels(
+        archive_channels=[
+            {"id": 5, "name": "CNN", "streams": [{"id": 1}, {"id": 2}]}
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    payload = client.create_channel.await_args.args[0]
+    assert "streams" not in payload
+    # no stream-attach client method was invoked by THIS importer
+    assert not hasattr(client, "add_stream") or not client.add_stream.await_count
+
+
+# ---------------------------------------------------------------------------
+# Profile reattach
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profile_reattach_happy_path():
+    """After create, each restored channel is reattached to its archived
+    channel-profile membership. The destination profile id is resolved through the
+    IdRemapTable (EntityType.CHANNEL_PROFILE) and update_profile_channel is called
+    with the destination profile id + destination channel id."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    # source profile 1 -> dest profile 101
+    remap = _remap(channel_profile={1: 101})
+
+    await import_channels(
+        archive_channels=[
+            {
+                "id": 5,
+                "name": "CNN",
+                "profile_memberships": [{"profile_id": 1, "enabled": True}],
+            }
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    # channel created with dest id 501
+    dest_channel_id = remap.resolve(EntityType.CHANNEL, 5)
+    assert dest_channel_id == 501
+    client.update_profile_channel.assert_awaited_once()
+    call = client.update_profile_channel.await_args
+    # update_profile_channel(profile_id, channel_id, data)
+    assert call.args[0] == 101  # destination profile id (resolved via remap)
+    assert call.args[1] == 501  # destination channel id
+    assert call.args[2] == {"enabled": True}
+
+
+@pytest.mark.asyncio
+async def test_profile_not_in_remap_skips_dependency_unresolved():
+    """A channel-profile membership whose profile is NOT in the remap (the
+    channel-profiles importer .12 has not run, or did not restore that profile) is
+    handled as DEPENDENCY_UNRESOLVED — no update_profile_channel call, no crash,
+    no guessed profile id. The channel itself still created successfully."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()  # no channel_profile mappings
+
+    await import_channels(
+        archive_channels=[
+            {
+                "id": 5,
+                "name": "CNN",
+                "profile_memberships": [{"profile_id": 1, "enabled": True}],
+            }
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    # channel created
+    assert report.category(EntityType.CHANNEL).created == 1
+    # but profile reattach was NOT issued (dependency unresolved)
+    client.update_profile_channel.assert_not_awaited()
+    # the unresolved membership is reported under CHANNEL_PROFILE as a skip
+    prof_cat = report.category(EntityType.CHANNEL_PROFILE)
+    assert prof_cat.skipped == 1
+    assert prof_cat.skip_details[0].reason == SkipReason.DEPENDENCY_UNRESOLVED
+
+
+@pytest.mark.asyncio
+async def test_profile_reattach_skipped_in_dry_run():
+    """Dry-run reattaches nothing — update_profile_channel is never called."""
+    client = _client()
+    report = _report(is_dry_run=True)
+    ledger = _ledger()
+    remap = _remap(channel_profile={1: 101})
+
+    await import_channels(
+        archive_channels=[
+            {
+                "id": 5,
+                "name": "CNN",
+                "profile_memberships": [{"profile_id": 1, "enabled": True}],
+            }
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+        is_dry_run=True,
+    )
+
+    client.update_profile_channel.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Name / number collision taxonomy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_existing_identical_channel_skipped_already_exists():
+    """A channel whose (name, channel_number) already exists on the destination is
+    skipped ALREADY_EXISTS_IDENTICAL — never re-created, never overwritten."""
+    client = _client(
+        existing_channels=[{"id": 30, "name": "CNN", "channel_number": 1}]
+    )
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channels(
+        archive_channels=[{"id": 5, "name": "CNN", "channel_number": 1}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    client.create_channel.assert_not_awaited()
+    cat = report.category(EntityType.CHANNEL)
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.ALREADY_EXISTS_IDENTICAL
+    # an already-existing channel still remaps source->existing dest id so a later
+    # profile reattach can resolve the channel.
+    assert remap.resolve(EntityType.CHANNEL, 5) == 30
+
+
+@pytest.mark.asyncio
+async def test_create_conflict_recorded_as_failure_conflict():
+    """If create_channel raises a CONFLICT-shaped upstream error (race: a colliding
+    channel appeared between the pre-check and the create), it is recorded as
+    FailureReason.CONFLICT with a sanitized message."""
+    async def _conflict(payload):
+        raise Exception(
+            'Channel creation failed: 400 - {"channel_number": ["already exists."]}'
+        )
+
+    client = _client(create_side_effect=_conflict)
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channels(
+        archive_channels=[{"id": 5, "name": "CNN", "channel_number": 1}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = report.category(EntityType.CHANNEL)
+    assert cat.failed == 1
+    assert cat.failure_details[0].reason == FailureReason.CONFLICT
+    assert cat.failure_details[0].label == "CNN"
+    assert ledger.entries == []
+
+
+@pytest.mark.asyncio
+async def test_upstream_error_recorded_as_failure_upstream_api_error():
+    """A non-conflict create failure is recorded UPSTREAM_API_ERROR, not CONFLICT."""
+    async def _boom(payload):
+        raise Exception("Channel creation failed: 500 - internal server error")
+
+    client = _client(create_side_effect=_boom)
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channels(
+        archive_channels=[{"id": 5, "name": "CNN"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = report.category(EntityType.CHANNEL)
+    assert cat.failed == 1
+    assert cat.failure_details[0].reason == FailureReason.UPSTREAM_API_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_issues_zero_creates_and_zero_ledger_entries():
+    """A dry-run issues no create_channel calls and records no ledger entries —
+    it only reports would_create so the operator sees the plan."""
+    client = _client()
+    report = _report(is_dry_run=True)
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channels(
+        archive_channels=[
+            {"id": 5, "name": "CNN"},
+            {"id": 6, "name": "ESPN"},
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+        is_dry_run=True,
+    )
+
+    client.create_channel.assert_not_awaited()
+    cat = report.category(EntityType.CHANNEL)
+    assert cat.would_create == 2
+    assert cat.created == 0
+    assert ledger.entries == []
+
+
+@pytest.mark.asyncio
+async def test_dry_run_reports_dependency_unresolved_would_skip():
+    """A dry-run with an unresolved FK reports would_skip DEPENDENCY_UNRESOLVED
+    so the operator sees the dependency gap before applying."""
+    client = _client()
+    report = _report(is_dry_run=True)
+    ledger = _ledger()
+    remap = _remap()  # group 10 not resolvable
+
+    await import_channels(
+        archive_channels=[{"id": 5, "name": "CNN", "channel_group_id": 10}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+        is_dry_run=True,
+    )
+
+    client.create_channel.assert_not_awaited()
+    cat = report.category(EntityType.CHANNEL)
+    assert cat.would_skip == 1
+    assert cat.would_create == 0
+    assert any(
+        d.reason == SkipReason.DEPENDENCY_UNRESOLVED for d in cat.skip_details
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rollback ledger records each created channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rollback_ledger_records_each_created_channel():
+    """Each successfully created channel is recorded in the rollback ledger with
+    its destination id and name label, so a later failure can compensate-delete."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channels(
+        archive_channels=[
+            {"id": 5, "name": "CNN"},
+            {"id": 6, "name": "ESPN"},
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    assert len(ledger.entries) == 2
+    for entry in ledger.entries:
+        assert entry.entity_type == EntityType.CHANNEL
+        assert entry.destination_id is not None
+        assert entry.label in ("CNN", "ESPN")
+    labels = {e.label for e in ledger.entries}
+    assert labels == {"CNN", "ESPN"}


### PR DESCRIPTION
## Bead
enhancedchannelmanager-4vouz — Phase 2 Channels B: channel-row create + profile reattach (split 2/4 of 0i2vt.14). Mirrors the l1p4p importer pattern.

## What
- New `backend/dbas/importers/channels.py`. For each archived channel: `create_channel(...)`, register source→dest in `IdRemapTable` (CHANNEL), record in `RollbackLedger`; collisions handled per the contract taxonomy.
- **FK remap**: `channel_group_id`→CHANNEL_GROUP, `stream_profile_id`→STREAM_PROFILE resolved through the remap; unresolvable → channel skipped `DEPENDENCY_UNRESOLVED` (no stale id sent). `logo_id`/`epg_data_id` dropped (no EntityType in the kxuj2 contract — those links are re-established by the logo/EPG importers, .15/.11).
- **Profile reattach** (post-create pass): resolves dest profile id via remap (CHANNEL_PROFILE, from importer .12) → `update_profile_channel(...)`; profile not in remap → `DEPENDENCY_UNRESOLVED` (no guessed id).
- Opt-in; dry-run issues zero creates + zero ledger entries.

## Scope boundary
Channel ROW + profile membership only. Stream matching/attachment is `.14` (integrating al6e3 matcher + nav0c create_stream + ahygg fallback) — a clean seam is left (pinned by `test_stream_fields_not_attached_seam_for_dot14`); already-exists channels are still remapped so `.14` resolves them.

## Tests
16 tests (create+remap+ledger, FK remap + missing-target skip, profile reattach + unresolved, collision taxonomy, opt-in off, dry-run, stream seam). Full backend suite green (5644 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)