### PR TITLE
v0.18.0-dbas: 0i2vt.14 channels integration -- 4-tier stream match + attach + fallback

### DIFF
--- a/backend/dbas/importers/channels.py
+++ b/backend/dbas/importers/channels.py
@@ -1,17 +1,41 @@
-"""The channels restore importer — channel-row create + profile reattach.
+"""The channels restore importer — channel-row create + profile reattach + streams.
 
-Bead ``enhancedchannelmanager-4vouz`` (split 2/4 of the ``0i2vt.14`` channels
-importer epic). This module restores the CHANNEL entity category from a
-Dispatcharr export archive: it creates each archived channel row and reattaches
-each channel to its archived channel-profile memberships.
+Bead ``enhancedchannelmanager-4vouz`` (split 2/4) created the channel-row +
+profile-reattach layer; bead ``enhancedchannelmanager-0i2vt.14`` (the INTEGRATION
+umbrella) extends it with the stream layer. This module restores the CHANNEL
+entity category from a Dispatcharr export archive: it creates each archived
+channel row, reattaches each channel to its archived channel-profile memberships,
+AND re-attaches each channel's archived embedded streams to the destination.
 
-SCOPE — TIGHT. This importer does channel-row create + profile membership
-reattach ONLY. It deliberately leaves a clean SEAM where bead ``0i2vt.14``
-integrates the stream matcher (``al6e3``) + ``create_stream`` (``nav0c``) +
-custom-stream fallback (``ahygg``) to match and attach an archived channel's
-streams. This importer NEVER matches a stream, NEVER attaches a stream, and
-strips any embedded ``streams`` payload from the create. Stream attachment is
-explicitly out of scope.
+THE STREAM LAYER (``0i2vt.14`` integration — wires the three sibling splits).
+For each restored channel, the archived embedded ``streams`` are matched against
+the destination instance's existing streams using the pure 4-tier matcher
+(:func:`dbas.stream_matcher.match_stream`, bead ``al6e3``):
+
+* Tier 1-4 HIT  -> the matched DESTINATION stream id is attached to the channel.
+  The existing stream is NOT created and NOT ledgered (it already exists; only
+  the attachment is new).
+* MISS (tier 0) -> the archived stream is an ORPHAN. Orphans are collected across
+  the WHOLE import and handed, ONCE, to
+  :func:`dbas.custom_stream_fallback.synthesize_custom_streams` (bead ``ahygg``),
+  threading one :class:`~dbas.custom_stream_fallback._FallbackState` so the
+  synthesized custom-stream M3U account is found-or-created at most once. The
+  synthesizer creates each orphan, ledgers it (``EntityType.STREAM``), records it
+  in the remap, and WARNs. The synthesized destination ids are then attached back
+  to the channels they came from.
+
+ATTACH MECHANISM. A Dispatcharr channel's stream set IS an ordered list of stream
+ids on the channel: ``client.update_channel(channel_id, {"streams": [ids…]})``
+replaces the channel's stream list (verified against ``routers/channels.py`` —
+reorder/merge use this same call). ORDERING is preserved by emitting the
+destination ids in the archived stream order: each archived stream owns one slot,
+filled with its matched id (immediately) or its synthesized id (after the batched
+fallback resolves), then the whole ordered list is sent in one ``update_channel``.
+
+create_stream (``nav0c``) is used ONLY inside the fallback synthesizer for
+orphans; a matched stream is never created. The STREAM-category counts in the
+report distinguish them: synthesized orphans land in ``created`` (ahygg), matched
+existing streams in ``updated`` (attached-not-created).
 
 FK remapping (the load-bearing correctness control). A Dispatcharr export records
 each entity's id *as it was on the source instance*; on restore the destination
