### PR TITLE
v0.18.0-dbas: 0i2vt.20 restore-complete summary + per-entity counts

### DIFF
--- a/frontend/src/components/BackupRestoreModal.tsx
+++ b/frontend/src/components/BackupRestoreModal.tsx
@@ -1,10 +1,11 @@
 import { useState, useCallback } from 'react';
 import { ModalOverlay } from './ModalOverlay';
 import { RestoreProgress } from './RestoreProgress';
+import { RestoreCompleteSummary } from './RestoreCompleteSummary';
 import { useRestoreProgress } from '../hooks/useRestoreProgress';
 import { useNavigateAwayGuard } from '../hooks/useNavigateAwayGuard';
 import * as api from '../services/api';
-import type { BackupValidation, BackupRestoreResult } from '../services/api';
+import type { BackupValidation, BackupRestoreResult, RestoreReport } from '../services/api';
 import { getDateLocale } from '../utils/formatting';
 import './ModalBase.css';
 import './BackupRestoreModal.css';
@@ -21,6 +22,14 @@ export function BackupRestoreModal({ onClose }: BackupRestoreModalProps) {
   const [validation, setValidation] = useState<BackupValidation | null>(null);
   const [selectedSections, setSelectedSections] = useState<Set<string>>(new Set());
   const [restoreResult, setRestoreResult] = useState<BackupRestoreResult | null>(null);
+  // SEAM (bead 0i2vt.20): the DBAS Phase-2 restore-complete summary. The
+  // async restore-trigger endpoint that returns a terminal `RestoreReport`
+  // does not exist yet (same null seam as `restoreTaskId` below). When that
+  // endpoint lands, set this from its terminal report and the
+  // RestoreCompleteSummary renders the tri-state outcome + per-entity counts.
+  // Until then it stays null and the results step falls back to the legacy
+  // section-level `BackupRestoreResult` view.
+  const [restoreReport, setRestoreReport] = useState<RestoreReport | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
 
@@ -117,11 +126,16 @@ export function BackupRestoreModal({ onClose }: BackupRestoreModalProps) {
     setStep('restoring');
     setError(null);
     // SEAM: when the multi-stage restore-trigger endpoint lands it will return a
-    // task id to feed the live progress poller, e.g.
+    // task id to feed the live progress poller, and a terminal RestoreReport to
+    // feed the RestoreCompleteSummary, e.g.
     //   const { task_id } = await api.startRestoreTask(file, sections);
     //   setRestoreTaskId(task_id);
-    // The current endpoint is synchronous, so leave the poller's task id null.
+    //   ...poll until terminal, then:
+    //   setRestoreReport(terminalReport);  // RestoreCompleteSummary renders it
+    // The current endpoint is synchronous and returns the legacy
+    // BackupRestoreResult, so leave the poller's task id and the report null.
     setRestoreTaskId(null);
+    setRestoreReport(null);
 
     try {
       const result = await api.restoreBackupYaml(file, Array.from(selectedSections));
@@ -242,7 +256,16 @@ export function BackupRestoreModal({ onClose }: BackupRestoreModalProps) {
             />
           )}
 
-          {step === 'results' && restoreResult && (
+          {/* SEAM (bead 0i2vt.20): once the async restore endpoint returns a
+              terminal RestoreReport, the DBAS summary renders the tri-state
+              outcome + per-entity counts. Bead .19's logo-miss RED banner slots
+              into RestoreCompleteSummary's `bannerSlot` prop. Falls back to the
+              legacy section-level result view while restoreReport is null. */}
+          {step === 'results' && restoreReport && (
+            <RestoreCompleteSummary report={restoreReport} mode="applied" />
+          )}
+
+          {step === 'results' && !restoreReport && restoreResult && (
             <div className="brm-results">
               <div
                 className={`brm-results-banner ${restoreResult.success ? 'is-success' : 'is-partial'}`}

--- a/frontend/src/components/RestoreCompleteSummary.css
+++ b/frontend/src/components/RestoreCompleteSummary.css
@@ -1,0 +1,222 @@
+/**
+ * RestoreCompleteSummary styles
+ *
+ * Uses common.css for: .badge, .badge-warning, .badge-error, .badge-sm
+ *   (skip/failure reason chips)
+ *
+ * The outcome banner, per-category counts grid, expandable reason lists, and
+ * the rollback residue note are component-specific and live here. The error
+ * tone reuses the semantic --error / --error-bg theme tokens (see index.css)
+ * so dark/light/high-contrast modes all stay legible.
+ */
+
+.restore-complete-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+}
+
+/* --- Outcome banner ------------------------------------------------------- */
+
+.rcs-outcome-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+  padding: 0.75rem 0.875rem;
+  border-radius: var(--radius-md);
+  border-left: 4px solid transparent;
+}
+
+.rcs-tone-success {
+  background-color: var(--success-bg);
+  border-left-color: var(--success);
+}
+
+.rcs-tone-error {
+  background-color: var(--error-bg);
+  border-left-color: var(--error);
+}
+
+.rcs-outcome-icon {
+  font-size: 1.5rem;
+  line-height: 1.4;
+}
+
+.rcs-tone-success .rcs-outcome-icon {
+  color: var(--success);
+}
+
+.rcs-tone-error .rcs-outcome-icon {
+  color: var(--error);
+}
+
+.rcs-outcome-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.rcs-outcome-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.rcs-outcome-detail {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+/* --- Rollback residue note (failed_rollback_incomplete) ------------------- */
+
+.rcs-residue-note {
+  background-color: var(--error-bg);
+  border: 1px solid var(--error);
+  border-radius: var(--radius-md);
+  padding: 0.625rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.rcs-residue-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--error);
+}
+
+.rcs-residue-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+}
+
+.rcs-residue-list li {
+  margin: 0.125rem 0;
+}
+
+/* --- Per-category breakdown ---------------------------------------------- */
+
+.rcs-categories {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.rcs-empty {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  padding: 0.75rem;
+  text-align: center;
+  border: 1px dashed var(--border-primary);
+  border-radius: var(--radius-md);
+}
+
+.rcs-category {
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  background-color: var(--bg-secondary);
+  padding: 0.625rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.rcs-category-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.rcs-category-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.rcs-counts {
+  display: flex;
+  gap: 1rem;
+}
+
+.rcs-count {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 3.5rem;
+}
+
+.rcs-count-value {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.rcs-count-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-muted);
+}
+
+/* --- Expandable reason lists --------------------------------------------- */
+
+.rcs-detail-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.rcs-detail-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.rcs-detail-toggle.is-failure {
+  color: var(--error);
+}
+
+.rcs-detail-toggle .material-icons {
+  font-size: 1.1rem;
+}
+
+.rcs-detail-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.rcs-detail-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+}
+
+.rcs-detail-label {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.rcs-detail-message {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}

--- a/frontend/src/components/RestoreCompleteSummary.test.tsx
+++ b/frontend/src/components/RestoreCompleteSummary.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * Tests for RestoreCompleteSummary — the aggregate restore-result surface
+ * (bead 0i2vt.20). Renders the tri-state outcome banner + per-entity
+ * created/updated/skipped/failed breakdown, and mirrors the dry-run preview
+ * shape (same component, `mode` prop).
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import { RestoreCompleteSummary } from './RestoreCompleteSummary';
+import type {
+  EntityCategoryReport,
+  RestoreReport,
+} from '../services/api';
+
+function category(overrides: Partial<EntityCategoryReport>): EntityCategoryReport {
+  return {
+    entity_type: 'channel',
+    created: 0,
+    updated: 0,
+    skipped: 0,
+    failed: 0,
+    would_create: 0,
+    would_update: 0,
+    would_skip: 0,
+    skip_details: [],
+    failure_details: [],
+    ...overrides,
+  };
+}
+
+function appliedReport(overrides: Partial<RestoreReport> = {}): RestoreReport {
+  return {
+    contract_version: 1,
+    is_dry_run: false,
+    outcome: 'success',
+    logo_misses: 0,
+    started_at: null,
+    completed_at: null,
+    notes: [],
+    categories: [
+      category({
+        entity_type: 'channel',
+        created: 12,
+        updated: 3,
+        skipped: 2,
+        failed: 0,
+        skip_details: [
+          { reason: 'already_exists_identical', label: 'CNN HD' },
+          { reason: 'excluded_by_operator', label: 'Local Access 5' },
+        ],
+      }),
+    ],
+    ...overrides,
+  };
+}
+
+function dryRunReport(overrides: Partial<RestoreReport> = {}): RestoreReport {
+  return {
+    contract_version: 1,
+    is_dry_run: true,
+    outcome: null,
+    logo_misses: 0,
+    started_at: null,
+    completed_at: null,
+    notes: [],
+    categories: [
+      category({
+        entity_type: 'channel',
+        would_create: 8,
+        would_update: 1,
+        would_skip: 4,
+        skip_details: [{ reason: 'already_exists_identical', label: 'ESPN' }],
+      }),
+    ],
+    ...overrides,
+  };
+}
+
+describe('RestoreCompleteSummary — per-entity counts', () => {
+  it('renders created/updated/skipped/failed counts for an applied category', () => {
+    render(<RestoreCompleteSummary report={appliedReport()} />);
+    const row = screen.getByTestId('rcs-category-channel');
+    expect(within(row).getByTestId('rcs-count-created')).toHaveTextContent('12');
+    expect(within(row).getByTestId('rcs-count-updated')).toHaveTextContent('3');
+    expect(within(row).getByTestId('rcs-count-skipped')).toHaveTextContent('2');
+    expect(within(row).getByTestId('rcs-count-failed')).toHaveTextContent('0');
+  });
+
+  it('labels the category by its human-readable entity name', () => {
+    render(<RestoreCompleteSummary report={appliedReport()} />);
+    const row = screen.getByTestId('rcs-category-channel');
+    expect(within(row).getByText('Channels')).toBeInTheDocument();
+  });
+
+  it('renders a row per category', () => {
+    const report = appliedReport({
+      categories: [
+        category({ entity_type: 'm3u_account', created: 1 }),
+        category({ entity_type: 'epg_source', created: 2 }),
+        category({ entity_type: 'channel', created: 3 }),
+      ],
+    });
+    render(<RestoreCompleteSummary report={report} />);
+    expect(screen.getByTestId('rcs-category-m3u_account')).toBeInTheDocument();
+    expect(screen.getByTestId('rcs-category-epg_source')).toBeInTheDocument();
+    expect(screen.getByTestId('rcs-category-channel')).toBeInTheDocument();
+  });
+
+  it('handles an empty/zero-count category gracefully', () => {
+    const report = appliedReport({
+      categories: [category({ entity_type: 'logo' })],
+    });
+    render(<RestoreCompleteSummary report={report} />);
+    const row = screen.getByTestId('rcs-category-logo');
+    expect(within(row).getByTestId('rcs-count-created')).toHaveTextContent('0');
+    // A zero-count category exposes no expandable reason detail.
+    expect(within(row).queryByTestId('rcs-skip-details')).not.toBeInTheDocument();
+    expect(within(row).queryByTestId('rcs-failure-details')).not.toBeInTheDocument();
+  });
+
+  it('renders gracefully with no categories at all', () => {
+    const report = appliedReport({ categories: [] });
+    render(<RestoreCompleteSummary report={report} />);
+    expect(screen.getByTestId('rcs-empty')).toBeInTheDocument();
+  });
+});
+
+describe('RestoreCompleteSummary — expandable reasons', () => {
+  it('expands skipped to its reasons + human labels', () => {
+    render(<RestoreCompleteSummary report={appliedReport()} />);
+    const row = screen.getByTestId('rcs-category-channel');
+    fireEvent.click(within(row).getByTestId('rcs-skip-toggle'));
+    const details = within(row).getByTestId('rcs-skip-details');
+    expect(within(details).getByText('CNN HD')).toBeInTheDocument();
+    expect(within(details).getByText('Local Access 5')).toBeInTheDocument();
+    // Human-readable reason label, not the raw enum value.
+    expect(within(details).getByText('Already exists (identical)')).toBeInTheDocument();
+    expect(within(details).getByText('Excluded by operator')).toBeInTheDocument();
+    expect(within(details).queryByText('already_exists_identical')).not.toBeInTheDocument();
+  });
+
+  it('expands failed to its reasons + sanitized messages', () => {
+    const report = appliedReport({
+      outcome: 'partial_failed_rolled_back',
+      categories: [
+        category({
+          entity_type: 'channel',
+          failed: 1,
+          failure_details: [
+            {
+              reason: 'upstream_api_error',
+              label: 'BBC One',
+              message: 'Dispatcharr returned 500',
+            },
+          ],
+        }),
+      ],
+    });
+    render(<RestoreCompleteSummary report={report} />);
+    const row = screen.getByTestId('rcs-category-channel');
+    fireEvent.click(within(row).getByTestId('rcs-failure-toggle'));
+    const details = within(row).getByTestId('rcs-failure-details');
+    expect(within(details).getByText('BBC One')).toBeInTheDocument();
+    expect(within(details).getByText('Upstream API error')).toBeInTheDocument();
+    expect(within(details).getByText('Dispatcharr returned 500')).toBeInTheDocument();
+  });
+});
+
+describe('RestoreCompleteSummary — tri-state outcome banner', () => {
+  it('renders a positive banner for success', () => {
+    render(<RestoreCompleteSummary report={appliedReport({ outcome: 'success' })} />);
+    const banner = screen.getByTestId('rcs-outcome-banner');
+    expect(banner).toHaveAttribute('data-outcome', 'success');
+    expect(banner).toHaveTextContent('Restore complete');
+  });
+
+  it('labels partial_failed_rolled_back as a FAILURE that was rolled back — never success', () => {
+    render(
+      <RestoreCompleteSummary
+        report={appliedReport({ outcome: 'partial_failed_rolled_back' })}
+      />
+    );
+    const banner = screen.getByTestId('rcs-outcome-banner');
+    expect(banner).toHaveAttribute('data-outcome', 'partial_failed_rolled_back');
+    expect(banner).toHaveTextContent(/restore failed/i);
+    expect(banner).toHaveTextContent(/rolled back/i);
+    // Hard contract: a rolled-back restore is NEVER labeled success/complete.
+    expect(banner.textContent ?? '').not.toMatch(/\bsuccess\b/i);
+    expect(banner.textContent ?? '').not.toMatch(/restore complete/i);
+  });
+
+  it('gives failed_rollback_incomplete the loudest treatment + residue note', () => {
+    render(
+      <RestoreCompleteSummary
+        report={appliedReport({
+          outcome: 'failed_rollback_incomplete',
+          notes: ['2 entities could not be removed: channel id=44, channel id=51'],
+        })}
+      />
+    );
+    const banner = screen.getByTestId('rcs-outcome-banner');
+    expect(banner).toHaveAttribute('data-outcome', 'failed_rollback_incomplete');
+    expect(banner).toHaveTextContent(/could not be fully rolled back|not be fully rolled back|NOT be fully rolled back/i);
+    expect(banner.textContent ?? '').not.toMatch(/\bsuccess\b/i);
+    // The ledger residue note is surfaced for manual cleanup.
+    const residue = screen.getByTestId('rcs-residue-note');
+    expect(residue).toHaveTextContent('2 entities could not be removed: channel id=44, channel id=51');
+  });
+
+  it('renders no outcome banner on a dry-run (a plan has no realized outcome)', () => {
+    render(<RestoreCompleteSummary report={dryRunReport()} mode="dry-run" />);
+    expect(screen.queryByTestId('rcs-outcome-banner')).not.toBeInTheDocument();
+  });
+});
+
+describe('RestoreCompleteSummary — dry-run vs applied framing (shared shape)', () => {
+  it('renders applied framing (created/updated/skipped) in applied mode', () => {
+    render(<RestoreCompleteSummary report={appliedReport()} mode="applied" />);
+    const summary = screen.getByTestId('restore-complete-summary');
+    expect(summary).toHaveAttribute('data-mode', 'applied');
+    const row = screen.getByTestId('rcs-category-channel');
+    expect(within(row).getByTestId('rcs-count-created')).toHaveTextContent('12');
+    expect(within(row).getByTestId('rcs-label-created')).toHaveTextContent(/^Created$/);
+  });
+
+  it('renders preview framing (will create/update/skip) in dry-run mode from the same shape', () => {
+    render(<RestoreCompleteSummary report={dryRunReport()} mode="dry-run" />);
+    const summary = screen.getByTestId('restore-complete-summary');
+    expect(summary).toHaveAttribute('data-mode', 'dry-run');
+    const row = screen.getByTestId('rcs-category-channel');
+    // Dry-run reads the would_* counts.
+    expect(within(row).getByTestId('rcs-count-created')).toHaveTextContent('8');
+    expect(within(row).getByTestId('rcs-count-updated')).toHaveTextContent('1');
+    expect(within(row).getByTestId('rcs-count-skipped')).toHaveTextContent('4');
+    // Dry-run framing reads "Will create", not "Created".
+    expect(within(row).getByTestId('rcs-label-created')).toHaveTextContent(/^Will create$/);
+  });
+
+  it('infers mode from is_dry_run when no mode prop is given', () => {
+    render(<RestoreCompleteSummary report={dryRunReport()} />);
+    expect(screen.getByTestId('restore-complete-summary')).toHaveAttribute('data-mode', 'dry-run');
+  });
+});
+
+describe('RestoreCompleteSummary — logo-miss banner seam (bead .19)', () => {
+  it('renders the bannerSlot at the top of the summary (insertion point for .19)', () => {
+    render(
+      <RestoreCompleteSummary
+        report={appliedReport()}
+        bannerSlot={<div data-testid="injected-banner">RED BANNER</div>}
+      />
+    );
+    expect(screen.getByTestId('injected-banner')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/RestoreCompleteSummary.tsx
+++ b/frontend/src/components/RestoreCompleteSummary.tsx
@@ -1,0 +1,278 @@
+/**
+ * Aggregate restore-result surface for a DBAS Phase-2 restore (bead 0i2vt.20).
+ *
+ * Renders, from a single {@link RestoreReport}:
+ *
+ *   1. A tri-state OUTCOME banner ({@link RestoreOutcome}). The contract is hard:
+ *      a rolled-back restore is NEVER labeled "success"/"complete". `success`
+ *      gets a positive banner; `partial_failed_rolled_back` reads
+ *      "Restore failed — your configuration was rolled back"; and
+ *      `failed_rollback_incomplete` gets the loudest treatment plus the ledger
+ *      residue note so an operator can finish cleanup manually.
+ *   2. A PER-ENTITY breakdown — one row per {@link EntityCategoryReport} with
+ *      created / updated / skipped / failed counts; skipped and failed rows
+ *      expand to their reasons (human-readable labels, not raw enum values).
+ *
+ * The SAME component renders both the dry-run counts-only preview (bead .16)
+ * and the realized restore result. The `mode` prop switches the framing
+ * ("Will create" vs "Created") and which counts are read (would_* vs the
+ * realized counts); the per-entity machinery is identical so an operator
+ * recognizes apply-vs-preview at a glance. When `mode` is omitted it is
+ * inferred from `report.is_dry_run`.
+ *
+ * SEAM for bead .19 (logo-miss RED banner): the `bannerSlot` prop renders at the
+ * very top of the summary, above the outcome banner. Bead .19 slots its
+ * prominent red "N channels are missing logos" banner there (driven by
+ * `report.logo_misses`) without restructuring this component.
+ *
+ * Styling reuses shared `.badge-*` classes from `common.css`; the
+ * summary/category layout lives in `RestoreCompleteSummary.css`.
+ */
+import { useState } from 'react';
+import type {
+  EntityCategoryReport,
+  RestoreEntityType,
+  RestoreFailureReason,
+  RestoreReport,
+  RestoreSkipReason,
+} from '../services/api';
+import './RestoreCompleteSummary.css';
+
+/** Which framing the summary renders. `dry-run` reads would_* counts. */
+export type RestoreSummaryMode = 'dry-run' | 'applied';
+
+interface RestoreCompleteSummaryProps {
+  /** The aggregate restore result / dry-run plan to render. */
+  report: RestoreReport;
+  /**
+   * Framing override. When omitted, inferred from `report.is_dry_run`
+   * (`true` → 'dry-run', `false` → 'applied').
+   */
+  mode?: RestoreSummaryMode;
+  /**
+   * SEAM for bead .19 — content rendered at the very top of the summary, above
+   * the outcome banner. Bead .19 injects its logo-miss RED banner here.
+   */
+  bannerSlot?: React.ReactNode;
+}
+
+const ENTITY_LABELS: Record<RestoreEntityType, string> = {
+  m3u_account: 'M3U accounts',
+  epg_source: 'EPG sources',
+  channel_group: 'Channel groups',
+  channel_profile: 'Channel profiles',
+  stream_profile: 'Stream profiles',
+  channel: 'Channels',
+  stream: 'Streams',
+  user_agent: 'User agents',
+  dvr_rule: 'DVR rules',
+  user: 'Users',
+  logo: 'Logos',
+};
+
+const SKIP_REASON_LABELS: Record<RestoreSkipReason, string> = {
+  already_exists_identical: 'Already exists (identical)',
+  excluded_by_operator: 'Excluded by operator',
+  current_admin_preserved: 'Current admin preserved',
+  unsupported_in_this_version: 'Unsupported in this version',
+  dependency_unresolved: 'Dependency unresolved',
+};
+
+const FAILURE_REASON_LABELS: Record<RestoreFailureReason, string> = {
+  validation_error: 'Validation error',
+  dependency_unresolved: 'Dependency unresolved',
+  upstream_api_error: 'Upstream API error',
+  upstream_timeout: 'Upstream timeout',
+  conflict: 'Conflict',
+  password_hash_unsupported: 'Password hash unsupported',
+  internal_error: 'Internal error',
+};
+
+/** Count labels per mode — applied reads past tense, dry-run reads "will …". */
+const COUNT_LABELS: Record<RestoreSummaryMode, { created: string; updated: string; skipped: string; failed: string }> = {
+  applied: { created: 'Created', updated: 'Updated', skipped: 'Skipped', failed: 'Failed' },
+  'dry-run': { created: 'Will create', updated: 'Will update', skipped: 'Will skip', failed: 'Failed' },
+};
+
+interface OutcomePresentation {
+  tone: 'success' | 'error';
+  icon: string;
+  title: string;
+  detail?: string;
+}
+
+/**
+ * Map the tri-state outcome to its banner treatment. The rolled-back states are
+ * presented as FAILURES (error tone, explicit "failed" copy) — never as success.
+ */
+const OUTCOME_PRESENTATION: Record<NonNullable<RestoreReport['outcome']>, OutcomePresentation> = {
+  success: {
+    tone: 'success',
+    icon: 'check_circle',
+    title: 'Restore complete',
+    detail: 'Your configuration was restored.',
+  },
+  partial_failed_rolled_back: {
+    tone: 'error',
+    icon: 'cancel',
+    title: 'Restore failed — your configuration was rolled back',
+    detail: 'One or more items failed, so the restore was undone. Your instance is back to its pre-restore state.',
+  },
+  failed_rollback_incomplete: {
+    tone: 'error',
+    icon: 'error',
+    title: 'Restore failed — state could NOT be fully rolled back',
+    detail: 'A failure occurred and the automatic rollback could not remove everything it created. Your instance is in an indeterminate state. Review the residue below and finish cleanup manually.',
+  },
+};
+
+function CountCell({ kind, value, label }: { kind: string; value: number; label: string }) {
+  return (
+    <div className="rcs-count" data-testid={`rcs-count-cell-${kind}`}>
+      <span className="rcs-count-value" data-testid={`rcs-count-${kind}`}>
+        {value}
+      </span>
+      <span className="rcs-count-label" data-testid={`rcs-label-${kind}`}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function CategoryRow({ category, mode }: { category: EntityCategoryReport; mode: RestoreSummaryMode }) {
+  const [skipOpen, setSkipOpen] = useState(false);
+  const [failureOpen, setFailureOpen] = useState(false);
+
+  const isDryRun = mode === 'dry-run';
+  const created = isDryRun ? category.would_create : category.created;
+  const updated = isDryRun ? category.would_update : category.updated;
+  const skipped = isDryRun ? category.would_skip : category.skipped;
+  const failed = category.failed;
+
+  const labels = COUNT_LABELS[mode];
+  const hasSkipDetails = category.skip_details.length > 0;
+  const hasFailureDetails = category.failure_details.length > 0;
+
+  return (
+    <div className="rcs-category" data-testid={`rcs-category-${category.entity_type}`}>
+      <div className="rcs-category-header">
+        <span className="rcs-category-name">{ENTITY_LABELS[category.entity_type]}</span>
+        <div className="rcs-counts">
+          <CountCell kind="created" value={created} label={labels.created} />
+          <CountCell kind="updated" value={updated} label={labels.updated} />
+          <CountCell kind="skipped" value={skipped} label={labels.skipped} />
+          <CountCell kind="failed" value={failed} label={labels.failed} />
+        </div>
+      </div>
+
+      {hasSkipDetails && (
+        <div className="rcs-detail-block">
+          <button
+            type="button"
+            className="rcs-detail-toggle"
+            data-testid="rcs-skip-toggle"
+            aria-expanded={skipOpen}
+            onClick={() => setSkipOpen((v) => !v)}
+          >
+            <span className="material-icons">{skipOpen ? 'expand_less' : 'expand_more'}</span>
+            {labels.skipped} reasons ({category.skip_details.length})
+          </button>
+          {skipOpen && (
+            <ul className="rcs-detail-list" data-testid="rcs-skip-details">
+              {category.skip_details.map((d, i) => (
+                <li key={`${d.label}-${i}`} className="rcs-detail-item">
+                  <span className="badge badge-warning badge-sm">{SKIP_REASON_LABELS[d.reason]}</span>
+                  <span className="rcs-detail-label">{d.label}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {hasFailureDetails && (
+        <div className="rcs-detail-block">
+          <button
+            type="button"
+            className="rcs-detail-toggle is-failure"
+            data-testid="rcs-failure-toggle"
+            aria-expanded={failureOpen}
+            onClick={() => setFailureOpen((v) => !v)}
+          >
+            <span className="material-icons">{failureOpen ? 'expand_less' : 'expand_more'}</span>
+            Failed reasons ({category.failure_details.length})
+          </button>
+          {failureOpen && (
+            <ul className="rcs-detail-list" data-testid="rcs-failure-details">
+              {category.failure_details.map((d, i) => (
+                <li key={`${d.label}-${i}`} className="rcs-detail-item rcs-detail-item-failure">
+                  <span className="badge badge-error badge-sm">{FAILURE_REASON_LABELS[d.reason]}</span>
+                  <span className="rcs-detail-label">{d.label}</span>
+                  {d.message && <span className="rcs-detail-message">{d.message}</span>}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function RestoreCompleteSummary({ report, mode, bannerSlot }: RestoreCompleteSummaryProps) {
+  const effectiveMode: RestoreSummaryMode = mode ?? (report.is_dry_run ? 'dry-run' : 'applied');
+
+  // Outcome banner only renders for a realized restore — a dry-run plan has no
+  // realized outcome (report.outcome is null), so no banner.
+  const presentation = report.outcome ? OUTCOME_PRESENTATION[report.outcome] : null;
+  const isResidueIncomplete = report.outcome === 'failed_rollback_incomplete';
+
+  return (
+    <div
+      className="restore-complete-summary"
+      data-testid="restore-complete-summary"
+      data-mode={effectiveMode}
+    >
+      {/* SEAM for bead .19 — logo-miss RED banner slots here, above everything. */}
+      {bannerSlot}
+
+      {presentation && (
+        <div
+          className={`rcs-outcome-banner rcs-tone-${presentation.tone}`}
+          data-testid="rcs-outcome-banner"
+          data-outcome={report.outcome ?? undefined}
+          role={presentation.tone === 'error' ? 'alert' : 'status'}
+        >
+          <span className="material-icons rcs-outcome-icon">{presentation.icon}</span>
+          <div className="rcs-outcome-text">
+            <span className="rcs-outcome-title">{presentation.title}</span>
+            {presentation.detail && <span className="rcs-outcome-detail">{presentation.detail}</span>}
+          </div>
+        </div>
+      )}
+
+      {isResidueIncomplete && report.notes.length > 0 && (
+        <div className="rcs-residue-note" data-testid="rcs-residue-note" role="alert">
+          <span className="rcs-residue-title">Manual cleanup required</span>
+          <ul className="rcs-residue-list">
+            {report.notes.map((note, i) => (
+              <li key={i}>{note}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="rcs-categories">
+        {report.categories.length === 0 ? (
+          <div className="rcs-empty" data-testid="rcs-empty">
+            No entity categories were included in this {effectiveMode === 'dry-run' ? 'preview' : 'restore'}.
+          </div>
+        ) : (
+          report.categories.map((cat) => (
+            <CategoryRow key={cat.entity_type} category={cat} mode={effectiveMode} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3621,6 +3621,104 @@ export interface BackupRestoreResult {
   errors: string[];
 }
 
+// ---------------------------------------------------------------------------
+// DBAS Phase-2 restore report (mirrors backend/dbas/restore_contracts.py)
+//
+// ONE shape carries the dry-run plan (bead 0i2vt.16) AND the realized
+// restore/rollback result (bead 0i2vt.18); the restore-complete summary UX
+// (bead 0i2vt.20) renders both, distinguished by `is_dry_run`. Keep the enum
+// string values byte-for-byte aligned with the backend `str, Enum` values —
+// the wire payload carries the raw string and the UI maps it to a label.
+// ---------------------------------------------------------------------------
+
+/** A restorable Dispatcharr/ECM entity type (one per distinct ID namespace). */
+export type RestoreEntityType =
+  | 'm3u_account'
+  | 'epg_source'
+  | 'channel_group'
+  | 'channel_profile'
+  | 'stream_profile'
+  | 'channel'
+  | 'stream'
+  | 'user_agent'
+  | 'dvr_rule'
+  | 'user'
+  | 'logo';
+
+/** Why an entity was (or would be) skipped. */
+export type RestoreSkipReason =
+  | 'already_exists_identical'
+  | 'excluded_by_operator'
+  | 'current_admin_preserved'
+  | 'unsupported_in_this_version'
+  | 'dependency_unresolved';
+
+/** Why an entity failed to apply. */
+export type RestoreFailureReason =
+  | 'validation_error'
+  | 'dependency_unresolved'
+  | 'upstream_api_error'
+  | 'upstream_timeout'
+  | 'conflict'
+  | 'password_hash_unsupported'
+  | 'internal_error';
+
+/**
+ * Overall tri-state result of a realized restore. `null` on a dry-run (a plan
+ * has no realized outcome). NEVER `success` on mixed state — the two rolled-back
+ * states are explicit failures, surfaced as such by the summary UX.
+ */
+export type RestoreOutcome =
+  | 'success'
+  | 'partial_failed_rolled_back'
+  | 'failed_rollback_incomplete';
+
+/** One skipped entity, with the reason and an operator-facing label (never a secret). */
+export interface RestoreSkipDetail {
+  reason: RestoreSkipReason;
+  label: string;
+  source_export_id?: number | null;
+}
+
+/** One failed entity, with the reason and a sanitized operator-facing message. */
+export interface RestoreFailureDetail {
+  reason: RestoreFailureReason;
+  label: string;
+  message: string;
+  source_export_id?: number | null;
+}
+
+/**
+ * Per-entity-category counts for ONE category. Apply populates
+ * created/updated/skipped/failed; dry-run populates would_create/would_update/
+ * would_skip. The detail lists are the source of truth for reasons.
+ */
+export interface EntityCategoryReport {
+  entity_type: RestoreEntityType;
+  created: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  would_create: number;
+  would_update: number;
+  would_skip: number;
+  skip_details: RestoreSkipDetail[];
+  failure_details: RestoreFailureDetail[];
+}
+
+/** The one restore response schema — dry-run, apply, and summary. */
+export interface RestoreReport {
+  contract_version: number;
+  is_dry_run: boolean;
+  outcome: RestoreOutcome | null;
+  categories: EntityCategoryReport[];
+  /** Aggregate count of unresolved logo references — bead .19 surfaces a red banner when > 0. */
+  logo_misses: number;
+  started_at?: string | null;
+  completed_at?: string | null;
+  notes: string[];
+}
+
 export async function getExportSections(): Promise<{key: string; label: string}[]> {
   return fetchJson(`${API_BASE}/backup/export-sections`);
 }


### PR DESCRIPTION
## Bead
enhancedchannelmanager-0i2vt.20 — Phase 2: Restore-complete UX — overall summary + per-entity counts (ADR-008 D9).

## What
New `RestoreCompleteSummary.tsx` (+ css/test) rendering the backend `RestoreReport`:
- **Tri-state outcome banner**: `success` → "Restore complete" (positive); `partial_failed_rolled_back` → **"Restore failed — your configuration was rolled back"** (error, asserted to NOT read "success"); `failed_rollback_incomplete` → loudest treatment + residue note for manual cleanup. Never labels mixed state as success.
- **Per-entity breakdown**: per `EntityCategoryReport` row — created/updated/skipped/failed; skipped/failed expand to reasons + labels.
- **Dry-run mirrored**: same component, `mode: 'dry-run' | 'applied'` (would-create/… vs created/…) so apply mirrors preview (.16).
- Added `RestoreReport` TS types (string-literal unions, project convention) to `services/api.ts`.

## Seam for .19
Top-of-summary `bannerSlot` prop (RestoreCompleteSummary.tsx:230) — .19 slots the red logo-miss banner there with zero restructuring.

## Wiring
Renders from a `report` prop; integrated into `BackupRestoreModal` results step behind the same seam g5xv7 left (`restoreReport` null until the async restore endpoint lands — filed gap bead). Legacy synchronous YAML restore view kept as fallback.

## Tests
15 vitest tests (per-entity counts, reason expansion, all three outcomes incl. never-success-on-mixed, dry-run vs applied framing, empty categories). lint(src)/tsc clean; vitest 1613 passed; build OK (via /tmp node_modules overlay — root-owned node_modules).

## NOT verified (overnight)
No human visual check — eyeball banner tones (dark/light/high-contrast), 13-category grid wrap on narrow modal, reason expand/collapse.

## Note
Pre-existing untracked `frontend/.dist_root/` (root-owned minified artifact, in session-start git status) trips full-dir eslint — not mine; candidate for `rm -rf` / gitignore cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)