### PR TITLE
v0.18.0-dbas: 0i2vt.12 bulk importer -- channel groups + channel profiles + stream profiles

### DIFF
--- a/backend/dbas/importers/__init__.py
+++ b/backend/dbas/importers/__init__.py
@@ -22,6 +22,12 @@ attach streams — this importer never matches or attaches a stream.
 
 from dbas.importers.channels import import_channels
 from dbas.importers.epg_sources import import_epg_sources
+from dbas.importers.groups_profiles import (
+    import_channel_groups,
+    import_channel_profiles,
+    import_groups_profiles,
+    import_stream_profiles,
+)
 from dbas.importers.m3u_accounts import (
     apply_deferred_auto_sync,
     import_m3u_accounts,
@@ -31,9 +37,13 @@ from dbas.importers.users import import_users
 
 __all__ = [
     "apply_deferred_auto_sync",
+    "import_channel_groups",
+    "import_channel_profiles",
     "import_channels",
     "import_epg_sources",
+    "import_groups_profiles",
     "import_m3u_accounts",
+    "import_stream_profiles",
     "import_users",
     "resolve_group",
 ]

--- a/backend/dbas/importers/groups_profiles.py
+++ b/backend/dbas/importers/groups_profiles.py
@@ -1,0 +1,518 @@
+"""The bulk groups/profiles restore importer — Phase-2 leaf dependencies.
+
+Bead ``enhancedchannelmanager-0i2vt.12``. This module restores the THREE
+leaf-dependency categories that the Channels importer (bead
+``enhancedchannelmanager-4vouz``) consumes, together as one "bulk importer":
+
+1. **Channel groups**   -> :data:`EntityType.CHANNEL_GROUP`
+2. **Channel profiles** -> :data:`EntityType.CHANNEL_PROFILE`
+3. **Stream profiles**  -> :data:`EntityType.STREAM_PROFILE`
+
+Each category restores its archived rows and POPULATES the shared
+:class:`~dbas.restore_contracts.IdRemapTable` under its own EntityType. The
+Channels importer reads those mappings to rewrite ``channel_group_id`` /
+``stream_profile_id`` FK references and channel-profile memberships before
+sending channels upstream. These three are LEAF dependencies — channels point at
+THEM, so they must be restored BEFORE channels (the hard Phase-2 ordering:
+``M3U → EPG → groups/profiles → Channels``; ADR-012). This importer only restores
+its rows + populates the remap; the dependency ORDERING across categories is the
+orchestrator's job (bead ``…-0i2vt.18``).
+
+It mirrors the established Phase-2 importer pattern (``importers/m3u_accounts.py``
+/ ``importers/channels.py`` / ``importers/users.py``): opt-in per category,
+consumes the shared restore contracts
+(:class:`~dbas.restore_contracts.IdRemapTable`,
+:class:`~dbas.restore_contracts.RollbackLedger`,
+:class:`~dbas.restore_contracts.RestoreReport`, the Skip/Failure taxonomy),
+per-entity results, and dry-run support. It imports the contracts module
+READ-ONLY.
+
+----------------------------------------------------------------------------
+IDENTITY / MATCH KEY (per category)
+----------------------------------------------------------------------------
+
+All three categories match an existing destination row by **name**,
+case-insensitive and whitespace-trimmed (:func:`_norm_name`). This mirrors ECM's
+existing upsert-by-name behaviour for channel groups (``backup.py`` —
+``_restore_channel_groups``) and stream profiles, and is the only stable identity
+these rows carry across instances (their numeric ids differ). On a name match the
+row is skipped ``ALREADY_EXISTS_IDENTICAL`` and its source id is remapped to the
+EXISTING destination id so a later FK reference resolves — NEVER the
+delete-all-then-recreate strategy, which would destroy the very relationships the
+remap exists to preserve (kxuj2 contract; ADR-008 grooming note).
+
+----------------------------------------------------------------------------
+FK REMAP (generic; N/A for the three real categories)
+----------------------------------------------------------------------------
+
+The generic per-category engine supports rewriting outbound FK references through
+the IdRemapTable (unresolvable -> ``DEPENDENCY_UNRESOLVED``, never sent upstream
+with a stale archive id). The three REAL Dispatcharr categories are leaf
+dependencies with NO outbound remappable FK — a group/profile does not reference
+another remapped entity; channels reference them. So
+:attr:`CategoryConfig.remappable_fk_fields` is empty for all three. The mechanism
+is kept and tested (via a synthetic config) so a future FK-bearing category can
+be added by config alone.
+
+----------------------------------------------------------------------------
+CREATE-METHOD SHAPES (verify-then-size: all three client methods pre-existed)
+----------------------------------------------------------------------------
+
+* ``client.create_channel_group(name)`` — takes a NAME STRING (not a dict). The
+  engine passes the row's name; channel groups carry no other create fields.
+* ``client.create_channel_profile(data)`` — takes a payload DICT.
+* ``client.create_stream_profile(data)`` — takes a payload DICT.
+
+The ``payload_style`` on :class:`CategoryConfig` selects which calling
+convention the engine uses; no new client methods were required.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from dbas.restore_contracts import (
+    EntityType,
+    FailureDetail,
+    FailureReason,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+    SkipDetail,
+    SkipReason,
+)
+from dispatcharr_client import DispatcharrClient
+
+logger = logging.getLogger(__name__)
+
+# Archive-source identifiers the destination assigns itself, never forwarded.
+_SOURCE_ID_KEYS = frozenset({"id", "pk"})
+
+# Embedded / read-only / derived keys that are NOT part of a create payload.
+# ``channels`` / membership lists are owned by the Channels importer (4vouz) and
+# reattached there — never sent on a group/profile create. The counts and
+# timestamps are read-only fields a GET echoes back.
+_NON_CREATE_KEYS = frozenset(
+    {
+        "channels",
+        "channel_count",
+        "channels_count",
+        "channelprofilemembership_set",
+        "channel_count_total",
+        "created_at",
+        "updated_at",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CategoryConfig:
+    """Per-category restore configuration for the generic import engine.
+
+    One config per restorable category. ``remappable_fk_fields`` maps an archive
+    payload field name to the :class:`EntityType` whose IdRemapTable namespace
+    rewrites it; it is EMPTY for the three real leaf categories (they carry no
+    outbound FK). ``payload_style`` selects the client create calling convention:
+    ``"name"`` calls ``create(name_string)`` (channel groups), ``"dict"`` calls
+    ``create(payload_dict)`` (channel/stream profiles).
+    """
+
+    entity_type: EntityType
+    getter: str
+    creator: str
+    log_prefix: str
+    payload_style: str = "dict"  # "dict" | "name"
+    remappable_fk_fields: dict = field(default_factory=dict)
+
+
+# Canonical config table for the three real leaf categories. Keyed by the archive
+# section name used in the export (and by the bulk entry's ``selected`` map).
+_CATEGORY_CONFIGS: dict[str, CategoryConfig] = {
+    "channel_groups": CategoryConfig(
+        entity_type=EntityType.CHANNEL_GROUP,
+        getter="get_channel_groups",
+        creator="create_channel_group",
+        log_prefix="DBAS-CHGROUP",
+        payload_style="name",
+    ),
+    "channel_profiles": CategoryConfig(
+        entity_type=EntityType.CHANNEL_PROFILE,
+        getter="get_channel_profiles",
+        creator="create_channel_profile",
+        log_prefix="DBAS-CHPROFILE",
+        payload_style="dict",
+    ),
+    "stream_profiles": CategoryConfig(
+        entity_type=EntityType.STREAM_PROFILE,
+        getter="get_stream_profiles",
+        creator="create_stream_profile",
+        log_prefix="DBAS-STRPROFILE",
+        payload_style="dict",
+    ),
+}
+
+
+def _row_label(archive_row: dict) -> str:
+    """Operator-facing identifier for a row — its name. Never a secret (these
+    categories carry no credentials, but we stay consistent with the pattern)."""
+    name = archive_row.get("name")
+    return str(name) if name else "<unknown>"
+
+
+def _norm_name(value) -> str | None:
+    """Case-insensitive, trimmed key for a name; None when absent/blank."""
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip().lower()
+    return trimmed or None
+
+
+def _existing_by_name(existing_rows: list) -> dict[str, dict]:
+    """Index existing destination rows by their normalized name (lowest id wins
+    on a duplicate name, deterministic / order-independent)."""
+    index: dict[str, dict] = {}
+    for row in existing_rows or []:
+        if not isinstance(row, dict):
+            continue
+        key = _norm_name(row.get("name"))
+        if key is None:
+            continue
+        current = index.get(key)
+        if current is None:
+            index[key] = row
+            continue
+        # Keep the lowest destination id for a stable, order-independent pick.
+        cur_id = current.get("id")
+        new_id = row.get("id")
+        if new_id is not None and (cur_id is None or int(new_id) < int(cur_id)):
+            index[key] = row
+    return index
+
+
+def _failure_reason_for(exc: Exception) -> FailureReason:
+    """Classify a create failure into a restore-contract FailureReason.
+
+    A name/uniqueness conflict maps to ``CONFLICT``; everything else is an
+    upstream API error. We inspect the exception's short text only.
+    """
+    text = str(exc).lower()
+    if "already exists" in text or "unique" in text or "conflict" in text:
+        return FailureReason.CONFLICT
+    return FailureReason.UPSTREAM_API_ERROR
+
+
+def _sanitize_failure(exc: Exception, noun: str) -> str:
+    """Produce a sanitized, operator-facing failure message (no raw traces)."""
+    return (str(exc) or "").strip() or f"Upstream rejected the {noun} creation request."
+
+
+def _build_create_payload(
+    archive_row: dict, config: CategoryConfig, remap: IdRemapTable
+) -> dict | None:
+    """Build a create payload dict, rewriting any remappable FK ids to dest ids.
+
+    Returns the payload on success, or ``None`` if a remappable FK reference could
+    not be resolved through ``remap`` (the row must then be skipped
+    ``DEPENDENCY_UNRESOLVED`` rather than created with a stale archive id). Drops
+    the archive source id and the embedded/read-only non-create keys.
+    """
+    dropped = _SOURCE_ID_KEYS | _NON_CREATE_KEYS
+    payload = {k: v for k, v in archive_row.items() if k not in dropped}
+    for field_name, entity_type in config.remappable_fk_fields.items():
+        source_id = archive_row.get(field_name)
+        if source_id is None:
+            continue
+        dest_id = remap.resolve(entity_type, int(source_id))
+        if dest_id is None:
+            return None
+        payload[field_name] = dest_id
+    return payload
+
+
+def _skip(cat, reason: SkipReason, label: str, source_export_id, is_dry_run: bool) -> None:
+    """Record a skip in both the count and the reasoned detail list."""
+    if is_dry_run:
+        cat.would_skip += 1
+    else:
+        cat.skipped += 1
+    cat.skip_details.append(
+        SkipDetail(reason=reason, label=label, source_export_id=source_export_id)
+    )
+
+
+async def _import_category(
+    *,
+    config: CategoryConfig,
+    archive_rows: list[dict],
+    client: DispatcharrClient,
+    selected: bool,
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    remap: IdRemapTable,
+    is_dry_run: bool = False,
+) -> None:
+    """Restore ONE category: create rows, populate the remap, record the ledger.
+
+    The generic engine behind the three per-category entries. Behaviour mirrors
+    the established Phase-2 importers:
+
+    * OPT-IN — off unless ``selected``; an unselected category records every row
+      ``EXCLUDED_BY_OPERATOR`` and creates nothing.
+    * Collision — a name match (case-insensitive/trimmed) against the destination
+      is skipped ``ALREADY_EXISTS_IDENTICAL`` and the source id is remapped to the
+      EXISTING destination id (never delete-all-then-recreate).
+    * FK remap — any ``remappable_fk_fields`` are rewritten through the remap;
+      unresolvable -> ``DEPENDENCY_UNRESOLVED`` (never a stale id upstream).
+    * Dry-run — reports ``would_create`` / ``would_skip``; no creates, no ledger.
+    * Failure taxonomy — a uniqueness race is ``CONFLICT``; other errors are
+      ``UPSTREAM_API_ERROR``.
+
+    Args:
+        config: The per-category configuration (entity type, client methods,
+            payload style, FK fields).
+        archive_rows: The category's rows from the export archive.
+        client: The Dispatcharr API client.
+        selected: The per-category opt-in flag.
+        report: The shared :class:`RestoreReport`; results land in
+            ``config.entity_type``'s category.
+        ledger: The shared :class:`RollbackLedger`; each created row is recorded
+            for compensating deletes.
+        remap: The shared :class:`IdRemapTable`; WRITTEN with each created (or
+            collision-resolved) row's source->dest id under ``config.entity_type``.
+        is_dry_run: When ``True``, nothing is created.
+    """
+    cat = report.category(config.entity_type)
+    noun = config.entity_type.value.replace("_", " ")
+
+    # OPT-IN. Off unless the operator selected this category.
+    if not selected:
+        logger.info("[%s] Category not selected; skipping %ss.", config.log_prefix, noun)
+        for archive_row in archive_rows:
+            _skip(
+                cat,
+                SkipReason.EXCLUDED_BY_OPERATOR,
+                _row_label(archive_row),
+                archive_row.get("id"),
+                is_dry_run,
+            )
+        return
+
+    logger.info(
+        "[%s] Restoring %ss (dry_run=%s); %d archived row(s).",
+        config.log_prefix,
+        noun,
+        is_dry_run,
+        len(archive_rows),
+    )
+
+    # Pre-fetch existing rows to detect name collisions (safe field only).
+    try:
+        existing = await getattr(client, config.getter)()
+    except Exception as exc:
+        logger.warning(
+            "[%s] Could not list existing %ss: %s", config.log_prefix, noun, exc
+        )
+        existing = []
+    existing_by_name = _existing_by_name(existing)
+
+    for archive_row in archive_rows:
+        label = _row_label(archive_row)
+        source_id = archive_row.get("id")
+
+        # Collision: a row with the same name already on the destination.
+        name_key = _norm_name(archive_row.get("name"))
+        existing_row = existing_by_name.get(name_key) if name_key else None
+        if existing_row is not None:
+            _skip(cat, SkipReason.ALREADY_EXISTS_IDENTICAL, label, source_id, is_dry_run)
+            existing_id = existing_row.get("id")
+            if source_id is not None and existing_id is not None:
+                remap.add(config.entity_type, int(source_id), int(existing_id))
+            logger.info(
+                "[%s] %s '%s' already exists (dest id=%s); skipped.",
+                config.log_prefix,
+                noun,
+                label,
+                existing_id,
+            )
+            continue
+
+        # FK remap: rewrite remappable FK ids; unresolved => DEPENDENCY_UNRESOLVED.
+        payload = _build_create_payload(archive_row, config, remap)
+        if payload is None:
+            logger.info(
+                "[%s] %s '%s' has an unresolved FK reference; skipped "
+                "DEPENDENCY_UNRESOLVED.",
+                config.log_prefix,
+                noun,
+                label,
+            )
+            _skip(cat, SkipReason.DEPENDENCY_UNRESOLVED, label, source_id, is_dry_run)
+            continue
+
+        if is_dry_run:
+            cat.would_create += 1
+            continue
+
+        try:
+            if config.payload_style == "name":
+                created = await getattr(client, config.creator)(payload.get("name"))
+            else:
+                created = await getattr(client, config.creator)(payload)
+        except Exception as exc:
+            reason = _failure_reason_for(exc)
+            cat.failed += 1
+            cat.failure_details.append(
+                FailureDetail(
+                    reason=reason,
+                    label=label,
+                    message=_sanitize_failure(exc, noun),
+                    source_export_id=source_id,
+                )
+            )
+            logger.warning(
+                "[%s] Failed to restore %s '%s': %s",
+                config.log_prefix,
+                noun,
+                label,
+                reason.value,
+            )
+            continue
+
+        dest_id = created.get("id") if isinstance(created, dict) else None
+        cat.created += 1
+        if dest_id is not None:
+            dest_id = int(dest_id)
+            if source_id is not None:
+                remap.add(config.entity_type, int(source_id), dest_id)
+            ledger.record_created(config.entity_type, dest_id, label)
+        logger.info("[%s] Restored %s '%s' (id=%s).", config.log_prefix, noun, label, dest_id)
+
+
+# ---------------------------------------------------------------------------
+# Per-category entries (thin wrappers over the generic engine)
+# ---------------------------------------------------------------------------
+
+
+async def import_channel_groups(
+    *,
+    archive_rows: list[dict],
+    client: DispatcharrClient,
+    selected: bool,
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    remap: IdRemapTable,
+    is_dry_run: bool = False,
+) -> None:
+    """Restore the CHANNEL_GROUP category. Identity match key: name
+    (case-insensitive / trimmed). Created via ``create_channel_group(name)``."""
+    await _import_category(
+        config=_CATEGORY_CONFIGS["channel_groups"],
+        archive_rows=archive_rows,
+        client=client,
+        selected=selected,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+        is_dry_run=is_dry_run,
+    )
+
+
+async def import_channel_profiles(
+    *,
+    archive_rows: list[dict],
+    client: DispatcharrClient,
+    selected: bool,
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    remap: IdRemapTable,
+    is_dry_run: bool = False,
+) -> None:
+    """Restore the CHANNEL_PROFILE category. Identity match key: name
+    (case-insensitive / trimmed). Channel membership is reattached by the Channels
+    importer (4vouz), never sent on a profile create."""
+    await _import_category(
+        config=_CATEGORY_CONFIGS["channel_profiles"],
+        archive_rows=archive_rows,
+        client=client,
+        selected=selected,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+        is_dry_run=is_dry_run,
+    )
+
+
+async def import_stream_profiles(
+    *,
+    archive_rows: list[dict],
+    client: DispatcharrClient,
+    selected: bool,
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    remap: IdRemapTable,
+    is_dry_run: bool = False,
+) -> None:
+    """Restore the STREAM_PROFILE category. Identity match key: name
+    (case-insensitive / trimmed)."""
+    await _import_category(
+        config=_CATEGORY_CONFIGS["stream_profiles"],
+        archive_rows=archive_rows,
+        client=client,
+        selected=selected,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+        is_dry_run=is_dry_run,
+    )
+
+
+# Order the bulk entry restores the categories within this bead's scope. NOTE:
+# all three are leaf dependencies (no FK between them), so intra-bundle order is
+# not load-bearing — but the BUNDLE as a whole runs AFTER M3U/EPG and BEFORE
+# Channels. That cross-bead ordering is the orchestrator's job (bead …-0i2vt.18),
+# not this module's.
+_BULK_ORDER = ("channel_groups", "channel_profiles", "stream_profiles")
+
+
+async def import_groups_profiles(
+    *,
+    archive: dict,
+    client: DispatcharrClient,
+    selected: dict,
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    remap: IdRemapTable,
+    is_dry_run: bool = False,
+) -> None:
+    """Restore all three groups/profiles categories — the bulk entry point.
+
+    A single clean entry the orchestrator (bead ``…-0i2vt.18``) registers so it
+    can restore the whole leaf-dependency bundle in one call and then run Channels
+    against the populated :class:`IdRemapTable`. Each category restores its rows
+    and writes its EntityType namespace into the remap.
+
+    Args:
+        archive: The export archive sections, keyed by category name
+            (``"channel_groups"`` / ``"channel_profiles"`` / ``"stream_profiles"``).
+            A missing key is treated as an empty list.
+        client: The Dispatcharr API client.
+        selected: Per-category opt-in flags, keyed by the same category names. A
+            missing key defaults OFF (opt-in) — nothing is created for it.
+        report: The shared :class:`RestoreReport`.
+        ledger: The shared :class:`RollbackLedger`.
+        remap: The shared :class:`IdRemapTable` the Channels importer consumes.
+        is_dry_run: When ``True``, nothing is created across all three categories.
+    """
+    for key in _BULK_ORDER:
+        config = _CATEGORY_CONFIGS[key]
+        await _import_category(
+            config=config,
+            archive_rows=archive.get(key) or [],
+            client=client,
+            selected=bool(selected.get(key, False)),
+            report=report,
+            ledger=ledger,
+            remap=remap,
+            is_dry_run=is_dry_run,
+        )

--- a/backend/tests/dbas/test_groups_profiles_importer.py
+++ b/backend/tests/dbas/test_groups_profiles_importer.py
@@ -1,0 +1,599 @@
+"""Tests for the bulk groups/profiles restore importer
+(enhancedchannelmanager-0i2vt.12 — Phase 2).
+
+Scope under test — THREE leaf-dependency categories restored together, each
+producing the IdRemapTable mappings the Channels importer (4vouz) consumes:
+
+1. Channel groups   -> EntityType.CHANNEL_GROUP
+2. Channel profiles -> EntityType.CHANNEL_PROFILE
+3. Stream profiles  -> EntityType.STREAM_PROFILE
+
+For EACH category the same behaviours are exercised:
+
+* Create happy path — the archived row is created via the category's Dispatcharr
+  client create method; source->dest is registered in the IdRemapTable (correct
+  EntityType) and the create is recorded in the RollbackLedger.
+* Collision skip + remap-to-existing — an archived row whose identity (name,
+  case-insensitive/trimmed) already exists on the destination is skipped
+  ALREADY_EXISTS_IDENTICAL and its source id is remapped to the EXISTING dest id
+  (so a later FK reference resolves) — never blind delete-all.
+* Opt-in off -> no-op — nothing is created; every row is EXCLUDED_BY_OPERATOR.
+* Dry-run -> zero creates + zero ledger; reports would_create.
+* CONFLICT vs UPSTREAM_API_ERROR — a create that races into a uniqueness
+  conflict is failed CONFLICT; a non-conflict error is UPSTREAM_API_ERROR.
+
+FK remap + DEPENDENCY_UNRESOLVED: the three real Dispatcharr categories are
+leaf dependencies (a group/profile has no outbound FK to another remapped
+entity — channels point at THEM, not the reverse). The generic FK-remap path is
+still exercised via a synthetic category config that declares a remappable FK,
+proving an unresolvable FK is skipped DEPENDENCY_UNRESOLVED rather than created
+with a stale archive id.
+
+The Dispatcharr client is mocked at the importer module level
+(``dbas.importers.groups_profiles``); the importer is exercised with an
+AsyncMock client.
+"""
+import pytest
+from unittest.mock import AsyncMock
+
+from dbas.importers.groups_profiles import (
+    _CATEGORY_CONFIGS,
+    CategoryConfig,
+    import_channel_groups,
+    import_channel_profiles,
+    import_groups_profiles,
+    import_stream_profiles,
+)
+from dbas.restore_contracts import (
+    EntityType,
+    FailureReason,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+    SkipReason,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _report(is_dry_run=False):
+    return RestoreReport(is_dry_run=is_dry_run)
+
+
+def _ledger():
+    return RollbackLedger(restore_id="test-restore")
+
+
+def _remap():
+    return IdRemapTable()
+
+
+def _client(*, groups=None, channel_profiles=None, stream_profiles=None):
+    """An AsyncMock Dispatcharr client with the three categories' get/create methods.
+
+    Each create method returns a row echoing the payload with a fresh dest id so
+    the importer's remap/ledger writes can be asserted.
+    """
+    client = AsyncMock()
+    client.get_channel_groups = AsyncMock(return_value=groups or [])
+    client.get_channel_profiles = AsyncMock(return_value=channel_profiles or [])
+    client.get_stream_profiles = AsyncMock(return_value=stream_profiles or [])
+
+    group_counter = {"n": 100}
+    profile_counter = {"n": 200}
+    stream_counter = {"n": 300}
+
+    async def _create_group(name):
+        group_counter["n"] += 1
+        return {"id": group_counter["n"], "name": name}
+
+    async def _create_channel_profile(data):
+        profile_counter["n"] += 1
+        return {"id": profile_counter["n"], **data}
+
+    async def _create_stream_profile(data):
+        stream_counter["n"] += 1
+        return {"id": stream_counter["n"], **data}
+
+    client.create_channel_group = AsyncMock(side_effect=_create_group)
+    client.create_channel_profile = AsyncMock(side_effect=_create_channel_profile)
+    client.create_stream_profile = AsyncMock(side_effect=_create_stream_profile)
+    return client
+
+
+# The three real categories, parametrized so each behavioural test runs once per
+# category. ``fn`` is the per-category entry, ``etype`` its EntityType, ``getter``
+# / ``creator`` the client method names, ``existing_kw`` the _client kwarg.
+_CATEGORIES = [
+    pytest.param(
+        import_channel_groups,
+        EntityType.CHANNEL_GROUP,
+        "create_channel_group",
+        "groups",
+        id="channel_groups",
+    ),
+    pytest.param(
+        import_channel_profiles,
+        EntityType.CHANNEL_PROFILE,
+        "create_channel_profile",
+        "channel_profiles",
+        id="channel_profiles",
+    ),
+    pytest.param(
+        import_stream_profiles,
+        EntityType.STREAM_PROFILE,
+        "create_stream_profile",
+        "stream_profiles",
+        id="stream_profiles",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Opt-in gating (per category)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fn, etype, creator, existing_kw", _CATEGORIES)
+async def test_category_skipped_when_not_selected(fn, etype, creator, existing_kw):
+    """OPT-IN: when the category is not selected, nothing is created — every
+    archived row is recorded EXCLUDED_BY_OPERATOR."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await fn(
+        archive_rows=[{"id": 5, "name": "Sports"}],
+        client=client,
+        selected=False,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    getattr(client, creator).assert_not_called()
+    cat = report.category(etype)
+    assert cat.created == 0
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.EXCLUDED_BY_OPERATOR
+    assert len(ledger.entries) == 0
+
+
+# ---------------------------------------------------------------------------
+# Create happy path — remap + ledger (per category)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fn, etype, creator, existing_kw", _CATEGORIES)
+async def test_create_happy_path_remap_and_ledger(fn, etype, creator, existing_kw):
+    """An archived row is created; source->dest is registered in the IdRemapTable
+    under the right EntityType, and the create is recorded in the RollbackLedger."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await fn(
+        archive_rows=[{"id": 5, "name": "Sports"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    getattr(client, creator).assert_awaited_once()
+    cat = report.category(etype)
+    assert cat.created == 1
+    dest_id = remap.resolve(etype, 5)
+    assert dest_id is not None
+    assert len(ledger.entries) == 1
+    assert ledger.entries[0].entity_type == etype
+    assert ledger.entries[0].destination_id == dest_id
+    assert ledger.entries[0].label == "Sports"
+
+
+@pytest.mark.asyncio
+async def test_channel_group_create_passes_name_string():
+    """Channel groups use ``create_channel_group(name)`` — a name STRING, not a
+    dict (mirrors the existing client signature)."""
+    client = _client()
+    await import_channel_groups(
+        archive_rows=[{"id": 5, "name": "Sports"}],
+        client=client,
+        selected=True,
+        report=_report(),
+        ledger=_ledger(),
+        remap=_remap(),
+    )
+    client.create_channel_group.assert_awaited_once_with("Sports")
+
+
+@pytest.mark.asyncio
+async def test_profile_create_strips_source_id_and_readonly_fields():
+    """A profile create payload drops the archive source id and the embedded /
+    read-only fields (channels membership list, counts) — those are owned by the
+    Channels importer, never sent on a profile create."""
+    captured = {}
+
+    async def _create(data):
+        captured.update(data)
+        return {"id": 201, **data}
+
+    client = _client()
+    client.create_channel_profile = AsyncMock(side_effect=_create)
+
+    await import_channel_profiles(
+        archive_rows=[{
+            "id": 5,
+            "name": "LiveTV",
+            "channels": [1, 2, 3],
+            "channel_count": 3,
+            "created_at": "2020-01-01",
+        }],
+        client=client,
+        selected=True,
+        report=_report(),
+        ledger=_ledger(),
+        remap=_remap(),
+    )
+
+    assert "id" not in captured
+    assert "channels" not in captured
+    assert "channel_count" not in captured
+    assert "created_at" not in captured
+    assert captured["name"] == "LiveTV"
+
+
+# ---------------------------------------------------------------------------
+# Collision skip + remap-to-existing (per category)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fn, etype, creator, existing_kw", _CATEGORIES)
+async def test_existing_by_name_skipped_and_remapped(fn, etype, creator, existing_kw):
+    """An archived row whose name already exists on the destination
+    (case-insensitive / trimmed) is skipped ALREADY_EXISTS_IDENTICAL and its
+    source id is remapped to the EXISTING dest id (so a later FK resolves).
+    No create, no ledger entry — never blind delete-all."""
+    client = _client(**{existing_kw: [{"id": 700, "name": "Sports"}]})
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await fn(
+        archive_rows=[{"id": 5, "name": "  sports  "}],  # trimmed/case-insensitive
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    getattr(client, creator).assert_not_called()
+    cat = report.category(etype)
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.ALREADY_EXISTS_IDENTICAL
+    assert remap.resolve(etype, 5) == 700
+    assert len(ledger.entries) == 0
+
+
+# ---------------------------------------------------------------------------
+# Dry-run (per category)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fn, etype, creator, existing_kw", _CATEGORIES)
+async def test_dry_run_no_creates_no_ledger(fn, etype, creator, existing_kw):
+    """Dry-run: no row is created, no ledger entry written; reports would_create."""
+    client = _client()
+    report = _report(is_dry_run=True)
+    ledger = _ledger()
+    remap = _remap()
+
+    await fn(
+        archive_rows=[{"id": 5, "name": "Sports"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+        is_dry_run=True,
+    )
+
+    getattr(client, creator).assert_not_called()
+    cat = report.category(etype)
+    assert cat.would_create == 1
+    assert cat.created == 0
+    assert len(ledger.entries) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fn, etype, creator, existing_kw", _CATEGORIES)
+async def test_dry_run_existing_reports_would_skip(fn, etype, creator, existing_kw):
+    """Dry-run with a collision: reports would_skip with the reason, still no
+    creates / ledger — and still records the remap so the dry-run plan is
+    consistent with what apply would do."""
+    client = _client(**{existing_kw: [{"id": 700, "name": "Sports"}]})
+    report = _report(is_dry_run=True)
+    remap = _remap()
+
+    await fn(
+        archive_rows=[{"id": 5, "name": "Sports"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=_ledger(),
+        remap=remap,
+        is_dry_run=True,
+    )
+
+    getattr(client, creator).assert_not_called()
+    cat = report.category(etype)
+    assert cat.would_skip == 1
+    assert cat.skip_details[0].reason == SkipReason.ALREADY_EXISTS_IDENTICAL
+
+
+# ---------------------------------------------------------------------------
+# Failure taxonomy — CONFLICT vs UPSTREAM_API_ERROR (per category)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fn, etype, creator, existing_kw", _CATEGORIES)
+async def test_create_conflict_recorded_as_failure_conflict(fn, etype, creator, existing_kw):
+    """A create that races into an upstream uniqueness conflict is failed CONFLICT
+    (not skipped); no ledger entry, no remap."""
+    client = _client()
+
+    async def _conflict(*args, **kwargs):
+        raise RuntimeError("name already exists")
+
+    setattr(client, creator, AsyncMock(side_effect=_conflict))
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await fn(
+        archive_rows=[{"id": 5, "name": "Sports"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = report.category(etype)
+    assert cat.failed == 1
+    assert cat.failure_details[0].reason == FailureReason.CONFLICT
+    assert len(ledger.entries) == 0
+    assert remap.resolve(etype, 5) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fn, etype, creator, existing_kw", _CATEGORIES)
+async def test_create_upstream_error_recorded_as_failure(fn, etype, creator, existing_kw):
+    """A non-conflict create error is failed UPSTREAM_API_ERROR."""
+    client = _client()
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("502 bad gateway")
+
+    setattr(client, creator, AsyncMock(side_effect=_boom))
+    report = _report()
+
+    await fn(
+        archive_rows=[{"id": 5, "name": "Sports"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=_ledger(),
+        remap=_remap(),
+    )
+
+    cat = report.category(etype)
+    assert cat.failed == 1
+    assert cat.failure_details[0].reason == FailureReason.UPSTREAM_API_ERROR
+
+
+# ---------------------------------------------------------------------------
+# FK remap + DEPENDENCY_UNRESOLVED (generic mechanism)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fk_remap_rewrites_resolvable_reference():
+    """When a category config declares a remappable FK and the reference resolves
+    through the IdRemapTable, the create payload carries the DEST id, not the
+    stale archive id."""
+    captured = {}
+
+    async def _create(data):
+        captured.update(data)
+        return {"id": 201, **data}
+
+    client = _client()
+    client.create_channel_profile = AsyncMock(side_effect=_create)
+
+    # Synthetic config: a CHANNEL_PROFILE create that remaps a stream_profile_id
+    # FK through STREAM_PROFILE. Proves the generic FK-remap path end to end.
+    config = CategoryConfig(
+        entity_type=EntityType.CHANNEL_PROFILE,
+        getter="get_channel_profiles",
+        creator="create_channel_profile",
+        log_prefix="DBAS-TEST",
+        remappable_fk_fields={"stream_profile_id": EntityType.STREAM_PROFILE},
+    )
+    remap = _remap()
+    remap.add(EntityType.STREAM_PROFILE, 50, 950)  # archived 50 -> dest 950
+
+    from dbas.importers.groups_profiles import _import_category
+
+    await _import_category(
+        config=config,
+        archive_rows=[{"id": 5, "name": "LiveTV", "stream_profile_id": 50}],
+        client=client,
+        selected=True,
+        report=_report(),
+        ledger=_ledger(),
+        remap=remap,
+    )
+
+    assert captured["stream_profile_id"] == 950  # remapped, not 50
+
+
+@pytest.mark.asyncio
+async def test_fk_unresolved_skipped_dependency_unresolved():
+    """When a remappable FK reference cannot be resolved through the IdRemapTable,
+    the row is skipped DEPENDENCY_UNRESOLVED rather than created with a stale id."""
+    client = _client()
+    config = CategoryConfig(
+        entity_type=EntityType.CHANNEL_PROFILE,
+        getter="get_channel_profiles",
+        creator="create_channel_profile",
+        log_prefix="DBAS-TEST",
+        remappable_fk_fields={"stream_profile_id": EntityType.STREAM_PROFILE},
+    )
+    report = _report()
+    remap = _remap()  # no mapping for the FK
+
+    from dbas.importers.groups_profiles import _import_category
+
+    await _import_category(
+        config=config,
+        archive_rows=[{"id": 5, "name": "LiveTV", "stream_profile_id": 50}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=_ledger(),
+        remap=remap,
+    )
+
+    client.create_channel_profile.assert_not_called()
+    cat = report.category(EntityType.CHANNEL_PROFILE)
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.DEPENDENCY_UNRESOLVED
+    assert remap.resolve(EntityType.CHANNEL_PROFILE, 5) is None
+
+
+# ---------------------------------------------------------------------------
+# Bulk entry point — all three categories in dependency order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_import_groups_profiles_runs_all_three_categories():
+    """The bulk entry point restores all three categories and populates the
+    IdRemapTable for each EntityType the Channels importer consumes."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_groups_profiles(
+        archive={
+            "channel_groups": [{"id": 1, "name": "Sports"}],
+            "channel_profiles": [{"id": 2, "name": "LiveTV"}],
+            "stream_profiles": [{"id": 3, "name": "ffmpeg"}],
+        },
+        client=client,
+        selected={
+            "channel_groups": True,
+            "channel_profiles": True,
+            "stream_profiles": True,
+        },
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    assert remap.resolve(EntityType.CHANNEL_GROUP, 1) is not None
+    assert remap.resolve(EntityType.CHANNEL_PROFILE, 2) is not None
+    assert remap.resolve(EntityType.STREAM_PROFILE, 3) is not None
+    assert len(ledger.entries) == 3
+    # Each category reported one create.
+    assert report.category(EntityType.CHANNEL_GROUP).created == 1
+    assert report.category(EntityType.CHANNEL_PROFILE).created == 1
+    assert report.category(EntityType.STREAM_PROFILE).created == 1
+
+
+@pytest.mark.asyncio
+async def test_import_groups_profiles_respects_per_category_selection():
+    """The bulk entry point honours per-category opt-in: an unselected category is
+    EXCLUDED_BY_OPERATOR while selected ones are restored."""
+    client = _client()
+    report = _report()
+    remap = _remap()
+
+    await import_groups_profiles(
+        archive={
+            "channel_groups": [{"id": 1, "name": "Sports"}],
+            "channel_profiles": [{"id": 2, "name": "LiveTV"}],
+            "stream_profiles": [{"id": 3, "name": "ffmpeg"}],
+        },
+        client=client,
+        selected={
+            "channel_groups": True,
+            "channel_profiles": False,  # opted out
+            "stream_profiles": True,
+        },
+        report=report,
+        ledger=_ledger(),
+        remap=remap,
+    )
+
+    client.create_channel_profile.assert_not_called()
+    assert report.category(EntityType.CHANNEL_PROFILE).skipped == 1
+    assert (
+        report.category(EntityType.CHANNEL_PROFILE).skip_details[0].reason
+        == SkipReason.EXCLUDED_BY_OPERATOR
+    )
+    assert remap.resolve(EntityType.CHANNEL_GROUP, 1) is not None
+    assert remap.resolve(EntityType.STREAM_PROFILE, 3) is not None
+
+
+@pytest.mark.asyncio
+async def test_import_groups_profiles_defaults_selection_to_off():
+    """When ``selected`` omits a category, it defaults OFF (opt-in) — nothing is
+    created for the omitted category."""
+    client = _client()
+    report = _report()
+
+    await import_groups_profiles(
+        archive={"channel_groups": [{"id": 1, "name": "Sports"}]},
+        client=client,
+        selected={},  # nothing selected
+        report=report,
+        ledger=_ledger(),
+        remap=_remap(),
+    )
+
+    client.create_channel_group.assert_not_called()
+    assert report.category(EntityType.CHANNEL_GROUP).skipped == 1
+
+
+# ---------------------------------------------------------------------------
+# Config integrity
+# ---------------------------------------------------------------------------
+
+
+def test_category_configs_cover_the_three_entity_types():
+    """The module's canonical config table covers exactly the three leaf
+    categories, each with NO outbound remappable FK (they are leaf dependencies
+    that channels point at — the FK direction is owned by the Channels importer)."""
+    etypes = {c.entity_type for c in _CATEGORY_CONFIGS.values()}
+    assert etypes == {
+        EntityType.CHANNEL_GROUP,
+        EntityType.CHANNEL_PROFILE,
+        EntityType.STREAM_PROFILE,
+    }
+    for config in _CATEGORY_CONFIGS.values():
+        assert config.remappable_fk_fields == {}


### PR DESCRIPTION
## Bead
enhancedchannelmanager-0i2vt.12 — Phase 2 bulk importer for 3 leaf categories that the Channels importer (4vouz) consumes via remap.

## What
New `backend/dbas/importers/groups_profiles.py` (mirrors m3u_accounts/channels/users pattern). Restores channel groups (`EntityType.CHANNEL_GROUP`), channel profiles (`CHANNEL_PROFILE`), stream profiles (`STREAM_PROFILE`) — each creating rows + populating the `IdRemapTable` (+ `RollbackLedger`) that channels.py resolves against.
- Verify-then-size: all client methods existed (`create_channel_group(name)` — string sig handled via `payload_style`; `create_channel_profile`/`create_stream_profile` — dict). None added. EntityTypes already existed (not re-added).
- Identity: name (ci/trimmed); collision → `ALREADY_EXISTS_IDENTICAL` skip + remap-to-existing-id; lowest-id tie-break. Leaf categories (no outbound FK) — generic FK-remap path still built + tested for future categories.
- Profile create strips embedded membership/count fields (membership reattach is channels.py's job).
- Credential-clean logging.

## Entry points (for orchestrator .18)
`import_groups_profiles(...)` (bulk, per-category opt-in) + `import_channel_groups`/`import_channel_profiles`/`import_stream_profiles`.

## Tests
29 tests across the 3 categories (create+remap+ledger, collision skip+remap, opt-in off, dry-run, CONFLICT vs UPSTREAM_API_ERROR, string-vs-dict create, membership-strip). Full suite green (5742 passed).

## Note
Stream profiles can't be deleted via the Dispatcharr API; restore is additive (create-missing-only) so rollback of a stream-profile create is residue (orchestrator surfaces it, never silent success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)