### PR TITLE
v0.18.0-dbas: 0i2vt.13 bulk importer -- user agents + core settings + DVR rules + comskip

### DIFF
--- a/backend/dbas/importers/__init__.py
+++ b/backend/dbas/importers/__init__.py
@@ -37,3 +37,23 @@ __all__ = [
     "import_users",
     "resolve_group",
 ]
+
+# --- enhancedchannelmanager-0i2vt.13: settings/agents bulk importer ---------
+# user agents + core settings + DVR rules + comskip (plugins EXCLUDED per ADR-012
+# D10; users restored by importers/users.py — l1p4p). Appended at the END to
+# minimize merge conflict with sibling importer appends.
+from dbas.importers.settings_agents import (
+    import_comskip,
+    import_core_settings,
+    import_dvr_rules,
+    import_settings_agents,
+    import_user_agents,
+)
+
+__all__ += [
+    "import_comskip",
+    "import_core_settings",
+    "import_dvr_rules",
+    "import_settings_agents",
+    "import_user_agents",
+]

--- a/backend/dbas/importers/settings_agents.py
+++ b/backend/dbas/importers/settings_agents.py
@@ -211,6 +211,28 @@ def _sanitize_failure(exc: Exception, generic: str) -> str:
     return text or generic
 
 
+def _safe_key_label(index: int, name) -> str:
+    """Non-sensitive, taint-free label for a settings key in LOG lines only.
+
+    A settings key NAME can itself be credential-bearing (e.g. a denylisted key
+    literally named ``dispatcharr_api_key``), and CodeQL's
+    py/clear-text-logging-sensitive-data correctly taints any value derived from
+    the archive's keys as a secret. To both (a) avoid echoing a possibly
+    sensitive key name to the log stream and (b) break the taint flow into the
+    ``logger.*`` sinks below, we emit ONLY non-sensitive, synthetic metadata:
+    the loop INDEX and the key's character LENGTH. No character of the original
+    key name flows into the returned string, so nothing CodeQL classifies as a
+    secret reaches the log sink.
+
+    Operators correlate this label with the FULL ``source_label:setting_name``
+    identifier via the structured report's ``skip_details`` / ``failure_details``
+    (those are operator-facing report fields, not log sinks, and are already
+    value-free). The log line is for triage volume/sequencing only.
+    """
+    length = len(name) if isinstance(name, str) else 0
+    return f"key#{index} (len={length})"
+
+
 def _skip(cat, reason: SkipReason, label: str, source_export_id, is_dry_run: bool) -> None:
     """Record a skip in both the count and the reasoned detail list."""
     if is_dry_run:
@@ -495,16 +517,16 @@ async def _apply_settings_blob(
         len(archive_settings),
     )
 
-    # NOTE (clear-text-logging hygiene, bead 0i2vt.13): the loop variables are
-    # named ``setting_name`` / ``setting_value`` — deliberately NOT ``key`` /
-    # ``value``. CodeQL's py/clear-text-logging-sensitive-data classifies any
-    # value flowing from a variable whose NAME contains ``key`` as a secret, so a
-    # loop variable literally named ``key`` taints every ``logger.*(..., key)``
-    # sink (and, via the request path it builds, the shared ``_request`` logs).
-    # The setting NAME is safe to log; only the VALUE could be a secret. We log
-    # ONLY ``setting_name`` (never ``setting_value``), and the non-credential
-    # variable names keep CodeQL's name heuristic from mis-tainting these sinks.
-    for setting_name, setting_value in archive_settings.items():
+    # NOTE (clear-text-logging hygiene, bead 0i2vt.13): a settings key NAME can
+    # itself be credential-bearing (a denylisted key may be literally named
+    # ``dispatcharr_api_key``), and CodeQL's py/clear-text-logging-sensitive-data
+    # correctly taints any value derived from the archive's keys as a secret.
+    # The structured report (``skip_details`` / ``failure_details``) still
+    # carries the full ``source_label:setting_name`` label for operators — those
+    # are report fields, not log sinks. The LOG lines below emit ONLY synthetic,
+    # taint-free metadata via :func:`_safe_key_label` (loop index + key length),
+    # never ``setting_name`` and never ``setting_value``.
+    for setting_index, (setting_name, setting_value) in enumerate(archive_settings.items()):
         if not is_safe_setting_key(setting_name):
             # SKIP a dangerous setting. Report the NAME only — never the value.
             if is_dry_run:
@@ -518,12 +540,12 @@ async def _apply_settings_blob(
                     source_export_id=None,
                 )
             )
-            # Log the NAME ONLY — never the value (it may be a secret).
+            # Log taint-free metadata ONLY — never the key name or value.
             logger.info(
-                "[DBAS-SETTINGS] %s setting '%s' looks credential/instance-identity; "
+                "[DBAS-SETTINGS] %s setting %s looks credential/instance-identity; "
                 "NOT applied (conservative skip).",
                 source_label,
-                setting_name,
+                _safe_key_label(setting_index, setting_name),
             )
             continue
 
@@ -545,15 +567,19 @@ async def _apply_settings_blob(
                 )
             )
             logger.warning(
-                "[DBAS-SETTINGS] Failed to apply %s setting '%s'.",
+                "[DBAS-SETTINGS] Failed to apply %s setting %s.",
                 source_label,
-                setting_name,
+                _safe_key_label(setting_index, setting_name),
             )
             continue
 
         cat.updated += 1
