### PR TITLE
v0.18.0-dbas: 0i2vt.16 dry-run engine -- counts-only, default-ON, parity with apply

### DIFF
--- a/backend/dbas/importers/channels.py
+++ b/backend/dbas/importers/channels.py
@@ -325,6 +325,12 @@ async def import_channels(
 
         if is_dry_run:
             cat.would_create += 1
+            # Provisional remap so a downstream reference to this would-be-created
+            # channel resolves on the dry-run as it would on apply (anti-drift).
+            # Source id used as a stable provisional destination id — never sent
+            # upstream.
+            if source_id is not None:
+                remap.add(EntityType.CHANNEL, int(source_id), int(source_id))
             continue
 
         try:

--- a/backend/dbas/importers/epg_sources.py
+++ b/backend/dbas/importers/epg_sources.py
@@ -315,6 +315,11 @@ async def import_epg_sources(
 
         if is_dry_run:
             cat.would_create += 1
+            # Provisional remap so a downstream FK to this would-be-created source
+            # resolves on the dry-run as it would on apply (anti-drift). Source id
+            # used as a stable provisional destination id — never sent upstream.
+            if source_id is not None:
+                remap.add(EntityType.EPG_SOURCE, int(source_id), int(source_id))
             continue
 
         payload = _build_create_payload(archive_source, m3u_dest_id)

--- a/backend/dbas/importers/groups_profiles.py
+++ b/backend/dbas/importers/groups_profiles.py
@@ -352,6 +352,13 @@ async def _import_category(
 
         if is_dry_run:
             cat.would_create += 1
+            # Provisional remap so the Channels importer's FK to this would-be-
+            # created group/profile resolves on the dry-run exactly as it would on
+            # apply (anti-drift: a channel referencing a creatable group must
+            # would_create, not would_skip DEPENDENCY_UNRESOLVED). Source id used as
+            # a stable provisional destination id — never sent upstream.
+            if source_id is not None:
+                remap.add(config.entity_type, int(source_id), int(source_id))
             continue
 
         try:

--- a/backend/dbas/importers/m3u_accounts.py
+++ b/backend/dbas/importers/m3u_accounts.py
@@ -420,6 +420,13 @@ async def import_m3u_accounts(
 
         if is_dry_run:
             cat.would_create += 1
+            # Provisional remap so a DOWNSTREAM importer's FK to this would-be-
+            # created account resolves on the dry-run exactly as it would on apply
+            # (anti-drift: dry-run and apply must agree on what is creatable). The
+            # source id is used as a stable provisional destination id — never sent
+            # upstream, only consulted by the in-run remap.
+            if source_id is not None:
+                remap.add(EntityType.M3U_ACCOUNT, int(source_id), int(source_id))
             continue
 
         payload = _build_create_payload(archive_account)

--- a/backend/dbas/restore_orchestrator.py
+++ b/backend/dbas/restore_orchestrator.py
@@ -404,6 +404,7 @@ async def run_restore(
     report: RestoreReport,
     ledger: RollbackLedger,
     remap: object,
+    confirm_apply: bool = False,
     deferred_apply_fn: Callable[..., Awaitable[list[dict]]] | None = None,
     ledger_dir: Path | None = None,
     max_entities_per_category: int = None,  # type: ignore[assignment]
@@ -412,6 +413,14 @@ async def run_restore(
 
     The single orchestration chokepoint. Behaviour:
 
+    0. **Default-ON dry-run guardrail (bead ``…-0i2vt.16``).** A restore is a
+       counts-only DRY-RUN unless the caller passes ``confirm_apply=True``. Apply
+       is opt-IN, never opt-out: without an explicit confirm the run is FORCED to
+       ``report.is_dry_run = True`` and makes ZERO mutations no matter what the
+       caller put on the report. This is an architectural property of the entry
+       point — not a UI toggle a client could bypass. The destructive apply path
+       requires both ``confirm_apply=True`` AND a non-dry-run report; a caller that
+       sets ``is_dry_run`` on the report keeps the dry-run even with a confirm.
     1. **Pre-flight** (``run_preflight``). On a FAIL the restore is refused with
        ZERO mutation — no importer step is called — and the report is returned
        with ``outcome=FAILED_ROLLBACK_INCOMPLETE`` only if mutation had occurred;
@@ -435,6 +444,9 @@ async def run_restore(
         report: The shared restore report (populated by the importers).
         ledger: The shared rollback ledger (populated by the importers).
         remap: The shared IdRemapTable (threaded through importers).
+        confirm_apply: The explicit opt-in to MUTATE. ``False`` (default) forces a
+            dry-run — no importer mutates, no rollback, no deferred phase. ``True``
+            lets the apply proceed ONLY when ``report.is_dry_run`` is also False.
         deferred_apply_fn: The deferred-apply coroutine (defaults to the M3U
             ``apply_deferred_auto_sync``); applied LAST on a clean run.
         ledger_dir: Override the durable ledger directory (tests).
@@ -443,6 +455,23 @@ async def run_restore(
     Returns:
         The :class:`RestoreReport` with its tri-state ``outcome`` set.
     """
+    # --- 0. Default-ON, UNBYPASSABLE dry-run guardrail. ---
+    # Apply is opt-IN. Absent an explicit confirm, the run degrades to a dry-run
+    # and makes ZERO mutations — the importers, rollback, and deferred phase all
+    # branch on ``report.is_dry_run`` below, so forcing it here is the single,
+    # architectural enforcement point. There is NO path that mutates without
+    # confirm_apply=True; a caller can never opt OUT of the dry-run.
+    if not confirm_apply and not report.is_dry_run:
+        report.is_dry_run = True
+        report.notes.append(
+            "apply not confirmed (confirm_apply=False) — produced a counts-only "
+            "dry-run; no mutation performed."
+        )
+        logger.info(
+            "[DBAS-RESTORE] Apply NOT confirmed; forcing counts-only dry-run "
+            "(default-ON guardrail)."
+        )
+
     report.started_at = report.started_at or datetime.now(timezone.utc)
 
     # --- 1. Pre-flight — refuse with ZERO mutation on failure. ---
@@ -493,12 +522,16 @@ async def run_restore(
                 step.entity_type.value,
                 type(exc).__name__,
             )
-            persist_ledger(ledger, ledger_dir=ledger_dir)
+            # A dry-run never creates, so there is nothing durable to persist — and
+            # it must make ZERO disk writes to the ledger path.
+            if not report.is_dry_run:
+                persist_ledger(ledger, ledger_dir=ledger_dir)
             break
 
         if deferred:
             ctx.deferred.extend(deferred)
-        persist_ledger(ledger, ledger_dir=ledger_dir)
+        if not report.is_dry_run:
+            persist_ledger(ledger, ledger_dir=ledger_dir)
 
         # A step that reports a category failure (without raising) also rolls back
         # — mixed state must never be reported as success.
@@ -542,11 +575,17 @@ async def run_restore(
             report.notes.append("deferred auto-sync phase reported an error; entities intact.")
 
     # --- 4. Outcome. ---
-    report.outcome = compute_outcome(
-        report=report,
-        failure_occurred=failure_occurred,
-        rollback=rollback,
-    )
+    # A DRY-RUN is a plan, not a realized restore — it has no outcome (kxuj2
+    # contract: ``outcome`` is None on a dry-run). Only an apply computes the
+    # tri-state outcome.
+    if report.is_dry_run:
+        report.outcome = None
+    else:
+        report.outcome = compute_outcome(
+            report=report,
+            failure_occurred=failure_occurred,
+            rollback=rollback,
+        )
     report.completed_at = datetime.now(timezone.utc)
 
     if report.outcome == RestoreOutcome.SUCCESS and not report.is_dry_run:
@@ -595,11 +634,55 @@ def default_importer_steps() -> list[ImporterStep]:
     The ORDER is the contract even where a slot is a seam — when an importer
     lands it slots into its place without reshuffling the sequence.
     """
+    s = _importer_step_builders()
+    # NOTE on the EPG-sources seam (…-0i2vt.11): EPG sources are not an FK-bearing
+    # remapped type, so the rollback ledger has no EntityType for them and the
+    # contracts module (read-only here) defines none. The EPG step therefore lives
+    # in the ordering as a documented position between M3U and channel groups, but
+    # is not a discrete ImporterStep row — when its importer lands it registers
+    # here (and, if it ever needs compensation, the contracts module gains the
+    # EntityType in its own bead, not this one).
+    return [
+        ImporterStep(EntityType.M3U_ACCOUNT, s["m3u"], defers=True),
+        # <- EPG sources (…-0i2vt.11) order position; SEAM, see note above.
+        ImporterStep(EntityType.CHANNEL_GROUP, None),                  # SEAM …-0i2vt.12
+        ImporterStep(EntityType.CHANNEL_PROFILE, None),               # SEAM …-0i2vt.12
+        ImporterStep(EntityType.STREAM_PROFILE, None),                # SEAM …-0i2vt.12
+        ImporterStep(EntityType.USER_AGENT, None),                    # SEAM …-0i2vt.13
+        ImporterStep(EntityType.USER, s["users"]),                    # WIRED …-l1p4p
+        ImporterStep(EntityType.CHANNEL, s["channels"]),              # WIRED …-4vouz
+        # logos SEAM …-0i2vt.15 — no EntityType row of its own; attaches to channels
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Dry-run registry — bead …-0i2vt.16. EVERY importer wired, counts-only.
+# ---------------------------------------------------------------------------
+
+
+def _importer_step_builders() -> dict[str, ImporterCallable]:
+    """Build the per-category importer-step callables, shared by both registries.
+
+    Each callable adapts one importer's keyword signature to the
+    :class:`ApplyContext`. The SAME callables back the apply registry
+    (:func:`default_importer_steps`) and the dry-run registry
+    (:func:`dry_run_importer_steps`); they thread ``ctx.is_dry_run`` straight into
+    each importer so the dry-run count comes from the importer's OWN plan/match
+    logic (the same code that decides create/update/skip on apply), never a
+    parallel counter. This is the anti-drift guarantee the parity test rests on.
+    """
     from dbas.importers.channels import import_channels
+    from dbas.importers.epg_sources import import_epg_sources
+    from dbas.importers.groups_profiles import (
+        import_channel_groups,
+        import_channel_profiles,
+        import_stream_profiles,
+    )
+    from dbas.importers.logos import import_logos
     from dbas.importers.m3u_accounts import import_m3u_accounts
     from dbas.importers.users import import_users
 
-    def _category_entities(ctx: ApplyContext, entity_type: EntityType) -> list[dict]:
+    def _entities(ctx: ApplyContext, entity_type: EntityType) -> list[dict]:
         cat = ctx.plan.category(entity_type)
         return list(cat.entities) if cat else []
 
@@ -609,7 +692,7 @@ def default_importer_steps() -> list[ImporterStep]:
 
     async def _m3u(ctx: ApplyContext) -> list[dict] | None:
         result = await import_m3u_accounts(
-            archive_accounts=_category_entities(ctx, EntityType.M3U_ACCOUNT),
+            archive_accounts=_entities(ctx, EntityType.M3U_ACCOUNT),
             client=ctx.client,
             selected=_selected(ctx, EntityType.M3U_ACCOUNT),
             report=ctx.report,
@@ -619,11 +702,47 @@ def default_importer_steps() -> list[ImporterStep]:
         )
         return result.deferred_auto_sync_settings or None
 
-    async def _channels(ctx: ApplyContext) -> list[dict] | None:
-        await import_channels(
-            archive_channels=_category_entities(ctx, EntityType.CHANNEL),
+    async def _epg(ctx: ApplyContext) -> list[dict] | None:
+        await import_epg_sources(
+            archive_sources=_entities(ctx, EntityType.EPG_SOURCE),
             client=ctx.client,
-            selected=_selected(ctx, EntityType.CHANNEL),
+            selected=_selected(ctx, EntityType.EPG_SOURCE),
+            report=ctx.report,
+            ledger=ctx.ledger,
+            remap=ctx.remap,
+            is_dry_run=ctx.is_dry_run,
+        )
+        return None
+
+    async def _channel_groups(ctx: ApplyContext) -> list[dict] | None:
+        await import_channel_groups(
+            archive_rows=_entities(ctx, EntityType.CHANNEL_GROUP),
+            client=ctx.client,
+            selected=_selected(ctx, EntityType.CHANNEL_GROUP),
+            report=ctx.report,
+            ledger=ctx.ledger,
+            remap=ctx.remap,
+            is_dry_run=ctx.is_dry_run,
+        )
+        return None
+
+    async def _channel_profiles(ctx: ApplyContext) -> list[dict] | None:
+        await import_channel_profiles(
+            archive_rows=_entities(ctx, EntityType.CHANNEL_PROFILE),
+            client=ctx.client,
+            selected=_selected(ctx, EntityType.CHANNEL_PROFILE),
+            report=ctx.report,
+            ledger=ctx.ledger,
+            remap=ctx.remap,
+            is_dry_run=ctx.is_dry_run,
+        )
+        return None
+
+    async def _stream_profiles(ctx: ApplyContext) -> list[dict] | None:
+        await import_stream_profiles(
+            archive_rows=_entities(ctx, EntityType.STREAM_PROFILE),
+            client=ctx.client,
+            selected=_selected(ctx, EntityType.STREAM_PROFILE),
             report=ctx.report,
             ledger=ctx.ledger,
             remap=ctx.remap,
@@ -633,7 +752,7 @@ def default_importer_steps() -> list[ImporterStep]:
 
     async def _users(ctx: ApplyContext) -> list[dict] | None:
         await import_users(
-            archive_users=_category_entities(ctx, EntityType.USER),
+            archive_users=_entities(ctx, EntityType.USER),
             client=ctx.client,
             selected=_selected(ctx, EntityType.USER),
             report=ctx.report,
@@ -642,21 +761,131 @@ def default_importer_steps() -> list[ImporterStep]:
         )
         return None
 
-    # NOTE on the EPG-sources seam (…-0i2vt.11): EPG sources are not an FK-bearing
-    # remapped type, so the rollback ledger has no EntityType for them and the
-    # contracts module (read-only here) defines none. The EPG step therefore lives
-    # in the ordering as a documented position between M3U and channel groups, but
-    # is not a discrete ImporterStep row — when its importer lands it registers
-    # here (and, if it ever needs compensation, the contracts module gains the
-    # EntityType in its own bead, not this one).
+    async def _channels(ctx: ApplyContext) -> list[dict] | None:
+        await import_channels(
+            archive_channels=_entities(ctx, EntityType.CHANNEL),
+            client=ctx.client,
+            selected=_selected(ctx, EntityType.CHANNEL),
+            report=ctx.report,
+            ledger=ctx.ledger,
+            remap=ctx.remap,
+            is_dry_run=ctx.is_dry_run,
+        )
+        return None
+
+    async def _logos(ctx: ApplyContext) -> list[dict] | None:
+        # clear_existing is the DESTRUCTIVE bulk-delete pre-step; the logos
+        # importer itself guards it behind ``not is_dry_run``, and a dry-run plan
+        # never carries an apply confirm — so it can never fire here on a dry-run.
+        await import_logos(
+            archive_logos=_entities(ctx, EntityType.LOGO),
+            client=ctx.client,
+            selected=_selected(ctx, EntityType.LOGO),
+            report=ctx.report,
+            ledger=ctx.ledger,
+            remap=ctx.remap,
+            is_dry_run=ctx.is_dry_run,
+            clear_existing=False,
+        )
+        return None
+
+    return {
+        "m3u": _m3u,
+        "epg": _epg,
+        "channel_groups": _channel_groups,
+        "channel_profiles": _channel_profiles,
+        "stream_profiles": _stream_profiles,
+        "users": _users,
+        "channels": _channels,
+        "logos": _logos,
+    }
+
+
+def dry_run_importer_steps() -> list[ImporterStep]:
+    """The Phase-2 ordering with EVERY importer WIRED for the counts-only dry-run.
+
+    Bead ``…-0i2vt.16``. Unlike :func:`default_importer_steps` — whose seams for
+    EPG sources / groups-profiles / logos await each importer's apply-path +
+    rollback wiring (bead ``.18`` / their own beads) — the dry-run registry wires
+    ALL importers, because every importer is provably zero-mutation on a dry-run
+    (it only reads to plan and increments ``would_*``). Wiring them here lets the
+    dry-run aggregate the ``would_*`` counts for the WHOLE archive into one
+    :class:`RestoreReport`, which is the point of the engine.
+
+    The order is the same hard Phase-2 sequence
+    (``M3U → EPG → groups/profiles → user-agents → users → channels → logos``);
+    on a dry-run the order is not load-bearing for mutation (there is none) but is
+    kept identical so the plan the operator previews mirrors what apply will do.
+
+    This registry is for DRY-RUN ONLY. It must not be handed to an apply
+    (``confirm_apply=True``) run until each wired importer's apply/rollback path is
+    registered in :func:`default_importer_steps` — the guardrail in
+    :func:`run_restore` forces ``is_dry_run`` when apply is not confirmed, so a
+    misuse degrades safely to a dry-run rather than mutating through an unwired
+    rollback path.
+    """
+    s = _importer_step_builders()
     return [
-        ImporterStep(EntityType.M3U_ACCOUNT, _m3u, defers=True),
-        # <- EPG sources (…-0i2vt.11) order position; SEAM, see note above.
-        ImporterStep(EntityType.CHANNEL_GROUP, None),                  # SEAM …-0i2vt.12
-        ImporterStep(EntityType.CHANNEL_PROFILE, None),               # SEAM …-0i2vt.12
-        ImporterStep(EntityType.STREAM_PROFILE, None),                # SEAM …-0i2vt.12
-        ImporterStep(EntityType.USER_AGENT, None),                    # SEAM …-0i2vt.13
-        ImporterStep(EntityType.USER, _users),                        # WIRED …-l1p4p
-        ImporterStep(EntityType.CHANNEL, _channels),                  # WIRED …-4vouz
-        # logos SEAM …-0i2vt.15 — no EntityType row of its own; attaches to channels
+        ImporterStep(EntityType.M3U_ACCOUNT, s["m3u"], defers=True),
+        ImporterStep(EntityType.EPG_SOURCE, s["epg"]),
+        ImporterStep(EntityType.CHANNEL_GROUP, s["channel_groups"]),
+        ImporterStep(EntityType.CHANNEL_PROFILE, s["channel_profiles"]),
+        ImporterStep(EntityType.STREAM_PROFILE, s["stream_profiles"]),
+        ImporterStep(EntityType.USER_AGENT, None),  # SEAM …-0i2vt.13 (no importer yet)
+        ImporterStep(EntityType.USER, s["users"]),
+        ImporterStep(EntityType.CHANNEL, s["channels"]),
+        ImporterStep(EntityType.LOGO, s["logos"]),
     ]
+
+
+async def run_dry_run(
+    *,
+    plan: ImportPlan,
+    client: DispatcharrClient,
+    steps: list[ImporterStep] | None = None,
+    ledger_dir: Path | None = None,
+    max_entities_per_category: int = None,  # type: ignore[assignment]
+) -> RestoreReport:
+    """Produce the counts-only restore PLAN for an archive — never mutates.
+
+    Bead ``…-0i2vt.16``. The default-ON entry: the restore UX ALWAYS calls this
+    first so the operator sees "would create N / update M / skip K" before any
+    apply. It runs every importer with dry-run on (``dry_run_importer_steps``),
+    aggregating each category's ``would_create`` / ``would_update`` / ``would_skip``
+    into one :class:`RestoreReport` whose ``is_dry_run`` is True and whose
+    ``outcome`` is ``None`` (a plan has no realized outcome).
+
+    Because it delegates to :func:`run_restore` with ``confirm_apply=False`` and a
+    dry-run report, the engine's guardrail guarantees ZERO mutation: no create,
+    update, delete, upload, bulk-delete, rollback, or deferred auto-sync fires.
+
+    Args:
+        plan: The restore plan (categories + manifest + any pre-known remap).
+        client: The Dispatcharr API client (only its READ methods are exercised).
+        steps: Override the importer registry (tests / a future endpoint that
+            shares the apply registry for the parity check). Defaults to
+            :func:`dry_run_importer_steps`.
+        ledger_dir: Override the durable ledger directory (tests). The dry-run
+            never writes ledger entries, but pre-flight refusal paths share the
+            signature.
+        max_entities_per_category: Pre-flight count bound override (tests).
+
+    Returns:
+        A :class:`RestoreReport` with ``is_dry_run=True`` carrying the per-category
+        ``would_*`` counts and the ``logo_misses`` aggregate.
+    """
+    report = RestoreReport(is_dry_run=True)
+    ledger = RollbackLedger(restore_id=new_restore_id())
+    from dbas.restore_contracts import IdRemapTable
+
+    return await run_restore(
+        plan=plan,
+        client=client,
+        steps=steps if steps is not None else dry_run_importer_steps(),
+        report=report,
+        ledger=ledger,
+        remap=plan.existing_remap or IdRemapTable(),
+        confirm_apply=False,
+        ledger_dir=ledger_dir,
+        max_entities_per_category=max_entities_per_category,
+    )

--- a/backend/tests/dbas/test_dry_run_engine.py
+++ b/backend/tests/dbas/test_dry_run_engine.py
@@ -1,0 +1,498 @@
+"""Tests for the Phase-2 DBAS DRY-RUN ENGINE (enhancedchannelmanager-0i2vt.16).
+
+Scope under test:
+
+1. PARITY (the headline, anti-drift): the SAME archive run through the dry-run
+   then through apply yields ``would_create == created`` /
+   ``would_update == updated`` / ``would_skip == skipped`` per category. The
+   dry-run counts come from the importers' OWN plan/match logic (the same code
+   apply uses), not a parallel counter — if they drifted, this fails.
+2. ZERO MUTATION: a dry-run fires NO create / update / delete / upload /
+   bulk_delete on ANY importer's client — asserted across every mutator,
+   ESPECIALLY the .15 logos ``bulk_delete_logos``.
+3. DEFAULT-ON / UNBYPASSABLE: ``run_restore`` produces a dry-run unless an
+   explicit ``confirm_apply=True`` is given AND the report is not a dry-run; a
+   caller can never opt OUT of the dry-run. ``run_dry_run`` always plans.
+4. NO ROLLBACK / NO DEFERRED on a dry-run.
+5. AGGREGATE: counts roll up across every category into one RestoreReport, with
+   ``is_dry_run=True`` and ``outcome=None`` (a plan has no realized outcome).
+
+The Dispatcharr client is mocked at module level; the durable ledger writes to a
+tmp dir, never CONFIG_DIR.
+"""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from dbas.preflight import ImportPlan, PlanCategory
+from dbas.restore_contracts import (
+    EntityType,
+    IdRemapTable,
+    RestoreOutcome,
+    RestoreReport,
+    RollbackLedger,
+)
+from dbas.restore_orchestrator import (
+    dry_run_importer_steps,
+    new_restore_id,
+    run_dry_run,
+    run_restore,
+)
+
+_GOOD_MANIFEST = {"schema_version": 1}
+
+# Every client mutator a dry-run must NEVER call. ``bulk_delete_logos`` is the
+# .15 destructive bulk-delete pre-step the grooming comment singles out.
+_MUTATORS = (
+    "create_m3u_account",
+    "create_epg_source",
+    "create_channel_group",
+    "create_channel_profile",
+    "create_stream_profile",
+    "create_channel",
+    "create_user",
+    "create_stream",
+    "update_channel",
+    "update_profile_channel",
+    "update_m3u_group_settings",
+    "patch_m3u_account",
+    "refresh_m3u_account",
+    "upload_logo_file",
+    "bulk_delete_logos",
+    "delete_m3u_account",
+    "delete_epg_source",
+    "delete_channel_group",
+    "delete_channel_profile",
+    "delete_channel",
+    "delete_stream",
+    "delete_user",
+)
+
+
+# ---------------------------------------------------------------------------
+# A shared archive — one selectable category per wired importer, destination
+# EMPTY so every entity is a create (clean parity arithmetic).
+# ---------------------------------------------------------------------------
+
+
+def _archive_plan():
+    """A multi-category plan: 2 m3u, 1 epg, 1 group, 1 profile, 1 stream-profile,
+    1 user, 2 channels (one with an FK to the archived group), 1 logo miss + 1
+    logo that will already exist on the destination (a skip)."""
+    return ImportPlan(
+        manifest=dict(_GOOD_MANIFEST),
+        categories=[
+            PlanCategory(
+                entity_type=EntityType.M3U_ACCOUNT,
+                entities=[
+                    {"id": 1, "name": "Provider A"},
+                    {"id": 2, "name": "Provider B"},
+                ],
+            ),
+            PlanCategory(
+                entity_type=EntityType.EPG_SOURCE,
+                entities=[{"id": 5, "name": "XMLTV Main", "source_type": "xmltv"}],
+            ),
+            PlanCategory(
+                entity_type=EntityType.CHANNEL_GROUP,
+                entities=[{"id": 10, "name": "Sports"}],
+            ),
+            PlanCategory(
+                entity_type=EntityType.CHANNEL_PROFILE,
+                entities=[{"id": 20, "name": "Default Profile"}],
+            ),
+            PlanCategory(
+                entity_type=EntityType.STREAM_PROFILE,
+                entities=[{"id": 30, "name": "Proxy"}],
+            ),
+            PlanCategory(
+                entity_type=EntityType.USER,
+                entities=[{"id": 40, "username": "alice"}],
+            ),
+            PlanCategory(
+                entity_type=EntityType.CHANNEL,
+                entities=[
+                    {"id": 50, "name": "ESPN", "channel_number": 1, "channel_group_id": 10},
+                    {"id": 51, "name": "CNN", "channel_number": 2},
+                ],
+            ),
+            PlanCategory(
+                entity_type=EntityType.LOGO,
+                entities=[
+                    # A miss → would_create on dry-run, created on apply. Valid PNG.
+                    {
+                        "id": 60,
+                        "name": "espn-logo",
+                        "filename": "espn.png",
+                        "content_type": "image/png",
+                        "content_b64": _PNG_B64,
+                    },
+                    # Already exists on the destination by name → would_skip/skipped.
+                    {"id": 61, "name": "existing-logo", "filename": "existing.png"},
+                ],
+            ),
+        ],
+    )
+
+
+# Smallest valid PNG (1x1) so the logos importer's magic-byte check passes.
+import base64  # noqa: E402
+
+_PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+_PNG_B64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+
+
+def _selected_all():
+    """Select every category in the plan (opt-in flags)."""
+    return None  # plan categories default selected=True
+
+
+def _client(*, created_ids=None):
+    """An AsyncMock client.
+
+    READ methods return realistic shapes for an EMPTY destination (so every
+    archived entity is a create) EXCEPT one pre-existing logo named
+    'existing-logo' (so logo id=61 is a skip — exercising would_skip parity).
+
+    Every MUTATOR returns a created dict with a destination id so apply records a
+    creation; on a dry-run none of these are ever called (the assertions verify).
+    """
+    ids = created_ids or {}
+    client = AsyncMock()
+
+    # --- READ methods (exercised on BOTH dry-run and apply). ---
+    client.get_m3u_accounts = AsyncMock(return_value=[])
+    client.get_epg_sources = AsyncMock(return_value=[])
+    client.get_channel_groups = AsyncMock(return_value=[])
+    client.get_channel_profiles = AsyncMock(return_value=[])
+    client.get_stream_profiles = AsyncMock(return_value=[])
+    client.get_users = AsyncMock(return_value=[])
+    client.get_current_user = AsyncMock(return_value={"id": 1, "username": "operator"})
+    client.get_user_schema_write_fields = AsyncMock(
+        return_value={"username", "email", "is_active"}
+    )
+    client.get_channels = AsyncMock(return_value={"results": [], "count": 0})
+    client.get_streams = AsyncMock(return_value={"results": [], "count": 0})
+    # One pre-existing destination logo → logo 'existing-logo' is a skip.
+    client.get_all_logos_paginated = AsyncMock(
+        return_value=[{"id": 700, "name": "existing-logo", "url": "/logos/existing.png"}]
+    )
+
+    # --- MUTATORS (only ever called on apply). ---
+    client.create_m3u_account = AsyncMock(return_value={"id": 901})
+    client.create_epg_source = AsyncMock(return_value={"id": 905})
+    client.create_channel_group = AsyncMock(return_value={"id": 910})
+    client.create_channel_profile = AsyncMock(return_value={"id": 920})
+    client.create_stream_profile = AsyncMock(return_value={"id": 930})
+    client.create_channel = AsyncMock(side_effect=_channel_creator())
+    client.create_user = AsyncMock(return_value={"id": 940})
+    client.upload_logo_file = AsyncMock(return_value={"id": 960})
+    client.update_channel = AsyncMock(return_value={"id": 0})
+    client.update_profile_channel = AsyncMock(return_value=None)
+    client.update_m3u_group_settings = AsyncMock(return_value=None)
+    client.patch_m3u_account = AsyncMock(return_value=None)
+    client.refresh_m3u_account = AsyncMock(return_value=None)
+    client.bulk_delete_logos = AsyncMock(return_value=None)
+    client.create_stream = AsyncMock(return_value={"id": 970})
+    for name in (
+        "delete_m3u_account",
+        "delete_epg_source",
+        "delete_channel_group",
+        "delete_channel_profile",
+        "delete_channel",
+        "delete_stream",
+        "delete_user",
+    ):
+        setattr(client, name, AsyncMock(return_value=None))
+    return client
+
+
+def _channel_creator():
+    counter = {"n": 0}
+
+    async def _create(payload):
+        counter["n"] += 1
+        return {"id": 500 + counter["n"]}
+
+    return _create
+
+
+def _assert_no_mutations(client):
+    """Assert NOT ONE client mutator was awaited (the zero-mutation guarantee)."""
+    for name in _MUTATORS:
+        method = getattr(client, name, None)
+        if method is not None:
+            method.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 1. PARITY — dry-run counts == apply counts, per category (anti-drift).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_counts_equal_apply_counts(tmp_path):
+    plan = _archive_plan()
+
+    # --- Dry-run pass. ---
+    dry = await run_dry_run(plan=_archive_plan(), client=_client(), ledger_dir=tmp_path)
+    assert dry.is_dry_run is True
+    assert dry.outcome is None  # a plan has no realized outcome
+
+    # --- Apply pass (same archive, same registry). ---
+    apply_report = RestoreReport(is_dry_run=False)
+    apply_ledger = RollbackLedger(restore_id=new_restore_id())
+    applied = await run_restore(
+        plan=plan,
+        client=_client(),
+        steps=dry_run_importer_steps(),
+        report=apply_report,
+        ledger=apply_ledger,
+        remap=IdRemapTable(),
+        confirm_apply=True,
+        ledger_dir=tmp_path,
+    )
+    assert applied.is_dry_run is False
+
+    # --- PARITY: per category, would_* == realized counts. ---
+    dry_by_type = {c.entity_type: c for c in dry.categories}
+    apply_by_type = {c.entity_type: c for c in applied.categories}
+    # Every category the apply touched must be present in the dry-run plan too.
+    for entity_type, applied_cat in apply_by_type.items():
+        dry_cat = dry_by_type.get(entity_type)
+        assert dry_cat is not None, f"dry-run missing category {entity_type}"
+        assert dry_cat.would_create == applied_cat.created, (
+            f"{entity_type}: would_create {dry_cat.would_create} != created "
+            f"{applied_cat.created}"
+        )
+        assert dry_cat.would_update == applied_cat.updated, (
+            f"{entity_type}: would_update {dry_cat.would_update} != updated "
+            f"{applied_cat.updated}"
+        )
+        assert dry_cat.would_skip == applied_cat.skipped, (
+            f"{entity_type}: would_skip {dry_cat.would_skip} != skipped "
+            f"{applied_cat.skipped}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_parity_specific_counts(tmp_path):
+    # Spot-check the arithmetic so a silently-empty parity can't pass vacuously.
+    dry = await run_dry_run(plan=_archive_plan(), client=_client(), ledger_dir=tmp_path)
+    by = {c.entity_type: c for c in dry.categories}
+    assert by[EntityType.M3U_ACCOUNT].would_create == 2
+    assert by[EntityType.EPG_SOURCE].would_create == 1
+    assert by[EntityType.CHANNEL_GROUP].would_create == 1
+    assert by[EntityType.CHANNEL].would_create == 2
+    assert by[EntityType.LOGO].would_create == 1   # the miss
+    assert by[EntityType.LOGO].would_skip == 1     # the pre-existing logo
+    assert dry.logo_misses == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. ZERO MUTATION on a dry-run — across EVERY importer's client mutators.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_makes_zero_client_mutations(tmp_path):
+    client = _client()
+    await run_dry_run(plan=_archive_plan(), client=client, ledger_dir=tmp_path)
+    _assert_no_mutations(client)
+
+
+@pytest.mark.asyncio
+async def test_dry_run_never_bulk_deletes_logos(tmp_path):
+    # The .15 destructive bulk-delete pre-step must NEVER fire on a dry-run,
+    # regardless of any clear-existing intent.
+    client = _client()
+    await run_dry_run(plan=_archive_plan(), client=client, ledger_dir=tmp_path)
+    client.bulk_delete_logos.assert_not_awaited()
+    client.upload_logo_file.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dry_run_writes_no_ledger_entries(tmp_path):
+    # Nothing is created, so nothing is ledgered — nothing to ever roll back.
+    dry = await run_dry_run(plan=_archive_plan(), client=_client(), ledger_dir=tmp_path)
+    assert dry.is_dry_run is True
+    # No ledger file is left behind for a dry-run.
+    assert not any(tmp_path.glob("restore_ledger_*.json"))
+
+
+# ---------------------------------------------------------------------------
+# 3. DEFAULT-ON, UNBYPASSABLE — apply is opt-IN; dry-run cannot be opted out.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_restore_without_confirm_is_forced_dry_run(tmp_path):
+    # A non-dry-run report + no confirm → the guardrail forces a dry-run and makes
+    # ZERO mutations. The caller cannot mutate without an explicit confirm.
+    client = _client()
+    report = RestoreReport(is_dry_run=False)  # caller asked to apply...
+    out = await run_restore(
+        plan=_archive_plan(),
+        client=client,
+        steps=dry_run_importer_steps(),
+        report=report,
+        ledger=RollbackLedger(restore_id="rid-x"),
+        remap=IdRemapTable(),
+        confirm_apply=False,  # ...but did NOT confirm.
+        ledger_dir=tmp_path,
+    )
+    assert out.is_dry_run is True  # forced
+    _assert_no_mutations(client)
+    assert any("apply not confirmed" in n for n in out.notes)
+
+
+@pytest.mark.asyncio
+async def test_run_restore_with_confirm_applies(tmp_path):
+    # Explicit confirm + non-dry-run report → mutations DO happen.
+    client = _client()
+    report = RestoreReport(is_dry_run=False)
+    out = await run_restore(
+        plan=_archive_plan(),
+        client=client,
+        steps=dry_run_importer_steps(),
+        report=report,
+        ledger=RollbackLedger(restore_id="rid-apply"),
+        remap=IdRemapTable(),
+        confirm_apply=True,
+        ledger_dir=tmp_path,
+    )
+    assert out.is_dry_run is False
+    client.create_m3u_account.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_confirm_apply_does_not_override_dry_run_report(tmp_path):
+    # A dry-run report stays a dry-run even if a confirm is (mistakenly) passed —
+    # the report's is_dry_run is the operator's plan intent and wins.
+    client = _client()
+    report = RestoreReport(is_dry_run=True)
+    out = await run_restore(
+        plan=_archive_plan(),
+        client=client,
+        steps=dry_run_importer_steps(),
+        report=report,
+        ledger=RollbackLedger(restore_id="rid-y"),
+        remap=IdRemapTable(),
+        confirm_apply=True,
+        ledger_dir=tmp_path,
+    )
+    assert out.is_dry_run is True
+    _assert_no_mutations(client)
+
+
+@pytest.mark.asyncio
+async def test_run_dry_run_always_plans(tmp_path):
+    out = await run_dry_run(plan=_archive_plan(), client=_client(), ledger_dir=tmp_path)
+    assert out.is_dry_run is True
+    assert out.outcome is None
+
+
+# ---------------------------------------------------------------------------
+# 4. NO ROLLBACK / NO DEFERRED on a dry-run.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_runs_no_deferred_auto_sync(tmp_path):
+    # The M3U importer would return deferred auto-sync settings on apply; on a
+    # dry-run the deferred phase must NOT fire (no refresh / patch / group-update).
+    client = _client()
+    await run_dry_run(plan=_archive_plan(), client=client, ledger_dir=tmp_path)
+    client.refresh_m3u_account.assert_not_awaited()
+    client.patch_m3u_account.assert_not_awaited()
+    client.update_m3u_group_settings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dry_run_runs_no_rollback_deletes(tmp_path):
+    client = _client()
+    await run_dry_run(plan=_archive_plan(), client=client, ledger_dir=tmp_path)
+    for name in (
+        "delete_m3u_account",
+        "delete_channel",
+        "delete_channel_group",
+        "delete_user",
+    ):
+        getattr(client, name).assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 5. AGGREGATE — counts roll up across categories into one report.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_aggregates_all_categories(tmp_path):
+    dry = await run_dry_run(plan=_archive_plan(), client=_client(), ledger_dir=tmp_path)
+    present = {c.entity_type for c in dry.categories}
+    # Every wired category that had entities appears in the aggregated report.
+    for entity_type in (
+        EntityType.M3U_ACCOUNT,
+        EntityType.EPG_SOURCE,
+        EntityType.CHANNEL_GROUP,
+        EntityType.CHANNEL_PROFILE,
+        EntityType.STREAM_PROFILE,
+        EntityType.USER,
+        EntityType.CHANNEL,
+        EntityType.LOGO,
+    ):
+        assert entity_type in present, f"missing {entity_type} in aggregate"
+    total_would_create = sum(c.would_create for c in dry.categories)
+    # 2 m3u + 1 epg + 1 group + 1 profile + 1 stream-profile + 1 user + 2 channels
+    # + 1 logo miss = 10.
+    assert total_would_create == 10
+
+
+@pytest.mark.asyncio
+async def test_dry_run_preflight_refusal_still_zero_mutation(tmp_path):
+    # A plan that fails pre-flight (dangling channel FK) is refused with no
+    # mutation even on the dry-run path — same chokepoint as apply.
+    plan = ImportPlan(
+        manifest=dict(_GOOD_MANIFEST),
+        categories=[
+            PlanCategory(
+                entity_type=EntityType.CHANNEL,
+                entities=[{"id": 1, "name": "ESPN", "channel_group_id": 9999}],
+            )
+        ],
+    )
+    client = _client()
+    out = await run_dry_run(plan=plan, client=client, ledger_dir=tmp_path)
+    assert out.outcome is None
+    assert any("pre-flight refused" in n for n in out.notes)
+    _assert_no_mutations(client)
+
+
+# ---------------------------------------------------------------------------
+# 6. The dry-run registry wires every importer (vs. the apply seams).
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_registry_wires_all_importers():
+    steps = dry_run_importer_steps()
+    wired = {s.entity_type for s in steps if s.importer is not None}
+    # Every entity-bearing importer is wired for the dry-run (unlike the apply
+    # default registry, which leaves EPG / groups-profiles / logos as seams).
+    for entity_type in (
+        EntityType.M3U_ACCOUNT,
+        EntityType.EPG_SOURCE,
+        EntityType.CHANNEL_GROUP,
+        EntityType.CHANNEL_PROFILE,
+        EntityType.STREAM_PROFILE,
+        EntityType.USER,
+        EntityType.CHANNEL,
+        EntityType.LOGO,
+    ):
+        assert entity_type in wired, f"{entity_type} not wired in dry-run registry"
+    # Order mirrors the hard Phase-2 sequence: M3U first, logos last.
+    order = [s.entity_type for s in steps]
+    assert order[0] == EntityType.M3U_ACCOUNT
+    assert order[-1] == EntityType.LOGO
+    assert order.index(EntityType.CHANNEL_GROUP) < order.index(EntityType.CHANNEL)

--- a/backend/tests/dbas/test_restore_orchestrator.py
+++ b/backend/tests/dbas/test_restore_orchestrator.py
@@ -176,6 +176,7 @@ async def test_preflight_failure_refuses_with_zero_mutation(tmp_path):
         report=report,
         ledger=ledger,
         remap=IdRemapTable(),
+        confirm_apply=True,
         ledger_dir=tmp_path,
     )
     assert called["n"] == 0  # zero mutation
@@ -201,6 +202,7 @@ async def test_preflight_pass_apply_proceeds(tmp_path):
         report=report,
         ledger=ledger,
         remap=IdRemapTable(),
+        confirm_apply=True,
         ledger_dir=tmp_path,
     )
     assert out.outcome == RestoreOutcome.SUCCESS
@@ -235,6 +237,7 @@ async def test_failure_midrun_rolls_back_in_compensation_order(tmp_path):
         report=report,
         ledger=ledger,
         remap=IdRemapTable(),
+        confirm_apply=True,
         ledger_dir=tmp_path,
     )
     assert out.outcome == RestoreOutcome.PARTIAL_FAILED_ROLLED_BACK
@@ -304,6 +307,7 @@ async def test_failure_with_non_404_rollback_error_outcome_incomplete(tmp_path):
         report=report,
         ledger=ledger,
         remap=IdRemapTable(),
+        confirm_apply=True,
         ledger_dir=tmp_path,
     )
     assert out.outcome == RestoreOutcome.FAILED_ROLLBACK_INCOMPLETE
@@ -351,6 +355,7 @@ async def test_happy_path_success_and_deferred_runs_last(tmp_path):
         report=report,
         ledger=ledger,
         remap=IdRemapTable(),
+        confirm_apply=True,
         deferred_apply_fn=_deferred_apply,
         ledger_dir=tmp_path,
     )
@@ -373,6 +378,7 @@ async def test_clean_success_removes_ledger_file(tmp_path):
         report=_report(),
         ledger=ledger,
         remap=IdRemapTable(),
+        confirm_apply=True,
         ledger_dir=tmp_path,
     )
     assert not _ledger_path("rid-clean", tmp_path).exists()
@@ -397,6 +403,7 @@ async def test_ledger_persisted_during_rollback(tmp_path):
         report=_report(),
         ledger=ledger,
         remap=IdRemapTable(),
+        confirm_apply=True,
         ledger_dir=tmp_path,
     )
     # Rollback INCOMPLETE (channel 500) → ledger file retained with the residue.
@@ -462,6 +469,7 @@ async def test_reported_failure_triggers_rollback(tmp_path):
         report=report,
         ledger=ledger,
         remap=IdRemapTable(),
+        confirm_apply=True,
         ledger_dir=tmp_path,
     )
     assert out.outcome == RestoreOutcome.PARTIAL_FAILED_ROLLED_BACK
@@ -486,6 +494,7 @@ async def test_seam_step_is_noop(tmp_path):
         report=report,
         ledger=ledger,
         remap=IdRemapTable(),
+        confirm_apply=True,
         ledger_dir=tmp_path,
     )
     assert out.outcome == RestoreOutcome.SUCCESS


### PR DESCRIPTION
## Bead
enhancedchannelmanager-0i2vt.16 — Phase 2: Dry-run engine (counts-only, default-ON for Dispatcharr restores; ADR-012 D7).

## Audit result (the load-bearing question)
All six importers ALREADY populate `would_create`/`would_update`/`would_skip` from the SAME plan/match logic apply uses, with every client mutation guarded behind `is_dry_run` (incl. `.15`'s `bulk_delete_logos` behind `clear_existing and not is_dry_run`). So `.16` is the ENGINE layer, not importer surgery.

## What
- `restore_orchestrator.py`: `run_restore(confirm_apply=False)` — **default-ON, unbypassable**: absent explicit `confirm_apply`, forces `is_dry_run=True` before pre-flight (single enforcement point; importers/rollback/deferred all branch on it). `run_dry_run()` is the entry the UX always calls first. No path mutates without `confirm_apply=True`.
- **Anti-drift fix**: a dry-run `would_create` records a provisional `source→source` remap (sentinel never sent upstream) so FK-dependent downstream entities (e.g. a channel whose group "would be created") count as `would_create`, mirroring apply exactly. Applied to m3u/epg/groups_profiles/channels producers.
- Dry-run leaves `outcome=None`, writes no ledger, fires no deferred auto-sync/EPG-download, runs no rollback.

## Tests
14 new (+ orchestrator apply tests updated for `confirm_apply`). Headline **`test_dry_run_counts_equal_apply_counts`** (same archive dry-run→apply, per-category parity) + `test_parity_specific_counts`. Zero-mutation across 21 mutators incl. `bulk_delete_logos`; no-rollback/no-deferred/no-ledger on dry-run. Importer tests unregressed. Full suite green (5826 passed).

## Scope/follow-ups
- COUNTS-ONLY (D7); entity-level diff tree deferred to v0.19.x.
- STREAM-category would_* counts out of scope (dry-run skips the stream-attach derived layer) — follow-up if a stream preview is wanted.
- Default-ON wired at the engine layer; the async restore endpoint (known gap) is the remaining seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)