### PR TITLE
v0.18.0-dbas: 0i2vt.15 logos importer -- 3-tier match + streaming upload + validation

### DIFF
--- a/backend/dbas/importers/__init__.py
+++ b/backend/dbas/importers/__init__.py
@@ -34,6 +34,11 @@ from dbas.importers.m3u_accounts import (
     resolve_group,
 )
 from dbas.importers.users import import_users
+from dbas.importers.logos import (
+    LogoImportResult,
+    import_logos,
+    resolve_logo_match,
+)
 
 __all__ = [
     "apply_deferred_auto_sync",
@@ -46,4 +51,7 @@ __all__ = [
     "import_stream_profiles",
     "import_users",
     "resolve_group",
+    "LogoImportResult",
+    "import_logos",
+    "resolve_logo_match",
 ]

--- a/backend/dbas/importers/logos.py
+++ b/backend/dbas/importers/logos.py
@@ -1,0 +1,593 @@
+"""The logos restore importer — streaming upload + 3-tier match + hardened validation.
+
+Bead ``enhancedchannelmanager-0i2vt.15``. Logos are the LAST entity in the hard
+Phase-2 ordering (``M3U → EPG → Channels → Logos``; ADR-012) and carry both the
+largest memory/bandwidth profile AND the only untrusted-file-upload surface in
+the restore. This module restores the LOGO entity category from a Dispatcharr
+export archive.
+
+It mirrors the established Phase-2 importer pattern (``importers/channels.py`` /
+``importers/m3u_accounts.py``): opt-in, consumes the shared restore contracts
+(:class:`~dbas.restore_contracts.IdRemapTable`,
+:class:`~dbas.restore_contracts.RollbackLedger`,
+:class:`~dbas.restore_contracts.RestoreReport`, the Skip/Failure taxonomy),
+per-entity results, dry-run support, and credential-clean logging.
+
+----------------------------------------------------------------------------
+STREAMING UPLOAD (ADR-008 D8 — the OOM-avoidance headline requirement)
+----------------------------------------------------------------------------
+
+A 50MB-per-logo cap × 2000 logos is a 100GB policy ceiling. The container is a
+single process; it CANNOT hold that in memory. So this importer processes ONE
+logo at a time: read its base64 string → decode to bytes → validate → upload →
+let the bytes go out of scope BEFORE the next logo is read. There is never more
+than a single decoded logo payload live at once — NOT a CumulativeMemoryTracker
+port (rejected by D8). The decode is isolated in :func:`_decode_logo_bytes` so a
+test can prove the read/upload interleave (one decode, one upload, repeat).
+
+----------------------------------------------------------------------------
+3-TIER MATCH (the logoMap contract — pure resolver :func:`resolve_logo_match`)
+----------------------------------------------------------------------------
+
+An archived logo is reconciled against the destination instance's logos by THREE
+strategies, in strict priority order — the first that hits wins:
+
+* **(1) src** — ``src:{source_id}``: the archived logo's source id resolves
+  through the :class:`IdRemapTable` ``LOGO`` namespace. Strongest signal.
+* **(2) name** — ``name:{lower(original_name)}``: case-insensitive name equality
+  against a destination logo. Tie-break = lowest destination id (deterministic).
+* **(3) file** — ``file:{sanitized_basename}``: the sanitized filename basename
+  equals a destination logo's basename (derived from its ``url``/``filename``).
+  Tie-break = lowest destination id.
+
+A match means the logo already exists on the destination: it is NOT re-uploaded
+(``ALREADY_EXISTS_IDENTICAL``), its ``source->dest`` id is recorded in the remap
+so channel ``logo_id`` references can resolve, and nothing is ledgered (nothing
+to roll back). A MISS uploads the logo (streaming), ledgers it, remaps it, and
+feeds :attr:`RestoreReport.logo_misses` (D9 red banner).
+
+----------------------------------------------------------------------------
+SECURITY VALIDATION (untrusted file upload — the security-review surface)
+----------------------------------------------------------------------------
+
+Every logo passes FOUR validations BEFORE any upload; a failure is a per-entity
+``VALIDATION_ERROR`` (sanitized message, no raw bytes/path), never a crash, and
+never writes/uploads anything:
+
+1. **Filename basename** — strip every directory component (POSIX ``/`` AND
+   Windows ``\\``); reject empty / ``.`` / ``..`` / control-char names. The
+   stripped basename is also a path-traversal guard: a ``../`` or absolute path
+   collapses to nothing usable and is rejected (see :func:`_safe_basename`).
+2. **Declared-size cap** — if the archive declares a ``size`` over 50MB, reject
+   BEFORE decoding (don't buffer a blob we already know is over cap).
+3. **Decoded-size cap** — after decode, the actual byte length is hard-capped at
+   50MB (the declared size is advisory; the decoded length is authoritative).
+4. **MIME magic-byte validation** — the decoded bytes' leading magic number must
+   match a known image type (PNG/JPEG/GIF/WebP/BMP). A ``.png`` file whose bytes
+   are ELF/PE/script is a disguised binary and is REJECTED — the extension and
+   the declared content-type are NEVER trusted. Magic checks are byte
+   comparisons / membership tests (no regex on dynamic input — Semgrep clean).
+
+----------------------------------------------------------------------------
+BULK-DELETE PRE-STEP (destructive — opt-in, never silent, never in dry-run)
+----------------------------------------------------------------------------
+
+When ``clear_existing=True`` AND not a dry-run, the importer clears the
+destination's existing logos via ``client.bulk_delete_logos`` before uploading
+the archive's logos. This is destructive, so it is OFF by default and never runs
+in dry-run (grooming guard: a mid-delete failure must not leave Dispatcharr with
+no logos and no replacements — so the delete is best-effort-logged and the upload
+proceeds regardless; the operator opts into this explicitly).
+
+----------------------------------------------------------------------------
+CREDENTIAL / PATH HYGIENE (the .8 / .13 clear-text-logging lesson)
+----------------------------------------------------------------------------
+
+Logo bytes, raw filenames/paths, and upstream SDK exception bodies (which can
+echo a logo url/path) NEVER reach a log line, a report label/message, or a
+ledger entry. We log/report ONLY safe fields: the logo's display name, the match
+tier, counts, and a failure-reason enum. :func:`_sanitize_failure` scrubs any
+upstream message that smells like a URL/path before it lands in the report.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+import os
+
+from pydantic import BaseModel, Field
+
+from dbas.restore_contracts import (
+    EntityType,
+    FailureDetail,
+    FailureReason,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+    SkipDetail,
+    SkipReason,
+)
+from dispatcharr_client import DispatcharrClient
+
+logger = logging.getLogger(__name__)
+
+# Hard per-logo size cap: 50MB (ADR-008 D8 / STRIDE). The decoded byte length is
+# authoritative; a declared size over this is rejected before decode.
+MAX_LOGO_BYTES = 50 * 1024 * 1024
+
+# Allowed image magic-byte signatures. Each entry is a (prefix_bytes, offset)
+# pair the decoded payload must start with at the given offset. These are plain
+# byte comparisons — NO regex on dynamic input (Semgrep-clean magic check).
+# WebP and (some) AVIF carry their tag at offset 8 inside a RIFF/ISO-BMFF box.
+_MAGIC_PREFIXES: tuple[tuple[bytes, int], ...] = (
+    (b"\x89PNG\r\n\x1a\n", 0),   # PNG
+    (b"\xff\xd8\xff", 0),         # JPEG (JFIF/EXIF)
+    (b"GIF87a", 0),              # GIF87a
+    (b"GIF89a", 0),              # GIF89a
+    (b"BM", 0),                  # BMP
+    (b"WEBP", 8),               # WebP (RIFF....WEBP)
+)
+
+# The smallest leading slice we must inspect to decide every magic above. Kept
+# small so we never read more than necessary to classify.
+_MAGIC_INSPECT_LEN = 16
+
+# Control bytes (NUL + C0 controls + DEL) are never valid in a logo filename.
+_CONTROL_BYTES = frozenset(range(0x00, 0x20)) | {0x7F}
+
+# Markers that, if present in an upstream message, mean it may carry a url/path —
+# we replace the whole message rather than risk leaking it into the report.
+_PATH_LEAK_MARKERS = ("http", "://", "/", "\\", "url", "token", "passw")
+
+
+class LogoImportResult(BaseModel):
+    """The logos importer's return value.
+
+    Carries safe aggregate counters for the orchestrator/UX. No per-logo bytes,
+    paths, or upstream error bodies — only counts and the logo-miss aggregate
+    (which is also reflected into :attr:`RestoreReport.logo_misses`).
+    """
+
+    uploaded: int = Field(default=0)
+    matched: int = Field(default=0)
+    misses: int = Field(default=0)
+    rejected: int = Field(default=0)
+    deleted_existing: int = Field(default=0)
+
+
+def _logo_label(archive_logo: dict) -> str:
+    """Operator-facing identifier for a logo — its display name, never a path."""
+    name = archive_logo.get("name")
+    return str(name) if name else "<unknown>"
+
+
+def _norm_name(value) -> str | None:
+    """Case-insensitive, trimmed key for a logo name; None when absent/blank."""
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip().lower()
+    return trimmed or None
+
+
+def _safe_basename(raw) -> str | None:
+    """Return a validated filename BASENAME, or ``None`` if the name is unsafe.
+
+    The single chokepoint for the filename-basename + path-traversal (Zip-Slip)
+    guards. This is intentionally STRICT — it REJECTS (does not silently strip) a
+    name that carries any directory structure, so a crafted archive entry never
+    has a chance to resolve outside the upload target:
+
+    * rejects any control byte (NUL-injection / log-forging);
+    * rejects a leading ``/`` (absolute POSIX path) or a Windows drive letter
+      (``C:``) / leading backslash (absolute / UNC path);
+    * rejects ANY embedded path separator (``/`` or ``\\``) — a legitimate logo
+      basename has none; a name with one is a path, not a basename, and we refuse
+      it rather than strip-and-trust;
+    * rejects a ``..`` traversal component anywhere;
+    * rejects empty / ``.`` / ``..`` (no usable basename).
+
+    A name that survives is a bare, separator-free basename safe to hand to the
+    multipart upload. Returns it on success, or ``None`` (caller ->
+    VALIDATION_ERROR — never logs the raw name).
+    """
+    if not isinstance(raw, str) or not raw:
+        return None
+    # Reject control characters outright (NUL-injection / log-forging).
+    if any(ord(ch) in _CONTROL_BYTES for ch in raw):
+        return None
+    # Reject a Windows drive-letter prefix (e.g. ``C:\\...`` or ``C:rel``).
+    if len(raw) >= 2 and raw[1] == ":" and raw[0].isalpha():
+        return None
+    # Reject ANY embedded separator — a valid basename has none. This catches a
+    # leading ``/`` (absolute), a leading ``\\`` (UNC/absolute), and every
+    # ``../`` / ``..\\`` traversal in one rule.
+    if "/" in raw or "\\" in raw:
+        return None
+    name = raw.strip()
+    if not name or name in (".", ".."):
+        return None
+    # Belt-and-braces: the value must equal its own basename on this platform.
+    if os.path.basename(name) != name:
+        return None
+    return name
+
+
+def _basename_key(value) -> str | None:
+    """Lowercased basename of a destination logo's url/filename, for tier-3 match."""
+    if not isinstance(value, str) or not value:
+        return None
+    last = value.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
+    last = last.strip().lower()
+    return last or None
+
+
+def resolve_logo_match(
+    archive_logo: dict,
+    *,
+    dest_logos: list[dict],
+    remap: IdRemapTable,
+) -> tuple[int | None, str]:
+    """Resolve an archived logo to a DESTINATION logo id via the 3-tier match.
+
+    Strategies, in strict priority order — the first that hits wins:
+
+    (1) ``src``  — source id through the :class:`IdRemapTable` ``LOGO`` namespace.
+    (2) ``name`` — case-insensitive name equality; tie-break = lowest dest id.
+    (3) ``file`` — sanitized basename equals a destination logo's basename;
+        tie-break = lowest dest id.
+
+    Args:
+        archive_logo: The archived logo record (``id`` / ``name`` / ``filename``).
+        dest_logos: The destination instance's logos (``id`` / ``name`` / ``url``).
+        remap: The shared :class:`IdRemapTable` (read-only here).
+
+    Returns:
+        ``(destination_id, tier)`` where ``tier`` is one of ``"src"`` / ``"name"``
+        / ``"file"`` on a hit, or ``(None, "miss")`` when no strategy resolved it.
+    """
+    # (1) src — explicit source->dest mapping.
+    source_id = archive_logo.get("id")
+    if source_id is not None:
+        mapped = remap.resolve(EntityType.LOGO, int(source_id))
+        if mapped is not None:
+            return mapped, "src"
+
+    # (2) name — case-insensitive, trimmed; lowest dest id wins.
+    name_key = _norm_name(archive_logo.get("name"))
+    if name_key is not None:
+        matches = [
+            d.get("id")
+            for d in dest_logos
+            if _norm_name(d.get("name")) == name_key and d.get("id") is not None
+        ]
+        if matches:
+            return min(int(m) for m in matches), "name"
+
+    # (3) file — sanitized basename equality; lowest dest id wins.
+    file_key = _basename_key(archive_logo.get("filename"))
+    if file_key is not None:
+        matches = []
+        for d in dest_logos:
+            if d.get("id") is None:
+                continue
+            dest_basename = _basename_key(d.get("url")) or _basename_key(d.get("filename"))
+            if dest_basename == file_key:
+                matches.append(d.get("id"))
+        if matches:
+            return min(int(m) for m in matches), "file"
+
+    return None, "miss"
+
+
+def _decode_logo_bytes(archive_logo: dict) -> bytes:
+    """Decode ONE logo's base64 payload to bytes (the streaming-read seam).
+
+    Isolated so the streaming pattern is observable in tests (one decode, one
+    upload, repeat — never decode-all-then-upload). Raises ``ValueError`` on a
+    non-decodable payload; the caller turns that into a VALIDATION_ERROR.
+    """
+    payload = archive_logo.get("content_b64")
+    if not isinstance(payload, str) or not payload:
+        raise ValueError("missing logo content")
+    try:
+        return base64.b64decode(payload, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("undecodable logo content") from exc
+
+
+def _magic_ok(data: bytes) -> bool:
+    """True if the decoded bytes start with a known IMAGE magic number.
+
+    Pure byte-prefix membership test (no regex). Rejects disguised binaries
+    (ELF/PE/script) whose extension or declared content-type claims an image.
+    """
+    head = data[:_MAGIC_INSPECT_LEN]
+    for prefix, offset in _MAGIC_PREFIXES:
+        if head[offset:offset + len(prefix)] == prefix:
+            return True
+    return False
+
+
+def _sanitize_failure(exc: Exception | str) -> str:
+    """Sanitized, operator-facing failure message — NO url/path/byte leak.
+
+    An upstream upload error body can echo the logo url/cache path. If the text
+    carries any path/url marker, replace it wholesale with a generic message
+    rather than risk leaking a path or token into the report.
+    """
+    text = (str(exc) or "").strip()
+    lowered = text.lower()
+    if not text or any(m in lowered for m in _PATH_LEAK_MARKERS):
+        return "Upstream rejected the logo upload request."
+    return text
+
+
+def _upstream_reason_for(exc: Exception) -> FailureReason:
+    """Classify an upload failure: timeout vs. generic upstream API error."""
+    text = str(exc).lower()
+    if "timeout" in text or "timed out" in text:
+        return FailureReason.UPSTREAM_TIMEOUT
+    return FailureReason.UPSTREAM_API_ERROR
+
+
+def _validate_logo(archive_logo: dict) -> tuple[bytes | None, str | None, str | None]:
+    """Run all four validations + decode for ONE logo (the security chokepoint).
+
+    Order is cheapest-first and decode-late so an over-declared-size or bad-name
+    logo is rejected BEFORE we decode/buffer it:
+
+    1. filename basename + path-traversal guard (:func:`_safe_basename`);
+    2. declared-size cap (pre-decode);
+    3. decode (base64 -> bytes);
+    4. decoded-size cap;
+    5. MIME magic-byte validation.
+
+    Returns ``(decoded_bytes, safe_basename, None)`` when the logo is safe to
+    upload, or ``(None, None, reason)`` with a SHORT, path-free reason string when
+    it must be rejected. The reason never contains the raw filename or bytes.
+    """
+    # 1. Filename basename + traversal guard.
+    basename = _safe_basename(archive_logo.get("filename"))
+    if basename is None:
+        return None, None, "unsafe or empty logo filename"
+
+    # 2. Declared-size cap — reject before decoding a blob we know is over cap.
+    declared = archive_logo.get("size")
+    if isinstance(declared, int) and declared > MAX_LOGO_BYTES:
+        return None, None, "declared logo size exceeds the 50MB cap"
+
+    # 3. Decode (base64 -> bytes).
+    try:
+        data = _decode_logo_bytes(archive_logo)
+    except ValueError:
+        return None, None, "logo content could not be decoded"
+
+    # 4. Decoded-size cap (authoritative).
+    if len(data) > MAX_LOGO_BYTES:
+        return None, None, "logo exceeds the 50MB cap"
+
+    # 5. MIME magic-byte validation (disguised-binary rejection).
+    if not _magic_ok(data):
+        return None, None, "logo bytes are not a recognised image type"
+
+    return data, basename, None
+
+
+async def import_logos(
+    *,
+    archive_logos: list[dict],
+    client: DispatcharrClient,
+    selected: bool,
+    report: RestoreReport,
+    ledger: RollbackLedger,
+    remap: IdRemapTable,
+    is_dry_run: bool = False,
+    clear_existing: bool = False,
+) -> LogoImportResult:
+    """Restore the LOGO category: 3-tier match + streaming upload of the misses.
+
+    Args:
+        archive_logos: The logo records from the export archive. Each carries the
+            source ``id``, display ``name``, ``filename``, ``content_type``, and
+            base64 ``content_b64`` (the D1 binary subtree decoded into records).
+        client: The Dispatcharr API client.
+        selected: The per-category opt-in flag. ``False`` -> the whole category is
+            skipped (no deletes, no uploads); each logo recorded
+            EXCLUDED_BY_OPERATOR.
+        report: The shared :class:`RestoreReport`; results land in the
+            ``EntityType.LOGO`` category and feed :attr:`RestoreReport.logo_misses`.
+        ledger: The shared :class:`RollbackLedger`; each UPLOADED logo is recorded
+            for compensating deletes (a matched existing logo is NOT ledgered).
+        remap: The shared :class:`IdRemapTable`. WRITTEN with each matched/uploaded
+            logo's ``source->dest`` id under ``EntityType.LOGO`` so channel
+            ``logo_id`` references resolve.
+        is_dry_run: ``True`` -> nothing is deleted or uploaded; the importer only
+            reports ``would_create`` / ``would_skip``.
+        clear_existing: ``True`` -> run the DESTRUCTIVE bulk-delete pre-step
+            (clear all destination logos before upload). OFF by default; NEVER
+            runs in dry-run.
+
+    Returns:
+        A :class:`LogoImportResult` with safe aggregate counters.
+    """
+    cat = report.category(EntityType.LOGO)
+    result = LogoImportResult()
+
+    # OPT-IN. Off unless the operator selected the logos category.
+    if not selected:
+        logger.info("[DBAS-LOGOS] Category not selected; skipping logos.")
+        for archive_logo in archive_logos:
+            _skip(
+                cat,
+                SkipReason.EXCLUDED_BY_OPERATOR,
+                _logo_label(archive_logo),
+                archive_logo.get("id"),
+                is_dry_run,
+            )
+        return result
+
+    logger.info(
+        "[DBAS-LOGOS] Restoring logos (dry_run=%s, clear_existing=%s); %d archived logo(s).",
+        is_dry_run,
+        clear_existing,
+        len(archive_logos),
+    )
+
+    # Enumerate destination logos ONCE for the 3-tier match (safe: id/name/url).
+    try:
+        dest_logos = await client.get_all_logos_paginated()
+    except Exception as exc:  # noqa: BLE001 - best-effort; match degrades to misses
+        logger.warning("[DBAS-LOGOS] Could not list destination logos: %s", _safe_failure_log(exc))
+        dest_logos = []
+
+    # DESTRUCTIVE bulk-delete pre-step — opt-in, never in dry-run.
+    if clear_existing and not is_dry_run:
+        existing_ids = [d.get("id") for d in dest_logos if isinstance(d.get("id"), int)]
+        if existing_ids:
+            try:
+                await client.bulk_delete_logos(existing_ids)
+                result.deleted_existing = len(existing_ids)
+                logger.info(
+                    "[DBAS-LOGOS] Bulk-delete pre-step cleared %d existing logo(s).",
+                    len(existing_ids),
+                )
+            except Exception as exc:  # noqa: BLE001 - log + proceed (don't leave no logos)
+                logger.warning(
+                    "[DBAS-LOGOS] Bulk-delete pre-step failed (%s); proceeding with upload.",
+                    _safe_failure_log(exc),
+                )
+        # After a clear, nothing remains to match against.
+        dest_logos = []
+
+    # STREAMING loop — process ONE logo at a time: match, validate+decode, upload,
+    # release. Never holds more than a single decoded payload in memory (D8).
+    for archive_logo in archive_logos:
+        label = _logo_label(archive_logo)
+        source_id = archive_logo.get("id")
+
+        # 3-tier match FIRST — a matched logo already exists; never re-uploaded.
+        dest_id, tier = resolve_logo_match(
+            archive_logo, dest_logos=dest_logos, remap=remap
+        )
+        if dest_id is not None:
+            _skip(cat, SkipReason.ALREADY_EXISTS_IDENTICAL, label, source_id, is_dry_run)
+            if source_id is not None:
+                remap.add(EntityType.LOGO, int(source_id), int(dest_id))
+            result.matched += 1
+            logger.info(
+                "[DBAS-LOGOS] Logo '%s' matched existing (tier=%s, dest id=%s); skipped.",
+                label,
+                tier,
+                dest_id,
+            )
+            continue
+
+        # MISS — this logo must be uploaded. Validate+decode BEFORE upload.
+        data, basename, reason = _validate_logo(archive_logo)
+        if reason is not None:
+            cat.failed += 1
+            result.rejected += 1
+            cat.failure_details.append(
+                FailureDetail(
+                    reason=FailureReason.VALIDATION_ERROR,
+                    label=label,
+                    message=reason,
+                    source_export_id=source_id,
+                )
+            )
+            # Log only the reason enum-style string + label — never the filename.
+            logger.warning(
+                "[DBAS-LOGOS] Rejected logo '%s': %s.", label, reason
+            )
+            continue
+
+        # A valid miss feeds the logo-miss aggregate (D9 red banner) regardless of
+        # dry-run vs. apply — it is a logo the destination did not already have.
+        report.logo_misses += 1
+        result.misses += 1
+
+        if is_dry_run:
+            cat.would_create += 1
+            # Release the decoded bytes promptly (no upload in dry-run).
+            del data
+            continue
+
+        content_type = _safe_content_type(archive_logo)
+        try:
+            created = await client.upload_logo_file(
+                label, basename, data, content_type
+            )
+        except Exception as exc:  # noqa: BLE001 - per-entity failure, never a crash
+            reason_enum = _upstream_reason_for(exc)
+            cat.failed += 1
+            cat.failure_details.append(
+                FailureDetail(
+                    reason=reason_enum,
+                    label=label,
+                    message=_sanitize_failure(exc),
+                    source_export_id=source_id,
+                )
+            )
+            logger.warning(
+                "[DBAS-LOGOS] Failed to upload logo '%s': %s", label, reason_enum.value
+            )
+            # Release the decoded bytes on the failure path too.
+            del data
+            continue
+        finally:
+            # Drop the decoded payload reference ASAP so it is collectable before
+            # the next logo is read (the D8 release-before-next guarantee).
+            data = None  # noqa: F841 - intentional release of the decoded payload
+
+        new_id = created.get("id") if isinstance(created, dict) else None
+        cat.created += 1
+        result.uploaded += 1
+        if new_id is not None:
+            new_id = int(new_id)
+            if source_id is not None:
+                remap.add(EntityType.LOGO, int(source_id), new_id)
+            ledger.record_created(EntityType.LOGO, new_id, label)
+        logger.info("[DBAS-LOGOS] Uploaded logo '%s' (id=%s).", label, new_id)
+
+    return result
+
+
+def _safe_content_type(archive_logo: dict) -> str:
+    """Return a SAFE content-type for the multipart upload.
+
+    The archive's declared content-type is advisory only (the magic-byte check is
+    the real gate). We pass it through when it looks like an image content-type,
+    else default to ``application/octet-stream`` so we never forward an arbitrary
+    attacker-controlled header value.
+    """
+    declared = archive_logo.get("content_type")
+    if isinstance(declared, str) and declared.lower().startswith("image/"):
+        # Strip any parameters / control chars defensively.
+        clean = declared.split(";", 1)[0].strip().lower()
+        if clean and all(ord(c) >= 0x20 for c in clean):
+            return clean
+    return "application/octet-stream"
+
+
+def _safe_failure_log(exc: Exception) -> str:
+    """A path-free string for a best-effort WARN log (list/delete failures)."""
+    return _sanitize_failure(exc)
+
+
+def _skip(
+    cat,
+    reason: SkipReason,
+    label: str,
+    source_export_id,
+    is_dry_run: bool,
+) -> None:
+    """Record a skip in both the count and the reasoned detail list."""
+    if is_dry_run:
+        cat.would_skip += 1
+    else:
+        cat.skipped += 1
+    cat.skip_details.append(
+        SkipDetail(reason=reason, label=label, source_export_id=source_export_id)
+    )

--- a/backend/dbas/restore_contracts.py
+++ b/backend/dbas/restore_contracts.py
@@ -83,6 +83,7 @@ class EntityType(str, Enum):
     USER_AGENT = "user_agent"              # …-0i2vt.13
     DVR_RULE = "dvr_rule"                  # …-0i2vt.13
     USER = "user"                          # …-l1p4p (crown-jewel, opt-in)
+    LOGO = "logo"                          # …-0i2vt.15 (streaming upload; 3-tier match)
 
 
 class RestoreActionKind(str, Enum):

--- a/backend/dispatcharr_client.py
+++ b/backend/dispatcharr_client.py
@@ -910,6 +910,54 @@ class DispatcharrClient:
         response = await self._request("DELETE", f"/api/channels/logos/{logo_id}/")
         response.raise_for_status()
 
+    async def bulk_delete_logos(self, logo_ids: list[int]) -> dict:
+        """Bulk-delete logos by id (DBAS restore bulk-delete pre-step, bead 0i2vt.15).
+
+        Issues a single ``DELETE /api/channels/logos/bulk-delete/`` with
+        ``{"logo_ids": [...]}``. Used by the logos importer to clear existing
+        logos before a streaming re-upload. An empty ``logo_ids`` is a no-op
+        (nothing to delete) and never hits the API.
+
+        Credential/path hygiene: this method logs only the COUNT of ids, never
+        the upstream response body (the response can echo names/paths) — the
+        importer surfaces a sanitized failure if the call raises.
+        """
+        if not logo_ids:
+            return {"deleted": 0}
+        response = await self._request(
+            "DELETE",
+            "/api/channels/logos/bulk-delete/",
+            json={"logo_ids": logo_ids},
+        )
+        if response.status_code >= 400:
+            # Do NOT echo the response body — it may carry logo names/paths. The
+            # status code alone is a safe operator-facing signal.
+            raise Exception(f"Logo bulk-delete failed: {response.status_code}")
+        return response.json() if response.content else {"deleted": len(logo_ids)}
+
+    async def get_all_logos_paginated(self, page_size: int = 500) -> list[dict]:
+        """Return ALL logos by walking every page (DBAS restore, bead 0i2vt.15).
+
+        Paginates ``GET /api/channels/logos/`` until the ``next`` link is
+        exhausted and returns the flattened list of logo records. Used by the
+        logos importer to (a) build the bulk-delete id list for the destructive
+        pre-step and (b) enumerate destination logos for the 3-tier match.
+
+        Mirrors :meth:`find_logo_by_url`'s pagination convention. Logs only the
+        running count — never a logo url/name/path.
+        """
+        logos: list[dict] = []
+        page = 1
+        while True:
+            result = await self.get_logos(page=page, page_size=page_size)
+            results = result.get("results", []) if isinstance(result, dict) else result
+            logos.extend(r for r in (results or []) if isinstance(r, dict))
+            if not (isinstance(result, dict) and result.get("next")):
+                break
+            page += 1
+        logger.debug("[DISPATCHARR] Fetched %d logo(s) across all pages.", len(logos))
+        return logos
+
     # -------------------------------------------------------------------------
     # EPG Sources
     # -------------------------------------------------------------------------

--- a/backend/tests/dbas/test_logos_importer.py
+++ b/backend/tests/dbas/test_logos_importer.py
@@ -1,0 +1,659 @@
+"""Tests for the logos restore importer
+(enhancedchannelmanager-0i2vt.15 — Phase 2 LAST entity; ADR-008 D8).
+
+Logos carry the largest memory/bandwidth profile in the restore AND the only
+untrusted-file-upload surface, so this suite is split into two halves:
+
+A. FUNCTIONAL
+   1. 3-tier match (logoMap contract) in strict priority order:
+        src:{source_id}       -> IdRemapTable LOGO namespace (primary)
+        name:{lower(name)}     -> destination logo by lowercased name (fallback 1)
+        file:{sanitized_file}  -> destination logo by sanitized basename (fallback 2)
+      First tier that hits wins; a miss is reported (feeds RestoreReport.logo_misses).
+   2. Streaming upload (D8 OOM avoidance): the importer reads + decodes + uploads
+      ONE logo at a time and releases its bytes before reading the next. Proven by
+      a read/upload INTERLEAVE assertion — no all-in-memory accumulation.
+   3. Bulk-delete pre-step (destructive, opt-in): clears existing logos via
+      ``client.bulk_delete_logos`` ONLY when ``clear_existing=True`` AND not dry-run.
+   4. Opt-in off -> no-op (no deletes, no uploads). Dry-run -> no deletes, no uploads.
+
+B. SECURITY (ATTACK CORPUS — each entry REJECTED as a per-entity FAILURE, with
+   NO upload call, NO disk write, and a sanitized message that leaks no raw bytes
+   or path):
+   - 60MB logo over the 50MB cap.
+   - ``.png`` extension but ELF / PE / shell-script magic bytes (MIME spoof).
+   - archive entry paths ``../../etc/passwd``, ``/abs/path``, ``..\\win`` (traversal).
+   - filename with directory components / control chars / empty / ``.`` / ``..``.
+
+The Dispatcharr client is mocked at the importer module level
+(``dbas.importers.logos``); the importer is exercised with an AsyncMock client.
+NOTHING touches the real filesystem — logo bytes arrive base64-encoded in the
+archive records (the D1 binary subtree is decoded into these records upstream).
+"""
+import base64
+
+import pytest
+from unittest.mock import AsyncMock
+
+from dbas.importers.logos import (
+    MAX_LOGO_BYTES,
+    import_logos,
+    resolve_logo_match,
+)
+from dbas.restore_contracts import (
+    EntityType,
+    FailureReason,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+    SkipReason,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# A 1x1 PNG (valid magic bytes \x89PNG\r\n\x1a\n).
+_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+    "+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+_GIF = b"GIF89a" + b"\x00" * 16
+_JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 16
+_WEBP = b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 8
+_ELF = b"\x7fELF" + b"\x00" * 16          # Linux executable
+_PE = b"MZ\x90\x00" + b"\x00" * 16        # Windows executable
+_SHELL = b"#!/bin/sh\nrm -rf /\n"          # shell script
+
+
+def _b64(raw: bytes) -> str:
+    return base64.b64encode(raw).decode("ascii")
+
+
+def _logo(
+    *,
+    src_id=None,
+    name="Logo",
+    filename="logo.png",
+    content=_PNG,
+    content_type="image/png",
+    content_b64=None,
+):
+    """Build one archive logo record."""
+    rec = {
+        "id": src_id,
+        "name": name,
+        "filename": filename,
+        "content_type": content_type,
+        "content_b64": _b64(content) if content_b64 is None else content_b64,
+    }
+    return rec
+
+
+def _client(*, dest_logos=None, upload_side_effect=None):
+    """AsyncMock Dispatcharr client with the methods the logos importer uses."""
+    client = AsyncMock()
+    client.get_all_logos_paginated = AsyncMock(return_value=dest_logos or [])
+    client.bulk_delete_logos = AsyncMock(return_value={"deleted": len(dest_logos or [])})
+
+    counter = {"n": 9000}
+
+    async def _upload(name, filename, content, content_type):
+        counter["n"] += 1
+        return {"id": counter["n"], "name": name}
+
+    client.upload_logo_file = AsyncMock(
+        side_effect=upload_side_effect or _upload
+    )
+    return client
+
+
+def _ctx():
+    return RestoreReport(is_dry_run=False), RollbackLedger(restore_id="t"), IdRemapTable()
+
+
+# ===========================================================================
+# A. FUNCTIONAL — 3-tier match
+# ===========================================================================
+
+
+def test_resolve_tier1_src_id_primary():
+    """Tier 1: source id resolves through the IdRemapTable LOGO namespace."""
+    remap = IdRemapTable()
+    remap.add(EntityType.LOGO, 7, 700)
+    logo = _logo(src_id=7, name="ESPN", filename="espn.png")
+    dest_id, tier = resolve_logo_match(logo, dest_logos=[], remap=remap)
+    assert dest_id == 700
+    assert tier == "src"
+
+
+def test_resolve_tier2_name_fallback():
+    """Tier 2: lowercased name equality when src id is unmapped."""
+    remap = IdRemapTable()
+    dest = [{"id": 801, "name": "ESPN"}]
+    logo = _logo(src_id=7, name="espn", filename="nomatch.png")
+    dest_id, tier = resolve_logo_match(logo, dest_logos=dest, remap=remap)
+    assert dest_id == 801
+    assert tier == "name"
+
+
+def test_resolve_tier3_file_fallback():
+    """Tier 3: sanitized basename equality when src id + name both miss."""
+    remap = IdRemapTable()
+    dest = [{"id": 802, "name": "Other", "url": "http://x/cache/espn-hd.png"}]
+    logo = _logo(src_id=7, name="NoNameMatch", filename="espn-hd.png")
+    dest_id, tier = resolve_logo_match(logo, dest_logos=dest, remap=remap)
+    assert dest_id == 802
+    assert tier == "file"
+
+
+def test_resolve_priority_src_beats_name_and_file():
+    """Priority: src id wins even when name + file would also match."""
+    remap = IdRemapTable()
+    remap.add(EntityType.LOGO, 7, 700)
+    dest = [
+        {"id": 801, "name": "ESPN"},
+        {"id": 802, "name": "Other", "url": "http://x/espn.png"},
+    ]
+    logo = _logo(src_id=7, name="ESPN", filename="espn.png")
+    dest_id, tier = resolve_logo_match(logo, dest_logos=dest, remap=remap)
+    assert dest_id == 700
+    assert tier == "src"
+
+
+def test_resolve_priority_name_beats_file():
+    """Priority: name match wins over a file match when src id misses."""
+    remap = IdRemapTable()
+    dest = [
+        {"id": 801, "name": "ESPN"},
+        {"id": 802, "name": "Other", "url": "http://x/espn.png"},
+    ]
+    logo = _logo(src_id=7, name="ESPN", filename="espn.png")
+    dest_id, tier = resolve_logo_match(logo, dest_logos=dest, remap=remap)
+    assert dest_id == 801
+    assert tier == "name"
+
+
+def test_resolve_miss_returns_none():
+    """A miss on all three tiers returns (None, miss)."""
+    remap = IdRemapTable()
+    logo = _logo(src_id=7, name="Nope", filename="nope.png")
+    dest_id, tier = resolve_logo_match(logo, dest_logos=[], remap=remap)
+    assert dest_id is None
+    assert tier == "miss"
+
+
+@pytest.mark.asyncio
+async def test_matched_logo_not_reuploaded_registered_in_remap():
+    """A tier-matched logo is NOT uploaded; src->dest is recorded in the remap."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[{"id": 801, "name": "ESPN"}])
+    logo = _logo(src_id=7, name="ESPN")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    client.upload_logo_file.assert_not_awaited()
+    assert remap.resolve(EntityType.LOGO, 7) == 801
+    cat = report.category(EntityType.LOGO)
+    assert cat.skipped == 1
+    assert cat.skip_details[0].reason == SkipReason.ALREADY_EXISTS_IDENTICAL
+
+
+@pytest.mark.asyncio
+async def test_unmatched_logo_uploaded_ledgered_remapped():
+    """A miss uploads the logo, ledgers it, and records src->dest in the remap."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=7, name="NewLogo")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    client.upload_logo_file.assert_awaited_once()
+    cat = report.category(EntityType.LOGO)
+    assert cat.created == 1
+    assert remap.resolve(EntityType.LOGO, 7) is not None
+    assert ledger.entries and ledger.entries[0].entity_type == EntityType.LOGO
+
+
+@pytest.mark.asyncio
+async def test_miss_increments_logo_misses_aggregate():
+    """An upload-eligible miss feeds RestoreReport.logo_misses (D9 banner)."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    await import_logos(
+        archive_logos=[_logo(src_id=1, name="A")],
+        client=client, selected=True, report=report, ledger=ledger, remap=remap,
+    )
+    assert report.logo_misses == 1
+
+
+# ===========================================================================
+# A. FUNCTIONAL — streaming (one logo at a time, released before the next)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_streaming_reads_one_uploads_then_reads_next():
+    """D8: bytes are decoded just-in-time and released before the next logo.
+
+    Proven by an INTERLEAVE: the importer decodes logo N, uploads it, and only
+    then decodes logo N+1 — never decoding all logos up front. We observe the
+    order of (decode, upload) events through a decode hook + the upload mock.
+    """
+    report, ledger, remap = _ctx()
+    events: list[str] = []
+
+    async def _upload(name, filename, content, content_type):
+        events.append(f"upload:{name}")
+        return {"id": 9000 + len(events), "name": name}
+
+    client = _client(dest_logos=[])
+    client.upload_logo_file = AsyncMock(side_effect=_upload)
+
+    logos = [_logo(src_id=i, name=f"L{i}") for i in range(5)]
+
+    # Hook the importer's decode seam so we can observe decode ordering.
+    import dbas.importers.logos as mod
+    real_decode = mod._decode_logo_bytes
+
+    def _decode_hook(rec):
+        events.append(f"decode:{rec.get('name')}")
+        return real_decode(rec)
+
+    mod._decode_logo_bytes = _decode_hook
+    try:
+        await import_logos(
+            archive_logos=logos, client=client, selected=True,
+            report=report, ledger=ledger, remap=remap,
+        )
+    finally:
+        mod._decode_logo_bytes = real_decode
+
+    # Strict interleave: decode L0, upload L0, decode L1, upload L1, ...
+    expected = []
+    for i in range(5):
+        expected.append(f"decode:L{i}")
+        expected.append(f"upload:L{i}")
+    assert events == expected
+
+
+@pytest.mark.asyncio
+async def test_streaming_does_not_decode_all_before_first_upload():
+    """No all-in-memory accumulation: at most ONE decoded payload is live.
+
+    We assert that the FIRST upload happens before the SECOND decode — i.e. the
+    importer never front-loads every decode (which is the OOM failure shape).
+    """
+    report, ledger, remap = _ctx()
+    events: list[str] = []
+
+    async def _upload(name, filename, content, content_type):
+        events.append("upload")
+        return {"id": 9000 + len(events), "name": name}
+
+    client = _client(dest_logos=[])
+    client.upload_logo_file = AsyncMock(side_effect=_upload)
+
+    import dbas.importers.logos as mod
+    real_decode = mod._decode_logo_bytes
+    decode_count = {"n": 0}
+
+    def _decode_hook(rec):
+        decode_count["n"] += 1
+        events.append("decode")
+        return real_decode(rec)
+
+    mod._decode_logo_bytes = _decode_hook
+    try:
+        await import_logos(
+            archive_logos=[_logo(src_id=i, name=f"L{i}") for i in range(3)],
+            client=client, selected=True, report=report, ledger=ledger, remap=remap,
+        )
+    finally:
+        mod._decode_logo_bytes = real_decode
+
+    # The first upload must precede the second decode.
+    first_upload = events.index("upload")
+    second_decode = [i for i, e in enumerate(events) if e == "decode"][1]
+    assert first_upload < second_decode
+
+
+# ===========================================================================
+# A. FUNCTIONAL — bulk-delete pre-step
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_invoked_when_clear_existing_enabled():
+    """clear_existing=True -> bulk_delete_logos is called with destination ids."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[{"id": 1, "name": "A"}, {"id": 2, "name": "B"}])
+    await import_logos(
+        archive_logos=[_logo(src_id=5, name="New")],
+        client=client, selected=True, report=report, ledger=ledger, remap=remap,
+        clear_existing=True,
+    )
+    client.bulk_delete_logos.assert_awaited_once()
+    sent_ids = client.bulk_delete_logos.await_args.args[0]
+    assert sorted(sent_ids) == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_not_invoked_when_clear_existing_disabled():
+    """Default (clear_existing=False) -> NO destructive bulk-delete."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[{"id": 1, "name": "A"}])
+    await import_logos(
+        archive_logos=[_logo(src_id=5, name="New")],
+        client=client, selected=True, report=report, ledger=ledger, remap=remap,
+        clear_existing=False,
+    )
+    client.bulk_delete_logos.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_not_invoked_in_dry_run_even_when_enabled():
+    """Destructive pre-step NEVER runs in dry-run (grooming guard)."""
+    report = RestoreReport(is_dry_run=True)
+    ledger, remap = RollbackLedger(restore_id="t"), IdRemapTable()
+    client = _client(dest_logos=[{"id": 1, "name": "A"}])
+    await import_logos(
+        archive_logos=[_logo(src_id=5, name="New")],
+        client=client, selected=True, report=report, ledger=ledger, remap=remap,
+        clear_existing=True, is_dry_run=True,
+    )
+    client.bulk_delete_logos.assert_not_awaited()
+    client.upload_logo_file.assert_not_awaited()
+
+
+# ===========================================================================
+# A. FUNCTIONAL — opt-in / dry-run
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_opt_in_off_is_noop():
+    """selected=False -> no deletes, no uploads, all EXCLUDED_BY_OPERATOR."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[{"id": 1, "name": "A"}])
+    await import_logos(
+        archive_logos=[_logo(src_id=5, name="New")],
+        client=client, selected=False, report=report, ledger=ledger, remap=remap,
+        clear_existing=True,
+    )
+    client.bulk_delete_logos.assert_not_awaited()
+    client.upload_logo_file.assert_not_awaited()
+    cat = report.category(EntityType.LOGO)
+    assert cat.skip_details[0].reason == SkipReason.EXCLUDED_BY_OPERATOR
+
+
+@pytest.mark.asyncio
+async def test_dry_run_no_uploads_reports_would_create():
+    """Dry-run uploads nothing; reports would_create for a miss."""
+    report = RestoreReport(is_dry_run=True)
+    ledger, remap = RollbackLedger(restore_id="t"), IdRemapTable()
+    client = _client(dest_logos=[])
+    await import_logos(
+        archive_logos=[_logo(src_id=5, name="New")],
+        client=client, selected=True, report=report, ledger=ledger, remap=remap,
+        is_dry_run=True,
+    )
+    client.upload_logo_file.assert_not_awaited()
+    cat = report.category(EntityType.LOGO)
+    assert cat.would_create == 1
+    assert ledger.entries == []
+
+
+# ===========================================================================
+# B. SECURITY — ATTACK CORPUS (each REJECTED; no upload, no write, sanitized msg)
+# ===========================================================================
+
+
+def _assert_rejected(report, client, *, source_id=None):
+    """Common assertions: per-entity FAILURE, no upload, sanitized message."""
+    client.upload_logo_file.assert_not_awaited()
+    cat = report.category(EntityType.LOGO)
+    assert cat.created == 0
+    assert cat.failed == 1
+    detail = cat.failure_details[0]
+    assert detail.reason == FailureReason.VALIDATION_ERROR
+    # Sanitized: no raw path/byte leak.
+    assert "/etc/passwd" not in detail.message
+    assert "\\" not in detail.message
+    assert "\x00" not in detail.message
+    if source_id is not None:
+        assert detail.source_export_id == source_id
+
+
+@pytest.mark.asyncio
+async def test_attack_oversize_60mb_rejected_before_upload():
+    """A 60MB logo (over the 50MB cap) is rejected; nothing uploads."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    oversize = b"\x89PNG\r\n\x1a\n" + b"\x00" * (MAX_LOGO_BYTES + 10)
+    logo = _logo(src_id=1, name="Huge", content=oversize)
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=1)
+
+
+@pytest.mark.asyncio
+async def test_attack_declared_size_oversize_rejected():
+    """An over-cap declared size is rejected without decoding the whole blob."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=1, name="Huge", content=_PNG)
+    logo["size"] = MAX_LOGO_BYTES + 1  # declared size over cap
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=1)
+
+
+@pytest.mark.asyncio
+async def test_attack_mime_spoof_elf_magic_rejected():
+    """.png extension but ELF magic bytes -> rejected (disguised binary)."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=1, name="Spoof", filename="evil.png",
+                 content=_ELF, content_type="image/png")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=1)
+
+
+@pytest.mark.asyncio
+async def test_attack_mime_spoof_pe_magic_rejected():
+    """.png extension but PE (MZ) magic bytes -> rejected."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=2, name="Spoof", filename="evil.png", content=_PE)
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=2)
+
+
+@pytest.mark.asyncio
+async def test_attack_mime_spoof_shell_script_rejected():
+    """.png extension but a shell script -> rejected."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=3, name="Spoof", filename="evil.png", content=_SHELL)
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=3)
+
+
+@pytest.mark.asyncio
+async def test_valid_image_types_accepted():
+    """PNG / JPEG / GIF / WebP magic bytes are all accepted and uploaded."""
+    for raw, ct in [(_PNG, "image/png"), (_JPEG, "image/jpeg"),
+                    (_GIF, "image/gif"), (_WEBP, "image/webp")]:
+        report, ledger, remap = _ctx()
+        client = _client(dest_logos=[])
+        await import_logos(
+            archive_logos=[_logo(src_id=1, name="Ok", filename="ok.img", content=raw,
+                                 content_type=ct)],
+            client=client, selected=True, report=report, ledger=ledger, remap=remap,
+        )
+        client.upload_logo_file.assert_awaited_once()
+        assert report.category(EntityType.LOGO).created == 1
+
+
+@pytest.mark.asyncio
+async def test_attack_path_traversal_dotdot_rejected():
+    """Archive entry path ../../etc/passwd -> rejected, no leak of the path."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=1, name="Trav", filename="../../etc/passwd")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=1)
+
+
+@pytest.mark.asyncio
+async def test_attack_path_traversal_absolute_rejected():
+    """An absolute archive path /etc/cron.d/evil -> rejected."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=2, name="Trav", filename="/etc/cron.d/evil")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=2)
+
+
+@pytest.mark.asyncio
+async def test_attack_path_traversal_windows_backslash_rejected():
+    """A Windows traversal ..\\win\\system32 -> rejected."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=3, name="Trav", filename="..\\win\\system32\\evil.png")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=3)
+
+
+@pytest.mark.asyncio
+async def test_attack_filename_empty_rejected():
+    """An empty filename -> rejected."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=1, name="Bad", filename="")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=1)
+
+
+@pytest.mark.asyncio
+async def test_attack_filename_dot_and_dotdot_rejected():
+    """Filenames '.' and '..' -> rejected (no usable basename)."""
+    for bad in (".", ".."):
+        report, ledger, remap = _ctx()
+        client = _client(dest_logos=[])
+        logo = _logo(src_id=1, name="Bad", filename=bad)
+        await import_logos(
+            archive_logos=[logo], client=client, selected=True,
+            report=report, ledger=ledger, remap=remap,
+        )
+        _assert_rejected(report, client, source_id=1)
+
+
+@pytest.mark.asyncio
+async def test_attack_filename_control_chars_rejected():
+    """A filename with a NUL / control char -> rejected."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=1, name="Bad", filename="lo\x00go.png")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=1)
+
+
+@pytest.mark.asyncio
+async def test_attack_invalid_base64_rejected():
+    """A non-decodable base64 payload -> rejected, no crash."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=1, name="Bad", content_b64="!!!not base64!!!")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=1)
+
+
+@pytest.mark.asyncio
+async def test_attack_directory_component_stripped_to_basename_then_validated():
+    """A traversal-laden filename never reaches upload even if it has a basename."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=1, name="Trav", filename="../../evil/logo.png")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=1)
+
+
+@pytest.mark.asyncio
+async def test_upload_failure_recorded_as_per_entity_failure():
+    """An upstream upload error is a sanitized per-entity FAILURE, not a crash."""
+    report, ledger, remap = _ctx()
+
+    async def _boom(name, filename, content, content_type):
+        raise Exception("Logo upload failed: 500 - http://secret/url?token=abc")
+
+    client = _client(dest_logos=[])
+    client.upload_logo_file = AsyncMock(side_effect=_boom)
+    await import_logos(
+        archive_logos=[_logo(src_id=1, name="Boom")],
+        client=client, selected=True, report=report, ledger=ledger, remap=remap,
+    )
+    cat = report.category(EntityType.LOGO)
+    assert cat.failed == 1
+    detail = cat.failure_details[0]
+    assert detail.reason == FailureReason.UPSTREAM_API_ERROR
+    # The upstream URL/token must NOT leak into the operator-facing message.
+    assert "token" not in detail.message
+    assert "http" not in detail.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_one_bad_logo_does_not_block_the_rest():
+    """A rejected logo is isolated — sibling valid logos still upload."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logos = [
+        _logo(src_id=1, name="Bad", filename="evil.png", content=_ELF),
+        _logo(src_id=2, name="Good"),
+    ]
+    await import_logos(
+        archive_logos=logos, client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    cat = report.category(EntityType.LOGO)
+    assert cat.failed == 1
+    assert cat.created == 1
+    client.upload_logo_file.assert_awaited_once()


### PR DESCRIPTION
## Bead
enhancedchannelmanager-0i2vt.15 — Phase 2: Logos importer (largest memory/bandwidth profile; untrusted file upload). ADR-008 D8 + STRIDE.

## What
New `backend/dbas/importers/logos.py`:
- **Streaming (D8 OOM guard)**: one decoded logo in memory at a time (decode→validate→upload→release before next). Proven by interleave tests. 50MB×2000 = 100GB ceiling survivable.
- **3-tier match**: `src:{id}` → `name:{lower(name)}` → `file:{basename}`; lowest-id tie-break; matched skipped/remapped (not re-uploaded), uploaded misses created+ledgered; misses feed `RestoreReport.logo_misses` (D9 banner). New `EntityType.LOGO`.
- **Bulk-delete pre-step**: opt-in (`clear_existing`, OFF default), gated off in dry-run, best-effort (delete fail → still upload, never leave zero-logos-no-replacement).
- New client methods: `bulk_delete_logos`, `get_all_logos_paginated` (verify-then-size; `upload_logo_file` already existed).

## Security validation (independently security-reviewed: SAFE TO MERGE, all 6 invariants hold)
- **Decoded-size cap** (authoritative, not declared size).
- **MIME magic-byte allowlist** (PNG/JPEG/GIF/BMP/WebP); extension + content-type never trusted; **SVG excluded** (XML/script-capable XSS surface).
- **Path-traversal/basename**: strict REJECT (not normalize) on any `/`/`\`/drive-letter/UNC/control-char/empty/`.`/`..`; nothing written to local FS (bytes → multipart HTTP).
- **Credential-clean logging** (the .8/.13 lesson): new methods log status/counts only, never bodies/paths/payloads.
- Attack corpus (ELF/PE/script spoof, traversal variants, oversize, control chars) — each rejected, no upload, no leak.

## Tests
32 tests incl. the attack corpus + streaming + per-entity isolation. Full suite green (5812 passed).

## Follow-ups (filed; non-gating)
LOW: strengthen/drop 2-byte BMP magic; add SVG/drive-letter regression tests; live 2000-logo OOM ceiling verification (needs the archive-subtree loader + live instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)