### PR TITLE
v0.18.0-dbas: 0i2vt.11 EPG sources importer

### DIFF
--- a/backend/dbas/importers/__init__.py
+++ b/backend/dbas/importers/__init__.py
@@ -21,6 +21,7 @@ attach streams — this importer never matches or attaches a stream.
 """
 
 from dbas.importers.channels import import_channels
+from dbas.importers.epg_sources import import_epg_sources
 from dbas.importers.m3u_accounts import (
     apply_deferred_auto_sync,
     import_m3u_accounts,
@@ -31,6 +32,7 @@ from dbas.importers.users import import_users
 __all__ = [
     "apply_deferred_auto_sync",
     "import_channels",
+    "import_epg_sources",
     "import_m3u_accounts",
     "import_users",
     "resolve_group",

--- a/backend/dbas/importers/epg_sources.py
+++ b/backend/dbas/importers/epg_sources.py
@@ -1,0 +1,371 @@
+"""The EPG sources restore importer — Phase-2, after M3U, before Channels.
+
+Bead ``enhancedchannelmanager-0i2vt.11``. EPG sources sit second in the hard
+Phase-2 ordering (``M3U → EPG → Channels → Logos``; ADR-012 D-table): they are
+restored AFTER M3U accounts (so an EPG source that references an M3U account can
+remap that FK) and BEFORE Channels (so a channel's ``epg_data`` linkage — handled
+by the channels/logos importers, NOT here — has its source rows to match
+against). This module restores the EPG_SOURCE entity category from a Dispatcharr
+export archive: the SOURCE rows only. EPG-to-channel linkage (``set_logo`` /
+``epg_data`` on channels) is explicitly out of scope here.
+
+It mirrors the established Phase-2 importer pattern (``importers/m3u_accounts.py``
+/ ``importers/channels.py`` / ``importers/users.py``): opt-in, consumes the
+shared restore contracts (:class:`~dbas.restore_contracts.IdRemapTable`,
+:class:`~dbas.restore_contracts.RollbackLedger`,
+:class:`~dbas.restore_contracts.RestoreReport`, the Skip/Failure taxonomy),
+per-entity results, and dry-run support.
+
+----------------------------------------------------------------------------
+CREDENTIAL HYGIENE (the bead .8 clear-text-logging lesson — read FIRST)
+----------------------------------------------------------------------------
+
+An EPG source can carry CREDENTIALS. An XMLTV source's ``url`` often embeds an
+authenticated token; a Schedules-Direct source carries ``username`` /
+``password`` (the password write-only, per ``docs/dispatcharr_api.md``). These
+NEVER surface in a log line, a :class:`RestoreReport` label/note, a
+:class:`RollbackLedger` entry, or a sanitized failure message. The ONLY fields we
+log or report are SAFE: the source ``name``, the source ``source_type``, the
+destination ``id``, counts, and status codes. We never log/echo a url, username,
+password, or an upstream SDK exception body verbatim (an error body can echo the
+url). The failure-message sanitizer below scrubs known credential markers
+defensively and falls back to a generic message.
+
+----------------------------------------------------------------------------
+IDENTITY / MATCH KEY
+----------------------------------------------------------------------------
+
+An archived EPG source is matched against the destination instance's existing
+sources by a STABLE identity: ``(source_type, normalized name)`` — the
+source_type discriminator plus the case-insensitive, whitespace-trimmed name.
+Rationale: the name is the operator-facing identity Dispatcharr displays, and
+including ``source_type`` prevents an ``xmltv`` "Sports" colliding with a
+``schedules_direct`` "Sports". We deliberately do NOT key on ``url``: an XMLTV
+url can embed a credential token, so matching on it would mean comparing (and
+risking logging) credential-bearing strings. A match → skip
+``ALREADY_EXISTS_IDENTICAL`` (and the source id is still remapped to the existing
+destination id so a later FK reference resolves). No match → create.
+
+----------------------------------------------------------------------------
+FK REMAP (m3u_account)
+----------------------------------------------------------------------------
+
+An EPG source may reference an M3U account (``m3u_account``) — e.g. a provider
+that serves both the playlist and its EPG. That FK points at a SOURCE id and is
+rewritten to the DESTINATION id through the :class:`IdRemapTable`
+``M3U_ACCOUNT`` namespace (populated by the M3U importer ``.10``, which runs
+first). An m3u_account reference that cannot be resolved is treated per the
+contract as ``DEPENDENCY_UNRESOLVED`` — the source is skipped and never sent
+upstream with a dangling source id. A null/absent m3u_account is NOT a dependency
+(a free-standing XMLTV/SD source) and is created normally.
+
+Integration with the restore contracts (bead ``kxuj2``): results land in the
+shared :class:`RestoreReport` (``EntityType.EPG_SOURCE`` category), created
+sources register source→dest in the :class:`IdRemapTable`, and every created
+source is recorded in the :class:`RollbackLedger` for compensating deletes. This
+importer imports the contracts module READ-ONLY.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from dbas.restore_contracts import (
+    EntityType,
+    FailureDetail,
+    FailureReason,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+    SkipDetail,
+    SkipReason,
+)
+from dispatcharr_client import DispatcharrClient
+
+logger = logging.getLogger(__name__)
+
+# Archive-source identifiers the destination assigns itself, never forwarded.
+_SOURCE_ID_KEYS = frozenset({"id", "pk"})
+
+# Read-only / derived keys a GET echoes back that are NOT part of a create
+# payload. Timestamps, status, and counts are server-maintained.
+_NON_CREATE_KEYS = frozenset(
+    {
+        "created_at",
+        "updated_at",
+        "last_refresh",
+        "status",
+        "epg_count",
+        "channel_count",
+        "sd_changes_remaining",
+        "sd_changes_reset_at",
+        "locked",
+    }
+)
+
+# All keys dropped before issuing the create. (The FK ``m3u_account`` is NOT
+# dropped here — it is remapped in place; see ``_build_create_payload``.)
+_DROPPED_CREATE_KEYS = _SOURCE_ID_KEYS | _NON_CREATE_KEYS
+
+# The FK reference an EPG source may carry into an M3U account.
+_M3U_ACCOUNT_FK = "m3u_account"
+
+# Credential markers scrubbed from any operator-facing failure message. An
+# upstream error body can echo a url / username / password; we never let it
+# through. ``http`` is included because any url leak starts with the scheme.
+_CREDENTIAL_MESSAGE_KEYS = frozenset({"url", "username", "password", "http"})
+
+
+def _source_label(archive_source: dict) -> str:
+    """Operator-facing identifier for an EPG source — its name, never a secret."""
+    name = archive_source.get("name")
+    return str(name) if name else "<unknown>"
+
+
+def _norm_name(value) -> str | None:
+    """Case-insensitive, trimmed key for a name; None when absent/blank."""
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip().lower()
+    return trimmed or None
+
+
+def _identity_key(source: dict) -> tuple[str | None, str | None]:
+    """The stable identity for an EPG source: (source_type, normalized name).
+
+    ``source_type`` is compared verbatim (a small enum: xmltv /
+    schedules_direct / dummy); the name is normalized case-insensitively and
+    trimmed. Neither field is a credential, so this key is safe to build, compare,
+    and (for the name) log.
+    """
+    return (source.get("source_type"), _norm_name(source.get("name")))
+
+
+def _existing_by_identity(existing_sources: list[dict]) -> dict[tuple, dict]:
+    """Index existing destination sources by their (source_type, name) identity."""
+    index: dict[tuple, dict] = {}
+    for src in existing_sources or []:
+        if isinstance(src, dict):
+            key = _identity_key(src)
+            if key[1] is not None and key not in index:
+                index[key] = src
+    return index
+
+
+def _build_create_payload(archive_source: dict, m3u_dest_id: int | None) -> dict:
+    """Build the create_epg_source payload from an archive source record.
+
+    Drops the archive source id and read-only / derived fields. Keeps the
+    credential fields (url / username / password) — they MUST be recreated for the
+    source to function — but they are NEVER logged or reported. The
+    ``m3u_account`` FK, if present, is rewritten in place to the remapped
+    destination id (``m3u_dest_id``).
+    """
+    payload = {
+        k: v for k, v in archive_source.items() if k not in _DROPPED_CREATE_KEYS
+    }
+    if _M3U_ACCOUNT_FK in payload:
+        # Rewrite the FK to the destination id (None when the source had no
+        # association — preserved as-is so a free-standing source stays
+        # free-standing).
+        payload[_M3U_ACCOUNT_FK] = m3u_dest_id
+    return payload
+
+
+def _resolve_m3u_fk(
+    archive_source: dict, remap: IdRemapTable
+) -> tuple[bool, int | None]:
+    """Resolve the source's optional ``m3u_account`` FK through the remap table.
+
+    Returns ``(resolved, dest_id)``:
+
+    - No FK (None / absent): ``(True, None)`` — a free-standing source, not a
+      dependency.
+    - FK present and remapped: ``(True, dest_id)``.
+    - FK present but unmapped: ``(False, None)`` — caller skips the source
+      ``DEPENDENCY_UNRESOLVED``; we never send a dangling source id upstream.
+    """
+    source_m3u = archive_source.get(_M3U_ACCOUNT_FK)
+    if source_m3u is None:
+        return (True, None)
+    dest_id = remap.resolve(EntityType.M3U_ACCOUNT, int(source_m3u))
+    if dest_id is None:
+        return (False, None)
+    return (True, dest_id)
+
+
+def _failure_reason_for(exc: Exception) -> FailureReason:
+    """Classify a create_epg_source failure into a restore-contract FailureReason.
+
+    A name/uniqueness conflict maps to ``CONFLICT``; everything else is an
+    upstream API error. (We inspect the exception's short text, never echo a
+    credential.)
+    """
+    text = str(exc).lower()
+    if "already exists" in text or "unique" in text or "conflict" in text:
+        return FailureReason.CONFLICT
+    return FailureReason.UPSTREAM_API_ERROR
+
+
+def _sanitize_failure(exc: Exception) -> str:
+    """Produce a sanitized, operator-facing failure message — NO credentials.
+
+    An upstream error body can echo the source url / username / password; this
+    scrubs any message that mentions a known credential marker and falls back to a
+    generic message rather than risk leaking a credential into the report.
+    """
+    text = (str(exc) or "").strip()
+    lowered = text.lower()
+    if any(marker in lowered for marker in _CREDENTIAL_MESSAGE_KEYS):
+        return "Upstream rejected the EPG source creation request."
+    return text or "Upstream rejected the EPG source creation request."
+
+
+async def import_epg_sources(
+    *,
+    archive_sources: list[dict],
+    client: DispatcharrClient,
+    selected: bool,
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    remap: IdRemapTable,
+    is_dry_run: bool = False,
+) -> None:
+    """Restore the EPG_SOURCE category: create sources; remap the m3u_account FK.
+
+    Args:
+        archive_sources: The EPG source records from the export archive.
+        client: The Dispatcharr API client.
+        selected: The per-category opt-in flag. When ``False`` the entire
+            category is skipped (no creates) — every source recorded
+            EXCLUDED_BY_OPERATOR.
+        report: The shared :class:`RestoreReport`; results land in the
+            ``EntityType.EPG_SOURCE`` category.
+        ledger: The shared :class:`RollbackLedger`; each created source is
+            recorded for compensating deletes.
+        remap: The shared :class:`IdRemapTable`. READ for the ``M3U_ACCOUNT`` FK;
+            WRITTEN with each created (or collision-resolved) source's
+            source->dest id under ``EntityType.EPG_SOURCE`` so later importers
+            resolve FK references.
+        is_dry_run: When ``True``, nothing is created — the importer only reports
+            ``would_create`` / ``would_skip``.
+    """
+    cat = report.category(EntityType.EPG_SOURCE)
+
+    # OPT-IN. Off unless the operator selected the EPG sources category.
+    if not selected:
+        logger.info("[DBAS-EPG] Category not selected; skipping EPG sources.")
+        for archive_source in archive_sources:
+            _skip(
+                cat,
+                SkipReason.EXCLUDED_BY_OPERATOR,
+                _source_label(archive_source),
+                archive_source.get("id"),
+                is_dry_run,
+            )
+        return
+
+    logger.info(
+        "[DBAS-EPG] Restoring EPG sources (dry_run=%s); %d archived source(s).",
+        is_dry_run,
+        len(archive_sources),
+    )
+
+    # Pre-fetch existing sources to detect identity collisions (safe fields only).
+    try:
+        existing = await client.get_epg_sources()
+    except Exception as exc:
+        logger.warning("[DBAS-EPG] Could not list existing EPG sources: %s", exc)
+        existing = []
+    existing_by_identity = _existing_by_identity(existing)
+
+    for archive_source in archive_sources:
+        label = _source_label(archive_source)
+        source_id = archive_source.get("id")
+
+        # FK resolution first — an unresolved m3u_account is a hard skip, no create.
+        resolved, m3u_dest_id = _resolve_m3u_fk(archive_source, remap)
+        if not resolved:
+            _skip(cat, SkipReason.DEPENDENCY_UNRESOLVED, label, source_id, is_dry_run)
+            logger.info(
+                "[DBAS-EPG] Source '%s' (type=%s) skipped: m3u_account dependency "
+                "unresolved.",
+                label,
+                archive_source.get("source_type"),
+            )
+            continue
+
+        # Collision: a source with the same (source_type, name) already on dest.
+        identity = _identity_key(archive_source)
+        existing_src = (
+            existing_by_identity.get(identity) if identity[1] is not None else None
+        )
+        if existing_src is not None:
+            _skip(cat, SkipReason.ALREADY_EXISTS_IDENTICAL, label, source_id, is_dry_run)
+            existing_id = existing_src.get("id")
+            if source_id is not None and existing_id is not None:
+                remap.add(EntityType.EPG_SOURCE, int(source_id), int(existing_id))
+            logger.info(
+                "[DBAS-EPG] Source '%s' (type=%s) already exists (dest id=%s); skipped.",
+                label,
+                archive_source.get("source_type"),
+                existing_id,
+            )
+            continue
+
+        if is_dry_run:
+            cat.would_create += 1
+            continue
+
+        payload = _build_create_payload(archive_source, m3u_dest_id)
+        try:
+            created = await client.create_epg_source(payload)
+        except Exception as exc:
+            reason = _failure_reason_for(exc)
+            cat.failed += 1
+            cat.failure_details.append(
+                FailureDetail(
+                    reason=reason,
+                    label=label,
+                    message=_sanitize_failure(exc),
+                    source_export_id=source_id,
+                )
+            )
+            logger.warning(
+                "[DBAS-EPG] Failed to restore EPG source '%s' (type=%s): %s",
+                label,
+                archive_source.get("source_type"),
+                reason.value,
+            )
+            continue
+
+        dest_id = created.get("id") if isinstance(created, dict) else None
+        cat.created += 1
+        if dest_id is not None:
+            dest_id = int(dest_id)
+            if source_id is not None:
+                remap.add(EntityType.EPG_SOURCE, int(source_id), dest_id)
+            ledger.record_created(EntityType.EPG_SOURCE, dest_id, label)
+        logger.info(
+            "[DBAS-EPG] Restored EPG source '%s' (type=%s, id=%s).",
+            label,
+            archive_source.get("source_type"),
+            dest_id,
+        )
+
+
+def _skip(
+    cat,
+    reason: SkipReason,
+    label: str,
+    source_export_id,
+    is_dry_run: bool,
+) -> None:
+    """Record a skip in both the count and the reasoned detail list."""
+    if is_dry_run:
+        cat.would_skip += 1
+    else:
+        cat.skipped += 1
+    cat.skip_details.append(
+        SkipDetail(reason=reason, label=label, source_export_id=source_export_id)
+    )

