### PR TITLE
v0.18.0-dbas: 0i2vt.17 schema_version validation on restore

### DIFF
--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -704,6 +704,178 @@ def verify_artifact_sha256(zip_path: Path, sidecar_path: Path) -> bool:
     return actual == expected
 
 
+# ---------------------------------------------------------------------------
+# Restore-ingest schema_version gate (0i2vt.17, ADR-008 D1 + S4)
+#
+# The new-format DBAS artifact (build_backup_artifact) carries a CLEARTEXT
+# manifest.json whose dedicated integer ``schema_version`` is the restore
+# compatibility gate. On restore we MUST refuse an artifact built by a NEWER
+# ECM (schema_version > BACKUP_SCHEMA_VERSION) BEFORE any mutation — a v0.19
+# archive restored on a v0.18 build would otherwise silently partial-restore
+# and corrupt state. The rule (mirrors build_backup_artifact's contract):
+# manifest schema_version <= BACKUP_SCHEMA_VERSION is accepted; anything newer
+# (or missing/malformed) is refused.
+#
+# SECURITY (D1 + S4 — no schema-internals leakage): the user-facing message is
+# EXACTLY "Unsupported backup version" with NO version numbers and NO schema
+# internals. The actual detail (got X, support up to Y) is logged SERVER-SIDE
+# only for operator troubleshooting.
+#
+# NOTE: the manifest ``schema_version`` and the embedded journal.db
+# alembic_version are TWO DISTINCT axes. This gate is ONLY the manifest
+# schema_version.
+# ---------------------------------------------------------------------------
+
+# The ONLY user-facing string for a version refusal. No interpolation: it must
+# never carry a version number or any schema internal.
+UNSUPPORTED_BACKUP_VERSION_MESSAGE = "Unsupported backup version"
+
+
+class UnsupportedBackupVersionError(Exception):
+    """Raised when a restore artifact's manifest schema_version is unsupported.
+
+    ``str(err)`` is EXACTLY :data:`UNSUPPORTED_BACKUP_VERSION_MESSAGE` — the
+    user-facing message — and carries NO version numbers or schema internals
+    (ADR-008 D1 + S4). The actual version detail is logged server-side by the
+    raiser before this is raised.
+    """
+
+    def __init__(self, message: str = UNSUPPORTED_BACKUP_VERSION_MESSAGE):
+        super().__init__(message)
+
+
+def validate_restore_schema_version(manifest) -> None:
+    """Refuse a restore artifact whose manifest schema_version is unsupported.
+
+    Reusable version comparator for the restore-ingest chokepoint. Applies the
+    same rule build_backup_artifact stamps: ``schema_version <=
+    BACKUP_SCHEMA_VERSION`` is accepted; a NEWER artifact (or one with a
+    missing/malformed schema_version) is REFUSED.
+
+    Raises :class:`UnsupportedBackupVersionError` whose message is EXACTLY
+    :data:`UNSUPPORTED_BACKUP_VERSION_MESSAGE` (no version leak). The actual
+    detail is logged server-side (lazy %%-formatting) BEFORE raising.
+
+    Args:
+        manifest: The parsed manifest dict. A non-dict, a missing
+            ``schema_version``, or a non-int (bool excluded) value is treated as
+            unknown/invalid and refused — never accepted by default.
+
+    Returns:
+        None on an accepted (supported) version.
+    """
+    version = manifest.get("schema_version") if isinstance(manifest, dict) else None
+
+    # bool is an int subclass; reject it explicitly so True/False can't pass.
+    if not isinstance(version, int) or isinstance(version, bool):
+        logger.warning(
+            "[BACKUP] Refusing restore: manifest schema_version missing or "
+            "malformed (got %r); this build supports up to %d",
+            version, BACKUP_SCHEMA_VERSION,
+        )
+        raise UnsupportedBackupVersionError()
+
+    if version > BACKUP_SCHEMA_VERSION:
+        logger.warning(
+            "[BACKUP] Refusing restore: artifact schema_version=%d is newer "
+            "than supported (this build supports up to %d). Refuse before any "
+            "mutation to avoid a silent partial restore.",
+            version, BACKUP_SCHEMA_VERSION,
+        )
+        raise UnsupportedBackupVersionError()
+
+    logger.debug(
+        "[BACKUP] Restore artifact schema_version=%d accepted (supported up to %d)",
+        version, BACKUP_SCHEMA_VERSION,
+    )
+
+
+def _verify_artifact_member_integrity(zf: zipfile.ZipFile, manifest: dict) -> None:
+    """Verify each manifest-listed member's SHA-256 against the ZIP bytes.
+
+    Pairs with the version gate at the same chokepoint (grooming: validate
+    version + integrity together BEFORE mutation). A member whose bytes do not
+    match the manifest hash, or a manifest member absent from the ZIP, refuses
+    the restore with a generic integrity message that leaks NO schema internals
+    (no schema_version numbers). The detail (which member, hash mismatch) is
+    logged server-side.
+
+    NOTE: the whole-artifact SHA-256 sidecar (verify_artifact_sha256) lives
+    next to the file on disk and is not present inside an uploaded ZIP; this
+    per-member check is the integrity guarantee available at the ingest
+    chokepoint from the ZIP alone.
+    """
+    files = manifest.get("files")
+    if not isinstance(files, list):
+        logger.warning("[BACKUP] Refusing restore: manifest has no per-file hash list")
+        raise HTTPException(status_code=400, detail="Backup integrity check failed")
+
+    names = set(zf.namelist())
+    for entry in files:
+        if not isinstance(entry, dict):
+            logger.warning("[BACKUP] Refusing restore: malformed manifest file entry %r", entry)
+            raise HTTPException(status_code=400, detail="Backup integrity check failed")
+        path = entry.get("path")
+        expected = entry.get("sha256")
+        if not isinstance(path, str) or not isinstance(expected, str):
+            logger.warning("[BACKUP] Refusing restore: malformed manifest file entry %r", entry)
+            raise HTTPException(status_code=400, detail="Backup integrity check failed")
+        if path not in names:
+            logger.warning("[BACKUP] Refusing restore: manifest member %s absent from artifact", path)
+            raise HTTPException(status_code=400, detail="Backup integrity check failed")
+        actual = hashlib.sha256(zf.read(path)).hexdigest()
+        if actual != expected:
+            logger.warning(
+                "[BACKUP] Refusing restore: integrity mismatch on member %s "
+                "(expected %s, got %s)", path, expected, actual,
+            )
+            raise HTTPException(status_code=400, detail="Backup integrity check failed")
+
+
+def validate_artifact_manifest(zf: zipfile.ZipFile) -> dict:
+    """Validate a new-format DBAS artifact at the restore-ingest chokepoint.
+
+    Runs BEFORE any restore mutation, in this order:
+
+    1. parse the cleartext ``manifest.json`` header,
+    2. **version gate** — refuse a newer/unknown schema_version (the highest
+       priority: an incompatible artifact is rejected before we even trust its
+       integrity claims), then
+    3. **integrity** — verify each manifest-listed member's SHA-256.
+
+    Returns the parsed manifest on success. Refusals raise ``HTTPException(400)``
+    with a user-facing message that leaks NO schema internals; the version
+    refusal message is EXACTLY :data:`UNSUPPORTED_BACKUP_VERSION_MESSAGE`. All
+    detail is logged server-side.
+    """
+    if ARTIFACT_MANIFEST_NAME not in zf.namelist():
+        logger.warning("[BACKUP] Refusing restore: artifact missing %s", ARTIFACT_MANIFEST_NAME)
+        raise HTTPException(status_code=400, detail="Not a valid ECM backup artifact")
+
+    try:
+        manifest = json.loads(zf.read(ARTIFACT_MANIFEST_NAME))
+    except (json.JSONDecodeError, KeyError) as e:
+        logger.warning("[BACKUP] Refusing restore: unreadable artifact manifest: %s", e)
+        raise HTTPException(status_code=400, detail="Invalid backup manifest")
+
+    if not isinstance(manifest, dict):
+        logger.warning("[BACKUP] Refusing restore: artifact manifest is not an object")
+        raise HTTPException(status_code=400, detail="Invalid backup manifest")
+
+    # 2. Version gate FIRST — refuse an incompatible artifact before trusting
+    #    anything else about it. Translate the internal exception into the
+    #    HTTP error WITHOUT adding any version detail to the body.
+    try:
+        validate_restore_schema_version(manifest)
+    except UnsupportedBackupVersionError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    # 3. Integrity AFTER the version is known-supported.
+    _verify_artifact_member_integrity(zf, manifest)
+
+    return manifest
+
+
 def _validate_backup_zip(zf: zipfile.ZipFile) -> dict:
     """Validate a backup zip file and return its manifest."""
     # Must contain manifest