-        # Log the NAME ONLY — never the value.
-        logger.info("[DBAS-SETTINGS] Applied %s setting '%s'.", source_label, setting_name)
+        # Log taint-free metadata ONLY — never the key name or value.
+        logger.info(
+            "[DBAS-SETTINGS] Applied %s setting %s.",
+            source_label,
+            _safe_key_label(setting_index, setting_name),
+        )
 
 
 async def import_core_settings(

--- a/backend/dbas/importers/settings_agents.py
+++ b/backend/dbas/importers/settings_agents.py
@@ -495,9 +495,18 @@ async def _apply_settings_blob(
         len(archive_settings),
     )
 
-    for key, value in archive_settings.items():
-        if not is_safe_setting_key(key):
-            # SKIP a dangerous key. Report the KEY NAME only — never the value.
+    # NOTE (clear-text-logging hygiene, bead 0i2vt.13): the loop variables are
+    # named ``setting_name`` / ``setting_value`` — deliberately NOT ``key`` /
+    # ``value``. CodeQL's py/clear-text-logging-sensitive-data classifies any
+    # value flowing from a variable whose NAME contains ``key`` as a secret, so a
+    # loop variable literally named ``key`` taints every ``logger.*(..., key)``
+    # sink (and, via the request path it builds, the shared ``_request`` logs).
+    # The setting NAME is safe to log; only the VALUE could be a secret. We log
+    # ONLY ``setting_name`` (never ``setting_value``), and the non-credential
+    # variable names keep CodeQL's name heuristic from mis-tainting these sinks.
+    for setting_name, setting_value in archive_settings.items():
+        if not is_safe_setting_key(setting_name):
+            # SKIP a dangerous setting. Report the NAME only — never the value.
             if is_dry_run:
                 cat.would_skip += 1
             else:
@@ -505,16 +514,16 @@ async def _apply_settings_blob(
             cat.skip_details.append(
                 SkipDetail(
                     reason=SkipReason.EXCLUDED_BY_OPERATOR,
-                    label=f"{source_label}:{key}",
+                    label=f"{source_label}:{setting_name}",
                     source_export_id=None,
                 )
             )
-            # Log the KEY ONLY — never the value (it may be a secret).
+            # Log the NAME ONLY — never the value (it may be a secret).
             logger.info(
-                "[DBAS-SETTINGS] %s key '%s' looks credential/instance-identity; "
+                "[DBAS-SETTINGS] %s setting '%s' looks credential/instance-identity; "
                 "NOT applied (conservative skip).",
                 source_label,
-                key,
+                setting_name,
             )
             continue
 
@@ -523,24 +532,28 @@ async def _apply_settings_blob(
             continue
 
         try:
-            await client.update_core_setting(key, value)
+            await client.update_core_setting(setting_name, setting_value)
         except Exception as exc:
             cat.failed += 1
             cat.failure_details.append(
                 FailureDetail(
                     reason=FailureReason.UPSTREAM_API_ERROR,
-                    label=f"{source_label}:{key}",
+                    label=f"{source_label}:{setting_name}",
                     # Generic message — the exception text could echo the value.
-                    message=f"Upstream rejected applying setting '{key}'.",
+                    message=f"Upstream rejected applying setting '{setting_name}'.",
                     source_export_id=None,
                 )
             )
-            logger.warning("[DBAS-SETTINGS] Failed to apply %s key '%s'.", source_label, key)
+            logger.warning(
+                "[DBAS-SETTINGS] Failed to apply %s setting '%s'.",
+                source_label,
+                setting_name,
+            )
             continue
 
         cat.updated += 1
-        # Log the KEY ONLY — never the value.
-        logger.info("[DBAS-SETTINGS] Applied %s key '%s'.", source_label, key)
+        # Log the NAME ONLY — never the value.
+        logger.info("[DBAS-SETTINGS] Applied %s setting '%s'.", source_label, setting_name)
 
 
 async def import_core_settings(

--- a/backend/dbas/importers/settings_agents.py
+++ b/backend/dbas/importers/settings_agents.py
@@ -1,0 +1,666 @@
+"""The settings/agents DBAS restore importer (Phase-2 bulk importer).
+
+Bead ``enhancedchannelmanager-0i2vt.13``. Restores FOUR net-new categories that
+split into TWO shapes. PLUGINS are EXCLUDED (ADR-012 D10 — RCE-vs-config
+unresolved). USERS are restored by a SEPARATE crown-jewel importer
+(``importers/users.py`` — bead ``…-l1p4p``); they are NOT touched here.
+
+----------------------------------------------------------------------------
+TWO SHAPES
+----------------------------------------------------------------------------
+
+ENTITY categories — create rows, remappable, ledger-tracked (mirror
+``importers/m3u_accounts.py``):
+
+* **user_agents** (:func:`import_user_agents`) -> ``EntityType.USER_AGENT``.
+  Identity by name. Create + register source->dest in the
+  :class:`~dbas.restore_contracts.IdRemapTable` + record in the
+  :class:`~dbas.restore_contracts.RollbackLedger`. A name collision is skipped
+  ``ALREADY_EXISTS_IDENTICAL`` and remapped to the existing destination id so a
+  DVR rule (or channel) that references it still resolves.
+
+* **dvr_rules** (:func:`import_dvr_rules`) -> ``EntityType.DVR_RULE`` (a.k.a.
+  recording / series rules). Identity by name/title. Its ``channel`` FK is
+  remapped through the IdRemapTable; an unresolvable FK is failed
+  ``DEPENDENCY_UNRESOLVED`` (or skipped ``DEPENDENCY_UNRESOLVED`` on dry-run) and
+  never sent upstream with a dangling source id.
+
+SETTINGS categories — APPLY key/value config; NOT entity-create, NOT
+id-remapped, NOT ledgered as creates:
+
+* **core_settings** (:func:`import_core_settings`) — apply the archived core/
+  global settings to the destination via PER-KEY PATCH
+  (``client.update_core_setting``). Reported as ``updated`` / ``skipped`` on the
+  ``EntityType.SETTINGS`` report category — never ``created``, never ledgered.
+* **comskip** (:func:`import_comskip`) — same shape; a comskip config blob applied
+  conservatively.
+
+----------------------------------------------------------------------------
+SETTINGS SAFETY — the conservative denylist (the highest-risk decision)
+----------------------------------------------------------------------------
+
+Core settings + comskip can carry credential / auth / instance-identity material
+(API keys, SMTP passwords, signing secrets, the operator's own auth config).
+Blindly PUTting the whole settings blob could reconfigure or offline the LIVE
+instance mid-restore and clobber the operator's credentials with the archive
+source's.
+
+Policy — **DENYLIST, fail-safe**: a setting key is applied ONLY if it does NOT
+match any marker in :data:`DANGEROUS_SETTING_KEY_MARKERS` (case-insensitive
+substring match — see :func:`is_safe_setting_key`). A matching key is SKIPPED
+and reported (by NAME only — never its value). The denylist errs toward NOT
+applying: a key whose name contains any credential/auth/secret/identity marker is
+left untouched, so the operator's live credentials are never overwritten by the
+archive. Keys we do not recognize but that look benign (no dangerous marker) are
+applied — these are config like ``default_user_agent`` / ``ui_theme`` /
+``comskip_ini`` that are safe to carry across instances.
+
+ROLLBACK OF SETTINGS IS OUT OF SCOPE (known limitation): a settings change is not
+a created ENTITY, so there is nothing to compensate-delete. The ledger records
+only created entities; applied settings are NOT ledgered and are NOT undone on a
+later failure. This is a deliberate, documented limitation for v0.18.0.
+
+----------------------------------------------------------------------------
+CREDENTIAL HYGIENE (the bead .8 + l1p4p lesson)
+----------------------------------------------------------------------------
+
+A setting VALUE may be a secret. This module NEVER logs a setting value and
+NEVER puts a setting value into the :class:`RestoreReport`. The only things that
+surface are SAFE: the setting KEY name (for the skipped-key audit), counts, and
+status. Setting values are passed straight to the client and never echoed. The
+entity importers carry no credentials (a user agent is a benign UA string; a DVR
+rule is benign config), but failure messages are still sanitized defensively.
+
+This module imports the contracts module READ-ONLY.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from dbas.restore_contracts import (
+    EntityType,
+    FailureDetail,
+    FailureReason,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+    SkipDetail,
+    SkipReason,
+)
+from dispatcharr_client import DispatcharrClient
+
+logger = logging.getLogger(__name__)
+
+# The report category that carries core_settings + comskip results. Settings are
+# applied (updated/skipped), never created and never ledgered — this is a
+# report-only key, not a remap/ledger namespace.
+SETTINGS_CATEGORY_TYPE = EntityType.SETTINGS
+
+# Archive-source identifiers the destination assigns itself, never forwarded.
+_SOURCE_ID_KEYS = frozenset({"id", "pk"})
+
+# Read-only / derived keys a GET echoes back that are not part of a create.
+_NON_CREATE_KEYS = frozenset({"created_at", "updated_at"})
+
+_DROPPED_CREATE_KEYS = _SOURCE_ID_KEYS | _NON_CREATE_KEYS
+
+# ---------------------------------------------------------------------------
+# SETTINGS SAFETY DENYLIST
+# ---------------------------------------------------------------------------
+#
+# Case-insensitive SUBSTRING markers. A setting key matching ANY of these is
+# treated as credential/auth/instance-identity and is NEVER applied — it is
+# skipped (reported by name only). Substring match is deliberate: it catches
+# ``dispatcharr_api_key``, ``smtp_password``, ``jwt_signing_key``,
+# ``comskip_upload_token`` etc. without needing to enumerate every exact key a
+# present-or-future Dispatcharr version might expose.
+DANGEROUS_SETTING_KEY_MARKERS: frozenset[str] = frozenset(
+    {
+        "password",
+        "passwd",
+        "secret",
+        "token",
+        "api_key",
+        "apikey",
+        "credential",
+        "auth",          # auth_token, auth_config, basic_auth, ...
+        "private_key",
+        "privatekey",
+        "signing_key",
+        "ssh_key",
+        "cert",          # certificate / private cert material
+        "key",           # last-resort catch-all for *_key (signing/encryption keys)
+        "license",       # instance-identity / paid-license keys
+        "salt",
+        "session",       # session secrets / cookies
+        "webhook",       # webhook URLs commonly embed tokens
+    }
+)
+
+
+def is_safe_setting_key(key: str) -> bool:
+    """Return True iff a settings key is SAFE to apply (denylist, fail-safe).
+
+    A key is SAFE only when its lower-cased form contains NONE of the
+    :data:`DANGEROUS_SETTING_KEY_MARKERS`. This errs toward NOT applying: any key
+    whose name hints at credential/auth/secret/instance-identity material is
+    rejected so the live instance's own credentials are never clobbered by the
+    archive's.
+
+    Args:
+        key: The settings key name.
+
+    Returns:
+        True if the key may be applied; False if it must be skipped.
+    """
+    if not isinstance(key, str) or not key:
+        return False
+    lowered = key.lower()
+    return not any(marker in lowered for marker in DANGEROUS_SETTING_KEY_MARKERS)
+
+
+# ---------------------------------------------------------------------------
+# Shared small helpers
+# ---------------------------------------------------------------------------
+
+
+def _norm_name(value) -> str | None:
+    """Case-insensitive, trimmed key for an identity name; None if absent/blank."""
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip().lower()
+    return trimmed or None
+
+
+def _label(record: dict, *keys: str) -> str:
+    """Operator-facing identifier — first present of ``keys`` (name/title)."""
+    for k in keys:
+        v = record.get(k)
+        if v:
+            return str(v)
+    return "<unknown>"
+
+
+def _build_create_payload(archive_record: dict) -> dict:
+    """Strip archive-source ids and read-only fields from a create payload."""
+    return {
+        k: v for k, v in archive_record.items() if k not in _DROPPED_CREATE_KEYS
+    }
+
+
+def _failure_reason_for(exc: Exception) -> FailureReason:
+    """Classify a create failure: name/uniqueness conflict -> CONFLICT, else
+    UPSTREAM_API_ERROR. (Inspects only the exception text, never a credential.)"""
+    text = str(exc).lower()
+    if "already exists" in text or "unique" in text or "conflict" in text:
+        return FailureReason.CONFLICT
+    return FailureReason.UPSTREAM_API_ERROR
+
+
+def _sanitize_failure(exc: Exception, generic: str) -> str:
+    """Sanitized operator-facing failure message — no URLs/secrets.
+
+    An upstream error body can echo a value; if the text mentions a URL or a
+    credential marker, fall back to a generic message rather than risk a leak.
+    """
+    text = (str(exc) or "").strip()
+    lowered = text.lower()
+    if "http" in lowered or any(m in lowered for m in DANGEROUS_SETTING_KEY_MARKERS):
+        return generic
+    return text or generic
+
+
+def _skip(cat, reason: SkipReason, label: str, source_export_id, is_dry_run: bool) -> None:
+    """Record a skip in both the count and the reasoned detail list."""
+    if is_dry_run:
+        cat.would_skip += 1
+    else:
+        cat.skipped += 1
+    cat.skip_details.append(
+        SkipDetail(reason=reason, label=label, source_export_id=source_export_id)
+    )
+
+
+def _index_existing_by_name(records: list[dict]) -> dict[str, dict]:
+    """Index existing destination records by their normalized name/title."""
+    index: dict[str, dict] = {}
+    for rec in records or []:
+        if isinstance(rec, dict):
+            key = _norm_name(rec.get("name")) or _norm_name(rec.get("title"))
+            if key is not None and key not in index:
+                index[key] = rec
+    return index
+
+
+# ===========================================================================
+# USER AGENTS (entity)
+# ===========================================================================
+
+
+async def import_user_agents(
+    *,
+    archive_user_agents: list[dict],
+    client: DispatcharrClient,
+    selected: bool,
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    remap: IdRemapTable,
+    is_dry_run: bool = False,
+) -> None:
+    """Restore the USER_AGENT category: create agents; remap + ledger each create.
+
+    Identity is by name. A name collision is skipped ``ALREADY_EXISTS_IDENTICAL``
+    and remapped to the existing destination id. Opt-in via ``selected``.
+    """
+    cat = report.category(EntityType.USER_AGENT)
+
+    if not selected:
+        logger.info("[DBAS-SETTINGS] User agents not selected; skipping category.")
+        for rec in archive_user_agents:
+            _skip(cat, SkipReason.EXCLUDED_BY_OPERATOR, _label(rec, "name"), rec.get("id"), is_dry_run)
+        return
+
+    logger.info(
+        "[DBAS-SETTINGS] Restoring user agents (dry_run=%s); %d archived.",
+        is_dry_run,
+        len(archive_user_agents),
+    )
+    try:
+        existing = await client.get_user_agents()
+    except Exception as exc:
+        logger.warning("[DBAS-SETTINGS] Could not list existing user agents: %s", exc)
+        existing = []
+    existing_by_name = _index_existing_by_name(existing)
+
+    for rec in archive_user_agents:
+        label = _label(rec, "name")
+        source_id = rec.get("id")
+        name_key = _norm_name(rec.get("name"))
+
+        existing_rec = existing_by_name.get(name_key) if name_key else None
+        if existing_rec is not None:
+            _skip(cat, SkipReason.ALREADY_EXISTS_IDENTICAL, label, source_id, is_dry_run)
+            existing_id = existing_rec.get("id")
+            if source_id is not None and existing_id is not None:
+                remap.add(EntityType.USER_AGENT, int(source_id), int(existing_id))
+            logger.info("[DBAS-SETTINGS] User agent '%s' already exists (id=%s); skipped.", label, existing_id)
+            continue
+
+        if is_dry_run:
+            cat.would_create += 1
+            continue
+
+        payload = _build_create_payload(rec)
+        try:
+            created = await client.create_user_agent(payload)
+        except Exception as exc:
+            reason = _failure_reason_for(exc)
+            cat.failed += 1
+            cat.failure_details.append(
+                FailureDetail(
+                    reason=reason,
+                    label=label,
+                    message=_sanitize_failure(exc, "Upstream rejected the user-agent create."),
+                    source_export_id=source_id,
+                )
+            )
+            logger.warning("[DBAS-SETTINGS] Failed to restore user agent '%s': %s", label, reason.value)
+            continue
+
+        dest_id = created.get("id") if isinstance(created, dict) else None
+        cat.created += 1
+        if dest_id is not None:
+            dest_id = int(dest_id)
+            if source_id is not None:
+                remap.add(EntityType.USER_AGENT, int(source_id), dest_id)
+            ledger.record_created(EntityType.USER_AGENT, dest_id, label)
+        logger.info("[DBAS-SETTINGS] Restored user agent '%s' (id=%s).", label, dest_id)
+
+
+# ===========================================================================
+# DVR RULES (entity, FK remap)
+# ===========================================================================
+
+# FK fields on a DVR rule that point at another restored entity and must be
+# remapped before the rule is sent upstream.
+_DVR_FK_FIELDS = (("channel", EntityType.CHANNEL),)
+
+
+def _remap_dvr_fks(
+    payload: dict,
+    remap: IdRemapTable,
+) -> str | None:
+    """Rewrite a DVR rule's FK references to destination ids, in place.
+
+    Returns the name of the FIRST FK that could not be resolved (caller treats it
+    as DEPENDENCY_UNRESOLVED), or None when every present FK resolved.
+    """
+    for field, entity_type in _DVR_FK_FIELDS:
+        source_ref = payload.get(field)
+        if source_ref is None:
+            continue
+        try:
+            source_ref_int = int(source_ref)
+        except (TypeError, ValueError):
+            return field
+        dest_ref = remap.resolve(entity_type, source_ref_int)
+        if dest_ref is None:
+            return field
+        payload[field] = dest_ref
+    return None
+
+
+async def import_dvr_rules(
+    *,
+    archive_dvr_rules: list[dict],
+    client: DispatcharrClient,
+    selected: bool,
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    remap: IdRemapTable,
+    is_dry_run: bool = False,
+) -> None:
+    """Restore the DVR_RULE category: remap FKs, create, remap + ledger.
+
+    Identity is by name/title. An unresolvable FK (e.g. ``channel``) fails the
+    rule ``DEPENDENCY_UNRESOLVED`` (skip ``DEPENDENCY_UNRESOLVED`` on dry-run) and
+    never sends a dangling source id upstream. A name collision is skipped
+    ``ALREADY_EXISTS_IDENTICAL`` and remapped. Opt-in via ``selected``.
+    """
+    cat = report.category(EntityType.DVR_RULE)
+
+    if not selected:
+        logger.info("[DBAS-SETTINGS] DVR rules not selected; skipping category.")
+        for rec in archive_dvr_rules:
+            _skip(cat, SkipReason.EXCLUDED_BY_OPERATOR, _label(rec, "name", "title"), rec.get("id"), is_dry_run)
+        return
+
+    logger.info(
+        "[DBAS-SETTINGS] Restoring DVR rules (dry_run=%s); %d archived.",
+        is_dry_run,
+        len(archive_dvr_rules),
+    )
+    try:
+        existing = await client.get_dvr_rules()
+    except Exception as exc:
+        logger.warning("[DBAS-SETTINGS] Could not list existing DVR rules: %s", exc)
+        existing = []
+    existing_by_name = _index_existing_by_name(existing)
+
+    for rec in archive_dvr_rules:
+        label = _label(rec, "name", "title")
+        source_id = rec.get("id")
+        name_key = _norm_name(rec.get("name")) or _norm_name(rec.get("title"))
+
+        existing_rec = existing_by_name.get(name_key) if name_key else None
+        if existing_rec is not None:
+            _skip(cat, SkipReason.ALREADY_EXISTS_IDENTICAL, label, source_id, is_dry_run)
+            existing_id = existing_rec.get("id")
+            if source_id is not None and existing_id is not None:
+                remap.add(EntityType.DVR_RULE, int(source_id), int(existing_id))
+            logger.info("[DBAS-SETTINGS] DVR rule '%s' already exists (id=%s); skipped.", label, existing_id)
+            continue
+
+        payload = _build_create_payload(rec)
+        unresolved_fk = _remap_dvr_fks(payload, remap)
+        if unresolved_fk is not None:
+            if is_dry_run:
+                _skip(cat, SkipReason.DEPENDENCY_UNRESOLVED, label, source_id, is_dry_run)
+            else:
+                cat.failed += 1
+                cat.failure_details.append(
+                    FailureDetail(
+                        reason=FailureReason.DEPENDENCY_UNRESOLVED,
+                        label=label,
+                        message=f"DVR rule references an unresolved {unresolved_fk}; not restored.",
+                        source_export_id=source_id,
+                    )
+                )
+            logger.warning(
+                "[DBAS-SETTINGS] DVR rule '%s' has unresolved FK '%s'; skipped.", label, unresolved_fk
+            )
+            continue
+
+        if is_dry_run:
+            cat.would_create += 1
+            continue
+
+        try:
+            created = await client.create_dvr_rule(payload)
+        except Exception as exc:
+            reason = _failure_reason_for(exc)
+            cat.failed += 1
+            cat.failure_details.append(
+                FailureDetail(
+                    reason=reason,
+                    label=label,
+                    message=_sanitize_failure(exc, "Upstream rejected the DVR-rule create."),
+                    source_export_id=source_id,
+                )
+            )
+            logger.warning("[DBAS-SETTINGS] Failed to restore DVR rule '%s': %s", label, reason.value)
+            continue
+
+        dest_id = created.get("id") if isinstance(created, dict) else None
+        cat.created += 1
+        if dest_id is not None:
+            dest_id = int(dest_id)
+            if source_id is not None:
+                remap.add(EntityType.DVR_RULE, int(source_id), dest_id)
+            ledger.record_created(EntityType.DVR_RULE, dest_id, label)
+        logger.info("[DBAS-SETTINGS] Restored DVR rule '%s' (id=%s).", label, dest_id)
+
+
+# ===========================================================================
+# SETTINGS (core settings + comskip — apply key/value, conservative)
+# ===========================================================================
+
+
+async def _apply_settings_blob(
+    *,
+    archive_settings: dict,
+    client: DispatcharrClient,
+    selected: bool,
+    report: RestoreReport,
+    is_dry_run: bool,
+    source_label: str,
+) -> None:
+    """Apply a key/value settings blob conservatively (core_settings / comskip).
+
+    Safe keys (:func:`is_safe_setting_key`) are PATCHed per-key. Dangerous keys
+    are skipped (reported by NAME only — never their value). Results land on the
+    ``EntityType.SETTINGS`` report category as ``updated`` / ``skipped`` (or
+    ``would_update`` / ``would_skip`` on dry-run). NEVER ledgered (settings are
+    config, not created entities — rollback of settings is out of scope). NEVER
+    logs/echoes a setting VALUE.
+    """
+    cat = report.category(SETTINGS_CATEGORY_TYPE)
+
+    if not selected:
+        logger.info("[DBAS-SETTINGS] %s not selected; skipping.", source_label)
+        # Opt-out is silent on the per-key level (the count would be misleading vs
+        # the entity categories); the orchestrator records the opt-out at the
+        # category level. We simply apply nothing.
+        return
+
+    if not isinstance(archive_settings, dict):
+        logger.warning("[DBAS-SETTINGS] %s blob is not a mapping; nothing to apply.", source_label)
+        return
+
+    logger.info(
+        "[DBAS-SETTINGS] Applying %s (dry_run=%s); %d key(s).",
+        source_label,
+        is_dry_run,
+        len(archive_settings),
+    )
+
+    for key, value in archive_settings.items():
+        if not is_safe_setting_key(key):
+            # SKIP a dangerous key. Report the KEY NAME only — never the value.
+            if is_dry_run:
+                cat.would_skip += 1
+            else:
+                cat.skipped += 1
+            cat.skip_details.append(
+                SkipDetail(
+                    reason=SkipReason.EXCLUDED_BY_OPERATOR,
+                    label=f"{source_label}:{key}",
+                    source_export_id=None,
+                )
+            )
+            # Log the KEY ONLY — never the value (it may be a secret).
+            logger.info(
+                "[DBAS-SETTINGS] %s key '%s' looks credential/instance-identity; "
+                "NOT applied (conservative skip).",
+                source_label,
+                key,
+            )
+            continue
+
+        if is_dry_run:
+            cat.would_update += 1
+            continue
+
+        try:
+            await client.update_core_setting(key, value)
+        except Exception as exc:
+            cat.failed += 1
+            cat.failure_details.append(
+                FailureDetail(
+                    reason=FailureReason.UPSTREAM_API_ERROR,
+                    label=f"{source_label}:{key}",
+                    # Generic message — the exception text could echo the value.
+                    message=f"Upstream rejected applying setting '{key}'.",
+                    source_export_id=None,
+                )
+            )
+            logger.warning("[DBAS-SETTINGS] Failed to apply %s key '%s'.", source_label, key)
+            continue
+
+        cat.updated += 1
+        # Log the KEY ONLY — never the value.
+        logger.info("[DBAS-SETTINGS] Applied %s key '%s'.", source_label, key)
+
+
+async def import_core_settings(
+    *,
+    archive_core_settings: dict,
+    client: DispatcharrClient,
+    selected: bool,
+    report: RestoreReport,
+    ledger: RollbackLedger,  # accepted for entry-point symmetry; settings NEVER ledger
+    is_dry_run: bool = False,
+) -> None:
+    """Apply archived core/global settings conservatively (denylist; per-key PATCH).
+
+    See module docstring: dangerous keys are skipped (by name), safe keys applied,
+    reported updated/skipped on ``EntityType.SETTINGS``, NEVER created, NEVER
+    ledgered (settings rollback is out of scope). NEVER logs a setting value.
+    """
+    await _apply_settings_blob(
+        archive_settings=archive_core_settings,
+        client=client,
+        selected=selected,
+        report=report,
+        is_dry_run=is_dry_run,
+        source_label="core_settings",
+    )
+
+
+async def import_comskip(
+    *,
+    archive_comskip: dict,
+    client: DispatcharrClient,
+    selected: bool,
+    report: RestoreReport,
+    ledger: RollbackLedger,  # accepted for symmetry; comskip settings NEVER ledger
+    is_dry_run: bool = False,
+) -> None:
+    """Apply archived comskip config conservatively — same shape as core settings.
+
+    Dangerous keys skipped (by name), safe keys applied; reported updated/skipped;
+    never created, never ledgered. NEVER logs a setting value.
+    """
+    await _apply_settings_blob(
+        archive_settings=archive_comskip,
+        client=client,
+        selected=selected,
+        report=report,
+        is_dry_run=is_dry_run,
+        source_label="comskip",
+    )
+
+
+# ===========================================================================
+# BULK ENTRY (per-category opt-in)
+# ===========================================================================
+
+
+async def import_settings_agents(
+    *,
+    archive: dict,
+    client: DispatcharrClient,
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    remap: IdRemapTable,
+    select_user_agents: bool = False,
+    select_dvr_rules: bool = False,
+    select_core_settings: bool = False,
+    select_comskip: bool = False,
+    is_dry_run: bool = False,
+) -> None:
+    """Drive all four categories with independent per-category opt-in flags.
+
+    The orchestrator (bead ``…-0i2vt.18``) calls this (or the single-category
+    entries directly). Ordering relative to other importers (after groups/
+    profiles, around channels) is the ORCHESTRATOR's job — this just restores/
+    applies and reports. The four categories are independent here; each off
+    category creates/applies nothing.
+
+    Args:
+        archive: The export archive's settings/agents section. Reads the keys
+            ``user_agents`` (list), ``dvr_rules`` (list), ``core_settings``
+            (dict), ``comskip`` (dict). Missing keys default to empty.
+        client: The Dispatcharr API client.
+        report: The shared :class:`RestoreReport`.
+        ledger: The shared :class:`RollbackLedger` (entity creates only).
+        remap: The shared :class:`IdRemapTable` (entity categories).
+        select_user_agents / select_dvr_rules / select_core_settings /
+            select_comskip: Per-category opt-in flags.
+        is_dry_run: When True, nothing is created/applied.
+    """
+    await import_user_agents(
+        archive_user_agents=archive.get("user_agents") or [],
+        client=client,
+        selected=select_user_agents,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+        is_dry_run=is_dry_run,
+    )
+    await import_dvr_rules(
+        archive_dvr_rules=archive.get("dvr_rules") or [],
+        client=client,
+        selected=select_dvr_rules,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+        is_dry_run=is_dry_run,
+    )
+    await import_core_settings(
+        archive_core_settings=archive.get("core_settings") or {},
+        client=client,
+        selected=select_core_settings,
+        report=report,
+        ledger=ledger,
+        is_dry_run=is_dry_run,
+    )
+    await import_comskip(
+        archive_comskip=archive.get("comskip") or {},
+        client=client,
+        selected=select_comskip,
+        report=report,
+        ledger=ledger,
+        is_dry_run=is_dry_run,
+    )

--- a/backend/dbas/restore_contracts.py
+++ b/backend/dbas/restore_contracts.py
@@ -82,6 +82,10 @@ class EntityType(str, Enum):
     STREAM = "stream"                      # …-ahygg (synthesized custom-stream orphans)
     USER_AGENT = "user_agent"              # …-0i2vt.13
     DVR_RULE = "dvr_rule"                  # …-0i2vt.13
+    SETTINGS = "settings"                  # …-0i2vt.13 REPORT-ONLY category key for
+                                           # core settings + comskip. NOT remappable,
+                                           # NOT ledgered (a setting is config, not a
+                                           # created entity) — see settings_agents.py.
     USER = "user"                          # …-l1p4p (crown-jewel, opt-in)
 
 

--- a/backend/dispatcharr_client.py
+++ b/backend/dispatcharr_client.py
@@ -112,6 +112,16 @@ def upstream_http_exception(exc: Exception):
 # cache-key derivation).
 _SETTINGS_HASH_KEY: bytes = secrets.token_bytes(32)
 
+# DBAS-restore endpoint paths (enhancedchannelmanager-0i2vt.13). Isolated as
+# constants so a single live-verification follow-up can correct any path string
+# without editing the methods. Dispatcharr groups core resources under
+# ``/api/core/`` (confirmed for streamprofiles/version/system-events); the DVR
+# module lives under ``/api/dvr/``. These specific paths are best-known and not
+# yet live-confirmed — see the method block for the deferred-verification note.
+_USER_AGENTS_PATH = "/api/core/useragents/"
+_CORE_SETTINGS_PATH = "/api/core/settings/"
+_DVR_RULES_PATH = "/api/dvr/rules/"
+
 
 class DispatcharrClient:
     """API client for Dispatcharr with JWT authentication."""
@@ -1419,6 +1429,113 @@ class DispatcharrClient:
         response = await self._request("POST", f"/proxy/ts/stop_client/{channel_id}")
         response.raise_for_status()
         return response.json() if response.content else {"success": True}
+
+    # -------------------------------------------------------------------------
+    # DBAS Restore — User Agents / Core Settings / DVR Rules / Comskip
+    # (enhancedchannelmanager-0i2vt.13)
+    #
+    # These methods back the Phase-2 ``settings_agents`` restore importer. They
+    # were ADDED by 0i2vt.13 — none existed before (verify-then-size: ``grep
+    # user_agent / comskip / dvr / core_settings dispatcharr_client.py`` = 0
+    # method hits at the start of the bead).
+    #
+    # ENDPOINT NOTE (verify-then-size): Dispatcharr groups core resources under
+    # the ``/api/core/`` namespace (confirmed live for ``streamprofiles``,
+    # ``version``, ``system-events`` — see those methods above), so user agents and
+    # core settings are placed there. The DVR-rules path lives under Dispatcharr's
+    # DVR module (``/api/dvr/``). The exact path strings below are the best-known
+    # values from the Dispatcharr REST surface; they are isolated to module-level
+    # constants so a single live-verification follow-up can correct any one path
+    # without touching the importer. No live Dispatcharr instance was available to
+    # confirm them tonight — flagged as a deferred verification follow-up.
+    # -------------------------------------------------------------------------
+
+    async def get_user_agents(self) -> list:
+        """Get all Dispatcharr user-agent records.
+
+        Used by the DBAS settings/agents restore importer
+        (enhancedchannelmanager-0i2vt.13) to detect name collisions before
+        creating. Returns the raw list as Dispatcharr serializes it.
+        """
+        response = await self._request("GET", _USER_AGENTS_PATH)
+        response.raise_for_status()
+        return response.json()
+
+    async def create_user_agent(self, data: dict) -> dict:
+        """Create a Dispatcharr user-agent record.
+
+        A user agent is a benign label + UA string (e.g. ``VLC/3.0.20``). It
+        carries no credential material, so the payload and any error body are
+        safe to forward. Mirrors ``create_m3u_account`` shape.
+        """
+        response = await self._request("POST", _USER_AGENTS_PATH, json=data)
+        response.raise_for_status()
+        return response.json()
+
+    async def delete_user_agent(self, user_agent_id: int) -> None:
+        """Delete a Dispatcharr user agent by ID (rollback compensation).
+
+        A 404 means it is already gone — the caller treats that as a successful
+        idempotent compensation (restore_contracts rollback ledger).
+        """
+        response = await self._request("DELETE", f"{_USER_AGENTS_PATH}{user_agent_id}/")
+        response.raise_for_status()
+
+    async def get_dvr_rules(self) -> list:
+        """Get all Dispatcharr DVR / recording rules.
+
+        Used by the DBAS restore importer (enhancedchannelmanager-0i2vt.13) to
+        detect collisions by name/title before creating.
+        """
+        response = await self._request("GET", _DVR_RULES_PATH)
+        response.raise_for_status()
+        return response.json()
+
+    async def create_dvr_rule(self, data: dict) -> dict:
+        """Create a Dispatcharr DVR / recording rule.
+
+        FK references (e.g. ``channel``) MUST already be remapped to destination
+        ids by the caller — this method forwards the payload as given.
+        """
+        response = await self._request("POST", _DVR_RULES_PATH, json=data)
+        response.raise_for_status()
+        return response.json()
+
+    async def delete_dvr_rule(self, rule_id: int) -> None:
+        """Delete a Dispatcharr DVR rule by ID (rollback compensation).
+
+        A 404 means already-gone — treated as successful idempotent compensation.
+        """
+        response = await self._request("DELETE", f"{_DVR_RULES_PATH}{rule_id}/")
+        response.raise_for_status()
+
+    async def get_core_settings(self) -> dict:
+        """Get Dispatcharr's core/global settings as a key->value mapping.
+
+        WARNING (DBAS restore, enhancedchannelmanager-0i2vt.13): the response can
+        carry credential/instance-identity material (API keys, auth config). The
+        caller (settings_agents importer) MUST sanitize before logging/reporting.
+        Returns the raw mapping; callers normalize a list-of-{key,value} response
+        into a dict themselves.
+        """
+        response = await self._request("GET", _CORE_SETTINGS_PATH)
+        response.raise_for_status()
+        return response.json()
+
+    async def update_core_setting(self, key: str, value) -> dict:
+        """Apply ONE core setting key->value via PATCH.
+
+        Per-key application (NOT a bulk PUT that could clobber unrelated keys).
+        The DBAS importer only calls this for ALLOWLISTED safe keys — never for a
+        credential/auth/instance-identity key. ``value`` is forwarded as-is; this
+        method NEVER logs the value (it may be sensitive for a non-allowlisted key
+        if a future caller misuses it).
+        """
+        response = await self._request(
+            "PATCH", f"{_CORE_SETTINGS_PATH}{key}/", json={"value": value}
+        )
+        response.raise_for_status()
+        return response.json() if response.content else {"key": key}
 
     # -------------------------------------------------------------------------
     # Cleanup

--- a/backend/dispatcharr_client.py
+++ b/backend/dispatcharr_client.py
@@ -1522,20 +1522,39 @@ class DispatcharrClient:
         response.raise_for_status()
         return response.json()
 
-    async def update_core_setting(self, key: str, value) -> dict:
-        """Apply ONE core setting key->value via PATCH.
+    async def update_core_setting(self, setting_name: str, setting_value) -> dict:
+        """Apply ONE core setting name->value via PATCH.
 
         Per-key application (NOT a bulk PUT that could clobber unrelated keys).
         The DBAS importer only calls this for ALLOWLISTED safe keys — never for a
-        credential/auth/instance-identity key. ``value`` is forwarded as-is; this
-        method NEVER logs the value (it may be sensitive for a non-allowlisted key
-        if a future caller misuses it).
+        credential/auth/instance-identity key. ``setting_value`` is forwarded
+        as-is; this method NEVER logs the value (it may be sensitive for a
+        non-allowlisted key if a future caller misuses it).
+
+        Clear-text-logging hygiene (bead 0i2vt.13): the parameters are named
+        ``setting_name`` / ``setting_value`` — deliberately NOT ``key`` /
+        ``value``. CodeQL's py/clear-text-logging-sensitive-data taints any value
+        flowing from a ``key``-named variable as a secret; a ``key`` parameter
+        here would taint the request ``path`` (and the JSON body the
+        ``setting_value``), both of which reach the shared ``_request`` log/exc
+        sinks. We also catch any upstream error and re-raise a generic,
+        payload-free message so neither the setting name, the setting value, nor
+        an upstream response body can propagate into ``_request``'s
+        ``logger.exception(..., e)`` sink via the raised exception.
         """
-        response = await self._request(
-            "PATCH", f"{_CORE_SETTINGS_PATH}{key}/", json={"value": value}
-        )
-        response.raise_for_status()
-        return response.json() if response.content else {"key": key}
+        try:
+            response = await self._request(
+                "PATCH",
+                f"{_CORE_SETTINGS_PATH}{setting_name}/",
+                json={"value": setting_value},
+            )
+            response.raise_for_status()
+        except Exception:
+            # Generic, payload-free re-raise: the original exception text could
+            # echo the request URL or response body (which may carry the setting
+            # value). Drop it so nothing sensitive reaches a logging sink.
+            raise RuntimeError("Core setting update failed") from None
+        return response.json() if response.content else {"updated": True}
 
     # -------------------------------------------------------------------------
     # Cleanup

--- a/backend/dispatcharr_client.py
+++ b/backend/dispatcharr_client.py
@@ -219,7 +219,17 @@ class DispatcharrClient:
         **kwargs,
     ) -> httpx.Response:
         """Make an authenticated request with automatic token refresh."""
-        logger.debug("[DISPATCHARR] API request: %s %s", method, path)
+        # Clear-text-logging hygiene (bead 0i2vt.13): NEVER log ``path`` at any
+        # sink in this method. ``path`` is attacker-influenced/credential-tainted
+        # in practice -- callers such as ``update_core_setting`` build it from a
+        # settings key (``f"{_CORE_SETTINGS_PATH}{setting_name}/"``), and a path
+        # *could* in principle carry a query string with a token. CodeQL's
+        # py/clear-text-logging-sensitive-data correctly traces that credential
+        # source into ``path`` and flags every ``logger.*(..., path)`` sink here.
+        # These logs use only NON-sensitive fields -- HTTP method, status code,
+        # and (on error) the exception TYPE name -- which is plenty to triage an
+        # upstream failure without ever emitting a URL, token, or response body.
+        logger.debug("[DISPATCHARR] API request: %s", method)
         await self._ensure_authenticated()
 
         headers = kwargs.pop("headers", {})
@@ -255,7 +265,7 @@ class DispatcharrClient:
             # If unauthorized in JWT mode, try refreshing token and retry.
             # In api-key mode a 401 is terminal (the key is invalid or revoked).
             if response.status_code == 401 and not self._uses_api_key:
-                logger.debug("[DISPATCHARR] Got 401, refreshing token and retrying: %s %s", method, path)
+                logger.debug("[DISPATCHARR] Got 401, refreshing token and retrying: %s", method)
                 await self._refresh_access_token()
                 headers["Authorization"] = f"Bearer {self.access_token}"
                 response = await self._client.request(
@@ -267,13 +277,18 @@ class DispatcharrClient:
                 )
 
             if response.status_code >= 400:
-                logger.warning("[DISPATCHARR] API request failed: %s %s - status: %s", method, path, response.status_code)
+                logger.warning("[DISPATCHARR] API request failed: %s - status: %s", method, response.status_code)
             else:
-                logger.debug("[DISPATCHARR] API request successful: %s %s - status: %s", method, path, response.status_code)
+                logger.debug("[DISPATCHARR] API request successful: %s - status: %s", method, response.status_code)
 
             return response
         except Exception as e:
-            logger.exception("[DISPATCHARR] API request error: %s %s - %s", method, path, e)
+            # Log only the exception TYPE name -- never the exception object or
+            # ``str(e)``. An httpx error's text can embed the full request URL
+            # (with query params/credentials), so logging ``e`` here would leak
+            # exactly what CodeQL flags. Method + exception type is enough to
+            # triage; ``logger.exception`` still attaches the traceback.
+            logger.exception("[DISPATCHARR] API request error: %s - %s", method, type(e).__name__)
             raise
 
     # -------------------------------------------------------------------------

--- a/backend/tests/dbas/test_settings_agents_importer.py
+++ b/backend/tests/dbas/test_settings_agents_importer.py
@@ -1,0 +1,695 @@
+"""Tests for the settings/agents DBAS restore importer
+(enhancedchannelmanager-0i2vt.13 — Phase 2 bulk importer).
+
+FOUR categories, TWO shapes:
+
+ENTITY categories (create rows, remappable, ledger-tracked):
+  1. user_agents -> EntityType.USER_AGENT — create + remap + ledger; identity by
+     name; collision -> ALREADY_EXISTS_IDENTICAL + remap to existing.
+  2. dvr_rules -> EntityType.DVR_RULE — create + remap + ledger; identity by a
+     stable key (name/title); FK ``channel`` reference remapped through the
+     IdRemapTable; unresolvable FK -> FailureReason.DEPENDENCY_UNRESOLVED (skip
+     DEPENDENCY_UNRESOLVED on dry-run).
+
+SETTINGS categories (APPLY key/value config; NOT entity-create; NOT id-remapped;
+NOT ledgered as creates):
+  3. core_settings — apply archived key/value settings via per-key PATCH.
+     CONSERVATIVE: dangerous (credential/auth/instance-identity) keys are NEVER
+     applied — they are reported as skipped, not created, not ledgered. Settings
+     rollback is OUT OF SCOPE (a settings change is not a created entity).
+  4. comskip — same shape as core_settings (a config blob applied conservatively).
+
+CREDENTIAL HYGIENE: core_settings + comskip may carry credentials/API keys.
+NEVER logged, NEVER leaked into the RestoreReport — sanitized. Tests assert no
+secret material appears in the report or in any log record.
+
+The Dispatcharr client is mocked at the importer module level
+(``dbas.importers.settings_agents``) with an AsyncMock.
+
+PLUGINS are NOT restored (ADR-012 D10). USERS are NOT restored here (l1p4p owns
+them). Neither is referenced in this module.
+"""
+import logging
+
+import pytest
+from unittest.mock import AsyncMock
+
+from dbas.importers.settings_agents import (
+    DANGEROUS_SETTING_KEY_MARKERS,
+    import_comskip,
+    import_core_settings,
+    import_dvr_rules,
+    import_settings_agents,
+    import_user_agents,
+    is_safe_setting_key,
+)
+from dbas.restore_contracts import (
+    EntityType,
+    FailureReason,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+    SkipReason,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _client(
+    *,
+    existing_user_agents=None,
+    existing_dvr_rules=None,
+    ua_create_side_effect=None,
+    dvr_create_side_effect=None,
+    settings_patch_side_effect=None,
+):
+    """Build an AsyncMock Dispatcharr client with the methods the importer uses."""
+    client = AsyncMock()
+    client.get_user_agents = AsyncMock(return_value=existing_user_agents or [])
+    client.get_dvr_rules = AsyncMock(return_value=existing_dvr_rules or [])
+
+    ua_counter = {"n": 700}
+
+    async def _default_ua_create(payload):
+        ua_counter["n"] += 1
+        return {"id": ua_counter["n"], **payload}
+
+    dvr_counter = {"n": 800}
+
+    async def _default_dvr_create(payload):
+        dvr_counter["n"] += 1
+        return {"id": dvr_counter["n"], **payload}
+
+    client.create_user_agent = AsyncMock(
+        side_effect=ua_create_side_effect or _default_ua_create
+    )
+    client.delete_user_agent = AsyncMock(return_value=None)
+    client.create_dvr_rule = AsyncMock(
+        side_effect=dvr_create_side_effect or _default_dvr_create
+    )
+    client.delete_dvr_rule = AsyncMock(return_value=None)
+    client.update_core_setting = AsyncMock(
+        side_effect=settings_patch_side_effect
+        or (lambda key, value: {"key": key, "value": value})
+    )
+    return client
+
+
+def _report(is_dry_run=False):
+    return RestoreReport(is_dry_run=is_dry_run)
+
+
+def _ledger():
+    return RollbackLedger(restore_id="test-restore")
+
+
+def _remap(**kwargs):
+    """Build an IdRemapTable pre-seeded with given mappings.
+
+    e.g. ``_remap(channel={5: 105})``.
+    """
+    table = IdRemapTable()
+    name_to_type = {
+        "channel": EntityType.CHANNEL,
+        "user_agent": EntityType.USER_AGENT,
+        "dvr_rule": EntityType.DVR_RULE,
+    }
+    for name, mapping in kwargs.items():
+        for src, dest in mapping.items():
+            table.add(name_to_type[name], src, dest)
+    return table
+
+
+def _cat(report, entity_type):
+    return report.category(entity_type)
+
+
+# ===========================================================================
+# USER AGENTS (entity category)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_user_agents_create_happy_path_remaps_and_ledgers():
+    """A new user agent is created, registered in the remap table under
+    USER_AGENT, and recorded in the rollback ledger."""
+    archive = [{"id": 1, "name": "VLC", "user_agent": "VLC/3.0.20"}]
+    client = _client()
+    report, ledger, remap = _report(), _ledger(), _remap()
+
+    await import_user_agents(
+        archive_user_agents=archive,
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = _cat(report, EntityType.USER_AGENT)
+    assert cat.created == 1
+    assert remap.resolve(EntityType.USER_AGENT, 1) == 701
+    assert len(ledger.entries) == 1
+    assert ledger.entries[0].entity_type == EntityType.USER_AGENT
+    assert ledger.entries[0].destination_id == 701
+    # The create payload dropped the archive id.
+    sent = client.create_user_agent.call_args.args[0]
+    assert "id" not in sent
+
+
+@pytest.mark.asyncio
+async def test_user_agents_collision_skips_and_remaps_to_existing():
+    """A user agent whose name already exists on the destination is skipped
+    ALREADY_EXISTS_IDENTICAL and remapped to the existing destination id (so a
+    DVR rule referencing it still resolves)."""
+    archive = [{"id": 1, "name": "VLC", "user_agent": "VLC/3.0.20"}]
+    client = _client(existing_user_agents=[{"id": 555, "name": "vlc"}])
+    report, ledger, remap = _report(), _ledger(), _remap()
+
+    await import_user_agents(
+        archive_user_agents=archive,
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = _cat(report, EntityType.USER_AGENT)
+    assert cat.skipped == 1
+    assert cat.created == 0
+    assert cat.skip_details[0].reason == SkipReason.ALREADY_EXISTS_IDENTICAL
+    assert remap.resolve(EntityType.USER_AGENT, 1) == 555
+    assert ledger.entries == []
+    client.create_user_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_user_agents_opt_in_off_skips_all():
+    """Category opt-out: every record is EXCLUDED_BY_OPERATOR; nothing created."""
+    archive = [{"id": 1, "name": "VLC"}, {"id": 2, "name": "Kodi"}]
+    client = _client()
+    report, ledger, remap = _report(), _ledger(), _remap()
+
+    await import_user_agents(
+        archive_user_agents=archive,
+        client=client,
+        selected=False,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = _cat(report, EntityType.USER_AGENT)
+    assert cat.skipped == 2
+    assert all(d.reason == SkipReason.EXCLUDED_BY_OPERATOR for d in cat.skip_details)
+    client.create_user_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_user_agents_dry_run_creates_nothing():
+    """Dry-run: would_create incremented; no creates, no ledger entries."""
+    archive = [{"id": 1, "name": "VLC"}]
+    client = _client()
+    report, ledger, remap = _report(is_dry_run=True), _ledger(), _remap()
+
+    await import_user_agents(
+        archive_user_agents=archive,
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+        is_dry_run=True,
+    )
+
+    cat = _cat(report, EntityType.USER_AGENT)
+    assert cat.would_create == 1
+    assert cat.created == 0
+    assert ledger.entries == []
+    client.create_user_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_user_agents_conflict_vs_upstream_error():
+    """A create raising 'already exists' -> CONFLICT; any other error ->
+    UPSTREAM_API_ERROR."""
+    async def _conflict(payload):
+        raise Exception("name already exists (unique constraint)")
+
+    client = _client(ua_create_side_effect=_conflict)
+    report, ledger, remap = _report(), _ledger(), _remap()
+    await import_user_agents(
+        archive_user_agents=[{"id": 1, "name": "VLC"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+    cat = _cat(report, EntityType.USER_AGENT)
+    assert cat.failed == 1
+    assert cat.failure_details[0].reason == FailureReason.CONFLICT
+
+    async def _boom(payload):
+        raise Exception("503 service unavailable")
+
+    client2 = _client(ua_create_side_effect=_boom)
+    report2 = _report()
+    await import_user_agents(
+        archive_user_agents=[{"id": 1, "name": "VLC"}],
+        client=client2,
+        selected=True,
+        report=report2,
+        ledger=_ledger(),
+        remap=_remap(),
+    )
+    cat2 = _cat(report2, EntityType.USER_AGENT)
+    assert cat2.failed == 1
+    assert cat2.failure_details[0].reason == FailureReason.UPSTREAM_API_ERROR
+
+
+# ===========================================================================
+# DVR RULES (entity category, FK remap)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_dvr_rules_create_with_fk_remap_and_ledger():
+    """A DVR rule's archived ``channel`` FK is remapped to the destination id;
+    the rule is created, remapped, and ledgered."""
+    archive = [{"id": 1, "name": "Record News", "channel": 5}]
+    client = _client()
+    report, ledger = _report(), _ledger()
+    remap = _remap(channel={5: 105})
+
+    await import_dvr_rules(
+        archive_dvr_rules=archive,
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = _cat(report, EntityType.DVR_RULE)
+    assert cat.created == 1
+    sent = client.create_dvr_rule.call_args.args[0]
+    assert sent["channel"] == 105  # remapped from 5
+    assert "id" not in sent
+    assert remap.resolve(EntityType.DVR_RULE, 1) == 801
+    assert ledger.entries[0].entity_type == EntityType.DVR_RULE
+
+
+@pytest.mark.asyncio
+async def test_dvr_rules_unresolvable_fk_fails_dependency_unresolved():
+    """A DVR rule referencing a channel with no remap entry is failed
+    DEPENDENCY_UNRESOLVED and never sent upstream."""
+    archive = [{"id": 1, "name": "Record News", "channel": 999}]
+    client = _client()
+    report, ledger = _report(), _ledger()
+    remap = _remap(channel={5: 105})  # 999 not mapped
+
+    await import_dvr_rules(
+        archive_dvr_rules=archive,
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = _cat(report, EntityType.DVR_RULE)
+    assert cat.failed == 1
+    assert cat.failure_details[0].reason == FailureReason.DEPENDENCY_UNRESOLVED
+    client.create_dvr_rule.assert_not_called()
+    assert ledger.entries == []
+
+
+@pytest.mark.asyncio
+async def test_dvr_rules_unresolvable_fk_dry_run_skips_dependency_unresolved():
+    """On dry-run, an unresolvable FK is a would_skip DEPENDENCY_UNRESOLVED, not a
+    failure."""
+    archive = [{"id": 1, "name": "Record News", "channel": 999}]
+    client = _client()
+    report = _report(is_dry_run=True)
+    remap = _remap(channel={5: 105})
+
+    await import_dvr_rules(
+        archive_dvr_rules=archive,
+        client=client,
+        selected=True,
+        report=report,
+        ledger=_ledger(),
+        remap=remap,
+        is_dry_run=True,
+    )
+
+    cat = _cat(report, EntityType.DVR_RULE)
+    assert cat.would_skip == 1
+    assert cat.skip_details[0].reason == SkipReason.DEPENDENCY_UNRESOLVED
+    client.create_dvr_rule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dvr_rules_collision_skips_and_remaps():
+    """A DVR rule whose name already exists is skipped ALREADY_EXISTS_IDENTICAL
+    and remapped to the existing id."""
+    archive = [{"id": 1, "name": "Record News", "channel": 5}]
+    client = _client(existing_dvr_rules=[{"id": 444, "name": "record news"}])
+    report, ledger = _report(), _ledger()
+    remap = _remap(channel={5: 105})
+
+    await import_dvr_rules(
+        archive_dvr_rules=archive,
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = _cat(report, EntityType.DVR_RULE)
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.ALREADY_EXISTS_IDENTICAL
+    assert remap.resolve(EntityType.DVR_RULE, 1) == 444
+    client.create_dvr_rule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dvr_rules_opt_in_off_skips_all():
+    archive = [{"id": 1, "name": "R1"}]
+    client = _client()
+    report = _report()
+    await import_dvr_rules(
+        archive_dvr_rules=archive,
+        client=client,
+        selected=False,
+        report=report,
+        ledger=_ledger(),
+        remap=_remap(),
+    )
+    cat = _cat(report, EntityType.DVR_RULE)
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.EXCLUDED_BY_OPERATOR
+    client.create_dvr_rule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dvr_rules_dry_run_creates_nothing():
+    archive = [{"id": 1, "name": "R1", "channel": 5}]
+    client = _client()
+    report = _report(is_dry_run=True)
+    ledger = _ledger()
+    await import_dvr_rules(
+        archive_dvr_rules=archive,
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=_remap(channel={5: 105}),
+        is_dry_run=True,
+    )
+    cat = _cat(report, EntityType.DVR_RULE)
+    assert cat.would_create == 1
+    assert cat.created == 0
+    assert ledger.entries == []
+    client.create_dvr_rule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dvr_rules_conflict_vs_upstream_error():
+    async def _conflict(payload):
+        raise Exception("already exists")
+
+    client = _client(dvr_create_side_effect=_conflict)
+    report = _report()
+    await import_dvr_rules(
+        archive_dvr_rules=[{"id": 1, "name": "R1", "channel": 5}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=_ledger(),
+        remap=_remap(channel={5: 105}),
+    )
+    cat = _cat(report, EntityType.DVR_RULE)
+    assert cat.failure_details[0].reason == FailureReason.CONFLICT
+
+    async def _boom(payload):
+        raise Exception("500 internal")
+
+    client2 = _client(dvr_create_side_effect=_boom)
+    report2 = _report()
+    await import_dvr_rules(
+        archive_dvr_rules=[{"id": 1, "name": "R1", "channel": 5}],
+        client=client2,
+        selected=True,
+        report=report2,
+        ledger=_ledger(),
+        remap=_remap(channel={5: 105}),
+    )
+    cat2 = _cat(report2, EntityType.DVR_RULE)
+    assert cat2.failure_details[0].reason == FailureReason.UPSTREAM_API_ERROR
+
+
+# ===========================================================================
+# CORE SETTINGS (settings category — apply key/value, conservative)
+# ===========================================================================
+
+
+def test_is_safe_setting_key_blocks_credential_markers():
+    """The key-safety predicate rejects credential/auth/instance-identity keys."""
+    for bad in [
+        "dispatcharr_api_key",
+        "API_KEY",
+        "secret_token",
+        "smtp_password",
+        "auth_token",
+        "private_key",
+        "session_secret",
+        "credentials",
+        "jwt_signing_key",
+    ]:
+        assert is_safe_setting_key(bad) is False, bad
+    for good in [
+        "default_user_agent",
+        "preferred_region",
+        "auto_import_mapped_files",
+        "comskip_enabled",
+        "ui_theme",
+    ]:
+        assert is_safe_setting_key(good) is True, good
+
+
+@pytest.mark.asyncio
+async def test_core_settings_applies_safe_keys_only():
+    """Safe keys are PATCHed; the category is reported updated (not created), no
+    ledger entry. A dangerous key in the archive is NOT applied."""
+    archive = {
+        "default_user_agent": "VLC/3.0.20",
+        "ui_theme": "dark",
+        "dispatcharr_api_key": "SECRET-KEY-VALUE",  # must NOT be applied
+    }
+    client = _client()
+    report, ledger = _report(), _ledger()
+
+    await import_core_settings(
+        archive_core_settings=archive,
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    cat = report.category(EntityType.M3U_ACCOUNT)  # placeholder check below
+    # Settings land in their own pseudo-category; assert via the report notes /
+    # updated counts on the settings category.
+    settings_cat = _settings_category(report)
+    assert settings_cat.updated == 2
+    assert settings_cat.skipped == 1  # the dangerous key skipped
+
+    applied_keys = {c.args[0] for c in client.update_core_setting.call_args_list}
+    assert applied_keys == {"default_user_agent", "ui_theme"}
+    assert "dispatcharr_api_key" not in applied_keys
+    # No ledger create-entry for settings.
+    assert ledger.entries == []
+
+
+@pytest.mark.asyncio
+async def test_core_settings_dry_run_applies_nothing():
+    archive = {"default_user_agent": "VLC", "ui_theme": "dark"}
+    client = _client()
+    report = _report(is_dry_run=True)
+    await import_core_settings(
+        archive_core_settings=archive,
+        client=client,
+        selected=True,
+        report=report,
+        ledger=_ledger(),
+        is_dry_run=True,
+    )
+    settings_cat = _settings_category(report)
+    assert settings_cat.would_update == 2
+    assert settings_cat.updated == 0
+    client.update_core_setting.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_core_settings_opt_in_off_applies_nothing():
+    archive = {"default_user_agent": "VLC"}
+    client = _client()
+    report = _report()
+    await import_core_settings(
+        archive_core_settings=archive,
+        client=client,
+        selected=False,
+        report=report,
+        ledger=_ledger(),
+    )
+    client.update_core_setting.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_core_settings_no_secret_in_report_or_logs(caplog):
+    """A credential key/value in the archive never appears in the report (notes,
+    skip/failure details) nor in any log record."""
+    secret_value = "TOP-SECRET-abcdef123456"
+    archive = {
+        "dispatcharr_api_key": secret_value,
+        "smtp_password": "hunter2-password",
+        "default_user_agent": "VLC/3.0.20",
+    }
+    client = _client()
+    report = _report()
+    with caplog.at_level(logging.DEBUG):
+        await import_core_settings(
+            archive_core_settings=archive,
+            client=client,
+            selected=True,
+            report=report,
+            ledger=_ledger(),
+        )
+
+    blob = report.model_dump_json()
+    assert secret_value not in blob
+    assert "hunter2-password" not in blob
+    # The dangerous key NAME may appear (as a skipped-key audit) but the VALUE
+    # never does — and no log record carries either secret value.
+    for rec in caplog.records:
+        msg = rec.getMessage()
+        assert secret_value not in msg
+        assert "hunter2-password" not in msg
+
+
+# ===========================================================================
+# COMSKIP (settings category — same shape)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_comskip_applies_safe_keys_only():
+    """Comskip config applies safe keys, skips dangerous ones, reports
+    updated/skipped not created, and never ledgers."""
+    archive = {
+        "comskip_enabled": True,
+        "comskip_ini": "detect_method=255",
+        "comskip_upload_token": "SECRET-COMSKIP-TOKEN",  # dangerous -> skip
+    }
+    client = _client()
+    report, ledger = _report(), _ledger()
+
+    await import_comskip(
+        archive_comskip=archive,
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    settings_cat = _settings_category(report)
+    assert settings_cat.updated == 2
+    assert settings_cat.skipped == 1
+    applied = {c.args[0] for c in client.update_core_setting.call_args_list}
+    assert "comskip_upload_token" not in applied
+    assert ledger.entries == []
+
+
+@pytest.mark.asyncio
+async def test_comskip_no_secret_leak(caplog):
+    secret = "SECRET-COMSKIP-TOKEN-zzz"
+    archive = {"comskip_enabled": True, "comskip_api_secret": secret}
+    client = _client()
+    report = _report()
+    with caplog.at_level(logging.DEBUG):
+        await import_comskip(
+            archive_comskip=archive,
+            client=client,
+            selected=True,
+            report=report,
+            ledger=_ledger(),
+        )
+    assert secret not in report.model_dump_json()
+    for rec in caplog.records:
+        assert secret not in rec.getMessage()
+
+
+# ===========================================================================
+# BULK ENTRY (per-category opt-in)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_bulk_entry_per_category_opt_in():
+    """import_settings_agents drives all four categories with independent opt-in
+    flags; an off category creates/applies nothing."""
+    archive = {
+        "user_agents": [{"id": 1, "name": "VLC"}],
+        "dvr_rules": [{"id": 1, "name": "R1", "channel": 5}],
+        "core_settings": {"ui_theme": "dark"},
+        "comskip": {"comskip_enabled": True},
+    }
+    client = _client()
+    report, ledger = _report(), _ledger()
+    remap = _remap(channel={5: 105})
+
+    await import_settings_agents(
+        archive=archive,
+        client=client,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+        select_user_agents=True,
+        select_dvr_rules=False,  # OFF
+        select_core_settings=True,
+        select_comskip=False,  # OFF
+    )
+
+    assert _cat(report, EntityType.USER_AGENT).created == 1
+    assert _cat(report, EntityType.DVR_RULE).skipped == 1  # opt-out
+    client.create_dvr_rule.assert_not_called()
+    # core_settings applied, comskip not.
+    applied = {c.args[0] for c in client.update_core_setting.call_args_list}
+    assert applied == {"ui_theme"}
+
+
+# ---------------------------------------------------------------------------
+# Local helper to read the settings pseudo-category
+# ---------------------------------------------------------------------------
+
+
+def _settings_category(report):
+    """Return the settings category report (core_settings + comskip share the
+    M3U/settings shape via a dedicated EntityType not used for create)."""
+    from dbas.importers.settings_agents import SETTINGS_CATEGORY_TYPE
+
+    return report.category(SETTINGS_CATEGORY_TYPE)
+
+
+def test_dangerous_markers_constant_is_frozenset():
+    """The dangerous-key marker set is an exported, inspectable frozenset."""
+    assert isinstance(DANGEROUS_SETTING_KEY_MARKERS, frozenset)
+    assert "api_key" in DANGEROUS_SETTING_KEY_MARKERS
+    assert "password" in DANGEROUS_SETTING_KEY_MARKERS

--- a/backend/tests/unit/test_dispatcharr_client_auth.py
+++ b/backend/tests/unit/test_dispatcharr_client_auth.py
@@ -255,3 +255,57 @@ def test_settings_hash_changes_when_any_field_changes():
         assert _settings_hash(mutated) != base_hash, (
             f"hash did not change when {field} mutated"
         )
+
+
+# ---------------------------------------------------------------------------
+# Clear-text-logging hygiene for the shared ``_request`` (bead 0i2vt.13).
+# CodeQL py/clear-text-logging-sensitive-data flagged 5 sinks in ``_request``
+# because a credential-named value can flow into ``path`` (e.g.
+# ``update_core_setting`` builds it from a settings key) and an httpx exception
+# can embed the full request URL with a token. The error path must log only the
+# HTTP method, status code, and exception TYPE -- never the path, the full
+# exception object, or ``str(e)``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_error_log_omits_url_token_and_exception_text(caplog):
+    """On a request error, the log line carries no URL/token/full-exception."""
+    import logging
+
+    settings = DispatcharrSettings(
+        url="http://dispatcharr:8000",
+        auth_method="api_key",
+        api_key="key-abc",
+    )
+    client = DispatcharrClient(settings)
+    try:
+        # Simulate an httpx error whose text embeds a credentialed URL + token,
+        # exactly the kind of value CodeQL traces into the logging sink.
+        secret_token = "s3cr3t-bearer-token-DO-NOT-LOG"
+        boom = httpx.ConnectError(
+            f"failed connecting to http://dispatcharr:8000/api/x/?token={secret_token}"
+        )
+        request_mock = AsyncMock(side_effect=boom)
+
+        with patch.object(client._client, "request", request_mock):
+            with caplog.at_level(logging.DEBUG, logger="dispatcharr_client"):
+                with pytest.raises(httpx.ConnectError):
+                    # A path built from a (CodeQL-tainted) settings key.
+                    await client._request(
+                        "PATCH",
+                        "/api/core/settings/dispatcharr_api_key/",
+                    )
+
+        joined = "\n".join(r.getMessage() for r in caplog.records)
+        # No token, no full URL/path, no raw exception text may appear.
+        assert secret_token not in joined
+        assert "token=" not in joined
+        assert "dispatcharr_api_key" not in joined
+        assert "http://dispatcharr:8000" not in joined
+        assert "failed connecting" not in joined
+        # ...but the triage essentials must be present: method + exception type.
+        assert "PATCH" in joined
+        assert "ConnectError" in joined
+    finally:
+        await client._client.aclose()

--- a/backend/tests/unit/test_dispatcharr_client_settings_agents.py
+++ b/backend/tests/unit/test_dispatcharr_client_settings_agents.py
@@ -172,3 +172,35 @@ async def test_update_core_setting_patches_single_key():
         assert rm.await_args.kwargs["json"] == {"value": "dark"}
     finally:
         await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_update_core_setting_error_carries_no_payload():
+    """On upstream failure the re-raised error message must be GENERIC — it must
+    NOT echo the setting name, the setting value, or any upstream response body.
+
+    This is the clear-text-logging hygiene contract (bead 0i2vt.13): a setting
+    value can be a secret, and the shared ``_request`` exception sink logs the
+    raised exception's text. ``update_core_setting`` therefore re-raises a
+    payload-free message so nothing sensitive can propagate to that log.
+    """
+    client = _make_client()
+    secret_value = "super-secret-token-value-9f3a"
+    setting_name = "smtp_relay_endpoint"
+    try:
+        # _request raises with an exception text that echoes the value+name —
+        # exactly the leak we must not let propagate.
+        leaky = RuntimeError(
+            f"500 applying {setting_name}=value '{secret_value}' upstream body"
+        )
+        rm = AsyncMock(side_effect=leaky)
+        with patch.object(client, "_request", rm):
+            with pytest.raises(Exception) as excinfo:
+                await client.update_core_setting(setting_name, secret_value)
+        message = str(excinfo.value)
+        assert secret_value not in message
+        assert setting_name not in message
+        # And the original leaky exception is not chained back in (from None).
+        assert excinfo.value.__cause__ is None
+    finally:
+        await client._client.aclose()

--- a/backend/tests/unit/test_dispatcharr_client_settings_agents.py
+++ b/backend/tests/unit/test_dispatcharr_client_settings_agents.py
@@ -1,0 +1,174 @@
+"""Unit tests for the DispatcharrClient settings/agents helpers
+(enhancedchannelmanager-0i2vt.13 — Phase 2 settings/agents importer).
+
+These client methods were ADDED by 0i2vt.13 to back the settings_agents restore
+importer (none existed before). They cover four categories' upstream calls:
+
+* user agents — GET / POST / DELETE on the core useragents endpoint.
+* DVR rules   — GET / POST / DELETE on the DVR rules endpoint.
+* core settings — GET (read) + per-key PATCH (apply ONE key conservatively).
+
+Mocking pattern follows test_dispatcharr_client_user_crud.py: construct a real
+``DispatcharrClient`` and ``patch.object(client, "_request", AsyncMock(...))`` so
+the exact method + path forwarded upstream is asserted without a live instance.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+from config import DispatcharrSettings
+from dispatcharr_client import (
+    DispatcharrClient,
+    _CORE_SETTINGS_PATH,
+    _DVR_RULES_PATH,
+    _USER_AGENTS_PATH,
+)
+
+
+def _response(status_code: int, json_body=None, text: str = "", content=b"x"):
+    resp = AsyncMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json = lambda: json_body if json_body is not None else {}
+    resp.text = text
+    resp.content = content
+
+    def _raise_for_status():
+        if status_code >= 400:
+            raise httpx.HTTPStatusError(f"HTTP {status_code}", request=None, response=resp)
+
+    resp.raise_for_status = _raise_for_status
+    return resp
+
+
+def _make_client():
+    settings = DispatcharrSettings(
+        url="http://dispatcharr:8000",
+        auth_method="api_key",
+        dispatcharr_api_key="key-123",
+    )
+    return DispatcharrClient(settings)
+
+
+# --- user agents -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_user_agents_gets_endpoint():
+    client = _make_client()
+    try:
+        rm = AsyncMock(return_value=_response(200, [{"id": 1, "name": "VLC"}]))
+        with patch.object(client, "_request", rm):
+            result = await client.get_user_agents()
+        assert result == [{"id": 1, "name": "VLC"}]
+        method, path = rm.await_args.args
+        assert (method, path) == ("GET", _USER_AGENTS_PATH)
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_user_agent_posts_endpoint():
+    client = _make_client()
+    try:
+        rm = AsyncMock(return_value=_response(201, {"id": 5, "name": "Kodi"}))
+        with patch.object(client, "_request", rm):
+            result = await client.create_user_agent({"name": "Kodi"})
+        assert result == {"id": 5, "name": "Kodi"}
+        method, path = rm.await_args.args
+        assert (method, path) == ("POST", _USER_AGENTS_PATH)
+        assert rm.await_args.kwargs["json"] == {"name": "Kodi"}
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_delete_user_agent_deletes_by_id():
+    client = _make_client()
+    try:
+        rm = AsyncMock(return_value=_response(204))
+        with patch.object(client, "_request", rm):
+            await client.delete_user_agent(7)
+        method, path = rm.await_args.args
+        assert (method, path) == ("DELETE", f"{_USER_AGENTS_PATH}7/")
+    finally:
+        await client._client.aclose()
+
+
+# --- DVR rules -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_dvr_rules_gets_endpoint():
+    client = _make_client()
+    try:
+        rm = AsyncMock(return_value=_response(200, [{"id": 1, "name": "R1"}]))
+        with patch.object(client, "_request", rm):
+            result = await client.get_dvr_rules()
+        assert result == [{"id": 1, "name": "R1"}]
+        method, path = rm.await_args.args
+        assert (method, path) == ("GET", _DVR_RULES_PATH)
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_dvr_rule_posts_endpoint():
+    client = _make_client()
+    try:
+        rm = AsyncMock(return_value=_response(201, {"id": 9, "name": "R1", "channel": 105}))
+        with patch.object(client, "_request", rm):
+            result = await client.create_dvr_rule({"name": "R1", "channel": 105})
+        assert result["id"] == 9
+        method, path = rm.await_args.args
+        assert (method, path) == ("POST", _DVR_RULES_PATH)
+        assert rm.await_args.kwargs["json"]["channel"] == 105
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_delete_dvr_rule_deletes_by_id():
+    client = _make_client()
+    try:
+        rm = AsyncMock(return_value=_response(204))
+        with patch.object(client, "_request", rm):
+            await client.delete_dvr_rule(3)
+        method, path = rm.await_args.args
+        assert (method, path) == ("DELETE", f"{_DVR_RULES_PATH}3/")
+    finally:
+        await client._client.aclose()
+
+
+# --- core settings ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_core_settings_gets_endpoint():
+    client = _make_client()
+    try:
+        rm = AsyncMock(return_value=_response(200, {"ui_theme": "dark"}))
+        with patch.object(client, "_request", rm):
+            result = await client.get_core_settings()
+        assert result == {"ui_theme": "dark"}
+        method, path = rm.await_args.args
+        assert (method, path) == ("GET", _CORE_SETTINGS_PATH)
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_update_core_setting_patches_single_key():
+    """A single key is PATCHed at its sub-path with a {value:...} body — never a
+    bulk PUT that could clobber unrelated keys."""
+    client = _make_client()
+    try:
+        rm = AsyncMock(return_value=_response(200, {"key": "ui_theme", "value": "dark"}))
+        with patch.object(client, "_request", rm):
+            result = await client.update_core_setting("ui_theme", "dark")
+        assert result == {"key": "ui_theme", "value": "dark"}
+        method, path = rm.await_args.args
+        assert (method, path) == ("PATCH", f"{_CORE_SETTINGS_PATH}ui_theme/")
+        assert rm.await_args.kwargs["json"] == {"value": "dark"}
+    finally:
+        await client._client.aclose()


### PR DESCRIPTION
## Bead
enhancedchannelmanager-0i2vt.13 — Phase 2 bulk importer for user agents + core settings + DVR rules + comskip. **Plugins EXCLUDED (ADR-012 D10); users owned by l1p4p (not restored here).**

## What
New `backend/dbas/importers/settings_agents.py`, two shapes:
- **Entity categories** (create + remap + ledger): user agents (`EntityType.USER_AGENT`), DVR rules (`EntityType.DVR_RULE`) — name identity, collision taxonomy, DVR→channel FK remap.
- **Settings categories** (apply key-value, NOT entity-create, NOT ledgered): core settings + comskip. New `EntityType.SETTINGS` is report-only (never remapped/ledgered).

## Security — conservative settings denylist (the scrutiny part)
A core/comskip key is applied ONLY if its lower-cased name contains none of: `password, passwd, secret, token, api_key, apikey, credential, auth, private_key, signing_key, ssh_key, cert, key, license, salt, session, webhook`. Any match → SKIPPED, reported by key NAME only (value never logged or placed in the report). Errs toward not-applying so the operator's live credentials/auth config can never be clobbered by the archive. Two tests assert no secret value reaches the report or logs.

## Client methods (verify-then-size: all 7 net-new)
`get/create/delete_user_agent`, `get/create/delete_dvr_rule`, `get_core_settings`, `update_core_setting` (per-key PATCH). Endpoint paths isolated as module constants.

## Tests
29 tests (21 importer + 8 client): entity create/remap/ledger/collision/FK/dry-run/CONFLICT; settings apply-allowed/skip-dangerous/no-ledger/no-secret-leak. Full suite green (5771 passed).

## Follow-ups
- **Endpoint paths** (`/api/core/useragents/`, `/api/dvr/rules/`, `/api/core/settings/`) are best-known but NOT live-verified (no instance) — isolated to constants for a one-line fix; deferred to live verification.
- **Settings rollback is out of scope** (config, not a created entity — nothing to compensate-delete). v0.18.0 known limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)