### PR TITLE
v0.18.0-dbas: 0i2vt.18 restore pre-flight validation + compensating-delete rollback

### DIFF
--- a/backend/dbas/preflight.py
+++ b/backend/dbas/preflight.py
@@ -1,0 +1,352 @@
+"""Phase-2 DBAS restore PRE-FLIGHT validation.
+
+Bead ``enhancedchannelmanager-0i2vt.18`` (part 1 of 2 — the other half is
+``restore_orchestrator``). Dispatcharr has no database transactions (ADR-012),
+so the cheapest way to avoid a half-applied restore is to refuse a restore that
+is *known* to be inconsistent BEFORE issuing a single upstream write. This module
+validates the ENTIRE import plan up front and returns a structured result; the
+orchestrator refuses the restore — with ZERO mutation — when the result does not
+pass.
+
+What pre-flight checks (all read-only — it never mutates the destination):
+
+* **schema-version gate** — delegates to ``routers.backup.validate_restore_schema_version``
+  (bead ``…-0i2vt.17``) so an artifact from a newer ECM build is refused at the
+  same chokepoint the upload path uses. This is the security/order guard the
+  bead requires invoked at the orchestration entry.
+* **FK references resolvable** — every FK reference an entity carries
+  (a channel's ``channel_group_id`` / ``stream_profile_id``, a profile
+  membership) must resolve to *something* in the plan: either another archived
+  entity of that type (it will be created), or — via the
+  :class:`~dbas.restore_contracts.IdRemapTable` — an entity already present on
+  the destination. A reference to neither is a dangling FK that would fail
+  mid-apply; pre-flight catches it now.
+* **required-unique names unique** — within a category whose name must be unique
+  (M3U accounts, channel groups, channel profiles), a duplicate name in the
+  archive is refused: the second create would CONFLICT mid-run.
+* **counts within bounds** — a category whose archived count exceeds a sane upper
+  bound is refused as a likely-malformed / hostile archive rather than attempting
+  a multi-thousand-entity apply that the rollback ledger would then have to undo.
+
+The result is a structured pass/fail with a list of human-readable problems; the
+orchestrator turns a failing pre-flight into a refused restore (no importer is
+ever called). Pre-flight is PURE and synchronous — no client, no I/O — so it is
+exhaustively unit-tested without mocks.
+
+Conventions (``docs/style_guide.md``): ``str, Enum`` self-describing values;
+Pydantic v2 ``BaseModel``; ``snake_case``; Google-style docstrings; lazy
+``%``-formatted logging; NO secrets in any problem message (we only ever read an
+entity's name / id, never its credentials).
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from dbas.restore_contracts import EntityType, IdRemapTable
+
+logger = logging.getLogger(__name__)
+
+# Upper bound per category. A well-formed archive is comfortably under this; a
+# count above it is treated as a malformed / hostile archive and refused before
+# any write rather than handed to the apply path. Generous on purpose — this is a
+# guardrail against absurd inputs, not a product limit.
+DEFAULT_MAX_ENTITIES_PER_CATEGORY = 100_000
+
+# Categories whose ``name`` must be unique on the destination. A duplicate name
+# inside the archive would make the second create CONFLICT mid-apply, so it is a
+# pre-flight failure, not a runtime surprise.
+_NAME_UNIQUE_CATEGORIES = frozenset(
+    {EntityType.M3U_ACCOUNT, EntityType.CHANNEL_GROUP, EntityType.CHANNEL_PROFILE}
+)
+
+
+class PreflightProblemKind(str, Enum):
+    """Why a pre-flight check failed.
+
+    Self-describing values so a log line or operator-facing problem reads without
+    the enum type for context (``docs/style_guide.md`` — naming discipline).
+    """
+
+    UNSUPPORTED_SCHEMA_VERSION = "unsupported_schema_version"
+    UNRESOLVED_FK_REFERENCE = "unresolved_fk_reference"
+    DUPLICATE_UNIQUE_NAME = "duplicate_unique_name"
+    COUNT_OUT_OF_BOUNDS = "count_out_of_bounds"
+
+
+class PreflightProblem(BaseModel):
+    """One pre-flight failure, with the category it concerns and a safe message.
+
+    ``message`` is operator-facing and carries NO secrets — only names, ids, and
+    counts. ``label`` is the offending entity's operator-facing identifier when
+    the problem is entity-scoped (a dangling FK, a duplicate name); ``None`` for
+    plan-scoped problems (schema version, count bound).
+    """
+
+    kind: PreflightProblemKind
+    entity_type: EntityType | None = Field(
+        default=None, description="The category the problem concerns; None if plan-scoped."
+    )
+    label: str | None = Field(
+        default=None, description="Operator-facing entity identifier — never a secret."
+    )
+    message: str = Field(description="Sanitized, operator-facing detail. No secrets.")
+
+
+class PreflightResult(BaseModel):
+    """The structured outcome of pre-flight validation.
+
+    ``passed`` is the single gate the orchestrator reads: ``True`` lets the apply
+    proceed, ``False`` refuses the restore with no mutation. ``problems`` carries
+    the reasons so the operator sees *why* a refusal happened.
+    """
+
+    passed: bool = Field(description="True only when there are zero problems.")
+    problems: list[PreflightProblem] = Field(default_factory=list)
+
+    @classmethod
+    def from_problems(cls, problems: list[PreflightProblem]) -> PreflightResult:
+        """Build a result whose ``passed`` is derived from the problem list."""
+        return cls(passed=not problems, problems=problems)
+
+
+class PlanCategory(BaseModel):
+    """One category's slice of the import plan: the archived entities + selection.
+
+    ``entities`` are the raw archive records (dicts) for this category.
+    ``selected`` is the operator opt-in: an unselected category contributes
+    nothing to the plan (no creates, so its FKs/names/counts are not validated —
+    nothing in it will be applied).
+    """
+
+    entity_type: EntityType
+    entities: list[dict] = Field(default_factory=list)
+    selected: bool = True
+
+
+class ImportPlan(BaseModel):
+    """The whole restore plan handed to pre-flight and the orchestrator.
+
+    ``manifest`` is the parsed artifact manifest (for the schema-version gate).
+    ``categories`` is the per-category archive slice. ``existing_remap`` carries
+    any source->dest mappings already known before the run (e.g. groups the
+    operator pre-created on the destination); pre-flight treats an FK that
+    resolves through it as satisfied even when the referenced entity is not in the
+    archive.
+    """
+
+    manifest: dict = Field(default_factory=dict)
+    categories: list[PlanCategory] = Field(default_factory=list)
+    existing_remap: IdRemapTable = Field(default_factory=IdRemapTable)
+
+    def category(self, entity_type: EntityType) -> PlanCategory | None:
+        """Return the plan slice for ``entity_type``, or None if not in the plan."""
+        for cat in self.categories:
+            if cat.entity_type == entity_type:
+                return cat
+        return None
+
+    def selected_categories(self) -> list[PlanCategory]:
+        """Return only the categories the operator opted into."""
+        return [c for c in self.categories if c.selected]
+
+
+# FK references a channel record can carry, and the category each points at.
+# Used to check every FK in the plan resolves to a will-be-created entity or an
+# already-present destination entity. Keyed by the archive field name.
+_CHANNEL_FK_FIELDS: dict[str, EntityType] = {
+    "channel_group_id": EntityType.CHANNEL_GROUP,
+    "stream_profile_id": EntityType.STREAM_PROFILE,
+}
+
+
+def _label(entity: dict) -> str:
+    """Operator-facing identifier for an arbitrary archive entity — never a secret."""
+    for key in ("name", "username", "title"):
+        value = entity.get(key)
+        if value:
+            return str(value)
+    ident = entity.get("id")
+    return f"<id={ident}>" if ident is not None else "<unknown>"
+
+
+def _source_ids_in_plan(plan: ImportPlan, entity_type: EntityType) -> set[int]:
+    """Source-export ids of every SELECTED archived entity of a type.
+
+    These are the entities that WILL be created this run, so an FK pointing at one
+    is satisfiable. An unselected category contributes nothing (it will not be
+    created).
+    """
+    cat = plan.category(entity_type)
+    if cat is None or not cat.selected:
+        return set()
+    ids: set[int] = set()
+    for entity in cat.entities:
+        ident = entity.get("id")
+        if ident is not None:
+            ids.add(int(ident))
+    return ids
+
+
+def _validate_schema_version(plan: ImportPlan, problems: list[PreflightProblem]) -> None:
+    """Refuse a restore whose manifest schema_version is unsupported (.17 gate).
+
+    Delegates to ``routers.backup.validate_restore_schema_version`` — the SAME
+    comparator the upload chokepoint uses — so there is one version policy. The
+    import is local to avoid a router-layer import at module load. The version
+    detail is logged by the validator; the operator-facing problem message
+    carries no version internals.
+    """
+    # Local import: the orchestration layer may import preflight before the web
+    # layer is fully wired, and we keep the dependency direction one-way.
+    from routers.backup import (
+        UnsupportedBackupVersionError,
+        validate_restore_schema_version,
+    )
+
+    try:
+        validate_restore_schema_version(plan.manifest)
+    except UnsupportedBackupVersionError as exc:
+        problems.append(
+            PreflightProblem(
+                kind=PreflightProblemKind.UNSUPPORTED_SCHEMA_VERSION,
+                message=str(exc),
+            )
+        )
+
+
+def _validate_unique_names(plan: ImportPlan, problems: list[PreflightProblem]) -> None:
+    """Refuse a category that carries a duplicate required-unique name.
+
+    Within a name-unique category (M3U accounts, channel groups, channel
+    profiles), two archived entities with the same case-insensitive, trimmed name
+    would make the second create CONFLICT mid-apply. Caught here as a pre-flight
+    failure so no partial state is created.
+    """
+    for cat in plan.selected_categories():
+        if cat.entity_type not in _NAME_UNIQUE_CATEGORIES:
+            continue
+        seen: set[str] = set()
+        for entity in cat.entities:
+            raw = entity.get("name")
+            if not isinstance(raw, str):
+                continue
+            key = raw.strip().lower()
+            if not key:
+                continue
+            if key in seen:
+                problems.append(
+                    PreflightProblem(
+                        kind=PreflightProblemKind.DUPLICATE_UNIQUE_NAME,
+                        entity_type=cat.entity_type,
+                        label=_label(entity),
+                        message=(
+                            f"Duplicate {cat.entity_type.value} name in archive: "
+                            f"'{raw}'. Names must be unique within this category."
+                        ),
+                    )
+                )
+            seen.add(key)
+
+
+def _validate_counts(
+    plan: ImportPlan,
+    problems: list[PreflightProblem],
+    max_per_category: int,
+) -> None:
+    """Refuse a category whose archived entity count exceeds the sane upper bound."""
+    for cat in plan.selected_categories():
+        count = len(cat.entities)
+        if count > max_per_category:
+            problems.append(
+                PreflightProblem(
+                    kind=PreflightProblemKind.COUNT_OUT_OF_BOUNDS,
+                    entity_type=cat.entity_type,
+                    message=(
+                        f"{cat.entity_type.value} count {count} exceeds the maximum "
+                        f"of {max_per_category}; refusing as a likely-malformed archive."
+                    ),
+                )
+            )
+
+
+def _validate_fk_references(plan: ImportPlan, problems: list[PreflightProblem]) -> None:
+    """Refuse a restore whose plan carries an unresolvable FK reference.
+
+    Currently validates channel FK references (``channel_group_id`` /
+    ``stream_profile_id``). A reference is satisfied when its source id is either
+    (a) the source id of a will-be-created entity of that type in the plan, or
+    (b) resolvable through the plan's ``existing_remap`` (already present on the
+    destination). Anything else is a dangling FK that would fail at apply time.
+
+    The seam is deliberately keyed on a per-category FK-field map so additional
+    categories' FK references (settings, DVR rules) register here as their
+    importers land, without changing the orchestrator.
+    """
+    channels = plan.category(EntityType.CHANNEL)
+    if channels is None or not channels.selected:
+        return
+
+    for archive_channel in channels.entities:
+        for field, target_type in _CHANNEL_FK_FIELDS.items():
+            ref = archive_channel.get(field)
+            if ref is None:
+                continue
+            ref_id = int(ref)
+            in_plan = ref_id in _source_ids_in_plan(plan, target_type)
+            on_dest = plan.existing_remap.resolve(target_type, ref_id) is not None
+            if not in_plan and not on_dest:
+                problems.append(
+                    PreflightProblem(
+                        kind=PreflightProblemKind.UNRESOLVED_FK_REFERENCE,
+                        entity_type=EntityType.CHANNEL,
+                        label=_label(archive_channel),
+                        message=(
+                            f"Channel '{_label(archive_channel)}' references "
+                            f"{target_type.value} id={ref_id}, which is neither in "
+                            f"the archive nor present on the destination."
+                        ),
+                    )
+                )
+
+
+def run_preflight(
+    plan: ImportPlan,
+    *,
+    max_entities_per_category: int = DEFAULT_MAX_ENTITIES_PER_CATEGORY,
+) -> PreflightResult:
+    """Validate the entire import plan BEFORE any mutation; return pass/problems.
+
+    Runs every check (schema version, FK resolvability, unique names, count
+    bounds) and accumulates ALL problems rather than short-circuiting on the
+    first — the operator sees every reason a restore was refused in one pass.
+
+    Args:
+        plan: The restore plan (manifest + per-category archive slices + any
+            pre-known source->dest remap).
+        max_entities_per_category: Upper bound per category; a count above it is a
+            ``COUNT_OUT_OF_BOUNDS`` problem.
+
+    Returns:
+        A :class:`PreflightResult`. ``passed`` is ``True`` only when there are
+        zero problems; the orchestrator refuses the restore (no mutation) when it
+        is ``False``.
+    """
+    problems: list[PreflightProblem] = []
+    _validate_schema_version(plan, problems)
+    _validate_counts(plan, problems, max_entities_per_category)
+    _validate_unique_names(plan, problems)
+    _validate_fk_references(plan, problems)
+
+    result = PreflightResult.from_problems(problems)
+    if result.passed:
+        logger.info("[DBAS-PREFLIGHT] Pre-flight passed; %d categor(ies) in plan.", len(plan.categories))
+    else:
+        logger.warning(
+            "[DBAS-PREFLIGHT] Pre-flight FAILED with %d problem(s); restore will be refused with no mutation.",
+            len(problems),
+        )
+    return result

--- a/backend/dbas/restore_orchestrator.py
+++ b/backend/dbas/restore_orchestrator.py
@@ -1,0 +1,662 @@
+"""Phase-2 DBAS restore ORCHESTRATOR — pre-flight + apply + compensating rollback.
+
+Bead ``enhancedchannelmanager-0i2vt.18``. Dispatcharr has no database
+transactions (ADR-012), so a restore that hits an upstream error mid-run could
+leave a half-applied archive. This module is the safety layer that prevents that:
+
+1. **Pre-flight** (``dbas.preflight``) validates the WHOLE plan before any write.
+   A failing pre-flight refuses the restore with ZERO mutation — no importer is
+   ever called.
+2. **Ordered apply** runs the per-category importers in the hard Phase-2
+   sequence through a clean registry of :class:`ImporterStep` callables. The
+   importers record every created entity into the shared
+   :class:`~dbas.restore_contracts.RollbackLedger` (they already do this); the
+   orchestrator persists that ledger DURABLY after each step so a mid-restore
+   ECM crash leaves a recoverable record.
+3. **Compensating rollback** — if any step fails (raises, or reports a category
+   failure), the orchestrator issues compensating DELETEs in
+   :meth:`RollbackLedger.compensation_order` (reverse creation = reverse
+   dependency order). A delete that 404s counts as SUCCESS (already gone); a
+   non-404 delete error means the rollback is INCOMPLETE.
+4. **Tri-state outcome** (:class:`~dbas.restore_contracts.RestoreOutcome`) is
+   computed from what actually happened and is NEVER ``SUCCESS`` on mixed state.
+
+----------------------------------------------------------------------------
+HARD ORDERING (ADR-012 D-table) + the DEFERRED phase
+----------------------------------------------------------------------------
+
+Importers run in strict dependency order::
+
+    M3U accounts → EPG sources → channel groups/profiles/stream profiles
+      → user agents / settings → channels → logos
+
+then the DEFERRED phase applies LAST: the M3U importer (and EPG importer) return
+auto-sync/EPG-download settings that MUST NOT fire during the run (they race the
+logo import on the Dispatcharr side). The orchestrator collects each importer's
+deferred settings and applies them only after every category is done, via
+``dbas.importers.m3u_accounts.apply_deferred_auto_sync``.
+
+----------------------------------------------------------------------------
+WIRED vs SEAM (be precise — this is scaffolding for in-flight importers)
+----------------------------------------------------------------------------
+
+The per-category importers are separate beads, not all built yet. The
+orchestrator runs whatever importer callables are registered in the
+:class:`ImporterStep` list it is given and treats a category with no registered
+importer as a no-op SEAM (logged, never a silent skip). The default registry
+(:func:`default_importer_steps`) wires the importers that EXIST today
+(M3U accounts, channels, users) and leaves explicit registration seams for the
+not-yet-built ones (EPG sources, channel groups/profiles, user agents/settings,
+logos). As each lands, it registers here without changing the orchestrator.
+
+----------------------------------------------------------------------------
+404-AS-SUCCESS + the credential-hygiene rule (the bead .8 lesson)
+----------------------------------------------------------------------------
+
+A compensating DELETE that returns 404 is treated as a successful compensation
+(the entity is already gone — desired end state). Only a non-404 upstream error
+counts as a failed compensation and drives ``FAILED_ROLLBACK_INCOMPLETE``.
+
+We log/report only SAFE fields — entity type, destination id, label (a name,
+never a credential), counts, status codes. We never log a server_url, username,
+password, or an upstream SDK exception body verbatim.
+
+Conventions (``docs/style_guide.md``): Pydantic v2 models; ``snake_case``;
+Google-style docstrings; lazy ``%``-formatted logging; no secrets in any log or
+report field.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+from config import CONFIG_DIR
+from dbas.preflight import ImportPlan, PreflightResult, run_preflight
+from dbas.restore_contracts import (
+    EntityType,
+    LedgerEntry,
+    RestoreOutcome,
+    RestoreReport,
+    RollbackLedger,
+)
+from dispatcharr_client import DispatcharrClient
+
+logger = logging.getLogger(__name__)
+
+# Durable ledger lives under the same mounted volume as journal.db / settings.json
+# (CONFIG_DIR), so a mid-restore ECM crash leaves a recoverable record.
+_LEDGER_DIR = CONFIG_DIR / "dbas"
+
+
+# ---------------------------------------------------------------------------
+# Importer registry — the clean seam importers register through
+# ---------------------------------------------------------------------------
+
+# An importer callable takes the shared apply context and applies ONE category.
+# It mutates the shared RestoreReport / RollbackLedger / IdRemapTable in place and
+# returns an optional list of deferred settings (M3U/EPG) to apply in the final
+# phase. ``None`` means "nothing deferred".
+ImporterCallable = Callable[["ApplyContext"], Awaitable["list[dict] | None"]]
+
+
+@dataclass
+class ImporterStep:
+    """One category's place in the hard restore sequence.
+
+    Attributes:
+        entity_type: The category this step restores (its place in the order).
+        importer: The async callable that applies the category, or ``None`` for a
+            registration SEAM — a category whose importer is a separate, not-yet-
+            built bead. A seam step is a logged no-op, never a silent skip.
+        defers: Whether this step returns deferred settings (M3U / EPG) that the
+            orchestrator must apply in the final deferred phase.
+    """
+
+    entity_type: EntityType
+    importer: ImporterCallable | None = None
+    defers: bool = False
+
+
+@dataclass
+class ApplyContext:
+    """The shared state threaded through every importer step.
+
+    Importers read the plan slice for their category and write into the shared
+    report / ledger / remap. The deferred-apply phase reads ``deferred``.
+    """
+
+    plan: ImportPlan
+    client: DispatcharrClient
+    report: RestoreReport
+    ledger: RollbackLedger
+    remap: "object"  # IdRemapTable; typed loosely to avoid a hard import cycle
+    is_dry_run: bool = False
+    # Collected deferred settings (M3U auto-sync, EPG download) — applied LAST.
+    deferred: list[dict] = field(default_factory=list)
+
+
+class ImporterStepError(RuntimeError):
+    """A category importer failed in a way that must trigger rollback.
+
+    Carries the category and a SANITIZED message (no secrets). Raised by the
+    orchestrator when an importer raises, or when a step reports a category
+    failure and the orchestrator decides to roll back.
+    """
+
+    def __init__(self, entity_type: EntityType, message: str):
+        self.entity_type = entity_type
+        super().__init__(message)
+
+
+# ---------------------------------------------------------------------------
+# Compensating-delete dispatch — EntityType -> client delete method
+# ---------------------------------------------------------------------------
+
+# Maps a ledgered entity type to the client coroutine that deletes one by id.
+# A type with no compensator here cannot be safely undone by a single-id DELETE;
+# the rollback treats it as an INCOMPLETE compensation (surfaced, never silently
+# counted as success) so we never claim a clean rollback we did not perform.
+def _delete_dispatch(client: DispatcharrClient) -> dict[EntityType, Callable[[int], Awaitable[None]]]:
+    """Build the EntityType -> single-id delete coroutine map for ``client``."""
+    return {
+        EntityType.M3U_ACCOUNT: client.delete_m3u_account,
+        EntityType.CHANNEL_GROUP: client.delete_channel_group,
+        EntityType.CHANNEL_PROFILE: client.delete_channel_profile,
+        EntityType.CHANNEL: client.delete_channel,
+        EntityType.STREAM: client.delete_stream,
+        EntityType.USER: client.delete_user,
+    }
+
+
+def _status_code_of(exc: Exception) -> int | None:
+    """Best-effort HTTP status code for an upstream delete error.
+
+    Delete helpers call ``response.raise_for_status()`` → ``httpx.HTTPStatusError``
+    carrying ``.response.status_code``. Some hand-built client helpers raise a
+    bare ``Exception`` whose text embeds the status; we recover the code from the
+    text as a fallback. ``None`` means "could not determine" (treated as non-404).
+    """
+    if isinstance(exc, httpx.HTTPStatusError) and exc.response is not None:
+        return exc.response.status_code
+    text = str(exc)
+    # Hand-built helpers format "<thing> failed: <status> - <body>".
+    for token in text.replace(":", " ").replace("-", " ").split():
+        if token.isdigit() and len(token) == 3:
+            return int(token)
+    return None
+
+
+def _is_already_gone(exc: Exception) -> bool:
+    """True when a compensating DELETE error is a 404 — already gone == success."""
+    return _status_code_of(exc) == 404
+
+
+# ---------------------------------------------------------------------------
+# Durable ledger persistence (atomic temp + os.replace)
+# ---------------------------------------------------------------------------
+
+
+def _ledger_path(restore_id: str, ledger_dir: Path | None = None) -> Path:
+    """On-disk path for a restore's durable ledger file."""
+    base = ledger_dir or _LEDGER_DIR
+    return base / f"restore_ledger_{restore_id}.json"
+
+
+def persist_ledger(ledger: RollbackLedger, *, ledger_dir: Path | None = None) -> Path:
+    """Write the ledger to disk atomically (temp file + ``os.replace``).
+
+    Called after each created-entity batch / step so a mid-restore crash leaves a
+    recoverable record. The write is atomic: a crash never leaves a half-written
+    ledger. Returns the path written.
+    """
+    base = ledger_dir or _LEDGER_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    final = _ledger_path(ledger.restore_id, base)
+    tmp = final.with_suffix(".json.tmp")
+    tmp.write_text(ledger.model_dump_json())
+    os.replace(tmp, final)
+    return final
+
+
+def delete_ledger(restore_id: str, *, ledger_dir: Path | None = None) -> None:
+    """Remove a restore's ledger file (clean success — no compensation needed)."""
+    path = _ledger_path(restore_id, ledger_dir)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Rollback
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RollbackResult:
+    """Outcome of a compensating-delete rollback run.
+
+    ``complete`` is ``True`` only when EVERY pending ledger entry was compensated
+    (deleted or confirmed already-gone via 404). ``residue`` carries the entries
+    that could NOT be compensated (a non-404 delete error, or no compensator
+    registered for the type) so the report can surface them for manual cleanup.
+    """
+
+    complete: bool
+    compensated: list[LedgerEntry] = field(default_factory=list)
+    residue: list[LedgerEntry] = field(default_factory=list)
+
+
+async def run_rollback(
+    *,
+    ledger: RollbackLedger,
+    client: DispatcharrClient,
+    ledger_dir: Path | None = None,
+) -> RollbackResult:
+    """Issue compensating DELETEs for every created entity, in compensation order.
+
+    Order is :meth:`RollbackLedger.compensation_order` — descending sequence =
+    reverse creation = reverse dependency order, so a parent is never deleted
+    while a child still points at it. Idempotent: a DELETE that 404s is a success
+    (already gone); an entry already marked compensated is skipped on a re-run.
+
+    A non-404 delete error (or a type with no registered compensator) leaves the
+    entry in the ledger as RESIDUE and makes the result INCOMPLETE — surfaced
+    loudly, never counted as success.
+
+    The ledger is persisted after each successful compensation so a crash mid-
+    rollback can resume without re-deleting.
+
+    Args:
+        ledger: The shared rollback ledger (mutated: entries marked compensated).
+        client: The Dispatcharr API client.
+        ledger_dir: Override the durable ledger directory (tests).
+
+    Returns:
+        A :class:`RollbackResult` with ``complete`` and the compensated/residue
+        split.
+    """
+    dispatch = _delete_dispatch(client)
+    compensated: list[LedgerEntry] = []
+    residue: list[LedgerEntry] = []
+
+    for entry in ledger.compensation_order():
+        deleter = dispatch.get(entry.entity_type)
+        if deleter is None:
+            logger.error(
+                "[DBAS-ROLLBACK] No compensator registered for entity_type=%s id=%s; "
+                "rollback INCOMPLETE for this entry — manual cleanup required.",
+                entry.entity_type.value,
+                entry.destination_id,
+            )
+            residue.append(entry)
+            continue
+        try:
+            await deleter(entry.destination_id)
+        except Exception as exc:  # noqa: BLE001 - classify by status, re-bucket below
+            if _is_already_gone(exc):
+                logger.info(
+                    "[DBAS-ROLLBACK] Compensating delete of %s id=%s returned 404 "
+                    "(already gone) — counted as success.",
+                    entry.entity_type.value,
+                    entry.destination_id,
+                )
+                entry.compensated = True
+                compensated.append(entry)
+                persist_ledger(ledger, ledger_dir=ledger_dir)
+                continue
+            logger.error(
+                "[DBAS-ROLLBACK] Compensating delete of %s id=%s FAILED (status=%s); "
+                "rollback INCOMPLETE — manual cleanup required.",
+                entry.entity_type.value,
+                entry.destination_id,
+                _status_code_of(exc),
+            )
+            residue.append(entry)
+            continue
+
+        entry.compensated = True
+        compensated.append(entry)
+        persist_ledger(ledger, ledger_dir=ledger_dir)
+        logger.info(
+            "[DBAS-ROLLBACK] Compensated %s id=%s.",
+            entry.entity_type.value,
+            entry.destination_id,
+        )
+
+    complete = not residue
+    logger.warning(
+        "[DBAS-ROLLBACK] Rollback %s: %d compensated, %d residue.",
+        "COMPLETE" if complete else "INCOMPLETE",
+        len(compensated),
+        len(residue),
+    )
+    return RollbackResult(complete=complete, compensated=compensated, residue=residue)
+
+
+# ---------------------------------------------------------------------------
+# Tri-state outcome
+# ---------------------------------------------------------------------------
+
+
+def _report_has_failures(report: RestoreReport) -> bool:
+    """True when any category in the report recorded at least one failure."""
+    return any(cat.failed > 0 for cat in report.categories)
+
+
+def compute_outcome(
+    *,
+    report: RestoreReport,
+    failure_occurred: bool,
+    rollback: RollbackResult | None,
+) -> RestoreOutcome:
+    """Derive the tri-state outcome — NEVER ``SUCCESS`` on mixed state.
+
+    The single guard that the whole bead exists to enforce:
+
+    * ``SUCCESS`` — only when NO failure occurred AND no category reported a
+      failure AND no rollback was needed. Any whiff of failure forbids SUCCESS.
+    * ``PARTIAL_FAILED_ROLLED_BACK`` — a failure occurred, a rollback ran, and it
+      was COMPLETE (every created entity deleted or confirmed 404-gone).
+    * ``FAILED_ROLLBACK_INCOMPLETE`` — a failure occurred and the rollback could
+      not fully undo (non-404 delete error, or a type with no compensator). The
+      worst state; reported loudly.
+
+    Args:
+        report: The shared restore report (its per-category failure counts are an
+            independent signal that something failed).
+        failure_occurred: Whether the apply phase raised / decided to roll back.
+        rollback: The rollback result, or ``None`` if no rollback ran.
+
+    Returns:
+        The :class:`RestoreOutcome`.
+    """
+    mixed = failure_occurred or _report_has_failures(report)
+    if not mixed:
+        return RestoreOutcome.SUCCESS
+
+    # A failure happened — SUCCESS is now impossible. Distinguish the two
+    # rolled-back states by whether the rollback fully undid the created entities.
+    if rollback is not None and rollback.complete:
+        return RestoreOutcome.PARTIAL_FAILED_ROLLED_BACK
+    return RestoreOutcome.FAILED_ROLLBACK_INCOMPLETE
+
+
+# ---------------------------------------------------------------------------
+# Orchestration entry point
+# ---------------------------------------------------------------------------
+
+
+async def run_restore(
+    *,
+    plan: ImportPlan,
+    client: DispatcharrClient,
+    steps: list[ImporterStep],
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    remap: object,
+    deferred_apply_fn: Callable[..., Awaitable[list[dict]]] | None = None,
+    ledger_dir: Path | None = None,
+    max_entities_per_category: int = None,  # type: ignore[assignment]
+) -> RestoreReport:
+    """Run a full restore: pre-flight → ordered apply → rollback-on-failure.
+
+    The single orchestration chokepoint. Behaviour:
+
+    1. **Pre-flight** (``run_preflight``). On a FAIL the restore is refused with
+       ZERO mutation — no importer step is called — and the report is returned
+       with ``outcome=FAILED_ROLLBACK_INCOMPLETE`` only if mutation had occurred;
+       a pure pre-flight refusal records the problems as notes and leaves
+       ``outcome`` ``None`` (nothing happened to have an outcome). The caller
+       inspects ``report.notes`` / the returned report for the refusal.
+    2. **Ordered apply**: run ``steps`` in registration order (the hard Phase-2
+       sequence). After each step the ledger is persisted durably. A step that
+       raises, or whose category reports a failure, triggers rollback of
+       EVERYTHING created so far and stops the apply.
+    3. **Deferred phase** (only when no failure): apply the collected deferred
+       settings LAST via ``deferred_apply_fn``.
+    4. **Outcome**: computed via ``compute_outcome`` — never SUCCESS on mixed
+       state. On clean success the durable ledger file is removed.
+
+    Args:
+        plan: The restore plan (categories + manifest + any pre-known remap).
+        client: The Dispatcharr API client.
+        steps: The ordered importer registry. A step with ``importer=None`` is a
+            logged no-op SEAM.
+        report: The shared restore report (populated by the importers).
+        ledger: The shared rollback ledger (populated by the importers).
+        remap: The shared IdRemapTable (threaded through importers).
+        deferred_apply_fn: The deferred-apply coroutine (defaults to the M3U
+            ``apply_deferred_auto_sync``); applied LAST on a clean run.
+        ledger_dir: Override the durable ledger directory (tests).
+        max_entities_per_category: Pre-flight count bound override (tests).
+
+    Returns:
+        The :class:`RestoreReport` with its tri-state ``outcome`` set.
+    """
+    report.started_at = report.started_at or datetime.now(timezone.utc)
+
+    # --- 1. Pre-flight — refuse with ZERO mutation on failure. ---
+    preflight_kwargs = {}
+    if max_entities_per_category is not None:
+        preflight_kwargs["max_entities_per_category"] = max_entities_per_category
+    preflight: PreflightResult = run_preflight(plan, **preflight_kwargs)
+    if not preflight.passed:
+        for problem in preflight.problems:
+            report.notes.append(f"pre-flight refused: {problem.message}")
+        report.outcome = None  # nothing was applied — a plan has no realized outcome
+        report.completed_at = datetime.now(timezone.utc)
+        logger.warning(
+            "[DBAS-RESTORE] Restore REFUSED by pre-flight (%d problem(s)); no mutation performed.",
+            len(preflight.problems),
+        )
+        return report
+
+    if plan_is_dry_run := report.is_dry_run:
+        logger.info("[DBAS-RESTORE] Dry-run: pre-flight passed; no apply performed.")
+
+    ctx = ApplyContext(
+        plan=plan,
+        client=client,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+        is_dry_run=report.is_dry_run,
+    )
+
+    # --- 2. Ordered apply (the hard Phase-2 sequence). ---
+    failure_occurred = False
+    failed_step: EntityType | None = None
+    for step in steps:
+        if step.importer is None:
+            logger.info(
+                "[DBAS-RESTORE] No importer registered for %s — registration seam, skipped.",
+                step.entity_type.value,
+            )
+            continue
+        try:
+            deferred = await step.importer(ctx)
+        except Exception as exc:  # noqa: BLE001 - any importer failure triggers rollback
+            failure_occurred = True
+            failed_step = step.entity_type
+            logger.error(
+                "[DBAS-RESTORE] Importer step %s raised; triggering rollback. (%s)",
+                step.entity_type.value,
+                type(exc).__name__,
+            )
+            persist_ledger(ledger, ledger_dir=ledger_dir)
+            break
+
+        if deferred:
+            ctx.deferred.extend(deferred)
+        persist_ledger(ledger, ledger_dir=ledger_dir)
+
+        # A step that reports a category failure (without raising) also rolls back
+        # — mixed state must never be reported as success.
+        cat = report.category(step.entity_type)
+        if cat.failed > 0:
+            failure_occurred = True
+            failed_step = step.entity_type
+            logger.error(
+                "[DBAS-RESTORE] Importer step %s reported %d failure(s); triggering rollback.",
+                step.entity_type.value,
+                cat.failed,
+            )
+            break
+
+    # --- 3a. Rollback on failure. ---
+    rollback: RollbackResult | None = None
+    if failure_occurred and not report.is_dry_run:
+        report.notes.append(
+            f"restore failed at category {failed_step.value if failed_step else 'unknown'}; "
+            "compensating rollback ran."
+        )
+        rollback = await run_rollback(ledger=ledger, client=client, ledger_dir=ledger_dir)
+        if rollback.complete:
+            report.notes.append(f"rollback completed: {len(rollback.compensated)} entity/entities removed.")
+        else:
+            report.notes.append(
+                f"rollback INCOMPLETE: {len(rollback.residue)} entity/entities could not be removed — "
+                "manual cleanup required."
+            )
+
+    # --- 3b. Deferred phase (clean run only) — applied LAST. ---
+    if not failure_occurred and not report.is_dry_run and ctx.deferred:
+        apply_fn = deferred_apply_fn or _default_deferred_apply_fn()
+        try:
+            await apply_fn(deferred=ctx.deferred, client=client)
+            report.notes.append(f"deferred auto-sync applied for {len(ctx.deferred)} account(s).")
+        except Exception:  # noqa: BLE001 - deferred apply is best-effort, post-create
+            logger.warning(
+                "[DBAS-RESTORE] Deferred auto-sync phase hit an error; created entities are intact."
+            )
+            report.notes.append("deferred auto-sync phase reported an error; entities intact.")
+
+    # --- 4. Outcome. ---
+    report.outcome = compute_outcome(
+        report=report,
+        failure_occurred=failure_occurred,
+        rollback=rollback,
+    )
+    report.completed_at = datetime.now(timezone.utc)
+
+    if report.outcome == RestoreOutcome.SUCCESS and not report.is_dry_run:
+        # Clean success — no compensation will ever be needed; drop the ledger.
+        delete_ledger(ledger.restore_id, ledger_dir=ledger_dir)
+
+    logger.info("[DBAS-RESTORE] Restore complete; outcome=%s.", report.outcome.value if report.outcome else "none")
+    return report
+
+
+def _default_deferred_apply_fn() -> Callable[..., Awaitable[list[dict]]]:
+    """Return the default deferred-apply coroutine (M3U auto-sync).
+
+    Imported lazily so the orchestrator module does not pull the importer package
+    at import time (one-way dependency direction).
+    """
+    from dbas.importers.m3u_accounts import apply_deferred_auto_sync
+
+    return apply_deferred_auto_sync
+
+
+def new_restore_id() -> str:
+    """A fresh unique restore id (names the durable ledger file)."""
+    return uuid.uuid4().hex
+
+
+# ---------------------------------------------------------------------------
+# Default importer registry — WIRED vs SEAM
+# ---------------------------------------------------------------------------
+
+
+def default_importer_steps() -> list[ImporterStep]:
+    """The hard Phase-2 ordering with today's importers WIRED and the rest as seams.
+
+    WIRED (importers that exist as of bead .18):
+      * M3U accounts (``…-0i2vt.10``) — defers auto-sync.
+      * channels (``…-4vouz``).
+      * users (``…-l1p4p``) — runs in the settings/users slot.
+
+    SEAM (separate beads, registered as ``importer=None`` no-ops until they land):
+      * EPG sources (``…-0i2vt.11``) — will defer EPG download.
+      * channel groups / profiles / stream profiles (``…-0i2vt.12``).
+      * user agents (``…-0i2vt.13``).
+      * logos (``…-0i2vt.15``).
+
+    The ORDER is the contract even where a slot is a seam — when an importer
+    lands it slots into its place without reshuffling the sequence.
+    """
+    from dbas.importers.channels import import_channels
+    from dbas.importers.m3u_accounts import import_m3u_accounts
+    from dbas.importers.users import import_users
+
+    def _category_entities(ctx: ApplyContext, entity_type: EntityType) -> list[dict]:
+        cat = ctx.plan.category(entity_type)
+        return list(cat.entities) if cat else []
+
+    def _selected(ctx: ApplyContext, entity_type: EntityType) -> bool:
+        cat = ctx.plan.category(entity_type)
+        return bool(cat.selected) if cat else False
+
+    async def _m3u(ctx: ApplyContext) -> list[dict] | None:
+        result = await import_m3u_accounts(
+            archive_accounts=_category_entities(ctx, EntityType.M3U_ACCOUNT),
+            client=ctx.client,
+            selected=_selected(ctx, EntityType.M3U_ACCOUNT),
+            report=ctx.report,
+            ledger=ctx.ledger,
+            remap=ctx.remap,
+            is_dry_run=ctx.is_dry_run,
+        )
+        return result.deferred_auto_sync_settings or None
+
+    async def _channels(ctx: ApplyContext) -> list[dict] | None:
+        await import_channels(
+            archive_channels=_category_entities(ctx, EntityType.CHANNEL),
+            client=ctx.client,
+            selected=_selected(ctx, EntityType.CHANNEL),
+            report=ctx.report,
+            ledger=ctx.ledger,
+            remap=ctx.remap,
+            is_dry_run=ctx.is_dry_run,
+        )
+        return None
+
+    async def _users(ctx: ApplyContext) -> list[dict] | None:
+        await import_users(
+            archive_users=_category_entities(ctx, EntityType.USER),
+            client=ctx.client,
+            selected=_selected(ctx, EntityType.USER),
+            report=ctx.report,
+            ledger=ctx.ledger,
+            is_dry_run=ctx.is_dry_run,
+        )
+        return None
+
+    # NOTE on the EPG-sources seam (…-0i2vt.11): EPG sources are not an FK-bearing
+    # remapped type, so the rollback ledger has no EntityType for them and the
+    # contracts module (read-only here) defines none. The EPG step therefore lives
+    # in the ordering as a documented position between M3U and channel groups, but
+    # is not a discrete ImporterStep row — when its importer lands it registers
+    # here (and, if it ever needs compensation, the contracts module gains the
+    # EntityType in its own bead, not this one).
+    return [
+        ImporterStep(EntityType.M3U_ACCOUNT, _m3u, defers=True),
+        # <- EPG sources (…-0i2vt.11) order position; SEAM, see note above.
+        ImporterStep(EntityType.CHANNEL_GROUP, None),                  # SEAM …-0i2vt.12
+        ImporterStep(EntityType.CHANNEL_PROFILE, None),               # SEAM …-0i2vt.12
+        ImporterStep(EntityType.STREAM_PROFILE, None),                # SEAM …-0i2vt.12
+        ImporterStep(EntityType.USER_AGENT, None),                    # SEAM …-0i2vt.13
+        ImporterStep(EntityType.USER, _users),                        # WIRED …-l1p4p
+        ImporterStep(EntityType.CHANNEL, _channels),                  # WIRED …-4vouz
+        # logos SEAM …-0i2vt.15 — no EntityType row of its own; attaches to channels
+    ]

