### PR TITLE
v0.18.0-dbas: ahygg custom-stream fallback synthesis (Channels import 4/4)

### DIFF
--- a/backend/dbas/custom_stream_fallback.py
+++ b/backend/dbas/custom_stream_fallback.py
@@ -1,0 +1,390 @@
+"""Custom-stream fallback synthesis for orphaned archived streams.
+
+Bead ``enhancedchannelmanager-ahygg`` (split 4/4 of the ``0i2vt.14`` channels
+importer epic).
+
+WHAT THIS IS. The 4-tier stream matcher (bead ``enhancedchannelmanager-al6e3``,
+:func:`dbas.stream_matcher.match_stream`) tries to re-attach an archived
+channel's embedded streams to streams that already exist on the *destination*
+Dispatcharr instance. When every tier misses (``MatchTier.MISS``), the archived
+stream is **orphaned** — the destination has no equivalent stream to point at.
+Rather than silently drop the orphan (losing the operator's stream) or attach it
+to a wrong stream, this module synthesizes a home for it:
+
+1. **Ensure ONE synthesized "custom-stream" M3U account exists** on the
+   destination. Find-or-create by a well-known name
+   (:data:`CUSTOM_STREAM_ACCOUNT_NAME`): if an account with that name already
+   exists (a prior restore run, or an earlier batch in this same run), reuse its
+   id; otherwise create it once. Idempotent — a second batch within the same run
+   reuses the just-created account (a one-call in-memory cache on the
+   :class:`_FallbackState` the caller threads through), and a re-run reuses the
+   account it finds on the destination.
+
+2. **Create each orphan under that synthesized account** via
+   ``client.create_stream`` (bead ``enhancedchannelmanager-nav0c``) and
+   **attribute** it — the created stream's ``m3u_account`` field is set to the
+   synthesized account's id so the orphan visibly belongs to the custom-stream
+   provider. Each created stream id is recorded in the
+   :class:`~dbas.restore_contracts.IdRemapTable` under
+   :data:`~dbas.restore_contracts.EntityType.STREAM` (source-export id ->
+   destination id) and in the
+   :class:`~dbas.restore_contracts.RollbackLedger` so a later restore failure
+   compensates by deleting them in reverse order (the ``kxuj2`` contract).
+
+3. **WARN on the fallback path EVERY time it fires** (``[DBAS_RESTORE]`` prefix,
+   lazy ``%`` formatting) including the orphan count. This is a
+   correctness/observability requirement, not optional: an operator MUST see
+   that some streams could not be matched and were synthesized, so they can
+   decide whether the destination's provider line-up is what they expected.
+
+SCOPE — TIGHT. This module does NOT run the matcher (that is ``al6e3``) and does
+NOT build the channel rows (that is ``4vouz``). It consumes the MISS results —
+the list of orphaned archived stream records — and is invoked by the ``0i2vt.14``
+integration umbrella, which threads the shared ``IdRemapTable`` / ``RollbackLedger``
+/ ``RestoreReport`` through. The integration umbrella owns persisting the ledger
+to disk after each create (the durable-write strategy lives in one place per the
+``kxuj2`` contract); this module only mutates the in-memory models.
+
+Conventions (``docs/style_guide.md`` / ``backend/CLAUDE.md``): ``snake_case``;
+Google-style docstrings; lazy ``%`` logging with a ``[DBAS_RESTORE]`` prefix;
+no bare ``re.*`` (this module builds no regex); imports the restore contracts
+READ-ONLY.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+
+from dbas.restore_contracts import (
+    EntityType,
+    FailureDetail,
+    FailureReason,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+)
+from dispatcharr_client import DispatcharrClient
+
+logger = logging.getLogger(__name__)
+
+# The well-known name of the single synthesized M3U account that owns every
+# orphaned stream. Find-or-create keys on this exact name (case-sensitive), so
+# it must stay stable across releases — changing it would orphan a prior run's
+# synthesized account and create a duplicate. Operator-facing (it shows up as a
+# provider in Dispatcharr), so it is descriptive, not an internal token.
+CUSTOM_STREAM_ACCOUNT_NAME = "ECM Custom Streams (DBAS restore)"
+
+# The create payload for the synthesized account. ``name`` is the find-or-create
+# key. No ``server_url`` / credentials — this account never refreshes from an
+# upstream M3U; it is a static container for operator streams that had no
+# destination match. (Dispatcharr accepts a credential-less account; the streams
+# under it are created explicitly, not ingested.)
+_ACCOUNT_CREATE_PAYLOAD = {"name": CUSTOM_STREAM_ACCOUNT_NAME}
+
+# Keys never forwarded onto the synthesized stream create: archive-source
+# identifiers the destination assigns itself, and ``m3u_account`` which we
+# OVERRIDE to the synthesized account id (the whole point of the fallback is to
+# re-home the orphan, not preserve its dead source provider).
+_DROPPED_STREAM_KEYS = frozenset({"id", "pk", "m3u_account"})
+
+
+@dataclass
+class _FallbackState:
+    """Per-restore-run cache of the synthesized account id.
+
+    Threaded through successive ``synthesize_custom_streams`` calls in ONE
+    restore run so the account is found-or-created at most once even across
+    multiple batches, without re-hitting ``get_m3u_accounts`` every batch. The
+    caller (the ``0i2vt.14`` umbrella) constructs one and reuses it; when omitted
+    each call resolves the account afresh (still idempotent against the
+    destination, just one extra ``get_m3u_accounts`` per batch).
+    """
+
+    account_id: int | None = None
+
+
+@dataclass
+class CustomStreamFallbackResult:
+    """What the fallback synthesized in one batch.
+
+    Returned so the ``0i2vt.14`` umbrella can fold the outcome into the overall
+    restore — e.g. surface the synthesized-account id and the created stream ids.
+
+    Attributes:
+        account_id: The synthesized account's destination id, or ``None`` when
+            there were no orphans (nothing synthesized).
+        created_stream_ids: Destination ids of every orphan stream created in
+            this batch, in creation order. Empty when there were no orphans (or
+            every create failed).
+        orphan_count: How many orphans were fed in (drives the WARN count).
+    """
+
+    account_id: int | None = None
+    created_stream_ids: list[int] = field(default_factory=list)
+    orphan_count: int = 0
+
+
+async def synthesize_custom_streams(
+    *,
+    orphans: Sequence[Mapping],
+    client: DispatcharrClient,
+    remap: IdRemapTable,
+    ledger: RollbackLedger,
+    report: RestoreReport,
+    state: _FallbackState | None = None,
+) -> CustomStreamFallbackResult:
+    """Synthesize a home for orphaned archived streams (the matcher-MISS path).
+
+    For each orphan (an archived stream the 4-tier matcher returned
+    ``MatchTier.MISS`` for): ensure the single synthesized custom-stream M3U
+    account exists (find-or-create, idempotent), create the orphan under it
+    attributed to that account, and record the created id in ``remap`` (under
+    :data:`~dbas.restore_contracts.EntityType.STREAM`) and ``ledger``.
+
+    WARN-logs on entry whenever there is at least one orphan, including the
+    orphan count, so an operator sees the heuristic fired. A zero-orphan call is
+    a complete no-op: no account is synthesized, nothing is created, and no WARN
+    is logged (the common happy case where every stream matched).
+
+    Args:
+        orphans: The archived stream records the matcher missed. Each is a
+            Mapping carrying at least ``id`` (its source-export id) and the
+            fields ``create_stream`` needs (``name``, ``url``). Never mutated.
+        client: The Dispatcharr API client. Uses ``get_m3u_accounts`` /
+            ``create_m3u_account`` (find-or-create the account) and
+            ``create_stream`` (create each orphan).
+        remap: The shared :class:`IdRemapTable`; each created orphan's
+            ``source_export_id -> destination_id`` is recorded under
+            ``EntityType.STREAM``.
+        ledger: The shared :class:`RollbackLedger`; each created orphan is
+            recorded for compensating deletes. This function only mutates the
+            in-memory model — the caller persists it per the kxuj2 contract.
+        report: The shared :class:`RestoreReport`; created/failed orphans land in
+            the ``EntityType.STREAM`` category.
+        state: Optional per-run cache of the synthesized account id, so the
+            account is resolved at most once across batches. Omit for a
+            single-batch call.
+
+    Returns:
+        A :class:`CustomStreamFallbackResult` carrying the synthesized account id
+        (``None`` if no orphans) and the created stream ids.
+    """
+    result = CustomStreamFallbackResult(orphan_count=len(orphans))
+
+    # Zero orphans => complete no-op. No account, no creates, NO WARN. This is
+    # the common happy case (every archived stream matched a destination stream)
+    # and must stay silent so the WARN means something when it does fire.
+    if not orphans:
+        return result
+
+    # Observability requirement: WARN EVERY time the fallback fires, with the
+    # count, so the operator sees streams could not be matched and were
+    # synthesized. Lazy %% formatting; [DBAS_RESTORE] prefix.
+    logger.warning(
+        "[DBAS_RESTORE] Stream matcher MISS — synthesizing custom-stream "
+        "account for %d orphaned stream(s) that matched no destination stream.",
+        len(orphans),
+    )
+
+    account_id = await _ensure_custom_stream_account(client, state)
+    result.account_id = account_id
+
+    cat = report.category(EntityType.STREAM)
+
+    for orphan in orphans:
+        source_export_id = orphan.get("id")
+        label = _orphan_label(orphan)
+        payload = _build_stream_payload(orphan, account_id)
+
+        try:
+            created = await client.create_stream(payload)
+        except Exception as exc:
+            cat.failed += 1
+            cat.failure_details.append(
+                FailureDetail(
+                    reason=FailureReason.UPSTREAM_API_ERROR,
+                    label=label,
+                    message=_sanitize_failure(exc),
+                    source_export_id=_as_int_or_none(source_export_id),
+                )
+            )
+            logger.warning(
+                "[DBAS_RESTORE] Failed to synthesize orphan stream '%s' under "
+                "custom-stream account %s: %s",
+                label,
+                account_id,
+                FailureReason.UPSTREAM_API_ERROR.value,
+            )
+            continue
+
+        dest_id = created.get("id") if isinstance(created, Mapping) else None
+        dest_id = _as_int_or_none(dest_id)
+        if dest_id is None:
+            # Upstream accepted the create but returned no usable id — we cannot
+            # ledger or remap it, so treat it as a failure rather than silently
+            # losing track of a created entity.
+            cat.failed += 1
+            cat.failure_details.append(
+                FailureDetail(
+                    reason=FailureReason.UPSTREAM_API_ERROR,
+                    label=label,
+                    message="create_stream returned no usable stream id.",
+                    source_export_id=_as_int_or_none(source_export_id),
+                )
+            )
+            logger.warning(
+                "[DBAS_RESTORE] Synthesized orphan stream '%s' but upstream "
+                "returned no id; not ledgered.",
+                label,
+            )
+            continue
+
+        cat.created += 1
+        result.created_stream_ids.append(dest_id)
+        ledger.record_created(EntityType.STREAM, dest_id, label)
+        src_int = _as_int_or_none(source_export_id)
+        if src_int is not None:
+            remap.add(EntityType.STREAM, src_int, dest_id)
+        logger.info(
+            "[DBAS_RESTORE] Synthesized orphan stream '%s' as id=%s under "
+            "custom-stream account %s.",
+            label,
+            dest_id,
+            account_id,
+        )
+
+    return result
+
+
+async def _ensure_custom_stream_account(
+    client: DispatcharrClient,
+    state: _FallbackState | None,
+) -> int:
+    """Find-or-create the single synthesized custom-stream M3U account.
+
+    Idempotent. Resolution order:
+
+    1. If a ``state`` cache already knows the account id (an earlier batch in
+       this run created/found it), reuse it without any API call.
+    2. Otherwise list the destination's M3U accounts and reuse the first one
+       whose name equals :data:`CUSTOM_STREAM_ACCOUNT_NAME` (a prior restore
+       run, or this run before the cache was populated).
+    3. Otherwise create it once and cache the new id.
+
+    Args:
+        client: The Dispatcharr API client.
+        state: Optional per-run cache; populated with the resolved id.
+
+    Returns:
+        The synthesized account's destination id.
+    """
+    if state is not None and state.account_id is not None:
+        return state.account_id
+
+    accounts = await client.get_m3u_accounts()
+    existing_id = _find_account_id_by_name(accounts, CUSTOM_STREAM_ACCOUNT_NAME)
+    if existing_id is not None:
+        logger.info(
+            "[DBAS_RESTORE] Reusing existing custom-stream account id=%s ('%s').",
+            existing_id,
+            CUSTOM_STREAM_ACCOUNT_NAME,
+        )
+        if state is not None:
+            state.account_id = existing_id
+        return existing_id
+
+    created = await client.create_m3u_account(dict(_ACCOUNT_CREATE_PAYLOAD))
+    account_id = created.get("id") if isinstance(created, Mapping) else None
+    account_id = _as_int_or_none(account_id)
+    if account_id is None:
+        # The account create is the load-bearing precondition for the whole
+        # fallback; if it returns no id there is nothing to attribute orphans to.
+        raise ValueError(
+            "create_m3u_account returned no usable id for the synthesized "
+            "custom-stream account."
+        )
+    logger.info(
+        "[DBAS_RESTORE] Created synthesized custom-stream account id=%s ('%s').",
+        account_id,
+        CUSTOM_STREAM_ACCOUNT_NAME,
+    )
+    if state is not None:
+        state.account_id = account_id
+    return account_id
+
+
+def _find_account_id_by_name(accounts, name: str) -> int | None:
+    """Return the id of the first account whose name equals ``name``, or None.
+
+    Case-sensitive exact match on the well-known synthesized-account name. A
+    non-list/garbled accounts response yields ``None`` (defensive — never
+    raises) so a transient upstream shape never blocks orphan synthesis from
+    falling through to a create.
+    """
+    if not isinstance(accounts, Sequence):
+        return None
+    for account in accounts:
+        if isinstance(account, Mapping) and account.get("name") == name:
+            return _as_int_or_none(account.get("id"))
+    return None
+
+
+def _build_stream_payload(orphan: Mapping, account_id: int) -> dict:
+    """Build the ``create_stream`` payload for an orphan, attributed to the account.
+
+    Copies the orphan's fields, drops archive-source identifiers
+    (:data:`_DROPPED_STREAM_KEYS`), and forces ``m3u_account`` to the synthesized
+    account id — the attribution that re-homes the orphan onto the custom-stream
+    provider. Never mutates the input orphan.
+
+    Args:
+        orphan: The archived stream record (a Mapping).
+        account_id: The synthesized account's destination id to attribute to.
+
+    Returns:
+        A fresh dict payload for ``client.create_stream``.
+    """
+    payload = {
+        key: value
+        for key, value in orphan.items()
+        if key not in _DROPPED_STREAM_KEYS
+    }
+    payload["m3u_account"] = account_id
+    return payload
+
+
+def _orphan_label(orphan: Mapping) -> str:
+    """Operator-facing label for an orphan — its name, or a sentinel.
+
+    Never a secret (a stream name is operator-facing); used in the report and
+    the ledger entry. Falls back to ``<unknown>`` for a missing/blank name.
+    """
+    name = orphan.get("name")
+    return str(name) if isinstance(name, str) and name else "<unknown>"
+
+
+def _sanitize_failure(exc: Exception) -> str:
+    """A sanitized, operator-facing failure message — no raw traces, no secrets.
+
+    ``create_stream`` raises ``"Stream creation failed: <status> - <body>"``; the
+    body is Dispatcharr's own error JSON (no ECM credentials), so ``str(exc)`` is
+    safe to surface. Truncated to keep the report compact.
+    """
+    text = str(exc)
+    return text[:300]
+
+
+def _as_int_or_none(value) -> int | None:
+    """Coerce ``value`` to ``int`` when it cleanly is one, else ``None``.
+
+    ``bool`` is rejected explicitly (it is an ``int`` subclass but never a valid
+    stream/account id). Used so a malformed id from an archive or upstream never
+    pollutes the remap/ledger with a non-int.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None