--- a/backend/tests/routers/test_0i2vt17_restore_version_gate.py
+++ b/backend/tests/routers/test_0i2vt17_restore_version_gate.py
@@ -1,0 +1,283 @@
+"""
+Tests for the restore-ingest schema_version gate (bead 0i2vt.17).
+
+Covers the NEW v0.18.0 artifact restore-ingest validation chokepoint:
+``routers.backup.validate_restore_schema_version`` (the reusable version
+comparator) and ``routers.backup.validate_artifact_manifest`` (the
+new-format ZIP validator that runs the version gate + per-member SHA-256
+integrity BEFORE any restore mutation).
+
+Security contract (ADR-008 D1 + S4 — no schema-internals leakage):
+
+  - schema_version == BACKUP_SCHEMA_VERSION  -> accepted.
+  - schema_version <  BACKUP_SCHEMA_VERSION  -> accepted (older artifact).
+  - schema_version >  BACKUP_SCHEMA_VERSION  -> REFUSED with the user-facing
+    message EXACTLY "Unsupported backup version" and NO version numbers /
+    schema internals in the user-facing body.
+  - missing / malformed schema_version       -> refused safely (same
+    user-facing message; detail logged server-side).
+  - the ACTUAL version detail (got X, support up to Y) is logged SERVER-SIDE
+    only (logger.warning, lazy %%-formatting).
+  - validation runs BEFORE any mutation: a refused version performs NO
+    restore/import side effect.
+
+NOTE: this bead is ONLY the manifest ``schema_version`` axis. The embedded
+journal.db alembic_version is a DISTINCT axis owned by another bead.
+"""
+import io
+import json
+import logging
+import zipfile
+
+import pytest
+from fastapi import HTTPException
+
+from routers import backup as backup_mod
+from routers.backup import (
+    BACKUP_SCHEMA_VERSION,
+    UnsupportedBackupVersionError,
+    UNSUPPORTED_BACKUP_VERSION_MESSAGE,
+    validate_artifact_manifest,
+    validate_restore_schema_version,
+)
+
+# The one user-facing string. Asserted verbatim everywhere a refusal surfaces.
+USER_FACING = "Unsupported backup version"
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build an in-memory new-format artifact ZIP with a chosen manifest.
+# ---------------------------------------------------------------------------
+
+
+def _member_sha256(data: bytes) -> str:
+    import hashlib
+
+    return hashlib.sha256(data).hexdigest()
+
+
+def _build_artifact_zip(schema_version, *, omit_schema_version=False,
+                        corrupt_member=False, extra_members=None):
+    """Return bytes of a new-format artifact ZIP carrying ``manifest.json``.
+
+    ``manifest.json`` is the cleartext header (per-member SHA-256 + schema
+    version). One trivial category member is always written so the integrity
+    check has something to verify.
+    """
+    members = {"categories/settings.yaml": b"key: value\n"}
+    if extra_members:
+        members.update(extra_members)
+
+    file_hashes = {path: _member_sha256(blob) for path, blob in members.items()}
+    manifest = {
+        "app_version": "0.17.6-test",
+        "created_at": "2026-06-18T00:00:00+00:00",
+        "redacted": True,
+        "files": [{"path": p, "sha256": h} for p, h in sorted(file_hashes.items())],
+    }
+    if not omit_schema_version:
+        manifest["schema_version"] = schema_version
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(manifest))
+        for path, blob in members.items():
+            payload = blob + (b"X" if corrupt_member else b"")
+            zf.writestr(path, payload)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def _open(zip_bytes):
+    return zipfile.ZipFile(io.BytesIO(zip_bytes), "r")
+
+
+# ---------------------------------------------------------------------------
+# validate_restore_schema_version — the reusable comparator
+# ---------------------------------------------------------------------------
+
+
+class TestVersionComparator:
+    def test_equal_version_accepted(self):
+        # No raise == accepted.
+        validate_restore_schema_version({"schema_version": BACKUP_SCHEMA_VERSION})
+
+    def test_older_version_accepted(self):
+        validate_restore_schema_version({"schema_version": BACKUP_SCHEMA_VERSION - 1})
+
+    def test_zero_version_accepted(self):
+        # A pre-1 artifact (hypothetical) is still <= current -> accepted.
+        validate_restore_schema_version({"schema_version": 0})
+
+    def test_newer_version_refused(self):
+        with pytest.raises(UnsupportedBackupVersionError) as exc:
+            validate_restore_schema_version(
+                {"schema_version": BACKUP_SCHEMA_VERSION + 1}
+            )
+        # User-facing message is EXACTLY the constant, nothing more.
+        assert str(exc.value) == USER_FACING
+
+    def test_newer_version_user_message_has_no_version_numbers(self):
+        newer = BACKUP_SCHEMA_VERSION + 7
+        with pytest.raises(UnsupportedBackupVersionError) as exc:
+            validate_restore_schema_version({"schema_version": newer})
+        msg = str(exc.value)
+        assert msg == USER_FACING
+        # No actual version numbers / schema internals leak into the message.
+        assert str(newer) not in msg
+        assert str(BACKUP_SCHEMA_VERSION) not in msg
+        assert "schema_version" not in msg
+
+    def test_newer_version_logs_detail_server_side(self, caplog):
+        newer = BACKUP_SCHEMA_VERSION + 3
+        with caplog.at_level(logging.WARNING, logger="routers.backup"):
+            with pytest.raises(UnsupportedBackupVersionError):
+                validate_restore_schema_version({"schema_version": newer})
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "[BACKUP]" in joined
+        # The ACTUAL detail (got X, support up to Y) IS in the server log.
+        assert str(newer) in joined
+        assert str(BACKUP_SCHEMA_VERSION) in joined
+
+    def test_missing_schema_version_refused(self):
+        with pytest.raises(UnsupportedBackupVersionError) as exc:
+            validate_restore_schema_version({"app_version": "0.18.0"})
+        assert str(exc.value) == USER_FACING
+
+    def test_missing_schema_version_logs_detail(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="routers.backup"):
+            with pytest.raises(UnsupportedBackupVersionError):
+                validate_restore_schema_version({"app_version": "0.18.0"})
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "[BACKUP]" in joined
+
+    @pytest.mark.parametrize("bad", ["1", 1.5, None, [], {}, "not-a-number"])
+    def test_malformed_schema_version_refused(self, bad):
+        with pytest.raises(UnsupportedBackupVersionError) as exc:
+            validate_restore_schema_version({"schema_version": bad})
+        assert str(exc.value) == USER_FACING
+
+    def test_non_dict_manifest_refused(self):
+        with pytest.raises(UnsupportedBackupVersionError) as exc:
+            validate_restore_schema_version(["not", "a", "dict"])
+        assert str(exc.value) == USER_FACING
+
+
+# ---------------------------------------------------------------------------
+# validate_artifact_manifest — the new-format ZIP chokepoint (version + SHA-256)
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactManifestValidator:
+    def test_current_version_artifact_accepted(self):
+        zb = _build_artifact_zip(BACKUP_SCHEMA_VERSION)
+        with _open(zb) as zf:
+            manifest = validate_artifact_manifest(zf)
+        assert manifest["schema_version"] == BACKUP_SCHEMA_VERSION
+
+    def test_older_version_artifact_accepted(self):
+        zb = _build_artifact_zip(BACKUP_SCHEMA_VERSION - 1)
+        with _open(zb) as zf:
+            manifest = validate_artifact_manifest(zf)
+        assert manifest["schema_version"] == BACKUP_SCHEMA_VERSION - 1
+
+    def test_newer_version_artifact_refused_http_400(self):
+        zb = _build_artifact_zip(BACKUP_SCHEMA_VERSION + 1)
+        with _open(zb) as zf:
+            with pytest.raises(HTTPException) as exc:
+                validate_artifact_manifest(zf)
+        assert exc.value.status_code == 400
+        assert exc.value.detail == USER_FACING
+
+    def test_newer_version_http_body_has_no_version_leak(self):
+        newer = BACKUP_SCHEMA_VERSION + 9
+        zb = _build_artifact_zip(newer)
+        with _open(zb) as zf:
+            with pytest.raises(HTTPException) as exc:
+                validate_artifact_manifest(zf)
+        body = exc.value.detail
+        assert body == USER_FACING
+        assert str(newer) not in body
+        assert str(BACKUP_SCHEMA_VERSION) not in body
+        assert "schema_version" not in body
+
+    def test_newer_version_logs_detail_server_side(self, caplog):
+        newer = BACKUP_SCHEMA_VERSION + 2
+        zb = _build_artifact_zip(newer)
+        with caplog.at_level(logging.WARNING, logger="routers.backup"):
+            with _open(zb) as zf:
+                with pytest.raises(HTTPException):
+                    validate_artifact_manifest(zf)
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert str(newer) in joined
+        assert str(BACKUP_SCHEMA_VERSION) in joined
+
+    def test_missing_manifest_refused(self):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("categories/settings.yaml", "k: v\n")
+        buf.seek(0)
+        with zipfile.ZipFile(buf, "r") as zf:
+            with pytest.raises(HTTPException) as exc:
+                validate_artifact_manifest(zf)
+        assert exc.value.status_code == 400
+
+    def test_malformed_manifest_json_refused(self):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("manifest.json", "{ this is not json")
+        buf.seek(0)
+        with zipfile.ZipFile(buf, "r") as zf:
+            with pytest.raises(HTTPException) as exc:
+                validate_artifact_manifest(zf)
+        assert exc.value.status_code == 400
+
+    def test_version_gate_runs_before_integrity_check(self, caplog):
+        # A NEWER-version artifact that ALSO has a corrupt member must be
+        # refused on VERSION (not integrity) — the version gate is first, and a
+        # corrupt newer artifact still surfaces the version message, never
+        # leaking integrity/schema internals.
+        zb = _build_artifact_zip(BACKUP_SCHEMA_VERSION + 1, corrupt_member=True)
+        with _open(zb) as zf:
+            with pytest.raises(HTTPException) as exc:
+                validate_artifact_manifest(zf)
+        assert exc.value.detail == USER_FACING
+
+    def test_integrity_failure_refused_when_version_ok(self):
+        # Version is fine, but a member's bytes don't match the manifest hash.
+        zb = _build_artifact_zip(BACKUP_SCHEMA_VERSION, corrupt_member=True)
+        with _open(zb) as zf:
+            with pytest.raises(HTTPException) as exc:
+                validate_artifact_manifest(zf)
+        assert exc.value.status_code == 400
+        # Integrity failure is a distinct, non-version message — but still must
+        # not leak schema internals (no schema_version numbers).
+        assert str(BACKUP_SCHEMA_VERSION) not in exc.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Validation runs BEFORE any mutation — refused version performs NO side effect.
+# ---------------------------------------------------------------------------
+
+
+class TestNoMutationOnRefusal:
+    def test_refused_version_does_not_invoke_any_restore_side_effect(self, monkeypatch):
+        """A newer-version artifact is refused at validation; nothing that
+        mutates state (restore/import) is ever reached."""
+        called = {"mutated": False}
+
+        # Sentinel: if any restore-mutation entry point were called, this flips.
+        def _boom(*a, **k):
+            called["mutated"] = True
+            raise AssertionError("restore mutation invoked on a refused artifact")
+
+        # Guard whatever mutation seams exist today on the module.
+        for name in ("_restore_from_zip",):
+            if hasattr(backup_mod, name):
+                monkeypatch.setattr(backup_mod, name, _boom)
+
+        zb = _build_artifact_zip(BACKUP_SCHEMA_VERSION + 1)
+        with _open(zb) as zf:
+            with pytest.raises(HTTPException):
+                validate_artifact_manifest(zf)
+        assert called["mutated"] is False