--- a/backend/tests/dbas/test_preflight.py
+++ b/backend/tests/dbas/test_preflight.py
@@ -1,0 +1,213 @@
+"""Tests for the Phase-2 DBAS restore PRE-FLIGHT validator
+(enhancedchannelmanager-0i2vt.18, part 1 of 2).
+
+Scope under test:
+
+1. A plan with an UNRESOLVABLE FK (a channel pointing at a channel_group that is
+   neither in the archive nor on the destination) → pre-flight FAILS.
+2. A plan with a DUPLICATE required-unique name → pre-flight FAILS.
+3. A plan with a category count OUT OF BOUNDS → pre-flight FAILS.
+4. An UNSUPPORTED schema_version → pre-flight FAILS (the .17 gate at the
+   orchestration entry).
+5. A clean plan → pre-flight PASSES.
+6. FK satisfaction by in-archive entity AND by the existing destination remap.
+7. Pre-flight is PURE — it accumulates ALL problems in one pass.
+
+Pre-flight is synchronous and client-free, so no mocks are needed.
+"""
+
+from dbas.preflight import (
+    ImportPlan,
+    PlanCategory,
+    PreflightProblemKind,
+    run_preflight,
+)
+from dbas.restore_contracts import EntityType, IdRemapTable
+
+# A manifest whose schema_version this build supports (BACKUP_SCHEMA_VERSION == 1).
+_GOOD_MANIFEST = {"schema_version": 1}
+
+
+def _plan(*categories, manifest=None, existing_remap=None):
+    return ImportPlan(
+        manifest=manifest if manifest is not None else dict(_GOOD_MANIFEST),
+        categories=list(categories),
+        existing_remap=existing_remap or IdRemapTable(),
+    )
+
+
+def _cat(entity_type, entities, selected=True):
+    return PlanCategory(entity_type=entity_type, entities=entities, selected=selected)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_clean_plan_passes():
+    plan = _plan(
+        _cat(EntityType.CHANNEL_GROUP, [{"id": 10, "name": "Sports"}]),
+        _cat(EntityType.CHANNEL, [{"id": 1, "name": "ESPN", "channel_group_id": 10}]),
+    )
+    result = run_preflight(plan)
+    assert result.passed is True
+    assert result.problems == []
+
+
+# ---------------------------------------------------------------------------
+# 1. Unresolvable FK
+# ---------------------------------------------------------------------------
+
+
+def test_unresolvable_fk_fails():
+    # Channel references group 99, which is neither in the archive nor on dest.
+    plan = _plan(
+        _cat(EntityType.CHANNEL_GROUP, [{"id": 10, "name": "Sports"}]),
+        _cat(EntityType.CHANNEL, [{"id": 1, "name": "ESPN", "channel_group_id": 99}]),
+    )
+    result = run_preflight(plan)
+    assert result.passed is False
+    kinds = {p.kind for p in result.problems}
+    assert PreflightProblemKind.UNRESOLVED_FK_REFERENCE in kinds
+
+
+def test_fk_satisfied_by_archived_entity():
+    plan = _plan(
+        _cat(EntityType.CHANNEL_GROUP, [{"id": 10, "name": "Sports"}]),
+        _cat(EntityType.CHANNEL, [{"id": 1, "name": "ESPN", "channel_group_id": 10}]),
+    )
+    assert run_preflight(plan).passed is True
+
+
+def test_fk_satisfied_by_existing_destination_remap():
+    # Group 10 is NOT in the archive, but the destination already has it (remap).
+    remap = IdRemapTable()
+    remap.add(EntityType.CHANNEL_GROUP, 10, 110)
+    plan = _plan(
+        _cat(EntityType.CHANNEL, [{"id": 1, "name": "ESPN", "channel_group_id": 10}]),
+        existing_remap=remap,
+    )
+    assert run_preflight(plan).passed is True
+
+
+def test_fk_to_unselected_category_fails():
+    # The group category exists but the operator did NOT select it, so it will not
+    # be created — the channel's FK is therefore unresolved.
+    plan = _plan(
+        _cat(EntityType.CHANNEL_GROUP, [{"id": 10, "name": "Sports"}], selected=False),
+        _cat(EntityType.CHANNEL, [{"id": 1, "name": "ESPN", "channel_group_id": 10}]),
+    )
+    result = run_preflight(plan)
+    assert result.passed is False
+    assert any(p.kind == PreflightProblemKind.UNRESOLVED_FK_REFERENCE for p in result.problems)
+
+
+# ---------------------------------------------------------------------------
+# 2. Duplicate required-unique name
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_unique_name_fails():
+    plan = _plan(
+        _cat(
+            EntityType.M3U_ACCOUNT,
+            [{"id": 1, "name": "Provider"}, {"id": 2, "name": "provider"}],  # case-insensitive dup
+        ),
+    )
+    result = run_preflight(plan)
+    assert result.passed is False
+    assert any(p.kind == PreflightProblemKind.DUPLICATE_UNIQUE_NAME for p in result.problems)
+
+
+def test_unique_names_distinct_passes():
+    plan = _plan(
+        _cat(
+            EntityType.CHANNEL_GROUP,
+            [{"id": 1, "name": "Sports"}, {"id": 2, "name": "News"}],
+        ),
+    )
+    assert run_preflight(plan).passed is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Count out of bounds
+# ---------------------------------------------------------------------------
+
+
+def test_count_out_of_bounds_fails():
+    entities = [{"id": i, "name": f"g{i}"} for i in range(10)]
+    plan = _plan(_cat(EntityType.CHANNEL_GROUP, entities))
+    result = run_preflight(plan, max_entities_per_category=5)
+    assert result.passed is False
+    assert any(p.kind == PreflightProblemKind.COUNT_OUT_OF_BOUNDS for p in result.problems)
+
+
+def test_count_within_bounds_passes():
+    entities = [{"id": i, "name": f"g{i}"} for i in range(3)]
+    plan = _plan(_cat(EntityType.CHANNEL_GROUP, entities))
+    assert run_preflight(plan, max_entities_per_category=5).passed is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Unsupported schema version (.17 gate)
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_schema_version_fails():
+    plan = _plan(
+        _cat(EntityType.CHANNEL_GROUP, [{"id": 10, "name": "Sports"}]),
+        manifest={"schema_version": 9999},
+    )
+    result = run_preflight(plan)
+    assert result.passed is False
+    assert any(p.kind == PreflightProblemKind.UNSUPPORTED_SCHEMA_VERSION for p in result.problems)
+
+
+def test_missing_schema_version_fails():
+    plan = _plan(
+        _cat(EntityType.CHANNEL_GROUP, [{"id": 10, "name": "Sports"}]),
+        manifest={},  # no schema_version
+    )
+    result = run_preflight(plan)
+    assert result.passed is False
+    assert any(p.kind == PreflightProblemKind.UNSUPPORTED_SCHEMA_VERSION for p in result.problems)
+
+
+# ---------------------------------------------------------------------------
+# 7. Accumulates ALL problems in one pass
+# ---------------------------------------------------------------------------
+
+
+def test_accumulates_all_problems():
+    plan = _plan(
+        _cat(
+            EntityType.M3U_ACCOUNT,
+            [{"id": 1, "name": "Dup"}, {"id": 2, "name": "Dup"}],  # duplicate name
+        ),
+        _cat(EntityType.CHANNEL, [{"id": 1, "name": "ESPN", "channel_group_id": 77}]),  # bad FK
+        manifest={"schema_version": 9999},  # bad version
+    )
+    result = run_preflight(plan)
+    assert result.passed is False
+    kinds = {p.kind for p in result.problems}
+    assert PreflightProblemKind.DUPLICATE_UNIQUE_NAME in kinds
+    assert PreflightProblemKind.UNRESOLVED_FK_REFERENCE in kinds
+    assert PreflightProblemKind.UNSUPPORTED_SCHEMA_VERSION in kinds
+
+
+def test_problem_messages_carry_no_secrets():
+    # Even if an archive entity carried credential-looking fields, the problem
+    # message is built from the safe label (name) only.
+    plan = _plan(
+        _cat(
+            EntityType.M3U_ACCOUNT,
+            [
+                {"id": 1, "name": "Prov", "password": "hunter2"},
+                {"id": 2, "name": "Prov", "password": "hunter2"},
+            ],
+        ),
+    )
+    result = run_preflight(plan)
+    for problem in result.problems:
+        assert "hunter2" not in problem.message