--- a/backend/dbas/restore_contracts.py
+++ b/backend/dbas/restore_contracts.py
@@ -74,6 +74,7 @@ class EntityType(str, Enum):
     """
 
     M3U_ACCOUNT = "m3u_account"            # …-0i2vt.10 (Phase-2 first entity; producer of remap)
+    EPG_SOURCE = "epg_source"              # …-0i2vt.11 (Phase-2; restored after M3U, before Channels)
     CHANNEL_GROUP = "channel_group"        # …-0i2vt.12 (producer of remap)
     CHANNEL_PROFILE = "channel_profile"    # …-0i2vt.12 (producer of remap)
     STREAM_PROFILE = "stream_profile"      # …-0i2vt.12 (producer of remap)

--- a/backend/tests/dbas/test_epg_sources_importer.py
+++ b/backend/tests/dbas/test_epg_sources_importer.py
@@ -1,0 +1,549 @@
+"""Tests for the EPG sources restore importer
+(enhancedchannelmanager-0i2vt.11 — Phase 2, restored AFTER M3U, BEFORE Channels).
+
+Scope under test:
+
+1. Create EPG sources. For each archived source, strip archive-only /
+   non-writable keys (id/pk, read-only timestamps/status) and create via
+   ``client.create_epg_source``. Register source->dest in the IdRemapTable under
+   EntityType.EPG_SOURCE and record each create in the RollbackLedger.
+
+2. Collision taxonomy: an existing identical source (matched on the stable
+   identity key ``(source_type, normalized name)``) is skipped
+   ALREADY_EXISTS_IDENTICAL, its source id still remapped to the existing dest
+   id so a later FK reference resolves. A create that races into an upstream
+   uniqueness conflict is failed CONFLICT.
+
+3. FK remap: an archived source carrying an ``m3u_account`` FK reference is
+   remapped through the IdRemapTable (M3U_ACCOUNT namespace). An unresolvable
+   FK is skipped DEPENDENCY_UNRESOLVED (no create attempted, no dangling id sent
+   upstream).
+
+4. Opt-in: nothing happens unless the operator selected the category.
+
+5. Dry-run: no creates, no ledger entries; reports would_create.
+
+6. NO credential leakage: report / ledger / logs carry only safe fields (name,
+   source_type, id, counts, status). A Schedules-Direct ``username`` /
+   ``password`` and an XMLTV ``url`` (which may embed a token) never surface in
+   the report, the ledger, or a sanitized failure message.
+
+The Dispatcharr client is mocked at the importer module level
+(``dbas.importers.epg_sources``); the importer is exercised with an AsyncMock
+client.
+"""
+import logging
+
+import pytest
+from unittest.mock import AsyncMock
+
+from dbas.importers.epg_sources import import_epg_sources
+from dbas.restore_contracts import (
+    EntityType,
+    FailureReason,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+    SkipReason,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _client(*, existing_sources=None, create_side_effect=None):
+    """Build an AsyncMock Dispatcharr client with the methods the importer uses."""
+    client = AsyncMock()
+    client.get_epg_sources = AsyncMock(return_value=existing_sources or [])
+    created_counter = {"n": 800}
+
+    async def _default_create(payload):
+        created_counter["n"] += 1
+        return {"id": created_counter["n"], **payload}
+
+    client.create_epg_source = AsyncMock(side_effect=create_side_effect or _default_create)
+    client.delete_epg_source = AsyncMock(return_value=None)
+    return client
+
+
+def _report(is_dry_run=False):
+    return RestoreReport(is_dry_run=is_dry_run)
+
+
+def _ledger():
+    return RollbackLedger(restore_id="test-restore")
+
+
+def _remap(**kwargs):
+    """Build an IdRemapTable pre-seeded with the given mappings.
+
+    e.g. ``_remap(m3u_account={1: 901}, epg_source={2: 802})``.
+    """
+    table = IdRemapTable()
+    name_to_type = {
+        "m3u_account": EntityType.M3U_ACCOUNT,
+        "epg_source": EntityType.EPG_SOURCE,
+    }
+    for name, mapping in kwargs.items():
+        for src, dest in mapping.items():
+            table.add(name_to_type[name], src, dest)
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Opt-in gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_category_skipped_when_not_selected():
+    """OPT-IN: when the operator did not select the category, nothing is created —
+    every archived source is recorded EXCLUDED_BY_OPERATOR."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+
+    await import_epg_sources(
+        archive_sources=[{"id": 5, "name": "EPG A", "source_type": "xmltv", "url": "http://e/a"}],
+        client=client,
+        selected=False,
+        report=report,
+        ledger=ledger,
+        remap=_remap(),
+    )
+
+    client.create_epg_source.assert_not_called()
+    cat = report.category(EntityType.EPG_SOURCE)
+    assert cat.created == 0
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.EXCLUDED_BY_OPERATOR
+
+
+# ---------------------------------------------------------------------------
+# Create — happy path (remap + ledger)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_source_happy_path_remap_and_ledger():
+    """An archived source is created; source->dest is registered in the
+    IdRemapTable (EPG_SOURCE) and the create is recorded in the RollbackLedger."""
+    async def _create(payload):
+        return {"id": 802, **payload}
+
+    client = _client()
+    client.create_epg_source = AsyncMock(side_effect=_create)
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_epg_sources(
+        archive_sources=[{"id": 5, "name": "EPG A", "source_type": "xmltv", "url": "http://e/a"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = report.category(EntityType.EPG_SOURCE)
+    assert cat.created == 1
+    assert remap.resolve(EntityType.EPG_SOURCE, 5) == 802
+    assert len(ledger.entries) == 1
+    assert ledger.entries[0].entity_type == EntityType.EPG_SOURCE
+    assert ledger.entries[0].destination_id == 802
+    assert ledger.entries[0].label == "EPG A"
+
+
+@pytest.mark.asyncio
+async def test_create_payload_strips_source_id_and_readonly_fields():
+    """The create payload drops the archive source id and read-only / derived
+    fields (timestamps, status, counts), but keeps name/source_type/url/creds."""
+    captured = {}
+
+    async def _create(payload):
+        captured.update(payload)
+        return {"id": 802, **payload}
+
+    client = _client()
+    client.create_epg_source = AsyncMock(side_effect=_create)
+
+    await import_epg_sources(
+        archive_sources=[{
+            "id": 5,
+            "name": "EPG A",
+            "source_type": "xmltv",
+            "url": "http://e/a",
+            "created_at": "2020-01-01",
+            "updated_at": "2020-02-02",
+            "status": "ok",
+            "last_refresh": "2020-03-03",
+        }],
+        client=client,
+        selected=True,
+        report=_report(),
+        ledger=_ledger(),
+        remap=_remap(),
+    )
+
+    assert "id" not in captured
+    assert "created_at" not in captured
+    assert "updated_at" not in captured
+    assert "status" not in captured
+    assert "last_refresh" not in captured
+    assert captured["name"] == "EPG A"
+    assert captured["source_type"] == "xmltv"
+    assert captured["url"] == "http://e/a"
+
+
+# ---------------------------------------------------------------------------
+# FK remap (m3u_account)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_m3u_account_fk_remapped_through_table():
+    """An archived source's ``m3u_account`` FK is rewritten from the source id to
+    the destination id via the IdRemapTable (M3U_ACCOUNT namespace) before
+    create."""
+    captured = {}
+
+    async def _create(payload):
+        captured.update(payload)
+        return {"id": 802, **payload}
+
+    client = _client()
+    client.create_epg_source = AsyncMock(side_effect=_create)
+    remap = _remap(m3u_account={1: 901})
+
+    await import_epg_sources(
+        archive_sources=[{
+            "id": 5,
+            "name": "EPG A",
+            "source_type": "xmltv",
+            "url": "http://e/a",
+            "m3u_account": 1,
+        }],
+        client=client,
+        selected=True,
+        report=_report(),
+        ledger=_ledger(),
+        remap=remap,
+    )
+
+    assert captured["m3u_account"] == 901  # remapped from source id 1
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_m3u_account_fk_skipped_dependency_unresolved():
+    """An archived source whose ``m3u_account`` FK cannot be resolved through the
+    remap table is skipped DEPENDENCY_UNRESOLVED — no create is attempted, no
+    dangling source id is sent upstream."""
+    client = _client()
+    report = _report()
+
+    await import_epg_sources(
+        archive_sources=[{
+            "id": 5,
+            "name": "EPG A",
+            "source_type": "xmltv",
+            "url": "http://e/a",
+            "m3u_account": 99,  # not in the remap table
+        }],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=_ledger(),
+        remap=_remap(),  # empty
+    )
+
+    client.create_epg_source.assert_not_called()
+    cat = report.category(EntityType.EPG_SOURCE)
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.DEPENDENCY_UNRESOLVED
+
+
+@pytest.mark.asyncio
+async def test_null_m3u_account_fk_is_not_treated_as_unresolved():
+    """A source with no m3u_account association (None / absent) is created
+    normally — a null FK is not an unresolved dependency."""
+    async def _create(payload):
+        return {"id": 802, **payload}
+
+    client = _client()
+    client.create_epg_source = AsyncMock(side_effect=_create)
+    report = _report()
+
+    await import_epg_sources(
+        archive_sources=[{
+            "id": 5,
+            "name": "EPG A",
+            "source_type": "xmltv",
+            "url": "http://e/a",
+            "m3u_account": None,
+        }],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=_ledger(),
+        remap=_remap(),
+    )
+
+    cat = report.category(EntityType.EPG_SOURCE)
+    assert cat.created == 1
+    assert cat.skipped == 0
+
+
+# ---------------------------------------------------------------------------
+# Collision taxonomy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_existing_source_by_identity_skipped_already_exists():
+    """An archived source whose (source_type, normalized name) already exists on
+    the destination is skipped ALREADY_EXISTS_IDENTICAL; its source id is still
+    remapped to the existing dest id so a later FK reference resolves."""
+    client = _client(existing_sources=[
+        {"id": 700, "name": "EPG A", "source_type": "xmltv"},
+    ])
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_epg_sources(
+        archive_sources=[{"id": 5, "name": "  epg a  ", "source_type": "xmltv", "url": "http://e/a"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    client.create_epg_source.assert_not_called()
+    cat = report.category(EntityType.EPG_SOURCE)
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.ALREADY_EXISTS_IDENTICAL
+    assert remap.resolve(EntityType.EPG_SOURCE, 5) == 700
+    assert len(ledger.entries) == 0
+
+
+@pytest.mark.asyncio
+async def test_same_name_different_source_type_is_not_a_collision():
+    """The identity key includes source_type: a same-name source of a DIFFERENT
+    source_type is NOT a collision and is created."""
+    async def _create(payload):
+        return {"id": 802, **payload}
+
+    client = _client(existing_sources=[
+        {"id": 700, "name": "EPG A", "source_type": "schedules_direct"},
+    ])
+    client.create_epg_source = AsyncMock(side_effect=_create)
+    report = _report()
+
+    await import_epg_sources(
+        archive_sources=[{"id": 5, "name": "EPG A", "source_type": "xmltv", "url": "http://e/a"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=_ledger(),
+        remap=_remap(),
+    )
+
+    cat = report.category(EntityType.EPG_SOURCE)
+    assert cat.created == 1
+    assert cat.skipped == 0
+
+
+@pytest.mark.asyncio
+async def test_create_conflict_recorded_as_failure_conflict():
+    """A create that races into an upstream uniqueness conflict is failed
+    CONFLICT (not skipped)."""
+    async def _conflict(payload):
+        raise RuntimeError("name already exists")
+
+    client = _client()
+    client.create_epg_source = AsyncMock(side_effect=_conflict)
+    report = _report()
+    ledger = _ledger()
+
+    await import_epg_sources(
+        archive_sources=[{"id": 5, "name": "EPG A", "source_type": "xmltv", "url": "http://e/a"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=_remap(),
+    )
+
+    cat = report.category(EntityType.EPG_SOURCE)
+    assert cat.failed == 1
+    assert cat.failure_details[0].reason == FailureReason.CONFLICT
+    assert len(ledger.entries) == 0
+
+
+@pytest.mark.asyncio
+async def test_create_upstream_error_recorded_as_failure():
+    """A non-conflict create error is failed UPSTREAM_API_ERROR."""
+    async def _boom(payload):
+        raise RuntimeError("502 bad gateway")
+
+    client = _client()
+    client.create_epg_source = AsyncMock(side_effect=_boom)
+    report = _report()
+
+    await import_epg_sources(
+        archive_sources=[{"id": 5, "name": "EPG A", "source_type": "xmltv", "url": "http://e/a"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=_ledger(),
+        remap=_remap(),
+    )
+
+    cat = report.category(EntityType.EPG_SOURCE)
+    assert cat.failed == 1
+    assert cat.failure_details[0].reason == FailureReason.UPSTREAM_API_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_no_creates_no_ledger():
+    """Dry-run: no source is created, no ledger entry written; the importer
+    reports would_create."""
+    client = _client()
+    report = _report(is_dry_run=True)
+    ledger = _ledger()
+
+    await import_epg_sources(
+        archive_sources=[{"id": 5, "name": "EPG A", "source_type": "xmltv", "url": "http://e/a"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=_remap(),
+        is_dry_run=True,
+    )
+
+    client.create_epg_source.assert_not_called()
+    cat = report.category(EntityType.EPG_SOURCE)
+    assert cat.would_create == 1
+    assert cat.created == 0
+    assert len(ledger.entries) == 0
+
+
+@pytest.mark.asyncio
+async def test_dry_run_unresolved_fk_reported_would_skip():
+    """Dry-run: an unresolvable FK is reported as a would-skip with reason
+    DEPENDENCY_UNRESOLVED (so the operator sees why before applying)."""
+    client = _client()
+    report = _report(is_dry_run=True)
+
+    await import_epg_sources(
+        archive_sources=[{
+            "id": 5, "name": "EPG A", "source_type": "xmltv",
+            "url": "http://e/a", "m3u_account": 99,
+        }],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=_ledger(),
+        remap=_remap(),
+        is_dry_run=True,
+    )
+
+    client.create_epg_source.assert_not_called()
+    cat = report.category(EntityType.EPG_SOURCE)
+    assert cat.would_skip == 1
+    assert cat.skip_details[0].reason == SkipReason.DEPENDENCY_UNRESOLVED
+
+
+# ---------------------------------------------------------------------------
+# Credential / secret hygiene (the bead .8 clear-text-logging lesson)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_report_and_ledger_carry_no_credential_material():
+    """No url (token-bearing) / username / password surfaces in the report
+    (labels, notes) or the ledger."""
+    async def _create(payload):
+        return {"id": 802, **payload}
+
+    client = _client()
+    client.create_epg_source = AsyncMock(side_effect=_create)
+    report = _report()
+    ledger = _ledger()
+
+    secret_markers = (
+        "http://secret-provider",
+        "s3cr3t-pass",
+        "secret-user",
+        "token=abc123",
+    )
+
+    await import_epg_sources(
+        archive_sources=[{
+            "id": 5,
+            "name": "EPG A",
+            "source_type": "schedules_direct",
+            "url": "http://secret-provider/epg.xml?token=abc123",
+            "username": "secret-user",
+            "password": "s3cr3t-pass",
+        }],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=_remap(),
+    )
+
+    blob = report.model_dump_json() + ledger.model_dump_json()
+    for marker in secret_markers:
+        assert marker not in blob
+
+
+@pytest.mark.asyncio
+async def test_failure_message_does_not_leak_url_or_credentials(caplog):
+    """An upstream error body that echoes the source url / credentials is scrubbed
+    from the operator-facing failure message AND not written to the log."""
+    async def _boom(payload):
+        raise RuntimeError(
+            "POST http://secret-provider/epg.xml?token=abc123 failed: "
+            "username=secret-user password=s3cr3t-pass rejected"
+        )
+
+    client = _client()
+    client.create_epg_source = AsyncMock(side_effect=_boom)
+    report = _report()
+
+    with caplog.at_level(logging.DEBUG):
+        await import_epg_sources(
+            archive_sources=[{
+                "id": 5,
+                "name": "EPG A",
+                "source_type": "schedules_direct",
+                "url": "http://secret-provider/epg.xml?token=abc123",
+                "username": "secret-user",
+                "password": "s3cr3t-pass",
+            }],
+            client=client,
+            selected=True,
+            report=report,
+            ledger=_ledger(),
+            remap=_remap(),
+        )
+
+    cat = report.category(EntityType.EPG_SOURCE)
+    assert cat.failed == 1
+    message = cat.failure_details[0].message
+    log_text = caplog.text
+    for marker in ("secret-provider", "token=abc123", "secret-user", "s3cr3t-pass"):
+        assert marker not in message
+        assert marker not in log_text


### PR DESCRIPTION
## Bead
enhancedchannelmanager-0i2vt.11 — Phase 2: EPG sources importer (restores EPG source rows; depends on .10).

## What
New `backend/dbas/importers/epg_sources.py` (mirrors m3u_accounts.py pattern). For each archived EPG source: create on destination, register source→dest in `IdRemapTable` (new `EntityType.EPG_SOURCE`) + `RollbackLedger`; m3u_account FK remapped, unresolvable → `DEPENDENCY_UNRESOLVED`.
- **Identity key**: `(source_type, normalized name)` — NOT url (XMLTV urls can embed credential tokens; matching on url would risk logging creds). Credential-clean: no url/token/username/password in report, ledger, message, or logs (asserted).
- Verify-then-size: all EPG client methods (`get_epg_sources`/`create_epg_source`/...) already existed — none added.
- Deferred: EPG-data download/refresh is NOT triggered at import (same race-avoidance as M3U deferred auto-sync) — orchestrator owns the "EPG download completes before Channels" wait.

## Tests
14 tests: create+remap+ledger, payload strips readonly, FK remap + unresolved skip, null-FK-not-unresolved, ALREADY_EXISTS_IDENTICAL skip + remap-to-existing, same-name-different-type not a collision, CONFLICT vs UPSTREAM_API_ERROR, opt-in off, dry-run, two credential-hygiene assertions. Full suite green (5688 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)