### PR TITLE
v0.18.0-dbas: g5xv7 restore + dry-run progress UI (polling stage indicator + navigate-away guard)

### DIFF
--- a/frontend/src/components/BackupRestoreModal.tsx
+++ b/frontend/src/components/BackupRestoreModal.tsx
@@ -1,5 +1,8 @@
 import { useState, useCallback } from 'react';
 import { ModalOverlay } from './ModalOverlay';
+import { RestoreProgress } from './RestoreProgress';
+import { useRestoreProgress } from '../hooks/useRestoreProgress';
+import { useNavigateAwayGuard } from '../hooks/useNavigateAwayGuard';
 import * as api from '../services/api';
 import type { BackupValidation, BackupRestoreResult } from '../services/api';
 import { getDateLocale } from '../utils/formatting';
@@ -20,6 +23,21 @@ export function BackupRestoreModal({ onClose }: BackupRestoreModalProps) {
   const [restoreResult, setRestoreResult] = useState<BackupRestoreResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+
+  // SEAM: the multi-stage restore-trigger endpoint / restore TaskScheduler is a
+  // LATER bead (the orchestrator .18 exists but emits no _set_progress, and no
+  // restore task is wired to task_scheduler yet). When that endpoint lands it
+  // returns a task id; set it here and the progress surface polls it live. Until
+  // then this stays null and the current synchronous restore drives an
+  // indeterminate (stage-1) progress view — the navigate-away guard still arms.
+  const [restoreTaskId, setRestoreTaskId] = useState<string | null>(null);
+  const progress = useRestoreProgress({ taskId: restoreTaskId });
+
+  // Guard against closing the tab mid-restore — the compensating rollback
+  // depends on the op completing (ADR-012: Dispatcharr has no DB transactions).
+  // Armed only while the restore step is live; released on completion/failure.
+  const isRestoring = step === 'restoring';
+  useNavigateAwayGuard(isRestoring);
 
   const handleFile = useCallback(async (selectedFile: File) => {
     if (!selectedFile.name.match(/\.ya?ml$/i)) {
@@ -98,6 +116,12 @@ export function BackupRestoreModal({ onClose }: BackupRestoreModalProps) {
     if (!file || selectedSections.size === 0) return;
     setStep('restoring');
     setError(null);
+    // SEAM: when the multi-stage restore-trigger endpoint lands it will return a
+    // task id to feed the live progress poller, e.g.
+    //   const { task_id } = await api.startRestoreTask(file, sections);
+    //   setRestoreTaskId(task_id);
+    // The current endpoint is synchronous, so leave the poller's task id null.
+    setRestoreTaskId(null);
 
     try {
       const result = await api.restoreBackupYaml(file, Array.from(selectedSections));
@@ -197,10 +221,25 @@ export function BackupRestoreModal({ onClose }: BackupRestoreModalProps) {
           )}
 
           {step === 'restoring' && (
-            <div className="modal-loading">
-              <span className="material-icons">sync</span>
-              <p>Restoring selected sections...</p>
-            </div>
+            <RestoreProgress
+              mode="restore"
+              view={
+                // When a restore task id is wired (later bead) the polled view
+                // drives the stage indicator. Until then the restore is a single
+                // synchronous request with no per-stage signal, so render an
+                // indeterminate "running, stage 1" view.
+                restoreTaskId
+                  ? progress
+                  : {
+                      ...progress,
+                      status: 'running',
+                      isRunning: true,
+                      isError: false,
+                      isComplete: false,
+                      stageNumber: 1,
+                    }
+              }
+            />
           )}
 
           {step === 'results' && restoreResult && (

--- a/frontend/src/components/RestoreProgress.css
+++ b/frontend/src/components/RestoreProgress.css
@@ -1,0 +1,75 @@
+/**
+ * RestoreProgress styles
+ *
+ * Uses common.css for: .spinning (sync icon animation)
+ * Uses ModalBase.css for: .modal-progress, .modal-progress-bar,
+ *   .modal-progress-fill, .modal-progress-detail (overall progress bar)
+ *
+ * Only the stage-indicator layout (header, "Stage N of M", per-item counts,
+ * error text) is component-specific and lives here.
+ */
+
+.restore-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+}
+
+.restore-progress-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.restore-progress-icon {
+  font-size: 1.5rem;
+  color: var(--text-secondary);
+}
+
+.restore-progress-icon.is-error {
+  color: var(--status-error, #ef4444);
+}
+
+.restore-progress-icon.is-complete {
+  color: var(--status-success, #22c55e);
+}
+
+.restore-progress-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.restore-progress-stage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.restore-progress-stage-counter {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.restore-progress-stage-name {
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.restore-progress-items {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+
+.restore-progress-error {
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  background-color: var(--bg-tertiary);
+  border-left: 3px solid var(--status-error, #ef4444);
+  padding: 0.625rem 0.75rem;
+  border-radius: var(--radius-md);
+}

--- a/frontend/src/components/RestoreProgress.test.tsx
+++ b/frontend/src/components/RestoreProgress.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Tests for the RestoreProgress component — the shared stage indicator for
+ * restore and dry-run modes.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RestoreProgress } from './RestoreProgress';
+import type { RestoreProgressView } from '../hooks/useRestoreProgress';
+
+/** A running view at the "channel" stage (9th of 13). */
+function runningView(overrides: Partial<RestoreProgressView> = {}): RestoreProgressView {
+  return {
+    progress: {
+      total: 10,
+      current: 4,
+      percentage: 65,
+      status: 'running',
+      current_item: 'channel',
+      success_count: 0,
+      failed_count: 0,
+      skipped_count: 0,
+      started_at: null,
+    },
+    stageNumber: 9,
+    totalStages: 13,
+    stageLabel: 'Channels',
+    itemCurrent: 4,
+    itemTotal: 10,
+    percentage: 65,
+    status: 'running',
+    isRunning: true,
+    isError: false,
+    isComplete: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('RestoreProgress', () => {
+  it('renders "Stage N of 13" with the category name', () => {
+    render(<RestoreProgress view={runningView()} />);
+    expect(screen.getByText('Stage 9 of 13')).toBeInTheDocument();
+    expect(screen.getByText('Channels')).toBeInTheDocument();
+  });
+
+  it('renders per-category item counts', () => {
+    render(<RestoreProgress view={runningView()} />);
+    expect(screen.getByText('4 of 10 items')).toBeInTheDocument();
+  });
+
+  it('renders an overall progress bar reflecting the percentage', () => {
+    render(<RestoreProgress view={runningView()} />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '65');
+    expect(bar).toHaveStyle({ width: '65%' });
+  });
+
+  it('uses restore labels in restore mode', () => {
+    render(<RestoreProgress view={runningView()} mode="restore" />);
+    expect(screen.getByText('Restoring')).toBeInTheDocument();
+  });
+
+  it('uses dry-run labels in dry-run mode (same machinery)', () => {
+    render(<RestoreProgress view={runningView()} mode="dry-run" />);
+    expect(screen.getByText('Computing dry-run')).toBeInTheDocument();
+    // Stage machinery is identical across modes.
+    expect(screen.getByText('Stage 9 of 13')).toBeInTheDocument();
+    expect(screen.getByTestId('restore-progress')).toHaveAttribute('data-mode', 'dry-run');
+  });
+
+  it('renders an explicit error state on failure (not a frozen spinner)', () => {
+    render(
+      <RestoreProgress
+        view={runningView({
+          status: 'failed',
+          isRunning: false,
+          isError: true,
+          isComplete: false,
+          error: 'Importer step channel raised',
+        })}
+      />
+    );
+    expect(screen.getByText('Restore failed')).toBeInTheDocument();
+    expect(screen.getByTestId('restore-progress-error')).toHaveTextContent(
+      'Importer step channel raised'
+    );
+    // No progress bar in the error state — nothing is "in progress".
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('renders a completion state when done', () => {
+    render(
+      <RestoreProgress
+        view={runningView({
+          status: 'completed',
+          percentage: 100,
+          isRunning: false,
+          isComplete: true,
+        })}
+      />
+    );
+    expect(screen.getByText('Restore complete')).toBeInTheDocument();
+  });
+
+  it('uses the dry-run error label in dry-run mode', () => {
+    render(
+      <RestoreProgress
+        view={runningView({ status: 'failed', isRunning: false, isError: true, error: 'boom' })}
+        mode="dry-run"
+      />
+    );
+    expect(screen.getByText('Dry-run failed')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/RestoreProgress.tsx
+++ b/frontend/src/components/RestoreProgress.tsx
@@ -1,0 +1,111 @@
+/**
+ * Reusable progress surface for a DBAS Phase-2 restore or dry-run.
+ *
+ * Renders a stage indicator ("Stage N of M" + current category + per-category
+ * item progress) plus an overall progress bar, driven by the normalized view
+ * from {@link useRestoreProgress}. The SAME component serves both modes — a
+ * `mode` prop ("restore" | "dry-run") only switches the labels; the stage and
+ * progress machinery is identical (dry-run is a counts-only pre-pass, bead .16).
+ *
+ * Error status renders an explicit error state (not a frozen spinner) so an
+ * operator never stares at a spinner that will never resolve. Completion renders
+ * a done state.
+ *
+ * Styling reuses the shared `modal-progress*` classes from `ModalBase.css`; the
+ * stage-specific layout lives in `RestoreProgress.css`.
+ */
+import type { RestoreProgressView } from '../hooks/useRestoreProgress';
+import type { RestoreProgressMode } from '../utils/restoreStages';
+import './RestoreProgress.css';
+
+interface RestoreProgressProps {
+  /** Normalized view from `useRestoreProgress`. */
+  view: RestoreProgressView;
+  /** Label mode — switches restore vs dry-run wording. The machinery is shared. */
+  mode?: RestoreProgressMode;
+}
+
+const MODE_LABELS: Record<RestoreProgressMode, { running: string; complete: string; error: string }> = {
+  restore: {
+    running: 'Restoring',
+    complete: 'Restore complete',
+    error: 'Restore failed',
+  },
+  'dry-run': {
+    running: 'Computing dry-run',
+    complete: 'Dry-run complete',
+    error: 'Dry-run failed',
+  },
+};
+
+export function RestoreProgress({ view, mode = 'restore' }: RestoreProgressProps) {
+  const labels = MODE_LABELS[mode];
+  const {
+    stageNumber,
+    totalStages,
+    stageLabel,
+    itemCurrent,
+    itemTotal,
+    percentage,
+    isError,
+    isComplete,
+    error,
+  } = view;
+
+  const pct = Math.max(0, Math.min(100, percentage));
+
+  return (
+    <div className="restore-progress" data-testid="restore-progress" data-mode={mode}>
+      <div className="restore-progress-header">
+        {isError ? (
+          <span className="material-icons restore-progress-icon is-error">error</span>
+        ) : isComplete ? (
+          <span className="material-icons restore-progress-icon is-complete">check_circle</span>
+        ) : (
+          <span className="material-icons spinning restore-progress-icon">sync</span>
+        )}
+        <span className="restore-progress-title">
+          {isError ? labels.error : isComplete ? labels.complete : labels.running}
+        </span>
+      </div>
+
+      {!isComplete && !isError && (
+        <>
+          <div className="restore-progress-stage">
+            <span className="restore-progress-stage-counter">
+              Stage {stageNumber} of {totalStages}
+            </span>
+            <span className="restore-progress-stage-name">{stageLabel}</span>
+          </div>
+
+          {itemTotal > 0 && (
+            <div className="restore-progress-items" data-testid="restore-progress-items">
+              {itemCurrent} of {itemTotal} items
+            </div>
+          )}
+
+          <div className="modal-progress">
+            <div className="modal-progress-bar">
+              <div
+                className="modal-progress-fill"
+                style={{ width: `${pct}%` }}
+                role="progressbar"
+                aria-valuenow={Math.round(pct)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${labels.running}: stage ${stageNumber} of ${totalStages}`}
+              />
+            </div>
+            <div className="modal-progress-detail">{Math.round(pct)}%</div>
+          </div>
+        </>
+      )}
+
+      {isError && (
+        <div className="restore-progress-error" data-testid="restore-progress-error">
+          {error || 'The operation ended in an error state. No further progress will be reported.'}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useNavigateAwayGuard.test.ts
+++ b/frontend/src/hooks/useNavigateAwayGuard.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for useNavigateAwayGuard — the beforeunload guard armed while a
+ * critical operation is in progress.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useNavigateAwayGuard } from './useNavigateAwayGuard';
+
+describe('useNavigateAwayGuard', () => {
+  let addSpy: ReturnType<typeof vi.spyOn>;
+  let removeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    addSpy = vi.spyOn(window, 'addEventListener');
+    removeSpy = vi.spyOn(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('arms a beforeunload handler while active is true', () => {
+    renderHook(() => useNavigateAwayGuard(true));
+    expect(addSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+
+  it('does not arm a handler while active is false', () => {
+    renderHook(() => useNavigateAwayGuard(false));
+    const beforeUnloadAdds = addSpy.mock.calls.filter((c: unknown[]) => c[0] === 'beforeunload');
+    expect(beforeUnloadAdds).toHaveLength(0);
+  });
+
+  it('releases the handler when active flips to false', () => {
+    const { rerender } = renderHook(({ active }) => useNavigateAwayGuard(active), {
+      initialProps: { active: true },
+    });
+    expect(addSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+
+    rerender({ active: false });
+    expect(removeSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+
+  it('releases the handler on unmount', () => {
+    const { unmount } = renderHook(() => useNavigateAwayGuard(true));
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+
+  it('the handler sets returnValue to trigger the native prompt', () => {
+    renderHook(() => useNavigateAwayGuard(true));
+    const call = addSpy.mock.calls.find((c: unknown[]) => c[0] === 'beforeunload');
+    expect(call).toBeDefined();
+    const handler = call![1] as (e: BeforeUnloadEvent) => unknown;
+
+    const event = {
+      preventDefault: vi.fn(),
+      returnValue: '',
+    } as unknown as BeforeUnloadEvent;
+    handler(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.returnValue).toContain('restore is in progress');
+  });
+});

--- a/frontend/src/hooks/useNavigateAwayGuard.ts
+++ b/frontend/src/hooks/useNavigateAwayGuard.ts
@@ -1,0 +1,42 @@
+/**
+ * Guard against navigating away / closing the tab while a critical operation
+ * is in progress.
+ *
+ * Mirrors the existing `beforeunload` pattern in `App.tsx` (the
+ * "unsaved changes" warning). A DBAS restore is a multi-minute, non-atomic job
+ * whose compensating rollback depends on the operation COMPLETING — killing the
+ * tab mid-flight (Dispatcharr has no DB transactions, ADR-012) can leave a
+ * half-applied archive. While `active` is true we attach a `beforeunload`
+ * handler so the browser shows its native "leave site?" confirmation; when the
+ * op reaches a terminal state the caller flips `active` to false and the
+ * handler is removed so a completed restore never nags the operator.
+ *
+ * This is the browser-level half of the guard. The in-app half (confirm-on-close
+ * inside the modal) lives in the modal that consumes the restore surface — the
+ * repo has no router-level `useBlocker`, so `beforeunload` + a modal-close
+ * confirm is the established pattern.
+ */
+import { useEffect } from 'react';
+
+/**
+ * Attach a `beforeunload` guard while `active` is true.
+ *
+ * @param active - Whether the guard is currently armed (op in progress).
+ */
+export function useNavigateAwayGuard(active: boolean): void {
+  useEffect(() => {
+    if (!active) return;
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Legacy browsers require a returnValue to trigger the native prompt;
+      // the string itself is ignored by modern browsers (they show a generic
+      // message), but setting it is what arms the dialog.
+      e.returnValue = 'A restore is in progress. Leaving now may leave your data in a partial state.';
+      return e.returnValue;
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [active]);
+}

--- a/frontend/src/hooks/useRestoreProgress.test.ts
+++ b/frontend/src/hooks/useRestoreProgress.test.ts
@@ -1,0 +1,165 @@
+/**
+ * TDD tests for useRestoreProgress.
+ *
+ * The hook polls the generic task status endpoint (`getTask`), maps the real
+ * `TaskProgress` payload to view state, stops on a terminal status, and clears
+ * its polling timer on unmount (no leaked interval).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useRestoreProgress } from './useRestoreProgress';
+import type { TaskProgress, TaskStatus } from '../services/api';
+
+vi.mock('../services/api', () => ({
+  getTask: vi.fn(),
+}));
+
+import * as api from '../services/api';
+
+const mockedGetTask = vi.mocked(api.getTask);
+
+/** Build a TaskStatus whose progress carries the fields the hook reads. */
+function makeTaskStatus(progress: Partial<TaskProgress>): TaskStatus {
+  const fullProgress: TaskProgress = {
+    total: 0,
+    current: 0,
+    percentage: 0,
+    status: 'running',
+    current_item: '',
+    success_count: 0,
+    failed_count: 0,
+    skipped_count: 0,
+    started_at: null,
+    ...progress,
+  };
+  return {
+    task_id: 'dbas_restore',
+    task_name: 'DBAS Restore',
+    task_description: '',
+    status: (fullProgress.status as TaskStatus['status']) ?? 'running',
+    enabled: true,
+    progress: fullProgress,
+    schedule: {} as TaskStatus['schedule'],
+    schedules: [],
+    last_run: null,
+    next_run: null,
+    config: {},
+  };
+}
+
+describe('useRestoreProgress', () => {
+  beforeEach(() => {
+    mockedGetTask.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not poll when taskId is null', () => {
+    const { result } = renderHook(() => useRestoreProgress({ taskId: null }));
+    expect(mockedGetTask).not.toHaveBeenCalled();
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.progress).toBeNull();
+  });
+
+  it('maps the progress payload to "Stage N of 13" + per-item counts', async () => {
+    mockedGetTask.mockResolvedValue(
+      makeTaskStatus({
+        status: 'running',
+        current_item: 'channel',
+        current: 4,
+        total: 10,
+        percentage: 65,
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 5 })
+    );
+
+    await waitFor(() => expect(result.current.progress).not.toBeNull());
+
+    expect(result.current.stageNumber).toBe(9); // channel is the 9th stage
+    expect(result.current.totalStages).toBe(13);
+    expect(result.current.stageLabel).toBe('Channels');
+    expect(result.current.itemCurrent).toBe(4);
+    expect(result.current.itemTotal).toBe(10);
+    expect(result.current.percentage).toBe(65);
+    expect(result.current.isRunning).toBe(true);
+  });
+
+  it('advances through mocked status responses and stops on terminal status', async () => {
+    mockedGetTask
+      .mockResolvedValueOnce(makeTaskStatus({ status: 'running', current_item: 'm3u_account' }))
+      .mockResolvedValueOnce(makeTaskStatus({ status: 'running', current_item: 'channel' }))
+      .mockResolvedValue(makeTaskStatus({ status: 'completed', current_item: 'finalize', percentage: 100 }));
+
+    const { result } = renderHook(() =>
+      useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 5 })
+    );
+
+    await waitFor(() => expect(result.current.isComplete).toBe(true));
+
+    expect(result.current.status).toBe('completed');
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.percentage).toBe(100);
+
+    // Polling stopped: no further calls after terminal.
+    const callsAtTerminal = mockedGetTask.mock.calls.length;
+    await new Promise((r) => setTimeout(r, 30));
+    expect(mockedGetTask.mock.calls.length).toBe(callsAtTerminal);
+  });
+
+  it('renders an error state on a failed status (not a frozen spinner)', async () => {
+    mockedGetTask.mockResolvedValue(
+      makeTaskStatus({ status: 'failed', current_item: 'channel' })
+    );
+
+    const { result } = renderHook(() =>
+      useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 5 })
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.status).toBe('failed');
+  });
+
+  it('clears its polling timer on unmount (no leaked interval)', async () => {
+    // Keep the task running so the hook would keep polling if not torn down.
+    mockedGetTask.mockResolvedValue(
+      makeTaskStatus({ status: 'running', current_item: 'channel' })
+    );
+
+    const { unmount } = renderHook(() =>
+      useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 5 })
+    );
+
+    await waitFor(() => expect(mockedGetTask).toHaveBeenCalled());
+
+    act(() => unmount());
+    const callsAfterUnmount = mockedGetTask.mock.calls.length;
+
+    // Wait several poll intervals — a leaked timer would fire more calls.
+    await new Promise((r) => setTimeout(r, 40));
+    expect(mockedGetTask.mock.calls.length).toBe(callsAfterUnmount);
+  });
+
+  it('stopPolling() halts further polling', async () => {
+    mockedGetTask.mockResolvedValue(
+      makeTaskStatus({ status: 'running', current_item: 'channel' })
+    );
+
+    const { result } = renderHook(() =>
+      useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 5 })
+    );
+
+    await waitFor(() => expect(mockedGetTask).toHaveBeenCalled());
+
+    act(() => result.current.stopPolling());
+    const callsAfterStop = mockedGetTask.mock.calls.length;
+
+    await new Promise((r) => setTimeout(r, 40));
+    expect(mockedGetTask.mock.calls.length).toBe(callsAfterStop);
+  });
+});

--- a/frontend/src/hooks/useRestoreProgress.ts
+++ b/frontend/src/hooks/useRestoreProgress.ts
@@ -1,0 +1,203 @@
+/**
+ * Polling hook for a DBAS Phase-2 restore / dry-run progress surface.
+ *
+ * Mirrors the poll / abort / cleanup conventions of
+ * `useAutoCreationExecution.ts` (`pollExecutionUntilTerminal`): a steady
+ * interval of cheap GETs against the task status endpoint, stop on a terminal
+ * status, honor an AbortSignal both before each fetch and inside the inter-poll
+ * sleep, and clear the interval on unmount so no timer leaks (there is a known
+ * dnd/observer-leak discipline in this repo — the same applies to polling
+ * timers).
+ *
+ * SEAM: the restore-trigger endpoint / restore TaskScheduler is a LATER bead.
+ * The backend orchestrator (`backend/dbas/restore_orchestrator.py`, bead .18)
+ * exists but does not yet emit `_set_progress`, and no restore task is wired to
+ * `task_scheduler`. This hook therefore takes the `taskId` as a prop/seam and
+ * polls the EXISTING generic task status endpoint (`getTask` →
+ * `/api/tasks/{id}`), reading the REAL `TaskProgress` shape
+ * (`backend/task_scheduler.py` — `TaskProgress.to_dict()`). When the restore
+ * task lands and emits its stage via `current_item`, this hook needs no change.
+ */
+import { useState, useCallback, useEffect, useRef } from 'react';
+import * as api from '../services/api';
+import type { TaskProgress } from '../services/api';
+import {
+  TOTAL_RESTORE_STAGES,
+  stageNumberFromCurrentItem,
+  stageLabelFromCurrentItem,
+} from '../utils/restoreStages';
+
+/** Task statuses that end polling — the job is done, no further updates come. */
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  'completed',
+  'failed',
+  'cancelled',
+]);
+
+/** Default poll cadence — small and steady; status reads are cheap GETs. */
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+
+/** Safety cap so a stuck task never polls forever (matches auto-creation hook). */
+const MAX_POLL_DURATION_MS = 30 * 60 * 1000;
+
+export interface UseRestoreProgressOptions {
+  /**
+   * Task id to poll. `null` disables polling (no task running yet) — the seam
+   * for the not-yet-wired restore-trigger endpoint.
+   */
+  taskId: string | null;
+  /** Poll cadence in ms (default 1000). */
+  pollIntervalMs?: number;
+}
+
+/** Normalized view state the progress component renders. */
+export interface RestoreProgressView {
+  /** Raw backend progress payload, or null before the first successful poll. */
+  progress: TaskProgress | null;
+  /** 1-based current stage ("Stage N of M"). */
+  stageNumber: number;
+  /** Total stages in the canonical sequence. */
+  totalStages: number;
+  /** Operator-facing label of the current stage. */
+  stageLabel: string;
+  /** Current item index WITHIN the active stage (from `progress.current`). */
+  itemCurrent: number;
+  /** Total items in the active stage (from `progress.total`). */
+  itemTotal: number;
+  /** Overall completion percentage (0-100) from the backend payload. */
+  percentage: number;
+  /** Raw task status string. */
+  status: string;
+  /** Whether the job is still running (not terminal, taskId present). */
+  isRunning: boolean;
+  /** Whether the job reached a failed/cancelled terminal status. */
+  isError: boolean;
+  /** Whether the job completed successfully. */
+  isComplete: boolean;
+  /** Polling/fetch error message, if any (transient errors are not surfaced). */
+  error: string | null;
+}
+
+const EMPTY_VIEW: RestoreProgressView = {
+  progress: null,
+  stageNumber: 1,
+  totalStages: TOTAL_RESTORE_STAGES,
+  stageLabel: stageLabelFromCurrentItem(null),
+  itemCurrent: 0,
+  itemTotal: 0,
+  percentage: 0,
+  status: 'idle',
+  isRunning: false,
+  isError: false,
+  isComplete: false,
+  error: null,
+};
+
+function viewFromProgress(progress: TaskProgress): RestoreProgressView {
+  const status = progress.status;
+  const isError = status === 'failed' || status === 'cancelled';
+  const isComplete = status === 'completed';
+  return {
+    progress,
+    stageNumber: stageNumberFromCurrentItem(progress.current_item),
+    totalStages: TOTAL_RESTORE_STAGES,
+    stageLabel: stageLabelFromCurrentItem(progress.current_item),
+    itemCurrent: progress.current,
+    itemTotal: progress.total,
+    percentage: progress.percentage,
+    status,
+    isRunning: !TERMINAL_STATUSES.has(status),
+    isError,
+    isComplete,
+    error: null,
+  };
+}
+
+export interface UseRestoreProgressResult extends RestoreProgressView {
+  /** Force-stop polling (e.g. user dismissed the surface after completion). */
+  stopPolling: () => void;
+}
+
+/**
+ * Poll a restore/dry-run task's status until it reaches a terminal state.
+ *
+ * Returns a normalized {@link RestoreProgressView} that the shared
+ * `RestoreProgress` component renders for both restore and dry-run modes.
+ */
+export function useRestoreProgress(
+  options: UseRestoreProgressOptions
+): UseRestoreProgressResult {
+  const { taskId, pollIntervalMs = DEFAULT_POLL_INTERVAL_MS } = options;
+
+  const [view, setView] = useState<RestoreProgressView>(EMPTY_VIEW);
+
+  // Holds the live abort controller so stopPolling() can tear down the loop.
+  const abortRef = useRef<AbortController | null>(null);
+
+  const stopPolling = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    if (!taskId) {
+      setView(EMPTY_VIEW);
+      return;
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const { signal } = controller;
+    const startedAt = Date.now();
+
+    // Async setState fires inside this poll loop (not synchronously in the
+    // effect body), so the set-state-in-effect lint rule does not apply.
+    const poll = async (): Promise<void> => {
+      while (!signal.aborted) {
+        try {
+          const taskStatus = await api.getTask(taskId);
+          if (signal.aborted) return;
+          const nextView = viewFromProgress(taskStatus.progress);
+          setView(nextView);
+          if (!nextView.isRunning) {
+            // Terminal — stop polling, leave the final view in place.
+            return;
+          }
+        } catch (err) {
+          if (signal.aborted) return;
+          // Transient fetch failure — surface the message but keep polling
+          // until the safety cap, mirroring the auto-creation hook's retry.
+          setView((prev) => ({
+            ...prev,
+            error: err instanceof Error ? err.message : 'Failed to fetch restore progress',
+          }));
+        }
+
+        if (Date.now() - startedAt > MAX_POLL_DURATION_MS) return;
+
+        await new Promise<void>((resolve) => {
+          const timer = window.setTimeout(resolve, pollIntervalMs);
+          signal.addEventListener(
+            'abort',
+            () => {
+              window.clearTimeout(timer);
+              resolve();
+            },
+            { once: true }
+          );
+        });
+      }
+    };
+
+    void poll();
+
+    return () => {
+      controller.abort();
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+      }
+    };
+  }, [taskId, pollIntervalMs]);
+
+  return { ...view, stopPolling };
+}

--- a/frontend/src/utils/restoreStages.test.ts
+++ b/frontend/src/utils/restoreStages.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for the restore stage definitions and the current_item -> stage mapper.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  RESTORE_STAGES,
+  TOTAL_RESTORE_STAGES,
+  stageIndexFromCurrentItem,
+  stageNumberFromCurrentItem,
+  stageLabelFromCurrentItem,
+} from './restoreStages';
+
+describe('restoreStages', () => {
+  it('defines a 13-stage sequence', () => {
+    expect(TOTAL_RESTORE_STAGES).toBe(13);
+    expect(RESTORE_STAGES).toHaveLength(13);
+  });
+
+  it('maps a known backend entity key to its 0-based stage index', () => {
+    // m3u_account is the second stage (index 1) after preflight (index 0).
+    expect(stageIndexFromCurrentItem('m3u_account')).toBe(1);
+    expect(stageIndexFromCurrentItem('channel')).toBe(8);
+  });
+
+  it('maps a stage key to a 1-based stage number for display', () => {
+    expect(stageNumberFromCurrentItem('m3u_account')).toBe(2);
+    expect(stageNumberFromCurrentItem('channel')).toBe(9);
+  });
+
+  it('resolves the operator-facing label for a stage key', () => {
+    expect(stageLabelFromCurrentItem('channel')).toBe('Channels');
+    expect(stageLabelFromCurrentItem('epg_source')).toBe('EPG sources');
+  });
+
+  it('matches the human label as well as the key (case-insensitive)', () => {
+    expect(stageIndexFromCurrentItem('Channels')).toBe(8);
+    expect(stageIndexFromCurrentItem('M3U accounts')).toBe(1);
+  });
+
+  it('falls back to stage 1 for an empty or unknown current_item (never throws)', () => {
+    expect(stageIndexFromCurrentItem('')).toBe(0);
+    expect(stageIndexFromCurrentItem(null)).toBe(0);
+    expect(stageIndexFromCurrentItem(undefined)).toBe(0);
+    expect(stageNumberFromCurrentItem('not_a_real_stage')).toBe(1);
+    expect(stageLabelFromCurrentItem('not_a_real_stage')).toBe('Pre-flight validation');
+  });
+});

--- a/frontend/src/utils/restoreStages.ts
+++ b/frontend/src/utils/restoreStages.ts
@@ -1,0 +1,91 @@
+/**
+ * Canonical stage definitions for a DBAS Phase-2 restore / dry-run.
+ *
+ * A full restore is a multi-stage job whose ordering is the contract owned by
+ * the backend orchestrator (`backend/dbas/restore_orchestrator.py` —
+ * `default_importer_steps()` / the ADR-012 D-table hard sequence). The backend
+ * task status endpoint (`/api/tasks/{id}`) exposes only the generic
+ * `TaskProgress` shape (`backend/task_scheduler.py` — `TaskProgress.to_dict()`):
+ *
+ *     { total, current, percentage, status, current_item,
+ *       success_count, failed_count, skipped_count, started_at }
+ *
+ * There is NO `stage_number` / `total_stages` field server-side — the grooming
+ * guessed a richer shape that does not exist. The stage decomposition is a
+ * FRONTEND concept: the future restore task sets `current_item` to the stage
+ * key (a category name) as it advances, and this module maps that key back to a
+ * stable "Stage N of M" position plus an operator-facing label.
+ *
+ * Keep `key` values aligned with the backend `EntityType` / phase keys
+ * (`backend/dbas/restore_contracts.py`) so the `current_item` string the task
+ * emits resolves here. Unknown keys fall through to a 0-index "preparing" state
+ * rather than throwing — the UI must never crash on an unexpected stage string.
+ */
+
+/** Operating mode for the shared progress surface. */
+export type RestoreProgressMode = 'restore' | 'dry-run';
+
+/** One stage in the canonical restore sequence. */
+export interface RestoreStage {
+  /** Stable key — matches the `current_item` the backend task emits. */
+  key: string;
+  /** Operator-facing label shown in the stage indicator. */
+  label: string;
+}
+
+/**
+ * The canonical 13-stage restore sequence (ADR-012 D-table order).
+ *
+ * The order is the contract even where the matching importer is still a seam
+ * (`backend/dbas/restore_orchestrator.py` — WIRED vs SEAM). When an importer
+ * lands it keeps its position here.
+ */
+export const RESTORE_STAGES: readonly RestoreStage[] = [
+  { key: 'preflight', label: 'Pre-flight validation' },
+  { key: 'm3u_account', label: 'M3U accounts' },
+  { key: 'epg_source', label: 'EPG sources' },
+  { key: 'channel_group', label: 'Channel groups' },
+  { key: 'channel_profile', label: 'Channel profiles' },
+  { key: 'stream_profile', label: 'Stream profiles' },
+  { key: 'user_agent', label: 'User agents' },
+  { key: 'user', label: 'Users' },
+  { key: 'channel', label: 'Channels' },
+  { key: 'stream', label: 'Streams' },
+  { key: 'logo', label: 'Logos' },
+  { key: 'deferred', label: 'Applying deferred settings' },
+  { key: 'finalize', label: 'Finalizing' },
+] as const;
+
+/** Total number of stages in the canonical sequence. */
+export const TOTAL_RESTORE_STAGES = RESTORE_STAGES.length;
+
+/**
+ * Resolve a backend `current_item` string to its stage index (0-based).
+ *
+ * Matching is case-insensitive and tolerant of the `current_item` being either
+ * the stage `key` or the human `label` (the task may emit either). Returns 0
+ * (the pre-flight / "preparing" stage) for an empty or unrecognized value — the
+ * UI degrades to "Stage 1 of N" rather than crashing on an unexpected string.
+ */
+export function stageIndexFromCurrentItem(currentItem: string | null | undefined): number {
+  if (!currentItem) return 0;
+  const needle = currentItem.trim().toLowerCase();
+  const idx = RESTORE_STAGES.findIndex(
+    (s) => s.key.toLowerCase() === needle || s.label.toLowerCase() === needle
+  );
+  return idx === -1 ? 0 : idx;
+}
+
+/**
+ * The 1-based stage number for display ("Stage N of M").
+ *
+ * Always within `[1, TOTAL_RESTORE_STAGES]`.
+ */
+export function stageNumberFromCurrentItem(currentItem: string | null | undefined): number {
+  return stageIndexFromCurrentItem(currentItem) + 1;
+}
+
+/** Resolve the operator-facing stage label for a `current_item` string. */
+export function stageLabelFromCurrentItem(currentItem: string | null | undefined): string {
+  return RESTORE_STAGES[stageIndexFromCurrentItem(currentItem)].label;
+}


### PR DESCRIPTION
## Bead
enhancedchannelmanager-g5xv7 — Phase 2: Restore + dry-run progress UI. Gates .16/.19/.20.

## What
- `RestoreProgress.tsx` (+ css/test) — stage indicator (Stage N of 13 + category + per-item counts + overall bar), `mode: 'restore' | 'dry-run'` (labels only; machinery shared).
- `useRestoreProgress.ts` — polling hook mirroring `useAutoCreationExecution`; polls `/api/tasks/{id}`, maps the REAL `TaskProgress` shape, stops on terminal status, cleans up on unmount.
- `useNavigateAwayGuard.ts` — reuses the app's existing `beforeunload` pattern (App.tsx:1276); armed only while restoring (rollback depends on the op completing), released on completion/failure.
- `restoreStages.ts` — frontend-owned 13-stage list derived from `default_importer_steps()` (the backend emits no stage metadata; see finding below).
- Integrated into `BackupRestoreModal.tsx` with `restoreTaskId` as a documented seam.

## Key findings
- The grooming's assumed progress payload (`{stage, stage_number, total_stages}`) **does not exist**. Real shape is `TaskProgress.to_dict()`: `{total, current, percentage, status, current_item, ...counts}`. The 13-stage decomposition is therefore frontend-owned (mapped from `current_item`).
- **No async restore-trigger endpoint/task exists yet** — `run_restore()` (.18) isn't wired to a TaskScheduler emitting `_set_progress`; current YAML restore is synchronous. Live polling activates with ZERO component changes once that lands (seam in `handleRestore`). Filed as a follow-up bead.

## Gates
lint clean (`--max-warnings 0`), tsc clean, vitest 1598 passed (25 new), build succeeds. (Run via the documented `/tmp` writable-node_modules overlay — main checkout's node_modules is root-owned; CI is the authoritative gate.)

## NOT verified (overnight)
No human visual verification. A human should eyeball: progress surface in light+dark theme (shared `modal-progress-fill` uses `--accent-primary` — CSS-guidelines contrast risk), the `beforeunload` prompt firing while-restoring/not-after, dry-run labels, error/completion states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)