--- a/backend/tests/dbas/test_restore_orchestrator.py
+++ b/backend/tests/dbas/test_restore_orchestrator.py
@@ -1,0 +1,512 @@
+"""Tests for the Phase-2 DBAS restore ORCHESTRATOR
+(enhancedchannelmanager-0i2vt.18, part 2 of 2).
+
+Scope under test:
+
+1. Pre-flight FAIL → restore refused, ZERO mutation (no importer step called).
+2. Pre-flight PASS → apply proceeds (importer steps run, in order).
+3. Rollback: an importer fails mid-run → every prior creation gets a compensating
+   DELETE, in compensation_order (reverse creation); outcome =
+   PARTIAL_FAILED_ROLLED_BACK.
+4. Rollback 404-as-success: a compensating DELETE that 404s counts as success.
+5. Rollback INCOMPLETE: a non-404 delete error → outcome =
+   FAILED_ROLLBACK_INCOMPLETE, residue surfaced, NOT reported success.
+6. Happy path: all steps succeed → SUCCESS; deferred phase runs LAST.
+7. Never-success-on-mixed-state invariant asserted directly (compute_outcome).
+8. A step that REPORTS a failure (without raising) also rolls back.
+9. Durable ledger: persisted during apply; removed on clean success.
+
+The Dispatcharr client and the importer steps are mocked at module level; the
+durable ledger writes to a tmp dir, never CONFIG_DIR.
+"""
+
+import httpx
+import pytest
+from unittest.mock import AsyncMock
+
+from dbas.preflight import ImportPlan, PlanCategory
+from dbas.restore_contracts import (
+    EntityType,
+    FailureDetail,
+    FailureReason,
+    IdRemapTable,
+    RestoreOutcome,
+    RestoreReport,
+    RollbackLedger,
+)
+from dbas.restore_orchestrator import (
+    ApplyContext,
+    ImporterStep,
+    RollbackResult,
+    compute_outcome,
+    run_restore,
+    run_rollback,
+)
+
+_GOOD_MANIFEST = {"schema_version": 1}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _plan(*categories, manifest=None):
+    return ImportPlan(
+        manifest=manifest if manifest is not None else dict(_GOOD_MANIFEST),
+        categories=list(categories),
+    )
+
+
+def _cat(entity_type, entities, selected=True):
+    return PlanCategory(entity_type=entity_type, entities=entities, selected=selected)
+
+
+def _client(*, delete_side_effects=None):
+    """An AsyncMock client with all the delete methods the rollback dispatches to.
+
+    ``delete_side_effects`` maps a delete-method name -> side_effect (e.g. an
+    exception) to simulate a 404 or a hard error during compensation.
+    """
+    client = AsyncMock()
+    for name in (
+        "delete_m3u_account",
+        "delete_channel_group",
+        "delete_channel_profile",
+        "delete_channel",
+        "delete_stream",
+        "delete_user",
+    ):
+        setattr(client, name, AsyncMock(return_value=None))
+    for name, eff in (delete_side_effects or {}).items():
+        getattr(client, name).side_effect = eff
+    return client
+
+
+def _http_error(status_code):
+    """Build an httpx.HTTPStatusError carrying a given status (mirrors raise_for_status)."""
+    request = httpx.Request("DELETE", "http://dispatcharr/api/x/1/")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError("error", request=request, response=response)
+
+
+def _report():
+    return RestoreReport(is_dry_run=False)
+
+
+def _ledger(restore_id="test-restore"):
+    return RollbackLedger(restore_id=restore_id)
+
+
+def _ctx(plan, client, report, ledger, remap=None):
+    return ApplyContext(
+        plan=plan,
+        client=client,
+        report=report,
+        ledger=ledger,
+        remap=remap or IdRemapTable(),
+    )
+
+
+def _creating_step(entity_type, dest_id, *, defers=None):
+    """An importer step that records ONE creation into report + ledger and succeeds."""
+
+    async def _importer(ctx: ApplyContext):
+        cat = ctx.report.category(entity_type)
+        cat.created += 1
+        ctx.ledger.record_created(entity_type, dest_id, f"{entity_type.value}-{dest_id}")
+        return defers
+
+    return ImporterStep(entity_type, _importer)
+
+
+def _raising_step(entity_type):
+    """An importer step that raises mid-run (fault injection)."""
+
+    async def _importer(ctx: ApplyContext):
+        raise RuntimeError("simulated upstream 500 at category midpoint")
+
+    return ImporterStep(entity_type, _importer)
+
+
+def _reporting_failure_step(entity_type, dest_id):
+    """A step that creates one entity, then REPORTS a failure without raising."""
+
+    async def _importer(ctx: ApplyContext):
+        cat = ctx.report.category(entity_type)
+        cat.created += 1
+        ctx.ledger.record_created(entity_type, dest_id, f"{entity_type.value}-{dest_id}")
+        cat.failed += 1
+        cat.failure_details.append(
+            FailureDetail(
+                reason=FailureReason.UPSTREAM_API_ERROR,
+                label="boom",
+                message="upstream rejected",
+            )
+        )
+        return None
+
+    return ImporterStep(entity_type, _importer)
+
+
+# ---------------------------------------------------------------------------
+# 1. Pre-flight FAIL → refused, ZERO mutation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preflight_failure_refuses_with_zero_mutation(tmp_path):
+    # Bad FK → pre-flight fails. The (would-be) importer must NEVER be called.
+    called = {"n": 0}
+
+    async def _importer(ctx):
+        called["n"] += 1
+        return None
+
+    plan = _plan(
+        _cat(EntityType.CHANNEL, [{"id": 1, "name": "ESPN", "channel_group_id": 999}]),
+    )
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    out = await run_restore(
+        plan=plan,
+        client=client,
+        steps=[ImporterStep(EntityType.CHANNEL, _importer)],
+        report=report,
+        ledger=ledger,
+        remap=IdRemapTable(),
+        ledger_dir=tmp_path,
+    )
+    assert called["n"] == 0  # zero mutation
+    assert out.outcome is None  # nothing applied → no realized outcome
+    assert ledger.entries == []
+    assert any("pre-flight refused" in note for note in out.notes)
+
+
+# ---------------------------------------------------------------------------
+# 2. Pre-flight PASS → apply proceeds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preflight_pass_apply_proceeds(tmp_path):
+    plan = _plan(_cat(EntityType.M3U_ACCOUNT, [{"id": 1, "name": "Prov"}]))
+    report = _report()
+    ledger = _ledger()
+    out = await run_restore(
+        plan=plan,
+        client=_client(),
+        steps=[_creating_step(EntityType.M3U_ACCOUNT, 901)],
+        report=report,
+        ledger=ledger,
+        remap=IdRemapTable(),
+        ledger_dir=tmp_path,
+    )
+    assert out.outcome == RestoreOutcome.SUCCESS
+    assert report.category(EntityType.M3U_ACCOUNT).created == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Rollback in compensation_order → PARTIAL_FAILED_ROLLED_BACK
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failure_midrun_rolls_back_in_compensation_order(tmp_path):
+    # Two successful creating steps, then a raising step. Both prior creations
+    # must be compensating-deleted, in reverse creation order.
+    client = _client()
+    plan = _plan(
+        _cat(EntityType.M3U_ACCOUNT, [{"id": 1, "name": "Prov"}]),
+        _cat(EntityType.CHANNEL, [{"id": 1, "name": "ESPN"}]),
+    )
+    report = _report()
+    ledger = _ledger()
+    steps = [
+        _creating_step(EntityType.M3U_ACCOUNT, 901),  # sequence 0
+        _creating_step(EntityType.CHANNEL, 501),      # sequence 1
+        _raising_step(EntityType.USER),               # boom
+    ]
+    out = await run_restore(
+        plan=plan,
+        client=client,
+        steps=steps,
+        report=report,
+        ledger=ledger,
+        remap=IdRemapTable(),
+        ledger_dir=tmp_path,
+    )
+    assert out.outcome == RestoreOutcome.PARTIAL_FAILED_ROLLED_BACK
+    # Both deletes issued.
+    client.delete_channel.assert_awaited_once_with(501)
+    client.delete_m3u_account.assert_awaited_once_with(901)
+    # Reverse creation order: channel (seq 1) compensated before m3u (seq 0).
+    # Assert via the await ordering on the shared mock parent.
+    call_order = [c for c in client.mock_calls if c[0] in ("delete_channel", "delete_m3u_account")]
+    assert [c[0] for c in call_order] == ["delete_channel", "delete_m3u_account"]
+    # Every ledger entry marked compensated.
+    assert all(e.compensated for e in ledger.entries)
+
+
+# ---------------------------------------------------------------------------
+# 4. 404-as-success during rollback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rollback_404_counts_as_success(tmp_path):
+    # The channel delete 404s (already gone) — still a COMPLETE rollback.
+    client = _client(delete_side_effects={"delete_channel": _http_error(404)})
+    ledger = _ledger()
+    ledger.record_created(EntityType.M3U_ACCOUNT, 901, "prov")
+    ledger.record_created(EntityType.CHANNEL, 501, "espn")
+    result = await run_rollback(ledger=ledger, client=client, ledger_dir=tmp_path)
+    assert result.complete is True
+    assert result.residue == []
+    assert all(e.compensated for e in ledger.entries)
+
+
+# ---------------------------------------------------------------------------
+# 5. Non-404 delete error → INCOMPLETE, residue surfaced, NOT success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rollback_non_404_is_incomplete(tmp_path):
+    client = _client(delete_side_effects={"delete_channel": _http_error(500)})
+    ledger = _ledger()
+    ledger.record_created(EntityType.M3U_ACCOUNT, 901, "prov")
+    ledger.record_created(EntityType.CHANNEL, 501, "espn")
+    result = await run_rollback(ledger=ledger, client=client, ledger_dir=tmp_path)
+    assert result.complete is False
+    assert len(result.residue) == 1
+    assert result.residue[0].entity_type == EntityType.CHANNEL
+    # The residue entry is NOT marked compensated.
+    chan_entry = next(e for e in ledger.entries if e.entity_type == EntityType.CHANNEL)
+    assert chan_entry.compensated is False
+
+
+@pytest.mark.asyncio
+async def test_failure_with_non_404_rollback_error_outcome_incomplete(tmp_path):
+    client = _client(delete_side_effects={"delete_m3u_account": _http_error(500)})
+    plan = _plan(_cat(EntityType.M3U_ACCOUNT, [{"id": 1, "name": "Prov"}]))
+    report = _report()
+    ledger = _ledger()
+    steps = [
+        _creating_step(EntityType.M3U_ACCOUNT, 901),
+        _raising_step(EntityType.CHANNEL),
+    ]
+    out = await run_restore(
+        plan=plan,
+        client=client,
+        steps=steps,
+        report=report,
+        ledger=ledger,
+        remap=IdRemapTable(),
+        ledger_dir=tmp_path,
+    )
+    assert out.outcome == RestoreOutcome.FAILED_ROLLBACK_INCOMPLETE
+    assert out.outcome != RestoreOutcome.SUCCESS
+    assert any("INCOMPLETE" in note for note in out.notes)
+
+
+# ---------------------------------------------------------------------------
+# 6. Happy path: SUCCESS; deferred phase runs LAST
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_happy_path_success_and_deferred_runs_last(tmp_path):
+    order: list[str] = []
+
+    async def _deferred_apply(*, deferred, client):
+        order.append("deferred")
+        return []
+
+    def _ordered_creating_step(entity_type, dest_id, defers=None):
+        async def _importer(ctx):
+            order.append(entity_type.value)
+            cat = ctx.report.category(entity_type)
+            cat.created += 1
+            ctx.ledger.record_created(entity_type, dest_id, f"{entity_type.value}-{dest_id}")
+            return defers
+
+        return ImporterStep(entity_type, _importer)
+
+    plan = _plan(
+        _cat(EntityType.M3U_ACCOUNT, [{"id": 1, "name": "Prov"}]),
+        _cat(EntityType.CHANNEL, [{"id": 1, "name": "ESPN"}]),
+    )
+    report = _report()
+    ledger = _ledger()
+    steps = [
+        _ordered_creating_step(EntityType.M3U_ACCOUNT, 901, defers=[{"m3u_account_id": 901, "settings": {}}]),
+        _ordered_creating_step(EntityType.CHANNEL, 501),
+    ]
+    out = await run_restore(
+        plan=plan,
+        client=_client(),
+        steps=steps,
+        report=report,
+        ledger=ledger,
+        remap=IdRemapTable(),
+        deferred_apply_fn=_deferred_apply,
+        ledger_dir=tmp_path,
+    )
+    assert out.outcome == RestoreOutcome.SUCCESS
+    # Deferred MUST be the last thing to run.
+    assert order[-1] == "deferred"
+    assert order == ["m3u_account", "channel", "deferred"]
+
+
+@pytest.mark.asyncio
+async def test_clean_success_removes_ledger_file(tmp_path):
+    from dbas.restore_orchestrator import _ledger_path
+
+    plan = _plan(_cat(EntityType.M3U_ACCOUNT, [{"id": 1, "name": "Prov"}]))
+    ledger = _ledger("rid-clean")
+    await run_restore(
+        plan=plan,
+        client=_client(),
+        steps=[_creating_step(EntityType.M3U_ACCOUNT, 901)],
+        report=_report(),
+        ledger=ledger,
+        remap=IdRemapTable(),
+        ledger_dir=tmp_path,
+    )
+    assert not _ledger_path("rid-clean", tmp_path).exists()
+
+
+@pytest.mark.asyncio
+async def test_ledger_persisted_during_rollback(tmp_path):
+    from dbas.restore_orchestrator import _ledger_path
+
+    client = _client(delete_side_effects={"delete_channel": _http_error(500)})
+    plan = _plan(_cat(EntityType.M3U_ACCOUNT, [{"id": 1, "name": "Prov"}]))
+    ledger = _ledger("rid-residue")
+    steps = [
+        _creating_step(EntityType.M3U_ACCOUNT, 901),
+        _creating_step(EntityType.CHANNEL, 501),
+        _raising_step(EntityType.USER),
+    ]
+    await run_restore(
+        plan=plan,
+        client=client,
+        steps=steps,
+        report=_report(),
+        ledger=ledger,
+        remap=IdRemapTable(),
+        ledger_dir=tmp_path,
+    )
+    # Rollback INCOMPLETE (channel 500) → ledger file retained with the residue.
+    assert _ledger_path("rid-residue", tmp_path).exists()
+
+
+# ---------------------------------------------------------------------------
+# 7. Never-success-on-mixed-state (compute_outcome, asserted directly)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_outcome_never_success_on_mixed_state():
+    # A report carrying a failure can NEVER yield SUCCESS, even if the caller
+    # somehow passes failure_occurred=False.
+    report = RestoreReport(is_dry_run=False)
+    cat = report.category(EntityType.CHANNEL)
+    cat.created = 3
+    cat.failed = 1  # mixed state
+    outcome = compute_outcome(report=report, failure_occurred=False, rollback=None)
+    assert outcome != RestoreOutcome.SUCCESS
+    assert outcome == RestoreOutcome.FAILED_ROLLBACK_INCOMPLETE
+
+
+def test_compute_outcome_clean_is_success():
+    report = RestoreReport(is_dry_run=False)
+    report.category(EntityType.CHANNEL).created = 3
+    outcome = compute_outcome(report=report, failure_occurred=False, rollback=None)
+    assert outcome == RestoreOutcome.SUCCESS
+
+
+def test_compute_outcome_complete_rollback_is_partial():
+    report = RestoreReport(is_dry_run=False)
+    report.category(EntityType.CHANNEL).failed = 1
+    rb = RollbackResult(complete=True, compensated=[], residue=[])
+    outcome = compute_outcome(report=report, failure_occurred=True, rollback=rb)
+    assert outcome == RestoreOutcome.PARTIAL_FAILED_ROLLED_BACK
+
+
+def test_compute_outcome_incomplete_rollback_is_incomplete():
+    report = RestoreReport(is_dry_run=False)
+    report.category(EntityType.CHANNEL).failed = 1
+    rb = RollbackResult(complete=False, compensated=[], residue=[object()])  # type: ignore[list-item]
+    outcome = compute_outcome(report=report, failure_occurred=True, rollback=rb)
+    assert outcome == RestoreOutcome.FAILED_ROLLBACK_INCOMPLETE
+
+
+# ---------------------------------------------------------------------------
+# 8. A reported failure (no raise) also triggers rollback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reported_failure_triggers_rollback(tmp_path):
+    client = _client()
+    plan = _plan(_cat(EntityType.M3U_ACCOUNT, [{"id": 1, "name": "Prov"}]))
+    report = _report()
+    ledger = _ledger()
+    steps = [_reporting_failure_step(EntityType.M3U_ACCOUNT, 901)]
+    out = await run_restore(
+        plan=plan,
+        client=client,
+        steps=steps,
+        report=report,
+        ledger=ledger,
+        remap=IdRemapTable(),
+        ledger_dir=tmp_path,
+    )
+    assert out.outcome == RestoreOutcome.PARTIAL_FAILED_ROLLED_BACK
+    client.delete_m3u_account.assert_awaited_once_with(901)
+
+
+# ---------------------------------------------------------------------------
+# 9. Seam steps are no-ops (default registry wiring)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_seam_step_is_noop(tmp_path):
+    # A step with importer=None must be skipped without error and without mutation.
+    plan = _plan(_cat(EntityType.CHANNEL_GROUP, [{"id": 10, "name": "Sports"}]))
+    report = _report()
+    ledger = _ledger()
+    out = await run_restore(
+        plan=plan,
+        client=_client(),
+        steps=[ImporterStep(EntityType.CHANNEL_GROUP, None)],
+        report=report,
+        ledger=ledger,
+        remap=IdRemapTable(),
+        ledger_dir=tmp_path,
+    )
+    assert out.outcome == RestoreOutcome.SUCCESS
+    assert ledger.entries == []
+
+
+def test_default_importer_steps_order_and_wiring():
+    from dbas.restore_orchestrator import default_importer_steps
+
+    steps = default_importer_steps()
+    order = [s.entity_type for s in steps]
+    # Hard ordering: M3U first, channels last; channel groups/profiles before
+    # channels; users before channels.
+    assert order[0] == EntityType.M3U_ACCOUNT
+    assert order[-1] == EntityType.CHANNEL
+    assert order.index(EntityType.CHANNEL_GROUP) < order.index(EntityType.CHANNEL)
+    assert order.index(EntityType.USER) < order.index(EntityType.CHANNEL)
+    # M3U is wired and defers; groups/profiles/user-agents are seams.
+    wired = {s.entity_type for s in steps if s.importer is not None}
+    seams = {s.entity_type for s in steps if s.importer is None}
+    assert {EntityType.M3U_ACCOUNT, EntityType.USER, EntityType.CHANNEL} <= wired
+    assert {EntityType.CHANNEL_GROUP, EntityType.CHANNEL_PROFILE, EntityType.STREAM_PROFILE, EntityType.USER_AGENT} <= seams
+    m3u_step = next(s for s in steps if s.entity_type == EntityType.M3U_ACCOUNT)
+    assert m3u_step.defers is True