--- a/backend/dbas/restore_contracts.py
+++ b/backend/dbas/restore_contracts.py
@@ -77,6 +77,7 @@ class EntityType(str, Enum):
     CHANNEL_PROFILE = "channel_profile"    # …-0i2vt.12 (producer of remap)
     STREAM_PROFILE = "stream_profile"      # …-0i2vt.12 (producer of remap)
     CHANNEL = "channel"                    # …-4vouz (consumer of remap)
+    STREAM = "stream"                      # …-ahygg (synthesized custom-stream orphans)
     USER_AGENT = "user_agent"              # …-0i2vt.13
     DVR_RULE = "dvr_rule"                  # …-0i2vt.13
     USER = "user"                          # …-l1p4p (crown-jewel, opt-in)

--- a/backend/tests/dbas/test_custom_stream_fallback.py
+++ b/backend/tests/dbas/test_custom_stream_fallback.py
@@ -1,0 +1,348 @@
+"""Tests for the custom-stream fallback synthesis
+(enhancedchannelmanager-ahygg — split 4/4 of the 0i2vt.14 channels importer).
+
+When the 4-tier stream matcher (al6e3) returns a MISS for an archived stream,
+that stream is "orphaned" — no destination stream matched it. This module
+synthesizes a home for orphans:
+
+1. Ensure ONE synthesized "custom-stream" M3U account exists on the destination
+   (find-or-create by a well-known name; idempotent — a second batch reuses it).
+2. Create each orphaned stream under that synthesized account and attribute it
+   (set ``m3u_account`` to the synthesized account id). Register each created
+   stream id in the IdRemapTable (STREAM) + RollbackLedger.
+3. WARN log EVERY time the fallback path fires (operator observability),
+   including the count of orphaned streams.
+
+The Dispatcharr client is mocked at the module level
+(``dbas.custom_stream_fallback``); the function is exercised with an AsyncMock
+client. The matcher itself is NOT run here — these tests feed pre-identified
+orphans (the MISS results), matching the bead's tight scope.
+"""
+import logging
+
+import pytest
+from unittest.mock import AsyncMock
+
+from dbas.custom_stream_fallback import (
+    CUSTOM_STREAM_ACCOUNT_NAME,
+    synthesize_custom_streams,
+)
+from dbas.restore_contracts import (
+    EntityType,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _client(*, existing_accounts=None, create_account_id=900, create_side_effect=None):
+    """Build an AsyncMock Dispatcharr client with the methods the fallback uses.
+
+    By default ``get_m3u_accounts`` returns no synthesized account (so it gets
+    created), ``create_m3u_account`` returns an account with id
+    ``create_account_id``, and ``create_stream`` assigns monotonic ids.
+    """
+    client = AsyncMock()
+    client.get_m3u_accounts = AsyncMock(return_value=existing_accounts or [])
+    client.create_m3u_account = AsyncMock(
+        return_value={"id": create_account_id, "name": CUSTOM_STREAM_ACCOUNT_NAME}
+    )
+
+    created_counter = {"n": 0}
+
+    async def _default_create_stream(payload):
+        created_counter["n"] += 1
+        return {"id": 1000 + created_counter["n"], **payload}
+
+    client.create_stream = AsyncMock(
+        side_effect=create_side_effect or _default_create_stream
+    )
+    return client
+
+
+def _report():
+    return RestoreReport(is_dry_run=False)
+
+
+def _ledger():
+    return RollbackLedger(restore_id="test-restore")
+
+
+def _remap():
+    return IdRemapTable()
+
+
+def _orphan(stream_id, name="Orphan Stream", url="http://example/x"):
+    """An archived stream record that the matcher returned MISS for."""
+    return {"id": stream_id, "name": name, "url": url, "m3u_account": 42}
+
+
+# ---------------------------------------------------------------------------
+# Happy path: zero orphans => no synthesis, no WARN, no creates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_zero_orphans_no_account_no_warn_no_creates(caplog):
+    """The common case where everything matched: no orphans => the fallback is
+    a complete no-op. No account synthesized, no stream created, no WARN."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    with caplog.at_level(logging.WARNING):
+        result = await synthesize_custom_streams(
+            orphans=[],
+            client=client,
+            remap=remap,
+            ledger=ledger,
+            report=report,
+        )
+
+    client.get_m3u_accounts.assert_not_awaited()
+    client.create_m3u_account.assert_not_awaited()
+    client.create_stream.assert_not_awaited()
+    assert result.account_id is None
+    assert result.created_stream_ids == []
+    # No WARN at all on the clean path.
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert ledger.entries == []
+
+
+# ---------------------------------------------------------------------------
+# Orphans present: account synthesized once + orphans created + attributed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_orphans_create_account_once_and_attribute_each(caplog):
+    """Orphans present => the synthesized account is created exactly once, each
+    orphan is created under it and attributed (m3u_account == account id), and
+    the remap + ledger record each created stream."""
+    client = _client(create_account_id=900)
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    orphans = [_orphan(11, "A"), _orphan(12, "B"), _orphan(13, "C")]
+
+    with caplog.at_level(logging.WARNING):
+        result = await synthesize_custom_streams(
+            orphans=orphans,
+            client=client,
+            remap=remap,
+            ledger=ledger,
+            report=report,
+        )
+
+    # Account synthesized exactly once.
+    client.create_m3u_account.assert_awaited_once()
+    assert result.account_id == 900
+
+    # Each orphan created under the synthesized account, attributed.
+    assert client.create_stream.await_count == 3
+    for call in client.create_stream.await_args_list:
+        payload = call.args[0]
+        assert payload["m3u_account"] == 900
+
+    # remap STREAM: source export id -> destination id for each orphan.
+    assert remap.resolve(EntityType.STREAM, 11) == 1001
+    assert remap.resolve(EntityType.STREAM, 12) == 1002
+    assert remap.resolve(EntityType.STREAM, 13) == 1003
+
+    # ledger records each created stream under EntityType.STREAM.
+    assert len(ledger.entries) == 3
+    assert all(e.entity_type == EntityType.STREAM for e in ledger.entries)
+    assert {e.destination_id for e in ledger.entries} == {1001, 1002, 1003}
+
+    assert result.created_stream_ids == [1001, 1002, 1003]
+
+
+# ---------------------------------------------------------------------------
+# WARN fires on the fallback path, with the orphan count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_warn_fires_with_orphan_count_on_fallback(caplog):
+    """Observability requirement: the fallback WARN-logs EVERY time it fires,
+    and the message includes the count of orphaned streams."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    orphans = [_orphan(21), _orphan(22)]
+
+    with caplog.at_level(logging.WARNING):
+        await synthesize_custom_streams(
+            orphans=orphans,
+            client=client,
+            remap=remap,
+            ledger=ledger,
+            report=report,
+        )
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected a WARN log on the fallback path"
+    # The orphan count (2) must appear in the rendered message.
+    assert any("2" in r.getMessage() for r in warnings)
+    assert any("[DBAS_RESTORE]" in r.getMessage() for r in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: a second batch reuses the account, does NOT create a second one
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_second_batch_reuses_synthesized_account(caplog):
+    """Idempotent find-or-create: after the first batch creates the account, a
+    second batch (now seeing it in get_m3u_accounts) reuses it — it does NOT
+    create a second synthesized account."""
+    # First batch: no account exists yet -> create id 900.
+    client = _client(existing_accounts=[], create_account_id=900)
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    first = await synthesize_custom_streams(
+        orphans=[_orphan(31)],
+        client=client,
+        remap=remap,
+        ledger=ledger,
+        report=report,
+    )
+    assert first.account_id == 900
+    client.create_m3u_account.assert_awaited_once()
+
+    # Second batch: the synthesized account is now present on the destination.
+    client.get_m3u_accounts = AsyncMock(
+        return_value=[{"id": 900, "name": CUSTOM_STREAM_ACCOUNT_NAME}]
+    )
+    second = await synthesize_custom_streams(
+        orphans=[_orphan(32)],
+        client=client,
+        remap=remap,
+        ledger=ledger,
+        report=report,
+    )
+
+    assert second.account_id == 900
+    # No SECOND create — still only the one from the first batch.
+    client.create_m3u_account.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Account-already-exists (pre-existing before any batch): reused, not recreated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_account_already_exists_is_reused_not_recreated():
+    """If the synthesized custom-stream account already exists on the
+    destination (e.g. from a prior restore run), the fallback reuses it by id
+    and never calls create_m3u_account."""
+    client = _client(
+        existing_accounts=[
+            {"id": 7, "name": "Some Other Provider"},
+            {"id": 8, "name": CUSTOM_STREAM_ACCOUNT_NAME},
+        ]
+    )
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    result = await synthesize_custom_streams(
+        orphans=[_orphan(41)],
+        client=client,
+        remap=remap,
+        ledger=ledger,
+        report=report,
+    )
+
+    assert result.account_id == 8
+    client.create_m3u_account.assert_not_awaited()
+    # Orphan still created + attributed to the reused account.
+    payload = client.create_stream.await_args_list[0].args[0]
+    assert payload["m3u_account"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Rollback ledger records every created orphan stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rollback_ledger_records_created_orphans():
+    """Every synthesized orphan stream is recorded in the RollbackLedger so a
+    later restore failure can compensate by deleting them (reverse order)."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    orphans = [_orphan(51, "X"), _orphan(52, "Y")]
+    await synthesize_custom_streams(
+        orphans=orphans,
+        client=client,
+        remap=remap,
+        ledger=ledger,
+        report=report,
+    )
+
+    assert len(ledger.entries) == 2
+    # Compensation order is reverse-creation (descending sequence).
+    order = ledger.compensation_order()
+    assert [e.destination_id for e in order] == [1002, 1001]
+    assert all(e.entity_type == EntityType.STREAM for e in order)
+
+
+# ---------------------------------------------------------------------------
+# A create that returns no usable id is reported failed, not ledgered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failed_orphan_create_is_reported_not_ledgered(caplog):
+    """If create_stream raises for one orphan, that orphan is reported failed
+    (RestoreReport CHANNEL... no: STREAM category) and is NOT recorded in the
+    ledger/remap, while the other orphans still succeed."""
+    async def _flaky_create(payload):
+        if payload.get("name") == "boom":
+            raise Exception("Stream creation failed: 400 - bad payload")
+        return {"id": 2000, **payload}
+
+    client = _client(create_side_effect=_flaky_create)
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    orphans = [_orphan(61, "boom"), _orphan(62, "ok")]
+
+    with caplog.at_level(logging.WARNING):
+        result = await synthesize_custom_streams(
+            orphans=orphans,
+            client=client,
+            remap=remap,
+            ledger=ledger,
+            report=report,
+        )
+
+    # Only the good one is ledgered/remapped.
+    assert len(ledger.entries) == 1
+    assert ledger.entries[0].destination_id == 2000
+    assert remap.resolve(EntityType.STREAM, 62) == 2000
+    assert remap.resolve(EntityType.STREAM, 61) is None
+    assert result.created_stream_ids == [2000]
+
+    cat = report.category(EntityType.STREAM)
+    assert cat.created == 1
+    assert cat.failed == 1
+    assert cat.failure_details[0].source_export_id == 61


### PR DESCRIPTION
## Bead
enhancedchannelmanager-ahygg — Phase 2 Channels D: custom-stream fallback synthesis for orphaned streams (split 4/4 of 0i2vt.14).

## What
New `backend/dbas/custom_stream_fallback.py` (sibling to `stream_matcher.py`, kept out of `importers/` to avoid contention). When the al6e3 matcher returns MISS (tier 0) for an archived stream, the orphan is homed:
- **Find-or-create** a single synthesized custom-stream M3U account (well-known name `"ECM Custom Streams (DBAS restore)"`), idempotent across batches via a per-run state cache + name scan; reuses existing/no double-create. (Verify-then-size: `get_m3u_accounts`/`create_m3u_account` + `create_stream` all already existed — no client method added.)
- Each orphan created under that account (`m3u_account` forced to the synthesized id), registered in `IdRemapTable` (STREAM) + `RollbackLedger`.
- **WARN on every fallback firing** (`[DBAS_RESTORE]`, with orphan count) so operators see the heuristic ran.
- Zero orphans → complete no-op (no account, no WARN, no creates).

Entry point for `.14`: `synthesize_custom_streams(*, orphans, client, remap, ledger, report, state=None) -> CustomStreamFallbackResult`.

## Contract change
Added `EntityType.STREAM` to `restore_contracts.py` (one additive enum member — `IdRemapTable`/`RollbackLedger` are keyed by `EntityType` and had no STREAM member; required to register orphans).

## Tests
7 tests (idempotent account synth, per-orphan attribution + remap + ledger, WARN-with-count, zero-orphan no-op, account-reuse, failed-create reported-not-ledgered). Full backend suite green (5635 passed).

## Live note
Synthesized account is created credential-less; if Dispatcharr 0.26.0 rejects that, the `.14` seeded-instance integration test surfaces it (unit tests mock the client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)