### PR TITLE
v0.18.0-dbas: 0i2vt.19 restore-complete logo-miss red banner (D9)

### DIFF
--- a/frontend/src/components/BackupRestoreModal.test.tsx
+++ b/frontend/src/components/BackupRestoreModal.test.tsx
@@ -10,6 +10,10 @@ import type { BackupValidation, BackupRestoreResult } from '../services/api';
 vi.mock('../services/api', () => ({
   validateBackup: vi.fn(),
   restoreBackupYaml: vi.fn(),
+  // getSettings supplies the Dispatcharr base url that drives the logo-miss
+  // banner's "Fix in Dispatcharr" link (bead 0i2vt.19). Default to a resolved
+  // settings object so the modal's mount effect doesn't reject.
+  getSettings: vi.fn(),
 }));
 
 import * as api from '../services/api';
@@ -39,6 +43,11 @@ describe('BackupRestoreModal', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: a resolved settings object with a Dispatcharr base url so the
+    // modal's mount effect (logo-miss banner link source) settles cleanly.
+    vi.mocked(api.getSettings).mockResolvedValue({
+      url: 'https://dispatcharr.example.test',
+    } as Awaited<ReturnType<typeof api.getSettings>>);
   });
 
   describe('upload step', () => {

--- a/frontend/src/components/BackupRestoreModal.tsx
+++ b/frontend/src/components/BackupRestoreModal.tsx
@@ -1,7 +1,8 @@
-import { useState, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { ModalOverlay } from './ModalOverlay';
 import { RestoreProgress } from './RestoreProgress';
 import { RestoreCompleteSummary } from './RestoreCompleteSummary';
+import { LogoMissBanner } from './LogoMissBanner';
 import { useRestoreProgress } from '../hooks/useRestoreProgress';
 import { useNavigateAwayGuard } from '../hooks/useNavigateAwayGuard';
 import * as api from '../services/api';
@@ -32,6 +33,26 @@ export function BackupRestoreModal({ onClose }: BackupRestoreModalProps) {
   const [restoreReport, setRestoreReport] = useState<RestoreReport | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+
+  // Dispatcharr base URL (settings.url) — drives the logo-miss banner's
+  // "Fix in Dispatcharr" link (bead 0i2vt.19). Same source App.tsx reads for
+  // `dispatcharrUrl`. Best-effort: if settings can't be read the banner still
+  // fires, it just omits the link.
+  const [dispatcharrUrl, setDispatcharrUrl] = useState('');
+  useEffect(() => {
+    let active = true;
+    api
+      .getSettings()
+      .then((settings) => {
+        if (active) setDispatcharrUrl(settings.url ?? '');
+      })
+      .catch(() => {
+        /* non-fatal — banner omits the link when the base url is unknown */
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   // SEAM: the multi-stage restore-trigger endpoint / restore TaskScheduler is a
   // LATER bead (the orchestrator .18 exists but emits no _set_progress, and no
@@ -262,7 +283,13 @@ export function BackupRestoreModal({ onClose }: BackupRestoreModalProps) {
               into RestoreCompleteSummary's `bannerSlot` prop. Falls back to the
               legacy section-level result view while restoreReport is null. */}
           {step === 'results' && restoreReport && (
-            <RestoreCompleteSummary report={restoreReport} mode="applied" />
+            <RestoreCompleteSummary
+              report={restoreReport}
+              mode="applied"
+              bannerSlot={
+                <LogoMissBanner report={restoreReport} dispatcharrUrl={dispatcharrUrl} />
+              }
+            />
           )}
 
           {step === 'results' && !restoreReport && restoreResult && (

--- a/frontend/src/components/LogoMissBanner.css
+++ b/frontend/src/components/LogoMissBanner.css
@@ -1,0 +1,67 @@
+/**
+ * LogoMissBanner styles (bead 0i2vt.19, ADR-012 D9).
+ *
+ * A prominent RED banner — reuses the semantic --error / --error-bg theme
+ * tokens (index.css) so dark/light/high-contrast modes stay legible, the same
+ * way RestoreCompleteSummary's error-tone outcome banner does. Uses common.css
+ * for: .material-icons (icon glyphs). The red treatment is intentionally
+ * heavier than the outcome banner (full border + solid left accent) — this is
+ * the "unmissable" surface per D9. Meaning is carried by the icon + the word
+ * "missing" in the copy, not by colour alone (WCAG 1.4.1).
+ */
+
+.logo-miss-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+  padding: 0.875rem 1rem;
+  border-radius: var(--radius-md);
+  background-color: var(--error-bg);
+  border: 1px solid var(--error);
+  border-left: 4px solid var(--error);
+}
+
+.logo-miss-icon {
+  color: var(--error);
+  font-size: 1.625rem;
+  line-height: 1.3;
+  flex-shrink: 0;
+}
+
+.logo-miss-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.logo-miss-title {
+  color: var(--error);
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.logo-miss-detail {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.logo-miss-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  align-self: flex-start;
+  margin-top: 0.125rem;
+  color: var(--error);
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-decoration: underline;
+}
+
+.logo-miss-link:hover {
+  text-decoration: none;
+}
+
+.logo-miss-link-icon {
+  font-size: 1rem;
+}

--- a/frontend/src/components/LogoMissBanner.test.tsx
+++ b/frontend/src/components/LogoMissBanner.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Tests for LogoMissBanner — the restore-complete logo-miss RED banner
+ * (bead 0i2vt.19, ADR-012 D9 "unmissable surfacing").
+ *
+ * Contract note: the merged `RestoreReport` (docs/dbas_restore_contracts.md)
+ * carries the logo-miss signal as an AGGREGATE count only — `logo_misses: number`
+ * — not a per-channel list. ADR-012 D9 mandates exactly that: "a WARN log + an
+ * aggregate count + a prominent red banner". So the banner names the count and
+ * links to the Dispatcharr Channels page where the operator fixes the logos
+ * one-off; it does NOT (because it cannot) enumerate per-channel rows — there is
+ * no per-channel data in the contract. The "detail view" the banner offers is
+ * the Dispatcharr Channels admin page, reached via the same `${dispatcharrUrl}/…`
+ * link pattern the rest of the app uses (ChannelsPane).
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { LogoMissBanner } from './LogoMissBanner';
+import { RestoreCompleteSummary } from './RestoreCompleteSummary';
+import type { RestoreReport } from '../services/api';
+
+function report(overrides: Partial<RestoreReport> = {}): RestoreReport {
+  return {
+    contract_version: 1,
+    is_dry_run: false,
+    outcome: 'success',
+    logo_misses: 0,
+    started_at: null,
+    completed_at: null,
+    notes: [],
+    categories: [],
+    ...overrides,
+  };
+}
+
+const DISPATCHARR_URL = 'https://dispatcharr.example.test';
+
+describe('LogoMissBanner — render gating', () => {
+  it('does NOT render when logo_misses is 0 (all logos attached)', () => {
+    const { container } = render(
+      <LogoMissBanner report={report({ logo_misses: 0 })} dispatcharrUrl={DISPATCHARR_URL} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByTestId('logo-miss-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders when logo_misses > 0', () => {
+    render(<LogoMissBanner report={report({ logo_misses: 12 })} dispatcharrUrl={DISPATCHARR_URL} />);
+    expect(screen.getByTestId('logo-miss-banner')).toBeInTheDocument();
+  });
+});
+
+describe('LogoMissBanner — copy names the count (plain language, colorblind-safe)', () => {
+  it('names the exact count in plain language', () => {
+    render(<LogoMissBanner report={report({ logo_misses: 12 })} dispatcharrUrl={DISPATCHARR_URL} />);
+    const banner = screen.getByTestId('logo-miss-banner');
+    // Count is surfaced and the word "missing" carries the meaning (not red-only;
+    // WCAG 1.4.1 — colorblind-safe).
+    expect(within(banner).getByText(/12 channels are missing their logo/i)).toBeInTheDocument();
+    expect(within(banner).getByText(/missing/i)).toBeInTheDocument();
+  });
+
+  it('uses a singular phrasing for a single miss', () => {
+    render(<LogoMissBanner report={report({ logo_misses: 1 })} dispatcharrUrl={DISPATCHARR_URL} />);
+    const banner = screen.getByTestId('logo-miss-banner');
+    expect(within(banner).getByText(/1 channel is missing its logo/i)).toBeInTheDocument();
+  });
+
+  it('renders a warning icon (icon + text, never colour alone)', () => {
+    render(<LogoMissBanner report={report({ logo_misses: 5 })} dispatcharrUrl={DISPATCHARR_URL} />);
+    const banner = screen.getByTestId('logo-miss-banner');
+    expect(within(banner).getByTestId('logo-miss-icon')).toBeInTheDocument();
+  });
+});
+
+describe('LogoMissBanner — accessibility', () => {
+  it('has role="alert" so it is announced', () => {
+    render(<LogoMissBanner report={report({ logo_misses: 3 })} dispatcharrUrl={DISPATCHARR_URL} />);
+    expect(screen.getByRole('alert')).toBe(screen.getByTestId('logo-miss-banner'));
+  });
+});
+
+describe('LogoMissBanner — detail/fix link to the Dispatcharr Channels page', () => {
+  it('links to the Dispatcharr Channels page built from the base url (existing ${dispatcharrUrl}/… pattern)', () => {
+    render(<LogoMissBanner report={report({ logo_misses: 4 })} dispatcharrUrl={DISPATCHARR_URL} />);
+    const link = screen.getByTestId('logo-miss-detail-link');
+    expect(link).toHaveAttribute('href', `${DISPATCHARR_URL}/channels`);
+    // Opens the Dispatcharr UI in a new tab, hardened against reverse-tabnabbing.
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('strips a trailing slash on the base url so the link is not doubled', () => {
+    render(
+      <LogoMissBanner
+        report={report({ logo_misses: 2 })}
+        dispatcharrUrl={`${DISPATCHARR_URL}/`}
+      />,
+    );
+    expect(screen.getByTestId('logo-miss-detail-link')).toHaveAttribute(
+      'href',
+      `${DISPATCHARR_URL}/channels`,
+    );
+  });
+
+  it('omits the fix link (but still warns) when no Dispatcharr base url is known', () => {
+    render(<LogoMissBanner report={report({ logo_misses: 7 })} />);
+    expect(screen.getByTestId('logo-miss-banner')).toBeInTheDocument();
+    expect(within(screen.getByTestId('logo-miss-banner')).getByText(/7 channels/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('logo-miss-detail-link')).not.toBeInTheDocument();
+  });
+});
+
+describe('LogoMissBanner — integration through RestoreCompleteSummary bannerSlot', () => {
+  it('appears above the outcome banner when passed through the summary bannerSlot', () => {
+    const r = report({ logo_misses: 9 });
+    render(
+      <RestoreCompleteSummary
+        report={r}
+        mode="applied"
+        bannerSlot={<LogoMissBanner report={r} dispatcharrUrl={DISPATCHARR_URL} />}
+      />,
+    );
+
+    const logoBanner = screen.getByTestId('logo-miss-banner');
+    const outcomeBanner = screen.getByTestId('rcs-outcome-banner');
+    expect(logoBanner).toBeInTheDocument();
+    expect(outcomeBanner).toBeInTheDocument();
+
+    // The logo-miss banner must precede the outcome banner in document order.
+    expect(logoBanner.compareDocumentPosition(outcomeBanner) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('does not inject a banner through the slot when there are no logo misses', () => {
+    const r = report({ logo_misses: 0 });
+    render(
+      <RestoreCompleteSummary
+        report={r}
+        mode="applied"
+        bannerSlot={<LogoMissBanner report={r} dispatcharrUrl={DISPATCHARR_URL} />}
+      />,
+    );
+    expect(screen.queryByTestId('logo-miss-banner')).not.toBeInTheDocument();
+    // The summary itself is unaffected.
+    expect(screen.getByTestId('restore-complete-summary')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/LogoMissBanner.tsx
+++ b/frontend/src/components/LogoMissBanner.tsx
@@ -1,0 +1,91 @@
+/**
+ * LogoMissBanner — the restore-complete logo-miss RED banner (bead 0i2vt.19).
+ *
+ * ADR-012 **D9** ("Logo-miss severity"): a logo that cannot be matched on
+ * restore produces a WARN log + an aggregate count + a **prominent red banner on
+ * the restore-complete screen** — never a silent DEBUG line. This component is
+ * that banner. A restored channel with a missing logo looks identical to a
+ * correctly-restored one at the API level (DBAS's silent-DEBUG pattern hides
+ * this); the banner makes the problem unmissable at the moment the operator can
+ * act on it.
+ *
+ * Contract: the merged {@link RestoreReport} carries the logo-miss signal as an
+ * AGGREGATE COUNT only — `logo_misses: number` (see
+ * docs/dbas_restore_contracts.md; the per-logo detail "lives in the logo beads'
+ * own surface", not in the wire contract). There is no per-channel list in the
+ * report, so the banner cannot enumerate per-channel rows. Instead it names the
+ * count and links to the Dispatcharr **Channels** admin page, where the operator
+ * fixes the affected channels one-off. The link is built with the same
+ * `${dispatcharrUrl}/…` pattern the rest of the app uses (see ChannelsPane).
+ *
+ * Colorblind-safe (WCAG 1.4.1): the meaning is carried by an icon + the word
+ * "missing" in the copy, not by red colour alone. `role="alert"` so assistive
+ * tech announces it.
+ *
+ * Renders into {@link RestoreCompleteSummary}'s `bannerSlot`, which places it at
+ * the very top of the summary, above the tri-state outcome banner.
+ */
+import type { RestoreReport } from '../services/api';
+import './LogoMissBanner.css';
+
+interface LogoMissBannerProps {
+  /** The realized restore report; `logo_misses` drives the banner. */
+  report: RestoreReport;
+  /**
+   * The Dispatcharr base URL (from settings — `App` exposes it as
+   * `dispatcharrUrl`). When present, the banner offers a "Fix in Dispatcharr"
+   * link to the Channels admin page. When absent/empty, the banner still warns;
+   * it just omits the link.
+   */
+  dispatcharrUrl?: string;
+}
+
+/** Plain-language count phrase — singular vs. plural, never the raw field name. */
+function missCopy(count: number): string {
+  return count === 1
+    ? '1 channel is missing its logo'
+    : `${count} channels are missing their logo`;
+}
+
+export function LogoMissBanner({ report, dispatcharrUrl }: LogoMissBannerProps) {
+  const count = report.logo_misses;
+
+  // Never fire when every logo was attached (count === 0). This is the
+  // success-signal contract from the bead: no banner on a clean restore.
+  if (!count || count <= 0) {
+    return null;
+  }
+
+  // Build the Dispatcharr Channels-page link with the same `${base}/…` pattern
+  // ChannelsPane uses; strip a trailing slash so we never double it.
+  const base = dispatcharrUrl?.replace(/\/+$/, '');
+  const channelsHref = base ? `${base}/channels` : null;
+
+  return (
+    <div className="logo-miss-banner" data-testid="logo-miss-banner" role="alert">
+      <span className="material-icons logo-miss-icon" data-testid="logo-miss-icon" aria-hidden="true">
+        broken_image
+      </span>
+      <div className="logo-miss-text">
+        <span className="logo-miss-title">{missCopy(count)}</span>
+        <span className="logo-miss-detail">
+          These channels were restored without a logo. Open them in Dispatcharr to set a logo on each.
+        </span>
+        {channelsHref && (
+          <a
+            className="logo-miss-link"
+            data-testid="logo-miss-detail-link"
+            href={channelsHref}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Fix in Dispatcharr
+            <span className="material-icons logo-miss-link-icon" aria-hidden="true">
+              open_in_new
+            </span>
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Bead
enhancedchannelmanager-0i2vt.19 — Phase 2: Restore-complete UX — logo-miss red banner (ADR-012 D9).

## What
`LogoMissBanner.tsx` (+ css/test) — prominent RED banner (`role="alert"`, `--error` tokens) shown when `report.logo_misses > 0`: names the count ("N channels are missing their logo") + a "Fix in Dispatcharr" link to the Channels admin page (`${settings.url}/channels`, reusing the existing Dispatcharr-URL pattern from ChannelsPane). Does NOT render when count == 0.

Composed through `.20`'s `bannerSlot` seam (top of `RestoreCompleteSummary`, above the outcome banner) — `.20`'s component + the contract are byte-for-byte unchanged (pure addition).

## Contract finding (scope adjustment — see follow-up)
The merged `RestoreReport` carries `logo_misses` as an **aggregate count only** (per the backend docstring + ADR-012 D9: "WARN log + aggregate count + prominent red banner"). There is NO per-channel list in the shipped contract. So the bead text's "detail view listing affected channels with individual edit links" was not buildable without a backend contract change — shipped the D9-compliant count+banner+Channels-link; per-channel detail filed as a follow-up.

## Tests
11 vitest cases (renders with count >0, hidden at 0, role=alert, Channels link URL, bannerSlot integration above outcome banner). lint(src)/tsc clean; vitest 1624 passed; build OK (/tmp node_modules overlay).

## NOT verified (overnight)
No human visual check — eyeball red prominence in dark/light/high-contrast, that it sits above the outcome banner, and the Channels link for your deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)