### PR DESCRIPTION
## Bead
enhancedchannelmanager-0i2vt.18 — Phase 2: Pre-flight validation + compensating-delete rollback (restore safety; Dispatcharr has no DB transactions).

## What
- `backend/dbas/preflight.py` — pure `run_preflight(plan) -> PreflightResult`: schema-version gate (delegates to .17's `validate_restore_schema_version`), unresolvable FK, duplicate-required-unique-name, count bounds. Accumulates ALL problems in one pass.
- `backend/dbas/restore_orchestrator.py` — `run_restore(...)`: pre-flight → ordered apply (hard sequence M3U→EPG→groups/profiles→user-agents/settings→Channels→Logos) → rollback-on-failure → **deferred phase last** (M3U auto-sync via `apply_deferred_auto_sync`) → tri-state outcome. `ImporterStep` registry is the clean seam.
- **Rollback** iterates `RollbackLedger.compensation_order()` (reverse dependency), dispatches `EntityType→client.delete_*`; **404=success (already gone)**, non-404=residue→INCOMPLETE; ledger persisted atomically per compensation.
- **Tri-state** `compute_outcome`: `SUCCESS` / `PARTIAL_FAILED_ROLLED_BACK` / `FAILED_ROLLBACK_INCOMPLETE`. Never SUCCESS on mixed state — guarded even if caller passes `failure_occurred=False` but a category has `failed>0`.

## Wired vs seam
WIRED: M3U accounts (defers auto-sync), channels, users. SEAM (no-op in correct ordering slot, `importer=None`): channel groups/profiles/stream-profiles (.12), user agents (.13), logos (.15). EPG (.11) registers when brought up-to-date. Pre-flight runs the .17 schema gate before any write; operator-preservation/SSRF/users-capability stay in their owning importers.

## Tests
29 tests: pre-flight zero-mutation refusal, pre-flight pass→apply, mid-run failure→compensating deletes in order→PARTIAL_FAILED_ROLLED_BACK, non-404 delete→FAILED_ROLLBACK_INCOMPLETE, 404-during-rollback=success, happy path→SUCCESS + deferred-runs-last, never-success-on-mixed-state. Credential-clean logging. Full suite green (5728 passed).

## Follow-ups
- Stream-profile/user-agent/DVR-rule compensators need their `delete_*` client methods when .12/.13 land (rollback currently treats unregistered compensator as residue, not silent success).
- Live fault-injection (500-at-Channels-midpoint vs seeded instance) is a deferred verification (no live instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)