### PR DESCRIPTION
## Bead
enhancedchannelmanager-0i2vt.17 — Phase 2: Schema version validation on restore (ADR-008 D1 + S4).

## What
At the restore-ingest chokepoint (`validate_artifact_manifest(zf)` in `backup.py`), BEFORE any mutation:
1. Parse the cleartext `manifest.json`.
2. **Version gate first** — `validate_restore_schema_version`: reuses `.7`'s rule (`schema_version <= BACKUP_SCHEMA_VERSION` accepted; newer/missing/malformed refused). `bool` excluded (int subclass).
3. **Integrity** — per-member SHA-256 verification (paired at the same chokepoint per grooming).

**Security (no schema-internals leak):** the user-facing refusal is EXACTLY `"Unsupported backup version"` — no version numbers, no internals. The actual detail (got X, support up to Y) is logged server-side only.

`validate_artifact_manifest` is the reusable chokepoint the restore orchestrator (.18/.14) calls — wired as a clean seam (no new-format restore endpoint exists yet; that's later).

## Tests
25 tests: exact-version accept, older accept, newer refuse, missing/malformed refuse, the user-facing message contains NO version numbers (asserted absent), server log HAS the detail (caplog), refusal happens before any mutation, plus the per-member integrity paths. Full suite verified by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)