@@ -65,7 +89,9 @@ READ-ONLY.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 
+from dbas.custom_stream_fallback import _FallbackState, synthesize_custom_streams
 from dbas.restore_contracts import (
     EntityType,
     FailureDetail,
@@ -76,6 +102,7 @@ from dbas.restore_contracts import (
     SkipDetail,
     SkipReason,
 )
+from dbas.stream_matcher import MatchTier, match_stream
 from dispatcharr_client import DispatcharrClient
 
 logger = logging.getLogger(__name__)
@@ -248,6 +275,19 @@ async def import_channels(
     # Each tuple: (archive_channel, destination_channel_id).
     reattach_queue: list[tuple[dict, int]] = []
 
+    # Per-channel stream-attach plans, built during the create loop and resolved
+    # after the batched custom-stream fallback runs. Each is a _ChannelStreamPlan
+    # carrying the channel's dest id + one ordered slot per archived stream.
+    stream_plans: list[_ChannelStreamPlan] = []
+
+    # Destination candidate streams for the matcher — fetched ONCE for the whole
+    # import (the matcher is pure; the candidate set is the destination's existing
+    # streams). Empty/failed fetch => every archived stream MISSes and routes to
+    # the custom-stream fallback (never a wrong attach).
+    candidate_streams = (
+        await _fetch_candidate_streams(client) if not is_dry_run else []
+    )
+
     for archive_channel in archive_channels:
         label = _channel_label(archive_channel)
         source_id = archive_channel.get("id")
@@ -263,6 +303,13 @@ async def import_channels(
                 remap.add(EntityType.CHANNEL, int(source_id), int(existing_id))
                 if not is_dry_run:
                     reattach_queue.append((archive_channel, int(existing_id)))
+                    _plan_streams(
+                        stream_plans,
+                        archive_channel,
+                        int(existing_id),
+                        candidate_streams,
+                        report,
+                    )
             continue
 
         # FK remap: rewrite remappable FK ids; unresolved => DEPENDENCY_UNRESOLVED.
@@ -306,12 +353,236 @@ async def import_channels(
                 remap.add(EntityType.CHANNEL, int(source_id), dest_id)
             ledger.record_created(EntityType.CHANNEL, dest_id, label)
             reattach_queue.append((archive_channel, dest_id))
+            _plan_streams(
+                stream_plans, archive_channel, dest_id, candidate_streams, report
+            )
         logger.info("[DBAS-CHANNELS] Restored channel '%s' (id=%s).", label, dest_id)
 
     # Profile reattach pass — runs AFTER all channels are created so every channel
     # has a destination id. Dry-run reattaches nothing.
     if not is_dry_run:
         await _reattach_profiles(reattach_queue, client=client, report=report, remap=remap)
+        # Stream layer: synthesize orphans (batched, one fallback state) + attach
+        # the matched + synthesized stream ids to each channel in archived order.
+        await _attach_streams(
+            stream_plans,
+            client=client,
+            report=report,
+            ledger=ledger,
+            remap=remap,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stream layer (0i2vt.14 integration: matcher al6e3 + fallback ahygg + attach)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StreamSlot:
+    """One archived stream's attach slot, preserving archived order.
+
+    Exactly one slot per archived embedded stream, in archived order, so the
+    final channel stream list mirrors the archive. A slot resolves to ONE
+    destination stream id:
+
+    * a tier 1-4 MATCH fills :attr:`dest_id` immediately (the existing
+      destination stream the matcher resolved — never created, never ledgered);
+    * a MISS leaves :attr:`dest_id` ``None`` and records the archived stream as
+      ``orphan`` so the batched fallback can synthesize it, after which its
+      synthesized id is resolved back into the slot via the shared remap.
+    """
+
+    dest_id: int | None = None
+    orphan: dict | None = None
+
+
+@dataclass
+class _ChannelStreamPlan:
+    """A channel's ordered stream-attach plan.
+
+    Built during the create loop (one per channel that has archived streams),
+    resolved after the batched custom-stream fallback runs: each slot's final
+    destination id is collected in order and sent in one ``update_channel``.
+    """
+
+    dest_channel_id: int
+    label: str
+    slots: list[_StreamSlot] = field(default_factory=list)
+
+
+async def _fetch_candidate_streams(client: DispatcharrClient) -> list[dict]:
+    """Fetch the destination instance's existing streams (matcher candidates).
+
+    Paginates ``get_streams`` so the matcher sees the full candidate universe.
+    A failed/garbled fetch yields an empty candidate list — every archived
+    stream then MISSes and routes to the custom-stream fallback (a safe outcome:
+    orphans are synthesized, never mis-attached). Never raises.
+    """
+    candidates: list[dict] = []
+    page = 1
+    try:
+        while True:
+            resp = await client.get_streams(page=page, page_size=1000)
+            if isinstance(resp, dict):
+                results = resp.get("results", [])
+            else:
+                results = resp
+            page_items = [s for s in (results or []) if isinstance(s, dict)]
+            candidates.extend(page_items)
+            # Stop when a page returns fewer than requested (last page) or the
+            # response is not the paginated dict shape (single-shot list).
+            if not isinstance(resp, dict) or len(page_items) < 1000:
+                break
+            page += 1
+    except Exception as exc:
+        logger.warning(
+            "[DBAS-CHANNELS] Could not list destination streams for matching; "
+            "every archived stream will route to the custom-stream fallback: %s",
+            exc,
+        )
+        return []
+    logger.info(
+        "[DBAS-CHANNELS] Fetched %d destination stream candidate(s) for matching.",
+        len(candidates),
+    )
+    return candidates
+
+
+def _archived_streams(archive_channel: dict) -> list[dict]:
+    """The channel's archived embedded stream records, in archived order.
+
+    Returns an empty list when the archive carries no ``streams`` (or a
+    non-list) — such a channel attaches nothing and fires no fallback.
+    """
+    streams = archive_channel.get("streams")
+    if not isinstance(streams, list):
+        return []
+    return [s for s in streams if isinstance(s, dict)]
+
+
+def _plan_streams(
+    plans: list[_ChannelStreamPlan],
+    archive_channel: dict,
+    dest_channel_id: int,
+    candidates: list[dict],
+    report: RestoreReport,
+) -> None:
+    """Build a channel's ordered stream-attach plan via the 4-tier matcher.
+
+    For each archived stream (in order) run :func:`match_stream`:
+
+    * a HIT records the matched destination id in the slot and counts the attach
+      as an ``updated`` STREAM in the report (attached, NOT created/ledgered);
+    * a MISS records the archived stream as an orphan slot for the batched
+      fallback to synthesize.
+
+    A channel with no archived streams produces no plan (nothing to attach).
+    """
+    archived = _archived_streams(archive_channel)
+    if not archived:
+        return
+
+    stream_cat = report.category(EntityType.STREAM)
+    plan = _ChannelStreamPlan(dest_channel_id=dest_channel_id, label=_channel_label(archive_channel))
+    for archived_stream in archived:
+        tier, match_id = match_stream(archived_stream, candidates)
+        if tier != MatchTier.MISS and match_id is not None:
+            plan.slots.append(_StreamSlot(dest_id=match_id))
+            # Matched an EXISTING destination stream: attached, not created — so
+            # it is an ``updated`` STREAM, never ledgered (nothing to roll back).
+            stream_cat.updated += 1
+        else:
+            plan.slots.append(_StreamSlot(orphan=archived_stream))
+    plans.append(plan)
+
+
+async def _attach_streams(
+    plans: list[_ChannelStreamPlan],
+    *,
+    client: DispatcharrClient,
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    remap: IdRemapTable,
+) -> None:
+    """Synthesize MISS orphans (batched, once) then attach streams per channel.
+
+    Two passes:
+
+    1. Collect every orphan across ALL channels and hand them to
+       :func:`synthesize_custom_streams` in ONE call, threading a single
+       :class:`_FallbackState` so the custom-stream account is found-or-created
+       at most once. The synthesizer creates/ledgers each orphan and records its
+       ``source_export_id -> dest_id`` in the shared remap.
+    2. Resolve each slot's destination id (the matched id, or — for a MISS slot —
+       the synthesized id looked up from the remap) in archived order, and send
+       the channel's full ordered stream list in one ``update_channel`` call.
+
+    A plan list with no orphans skips the fallback entirely (no synthesized
+    account, no WARN) — the common happy case where every stream matched.
+    """
+    if not plans:
+        return
+
+    # Pass 1 — batched fallback over EVERY orphan, one threaded state.
+    orphans = [
+        slot.orphan
+        for plan in plans
+        for slot in plan.slots
+        if slot.orphan is not None
+    ]
+    if orphans:
+        state = _FallbackState()
+        await synthesize_custom_streams(
+            orphans=orphans,
+            client=client,
+            remap=remap,
+            ledger=ledger,
+            report=report,
+            state=state,
+        )
+
+    # Pass 2 — resolve each slot to a dest id (matched or synthesized) and attach.
+    for plan in plans:
+        ordered_ids: list[int] = []
+        for slot in plan.slots:
+            if slot.dest_id is not None:
+                ordered_ids.append(slot.dest_id)
+                continue
+            # MISS slot: resolve the synthesized id the fallback recorded under
+            # EntityType.STREAM. A synthesize failure (no id recorded) drops the
+            # orphan from the attach list rather than attaching a wrong/None id.
+            source_id = slot.orphan.get("id") if slot.orphan else None
+            if source_id is None:
+                continue
+            synthesized = remap.resolve(EntityType.STREAM, int(source_id))
+            if synthesized is not None:
+                ordered_ids.append(synthesized)
+
+        if not ordered_ids:
+            continue
+        try:
+            await client.update_channel(
+                plan.dest_channel_id, {"streams": ordered_ids}
+            )
+        except Exception as exc:
+            stream_cat = report.category(EntityType.STREAM)
+            stream_cat.failed += 1
+            stream_cat.failure_details.append(
+                FailureDetail(
+                    reason=FailureReason.UPSTREAM_API_ERROR,
+                    label=plan.label,
+                    message=_sanitize_failure(exc),
+                    source_export_id=None,
+                )
+            )
+            logger.warning(
+                "[DBAS-CHANNELS] Failed to attach streams to channel '%s' "
+                "(dest id %s): %s",
+                plan.label,
+                plan.dest_channel_id,
+                FailureReason.UPSTREAM_API_ERROR.value,
+            )
 
 
 async def _reattach_profiles(

--- a/backend/tests/dbas/test_channels_importer.py
+++ b/backend/tests/dbas/test_channels_importer.py
@@ -66,6 +66,12 @@ def _client(*, existing_channels=None, profiles=None, create_side_effect=None):
     client.create_channel = AsyncMock(side_effect=create_side_effect or _default_create)
     client.update_profile_channel = AsyncMock(return_value={"success": True})
     client.delete_channel = AsyncMock(return_value=None)
+    # Stream layer (0i2vt.14): an empty destination-stream candidate set + an
+    # attach call. The 4vouz tests use channels with no embedded streams, so the
+    # stream layer is a no-op for them; these stubs keep the candidate fetch from
+    # hitting an auto-generated MagicMock.
+    client.get_streams = AsyncMock(return_value={"results": [], "count": 0})
+    client.update_channel = AsyncMock(return_value={"success": True})
     return client
 
 
@@ -287,30 +293,38 @@ async def test_non_remappable_fk_fields_dropped_not_sent_stale():
 
 
 @pytest.mark.asyncio
-async def test_stream_fields_not_attached_seam_for_dot14():
-    """SCOPE SEAM: this importer creates the channel row only — it does NOT match
-    or attach streams. Any embedded stream payload is stripped from the create and
-    never forwarded to a stream-add call (bead 0i2vt.14 owns attachment)."""
+async def test_streams_stripped_from_create_payload():
+    """The embedded ``streams`` payload is never part of the channel CREATE body —
+    the destination assigns the channel its own id, then streams are attached
+    separately (the 0i2vt.14 stream layer, tested in test_channels_integration.py).
+    Here we only assert the create payload carries no ``streams`` key; the stream
+    layer is patched out so this test stays scoped to the create body."""
+    from unittest.mock import patch
+    import dbas.importers.channels as channels_mod
+    from dbas.custom_stream_fallback import CustomStreamFallbackResult
+
     client = _client()
+    client.get_streams = AsyncMock(return_value={"results": [], "count": 0})
+    client.update_channel = AsyncMock(return_value={"success": True})
     report = _report()
     ledger = _ledger()
     remap = _remap()
 
-    await import_channels(
-        archive_channels=[
-            {"id": 5, "name": "CNN", "streams": [{"id": 1}, {"id": 2}]}
-        ],
-        client=client,
-        selected=True,
-        report=report,
-        ledger=ledger,
-        remap=remap,
-    )
+    synth = AsyncMock(return_value=CustomStreamFallbackResult())
+    with patch.object(channels_mod, "synthesize_custom_streams", synth):
+        await import_channels(
+            archive_channels=[
+                {"id": 5, "name": "CNN", "streams": [{"id": 1}, {"id": 2}]}
+            ],
+            client=client,
+            selected=True,
+            report=report,
+            ledger=ledger,
+            remap=remap,
+        )
 
     payload = client.create_channel.await_args.args[0]
     assert "streams" not in payload
-    # no stream-attach client method was invoked by THIS importer
-    assert not hasattr(client, "add_stream") or not client.add_stream.await_count
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/dbas/test_channels_integration.py
+++ b/backend/tests/dbas/test_channels_integration.py
@@ -1,0 +1,491 @@
+"""Integration tests for the channels importer stream layer
+(enhancedchannelmanager-0i2vt.14 — the integration umbrella).
+
+This umbrella WIRES the four merged splits together inside
+``dbas.importers.channels.import_channels``:
+
+* 4vouz — channel-row create + profile reattach (already covered by
+  ``test_channels_importer.py``; this file must NOT regress it).
+* al6e3 — the pure 4-tier ``match_stream`` matcher (used real, not mocked —
+  it is pure, so feeding it real candidate lists is the strongest test).
+* ahygg — ``synthesize_custom_streams`` for MISS orphans (mocked at the
+  channels module level so we can assert it is called with exactly the orphans
+  and thread one fallback state across the whole import).
+* nav0c — ``create_stream`` / attach client methods (the attach is
+  ``client.update_channel(dest_channel_id, {"streams": [ordered_ids]})``).
+
+What this layer adds on top of 4vouz: for each restored channel, the archived
+embedded streams are matched against the destination's existing streams; tier
+1-4 hits are attached by their matched destination id; MISS (tier 0) streams are
+collected as orphans and routed to ``synthesize_custom_streams`` (once, batched
+across the whole import, threading one fallback ``state`` so the synthesized
+account is created at most once). The final per-channel stream ordering mirrors
+the archived order. Matched-existing streams are attached but NEVER
+created/ledgered (they already exist); synthesized orphans ARE ledgered (ahygg).
+
+The Dispatcharr client and the fallback synthesizer are mocked at the channels
+module level; the real pure matcher runs against real candidate lists.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+import dbas.importers.channels as channels_mod
+from dbas.importers.channels import import_channels
+from dbas.custom_stream_fallback import CustomStreamFallbackResult
+from dbas.restore_contracts import (
+    EntityType,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _client(*, existing_channels=None, dest_streams=None):
+    """AsyncMock client.
+
+    ``dest_streams`` is the destination instance's existing streams — the
+    candidate set fed to the real matcher via ``get_streams``.
+    """
+    client = AsyncMock()
+    client.get_channels = AsyncMock(
+        return_value={"results": existing_channels or [], "count": len(existing_channels or [])}
+    )
+    client.get_channel_profiles = AsyncMock(return_value=[])
+    client.update_profile_channel = AsyncMock(return_value={"success": True})
+    client.delete_channel = AsyncMock(return_value=None)
+
+    # get_streams returns the paginated shape {"results": [...]} that the
+    # importer unwraps to a candidate list for the matcher.
+    streams = dest_streams or []
+    client.get_streams = AsyncMock(
+        return_value={"results": streams, "count": len(streams)}
+    )
+
+    created_counter = {"n": 500}
+
+    async def _default_create(payload):
+        created_counter["n"] += 1
+        return {"id": created_counter["n"], **payload}
+
+    client.create_channel = AsyncMock(side_effect=_default_create)
+    client.update_channel = AsyncMock(return_value={"success": True})
+    return client
+
+
+def _report(is_dry_run=False):
+    return RestoreReport(is_dry_run=is_dry_run)
+
+
+def _ledger():
+    return RollbackLedger(restore_id="test-restore")
+
+
+def _remap():
+    return IdRemapTable()
+
+
+def _channel(channel_id, name, streams, number=None):
+    ch = {"id": channel_id, "name": name, "streams": streams}
+    if number is not None:
+        ch["channel_number"] = number
+    return ch
+
+
+def _patched_fallback(synth_mock):
+    """Patch synthesize_custom_streams at the channels module level."""
+    return patch.object(channels_mod, "synthesize_custom_streams", synth_mock)
+
+
+# ---------------------------------------------------------------------------
+# All streams match (tiers 1-4) — attach by matched id, NO fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_streams_match_attached_no_fallback():
+    """A channel whose archived streams ALL match destination streams (tier 1-4)
+    has each matched destination id attached to the created channel via
+    update_channel; the fallback synthesizer is NEVER called; no synthesized
+    account is created."""
+    # Destination streams: exact-URL matches for both archived streams.
+    dest_streams = [
+        {"id": 9001, "name": "CNN", "url": "http://prov/cnn", "m3u_account": 1},
+        {"id": 9002, "name": "ESPN", "url": "http://prov/espn", "m3u_account": 1},
+    ]
+    client = _client(dest_streams=dest_streams)
+    report, ledger, remap = _report(), _ledger(), _remap()
+
+    synth = AsyncMock(return_value=CustomStreamFallbackResult())
+    with _patched_fallback(synth):
+        await import_channels(
+            archive_channels=[
+                _channel(
+                    5,
+                    "CNN+ESPN",
+                    [
+                        {"id": 1, "name": "CNN", "url": "http://prov/cnn"},
+                        {"id": 2, "name": "ESPN", "url": "http://prov/espn"},
+                    ],
+                )
+            ],
+            client=client,
+            selected=True,
+            report=report,
+            ledger=ledger,
+            remap=remap,
+        )
+
+    # Fallback never fired — every stream matched.
+    synth.assert_not_awaited()
+
+    # The created channel (dest id 501) was attached the two matched dest ids,
+    # in archived order.
+    dest_channel_id = remap.resolve(EntityType.CHANNEL, 5)
+    assert dest_channel_id == 501
+    client.update_channel.assert_awaited_once_with(501, {"streams": [9001, 9002]})
+
+    # Matched-existing streams are NOT created/ledgered.
+    assert ledger.entries[0].entity_type == EntityType.CHANNEL  # only the channel
+    assert all(e.entity_type != EntityType.STREAM for e in ledger.entries)
+
+
+# ---------------------------------------------------------------------------
+# Some MISS — matched attached, MISS routed to fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_some_miss_routes_only_orphans_to_fallback():
+    """A channel with SOME MISS streams: matched ones attach by matched id, MISS
+    ones are passed to synthesize_custom_streams (exactly the orphans), and the
+    synthesized ids are attached back to the channel."""
+    dest_streams = [
+        {"id": 9001, "name": "CNN", "url": "http://prov/cnn", "m3u_account": 1},
+    ]
+    client = _client(dest_streams=dest_streams)
+    report, ledger, remap = _report(), _ledger(), _remap()
+
+    orphan = {"id": 2, "name": "Local Cam", "url": "http://home/cam"}
+
+    async def _synth(*, orphans, client, remap, ledger, report, state=None):
+        # synthesize the orphan as dest id 7777 and remap it.
+        remap.add(EntityType.STREAM, 2, 7777)
+        ledger.record_created(EntityType.STREAM, 7777, "Local Cam")
+        return CustomStreamFallbackResult(
+            account_id=4242, created_stream_ids=[7777], orphan_count=len(orphans)
+        )
+
+    synth = AsyncMock(side_effect=_synth)
+    with _patched_fallback(synth):
+        await import_channels(
+            archive_channels=[
+                _channel(
+                    5,
+                    "Mixed",
+                    [
+                        {"id": 1, "name": "CNN", "url": "http://prov/cnn"},  # tier1 hit
+                        orphan,  # MISS
+                    ],
+                )
+            ],
+            client=client,
+            selected=True,
+            report=report,
+            ledger=ledger,
+            remap=remap,
+        )
+
+    # Fallback called with EXACTLY the orphan(s).
+    synth.assert_awaited_once()
+    passed_orphans = synth.await_args.kwargs["orphans"]
+    assert list(passed_orphans) == [orphan]
+
+    # Channel attached: matched 9001 first, synthesized 7777 second (archived order).
+    client.update_channel.assert_awaited_once_with(501, {"streams": [9001, 7777]})
+
+
+@pytest.mark.asyncio
+async def test_warn_fires_on_fallback(caplog):
+    """The fallback path WARNs (ahygg's own warning) when it fires. We assert the
+    real synthesizer emits its WARN by invoking the REAL synthesize_custom_streams
+    end-to-end with a create_stream-capable client."""
+    import logging
+
+    dest_streams = []  # nothing matches -> all MISS
+    client = _client(dest_streams=dest_streams)
+    # real synthesizer needs m3u-account + create_stream.
+    client.get_m3u_accounts = AsyncMock(return_value=[])
+    client.create_m3u_account = AsyncMock(return_value={"id": 4242})
+    client.create_stream = AsyncMock(return_value={"id": 7777})
+
+    report, ledger, remap = _report(), _ledger(), _remap()
+
+    with caplog.at_level(logging.WARNING):
+        await import_channels(
+            archive_channels=[
+                _channel(5, "Orphan", [{"id": 2, "name": "Cam", "url": "http://home/cam"}])
+            ],
+            client=client,
+            selected=True,
+            report=report,
+            ledger=ledger,
+            remap=remap,
+        )
+
+    assert any(
+        "synthesizing custom-stream" in rec.message.lower()
+        or "stream matcher miss" in rec.message.lower()
+        for rec in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# All MISS — every stream goes to fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_miss_all_to_fallback():
+    """A channel with no matching destination streams routes ALL its archived
+    streams to the fallback."""
+    client = _client(dest_streams=[])  # empty candidates -> all MISS
+    report, ledger, remap = _report(), _ledger(), _remap()
+
+    o1 = {"id": 1, "name": "A", "url": "http://x/a"}
+    o2 = {"id": 2, "name": "B", "url": "http://x/b"}
+
+    async def _synth(*, orphans, client, remap, ledger, report, state=None):
+        ids = {1: 8001, 2: 8002}
+        created = []
+        for o in orphans:
+            d = ids[o["id"]]
+            remap.add(EntityType.STREAM, o["id"], d)
+            created.append(d)
+        return CustomStreamFallbackResult(
+            account_id=4242, created_stream_ids=created, orphan_count=len(orphans)
+        )
+
+    synth = AsyncMock(side_effect=_synth)
+    with _patched_fallback(synth):
+        await import_channels(
+            archive_channels=[_channel(5, "AllMiss", [o1, o2])],
+            client=client,
+            selected=True,
+            report=report,
+            ledger=ledger,
+            remap=remap,
+        )
+
+    synth.assert_awaited_once()
+    assert list(synth.await_args.kwargs["orphans"]) == [o1, o2]
+    client.update_channel.assert_awaited_once_with(501, {"streams": [8001, 8002]})
+
+
+# ---------------------------------------------------------------------------
+# Fallback state threaded — account synthesized ONCE across channels
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fallback_state_threaded_once_across_channels():
+    """Two channels both produce orphans. The fallback is invoked with one shared
+    ``state`` so the synthesized account is created at most once across the whole
+    import (state threaded, not a fresh state per channel/batch)."""
+    client = _client(dest_streams=[])
+    report, ledger, remap = _report(), _ledger(), _remap()
+
+    seen_states = []
+
+    async def _synth(*, orphans, client, remap, ledger, report, state=None):
+        seen_states.append(state)
+        return CustomStreamFallbackResult(orphan_count=len(orphans))
+
+    synth = AsyncMock(side_effect=_synth)
+    with _patched_fallback(synth):
+        await import_channels(
+            archive_channels=[
+                _channel(5, "Ch1", [{"id": 1, "name": "A", "url": "http://x/a"}]),
+                _channel(6, "Ch2", [{"id": 2, "name": "B", "url": "http://x/b"}]),
+            ],
+            client=client,
+            selected=True,
+            report=report,
+            ledger=ledger,
+            remap=remap,
+        )
+
+    # However the importer batches, the SAME non-None state object must be
+    # threaded through every fallback invocation (so the account is created once).
+    assert seen_states, "fallback was never invoked"
+    assert all(s is not None for s in seen_states)
+    first = seen_states[0]
+    assert all(s is first for s in seen_states)
+
+
+# ---------------------------------------------------------------------------
+# Ordering preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_ordering_preserved_mixed():
+    """The attached stream order mirrors the archived order, interleaving matched
+    and synthesized ids."""
+    dest_streams = [
+        {"id": 9001, "name": "A", "url": "http://x/a", "m3u_account": 1},
+        {"id": 9003, "name": "C", "url": "http://x/c", "m3u_account": 1},
+    ]
+    client = _client(dest_streams=dest_streams)
+    report, ledger, remap = _report(), _ledger(), _remap()
+
+    async def _synth(*, orphans, client, remap, ledger, report, state=None):
+        # B (id 2) is the only orphan -> synthesized 8002.
+        for o in orphans:
+            remap.add(EntityType.STREAM, o["id"], 8002)
+        return CustomStreamFallbackResult(
+            account_id=42, created_stream_ids=[8002], orphan_count=len(orphans)
+        )
+
+    synth = AsyncMock(side_effect=_synth)
+    with _patched_fallback(synth):
+        await import_channels(
+            archive_channels=[
+                _channel(
+                    5,
+                    "Ordered",
+                    [
+                        {"id": 1, "name": "A", "url": "http://x/a"},  # -> 9001
+                        {"id": 2, "name": "B", "url": "http://x/b"},  # MISS -> 8002
+                        {"id": 3, "name": "C", "url": "http://x/c"},  # -> 9003
+                    ],
+                )
+            ],
+            client=client,
+            selected=True,
+            report=report,
+            ledger=ledger,
+            remap=remap,
+        )
+
+    # archived order A, B, C -> dest ids 9001, 8002, 9003.
+    client.update_channel.assert_awaited_once_with(501, {"streams": [9001, 8002, 9003]})
+
+
+# ---------------------------------------------------------------------------
+# Matched-existing NOT ledgered; synthesized ARE ledgered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_matched_existing_not_ledgered_synthesized_are():
+    """Matched (existing) destination streams are attached but NOT created or
+    ledgered (they already exist). Synthesized orphans ARE ledgered (ahygg does
+    that). We use the REAL synthesizer to assert the ledger end-to-end."""
+    dest_streams = [
+        {"id": 9001, "name": "Match", "url": "http://x/match", "m3u_account": 1},
+    ]
+    client = _client(dest_streams=dest_streams)
+    client.get_m3u_accounts = AsyncMock(return_value=[])
+    client.create_m3u_account = AsyncMock(return_value={"id": 4242})
+    client.create_stream = AsyncMock(return_value={"id": 7777})
+
+    report, ledger, remap = _report(), _ledger(), _remap()
+
+    await import_channels(
+        archive_channels=[
+            _channel(
+                5,
+                "Mix",
+                [
+                    {"id": 1, "name": "Match", "url": "http://x/match"},  # matched 9001
+                    {"id": 2, "name": "Orphan", "url": "http://x/orphan"},  # MISS
+                ],
+            )
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    stream_ledger = [e for e in ledger.entries if e.entity_type == EntityType.STREAM]
+    # Only the synthesized orphan (7777) is ledgered — NOT the matched 9001.
+    assert len(stream_ledger) == 1
+    assert stream_ledger[0].destination_id == 7777
+    assert all(e.destination_id != 9001 for e in stream_ledger)
+
+    # The channel got both: matched 9001 + synthesized 7777, archived order.
+    client.update_channel.assert_awaited_once_with(501, {"streams": [9001, 7777]})
+
+
+# ---------------------------------------------------------------------------
+# Dry-run — no creates, no attach side-effects, no synthesized account
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_no_attach_no_synthesis():
+    """A dry-run issues no create_channel, no update_channel (attach), and never
+    calls the fallback synthesizer."""
+    client = _client(dest_streams=[{"id": 9001, "name": "A", "url": "http://x/a"}])
+    report, ledger, remap = _report(is_dry_run=True), _ledger(), _remap()
+
+    synth = AsyncMock(return_value=CustomStreamFallbackResult())
+    with _patched_fallback(synth):
+        await import_channels(
+            archive_channels=[
+                _channel(
+                    5,
+                    "Dry",
+                    [
+                        {"id": 1, "name": "A", "url": "http://x/a"},
+                        {"id": 2, "name": "B", "url": "http://x/b"},
+                    ],
+                )
+            ],
+            client=client,
+            selected=True,
+            report=report,
+            ledger=ledger,
+            remap=remap,
+            is_dry_run=True,
+        )
+
+    client.create_channel.assert_not_awaited()
+    client.update_channel.assert_not_awaited()
+    synth.assert_not_awaited()
+    assert ledger.entries == []
+
+
+# ---------------------------------------------------------------------------
+# A channel with no streams attaches nothing and fires no fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_channel_without_streams_no_attach_no_fallback():
+    """A channel with no archived streams: created, but no attach call and no
+    fallback (the no-stream channel must not regress 4vouz's create path)."""
+    client = _client(dest_streams=[{"id": 9001, "name": "A", "url": "http://x/a"}])
+    report, ledger, remap = _report(), _ledger(), _remap()
+
+    synth = AsyncMock(return_value=CustomStreamFallbackResult())
+    with _patched_fallback(synth):
+        await import_channels(
+            archive_channels=[{"id": 5, "name": "NoStreams"}],
+            client=client,
+            selected=True,
+            report=report,
+            ledger=ledger,
+            remap=remap,
+        )
+
+    assert report.category(EntityType.CHANNEL).created == 1
+    client.update_channel.assert_not_awaited()
+    synth.assert_not_awaited()


### PR DESCRIPTION
## Bead
enhancedchannelmanager-0i2vt.14 — Phase 2 Channels integration umbrella. Wires the four merged splits (nav0c create_stream, 4vouz channel-row create, al6e3 matcher, ahygg fallback) into full channel restore with stream attachment.

## What
Extends `backend/dbas/importers/channels.py` (4vouz) to add the stream layer:
- Per-channel: build an ordered `_StreamSlot` plan; for each archived embedded stream call `match_stream` (al6e3) against destination candidates. Tier 1-4 hit → record matched dest id; MISS (tier 0) → park as orphan.
- Import-wide batched fallback: ALL orphans across ALL channels → one `synthesize_custom_streams` (ahygg) call threading a single `_FallbackState` (synthesized account created once; one WARN with total orphan count).
- Attach = `update_channel(channel_id, {"streams": [ordered_ids]})` (verified the channel's ordered id list IS the attachment + ordering). Ordering preserved (matched/synthesized interleaved in archived order).
- Matched-existing streams: attached, counted `STREAM.updated`, NOT ledgered. Synthesized: `STREAM.created`, ledgered (by ahygg). Candidates fetched once (paginated); failed fetch → all MISS → fallback (never mis-attach). Dry-run → no creates/attach/synth.

## Tests
9 integration tests (all-match→attach no fallback, some-MISS→fallback, all-MISS, state-threaded single account, ordering preserved, matched-not-ledgered/synthesized-ledgered, dry-run) + 4vouz channel-row/profile tests intact (seam test rewritten). Full suite green (5780 passed).

## Deferred
The ">99%/100% stream match rate over the seed snapshot" success signal is a live/seeded-instance integration test (deferred — no instance tonight). Unit tests prove the wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)