### PR TITLE
v0.18.0-dbas: o8tbv async restore-trigger endpoint + DbasRestoreTask (round-trip capstone)

### DIFF
--- a/backend/auth/__init__.py
+++ b/backend/auth/__init__.py
@@ -86,6 +86,8 @@ try:
         RequireAuthIfEnabled,
         require_admin_if_enabled,
         RequireAdminIfEnabled,
+        resolve_is_admin_if_enabled,
+        ResolveIsAdminIfEnabled,
     )
     __all__.extend([
         "AuthenticationError",
@@ -99,6 +101,8 @@ try:
         "RequireAuthIfEnabled",
         "require_admin_if_enabled",
         "RequireAdminIfEnabled",
+        "resolve_is_admin_if_enabled",
+        "ResolveIsAdminIfEnabled",
     ])
 except ImportError as e:
     logger.debug("[AUTH] Suppressed dependencies import error: %s", e)

--- a/backend/auth/dependencies.py
+++ b/backend/auth/dependencies.py
@@ -322,3 +322,45 @@ def require_admin_if_enabled():
 
 
 RequireAdminIfEnabled = Depends(require_admin_if_enabled())
+
+
+def resolve_is_admin_if_enabled():
+    """Factory: resolve whether the caller is privileged, WITHOUT rejecting.
+
+    Mirrors :func:`require_admin_if_enabled` exactly for the auth-disabled
+    (setup-incomplete / ``require_auth=False``) case — it returns ``True`` so
+    behaviour is identical to the rest of the app in setup mode. The difference
+    is that an authenticated **non-admin** does NOT get a 403 here; the caller
+    receives ``False`` and decides what to do.
+
+    This is for endpoints that are reachable by ordinary users for ordinary
+    work but must gate a *subset* of their behaviour to admins (e.g. the
+    generic task-run endpoint, which serves user-triggerable tasks but must
+    refuse privileged task ids for non-admins). It lets the handler enforce the
+    admin requirement only for the privileged path while leaving ordinary
+    behaviour unchanged.
+
+    Returns:
+        A dependency that yields ``True`` when the caller is an admin (or auth
+        is disabled) and ``False`` when the caller is an authenticated
+        non-admin. A missing/invalid token in auth-enabled mode still raises
+        via :func:`get_current_user` (the endpoint is not anonymous).
+    """
+    async def check(
+        request: Request,
+        session: Session = Depends(get_session),
+    ) -> bool:
+        settings = get_auth_settings()
+
+        # Auth disabled (setup mode) — treat as privileged, exactly like
+        # RequireAdminIfEnabled, so setup-mode behaviour is unchanged.
+        if not settings.require_auth or not settings.setup_complete:
+            return True
+
+        user = await get_current_user(request, session)
+        return bool(user.is_admin)
+
+    return check
+
+
+ResolveIsAdminIfEnabled = Depends(resolve_is_admin_if_enabled())

--- a/backend/dbas/restore_artifact.py
+++ b/backend/dbas/restore_artifact.py
@@ -238,6 +238,15 @@ def decode_artifact_to_plan(zf: zipfile.ZipFile) -> ImportPlan:
         whole archive is in scope; a caller may deselect categories before
         handing the plan to the orchestrator.
     """
+    # D2 zip-bomb guard at the START of decode too — defence in depth. The
+    # caller (DbasRestoreTask) runs validate_artifact_manifest first, which
+    # already guards, but decode is a separately-callable read site, so re-assert
+    # the cap before any zf.read() here. Imported lazily to keep the heavy backup
+    # router off this module's import path (see module docstring).
+    from routers.backup import guard_artifact_against_zip_bomb
+
+    guard_artifact_against_zip_bomb(zf)
+
     manifest = _parse_manifest(zf)
     categories = _decode_categories(zf)
 

--- a/backend/dbas/restore_artifact.py
+++ b/backend/dbas/restore_artifact.py
@@ -1,0 +1,255 @@
+"""Decode a new-format DBAS backup artifact into a restore :class:`ImportPlan`.
+
+Bead ``enhancedchannelmanager-o8tbv`` — the "round-trip gap" glue. Every
+backend restore primitive existed before this module
+(``validate_artifact_manifest`` .17, ``run_restore`` / ``run_dry_run`` .18/.16,
+every importer .10-.15) but NOTHING turned an on-disk
+:func:`routers.backup.build_backup_artifact` ZIP into the
+:class:`~dbas.preflight.ImportPlan` the orchestrator consumes. This module is
+that decode step, and it is the SINGLE place an untrusted uploaded artifact is
+unpacked into structured records.
+
+Decode pipeline (validate-before-decode, never the reverse)
+-----------------------------------------------------------
+1. :func:`routers.backup.validate_artifact_manifest` runs FIRST (version gate +
+   per-member SHA-256). It is the caller's responsibility to call it before
+   :func:`decode_artifact_to_plan`; this module re-asserts the manifest is
+   present and parses it but does NOT re-run integrity (the caller already did,
+   on the same open ``ZipFile``). The orchestrator then re-checks the
+   schema-version a SECOND time in pre-flight (defence in depth — .17 + .18).
+
+2. Per-category YAML (``categories/<section>.yaml``) is parsed and the entity
+   list extracted from its ``dispatcharr.<section>`` / ``database.<section>``
+   slice. Each artifact section maps to exactly one :class:`EntityType`.
+
+3. The binary subtree (``binary/logos/<rel>`` + ``binary/metadata.json``) is
+   decoded into the per-logo records the logos importer (.15) consumes:
+   ``{"name", "filename", "content_b64", "size"}``. The bytes are base64-encoded
+   here so the importer's one-at-a-time decode/upload loop (.15, D8) drives the
+   memory profile — this module never decodes a logo's IMAGE bytes, only reads
+   the stored file bytes and re-encodes them as the transport the importer
+   already expects.
+
+ZIP-SLIP / PATH-TRAVERSAL SAFETY (the untrusted-upload surface)
+---------------------------------------------------------------
+This module NEVER extracts a member to the filesystem — it only ``zf.read()``s
+named members it itself chose (the manifest-listed categories + the enumerated
+binary subtree). Even so, every member name pulled from the artifact's own
+listing is screened by :func:`_is_safe_member` (reject absolute paths, ``..``
+segments, and backslash separators) before it is read, so a crafted archive
+entry can never widen the read surface. The logos importer (.15) independently
+re-validates each filename basename before any upload — defence in depth.
+
+Conventions (``docs/style_guide.md``): ``snake_case``; Google-style docstrings;
+lazy ``%``-formatted logging; no secrets in any log line.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import posixpath
+import zipfile
+
+import yaml
+
+from dbas.preflight import ImportPlan, PlanCategory
+from dbas.restore_contracts import EntityType
+
+logger = logging.getLogger(__name__)
+
+# Artifact layout constants mirror routers.backup (the builder). Kept here as a
+# local copy so the decoder does not import the heavy backup router module at
+# import time; a drift between the two is caught by the round-trip test.
+_CATEGORY_DIR = "categories"
+_LOGO_DIR = "binary/logos"
+_BINARY_METADATA = "binary/metadata.json"
+_MANIFEST_NAME = "manifest.json"
+
+# Artifact category-file (section) -> the EntityType it restores. The section
+# key is the YAML leaf the builder wrote under ``dispatcharr`` / ``database``.
+# Sections with no restorable EntityType (settings, scheduled_tasks, …) are not
+# listed and are ignored by the decode — they are restored by the legacy YAML
+# path, not the Phase-2 importers.
+_SECTION_TO_ENTITY: dict[str, EntityType] = {
+    "m3u_accounts": EntityType.M3U_ACCOUNT,
+    "epg_sources": EntityType.EPG_SOURCE,
+    "channel_groups": EntityType.CHANNEL_GROUP,
+    "channel_profiles": EntityType.CHANNEL_PROFILE,
+    "stream_profiles": EntityType.STREAM_PROFILE,
+}
+
+# Where in the parsed category YAML each section's entity list lives. The
+# Dispatcharr-managed sections sit under ``dispatcharr``; ECM DB sections under
+# ``database``. We probe both so the decode is robust to either.
+_YAML_CONTAINERS = ("dispatcharr", "database")
+
+
+def _is_safe_member(name: str) -> bool:
+    """True when an artifact member name is safe to ``zf.read()`` (no traversal).
+
+    Rejects absolute paths, any ``..`` path segment, and backslash separators
+    (a Windows-style traversal). This is a screen on the member NAME only — the
+    decoder never writes a member to disk — but it keeps a crafted listing from
+    widening the read surface beyond the well-formed subtree we expect.
+    """
+    if not name or name.startswith("/") or name.startswith("\\"):
+        return False
+    if "\\" in name:
+        return False
+    # Reject ANY parent-ref segment in the RAW name (before normalisation): a
+    # ``binary/logos/../../x`` collapses to a harmless ``x`` under normpath, which
+    # would mask the traversal intent. Screening the raw segments refuses the
+    # crafted entry outright rather than silently relocating its read target.
+    if ".." in name.split("/"):
+        return False
+    # Belt-and-braces: the normalised form must not escape upward either.
+    normalized = posixpath.normpath(name)
+    return not (normalized.startswith("..") or normalized.startswith("/"))
+
+
+def _extract_section_entities(parsed: object, section_key: str) -> list[dict]:
+    """Pull the entity list for ``section_key`` from a parsed category YAML.
+
+    Probes the ``dispatcharr`` then ``database`` container. Returns a list of
+    dict records (the raw archive rows) or an empty list when the section is
+    absent / malformed — a missing category is a no-op, never a crash.
+    """
+    if not isinstance(parsed, dict):
+        return []
+    for container in _YAML_CONTAINERS:
+        block = parsed.get(container)
+        if isinstance(block, dict) and section_key in block:
+            rows = block[section_key]
+            if isinstance(rows, list):
+                return [r for r in rows if isinstance(r, dict)]
+    return []
+
+
+def _decode_categories(zf: zipfile.ZipFile) -> list[PlanCategory]:
+    """Decode every ``categories/<section>.yaml`` member into PlanCategories.
+
+    Only sections present in :data:`_SECTION_TO_ENTITY` produce a category; a
+    section file that is missing, empty, or carries no rows yields an empty
+    category (still listed so the operator sees "0" rather than a gap).
+    """
+    categories: list[PlanCategory] = []
+    names = set(zf.namelist())
+    for section_key, entity_type in _SECTION_TO_ENTITY.items():
+        member = "%s/%s.yaml" % (_CATEGORY_DIR, section_key)
+        entities: list[dict] = []
+        if member in names and _is_safe_member(member):
+            try:
+                parsed = yaml.safe_load(zf.read(member).decode("utf-8"))
+            except (yaml.YAMLError, UnicodeDecodeError) as exc:
+                # A malformed category YAML is a per-category empty (logged), not
+                # a whole-restore crash. Pre-flight still sees a consistent plan.
+                logger.warning(
+                    "[DBAS-RESTORE] Category %s YAML unreadable; treating as empty: %s",
+                    section_key, exc,
+                )
+                parsed = None
+            entities = _extract_section_entities(parsed, section_key)
+        categories.append(PlanCategory(entity_type=entity_type, entities=entities))
+    return categories
+
+
+def _decode_logo_records(zf: zipfile.ZipFile) -> list[dict]:
+    """Decode the binary logo subtree into per-logo importer records.
+
+    Each ``binary/logos/<rel>`` member becomes a record the logos importer (.15)
+    consumes::
+
+        {"name": <basename-stem>, "filename": <basename>,
+         "content_b64": <base64 of the file bytes>, "size": <byte length>}
+
+    The artifact carries no source logo id, so tier-1 (src) match never applies;
+    the importer's tier-2 (name) / tier-3 (file) match handle reconciliation.
+
+    Member names are screened by :func:`_is_safe_member` before read; an unsafe
+    name is skipped (logged), never read.
+    """
+    records: list[dict] = []
+    prefix = _LOGO_DIR + "/"
+    for name in zf.namelist():
+        if not name.startswith(prefix) or name == prefix:
+            continue
+        if not _is_safe_member(name):
+            logger.warning("[DBAS-RESTORE] Skipping unsafe logo member %r", name)
+            continue
+        info = zf.getinfo(name)
+        if info.is_dir():
+            continue
+        raw = zf.read(name)
+        basename = posixpath.basename(name)
+        if not basename:
+            continue
+        stem = basename.rsplit(".", 1)[0]
+        records.append(
+            {
+                "name": stem,
+                "filename": basename,
+                "content_b64": base64.b64encode(raw).decode("ascii"),
+                "size": len(raw),
+            }
+        )
+    return records
+
+
+def _parse_manifest(zf: zipfile.ZipFile) -> dict:
+    """Parse the cleartext ``manifest.json`` header, or return ``{}`` if absent.
+
+    The caller is expected to have already run
+    :func:`routers.backup.validate_artifact_manifest` (which refuses a missing /
+    malformed / newer-version manifest). This is a best-effort re-parse so the
+    plan carries the manifest for pre-flight's second version check.
+    """
+    import json
+
+    if _MANIFEST_NAME not in zf.namelist():
+        return {}
+    try:
+        manifest = json.loads(zf.read(_MANIFEST_NAME))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.warning("[DBAS-RESTORE] Manifest unreadable during decode: %s", exc)
+        return {}
+    return manifest if isinstance(manifest, dict) else {}
+
+
+def decode_artifact_to_plan(zf: zipfile.ZipFile) -> ImportPlan:
+    """Decode a validated DBAS artifact into an :class:`ImportPlan`.
+
+    PRECONDITION: the caller has already run
+    :func:`routers.backup.validate_artifact_manifest` on ``zf`` (version gate +
+    per-member integrity) — this function does NOT re-run integrity. It builds
+    the plan the orchestrator (.18) / dry-run engine (.16) consume:
+
+    * the parsed manifest (for pre-flight's independent schema-version gate),
+    * one :class:`~dbas.preflight.PlanCategory` per artifact section
+      (M3U / EPG / channel groups / channel profiles / stream profiles), and
+    * a :class:`~dbas.restore_contracts.EntityType.LOGO` category decoded from
+      the binary subtree.
+
+    Args:
+        zf: An OPEN, already-validated artifact ``ZipFile`` (read mode).
+
+    Returns:
+        The :class:`ImportPlan` — categories default to ``selected=True`` so the
+        whole archive is in scope; a caller may deselect categories before
+        handing the plan to the orchestrator.
+    """
+    manifest = _parse_manifest(zf)
+    categories = _decode_categories(zf)
+
+    logo_records = _decode_logo_records(zf)
+    categories.append(
+        PlanCategory(entity_type=EntityType.LOGO, entities=logo_records)
+    )
+
+    logger.info(
+        "[DBAS-RESTORE] Decoded artifact: %s",
+        ", ".join(
+            "%s=%d" % (c.entity_type.value, len(c.entities)) for c in categories
+        ),
+    )
+    return ImportPlan(manifest=manifest, categories=categories)

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -15,6 +15,7 @@ import shutil
 import sqlite3
 import stat
 import tempfile
+import time
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -373,6 +374,24 @@ _RESTORE_UPLOAD_CHUNK = 1024 * 1024  # 1 MiB
 # whole upload to discover the size. 2 GiB is generous headroom over a realistic
 # redacted artifact while still bounding the temp-file write.
 _RESTORE_MAX_UPLOAD_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
+
+# --- Decompression-bomb (D2) caps. -----------------------------------------
+# The 2 GiB upload cap above bounds only the COMPRESSED bytes. A small ZIP with a
+# high compression ratio can still expand to gigabytes on zf.read(), OOMing the
+# single-process container — reachable even on the admin dry-run path. These caps
+# implement the threat-model D2 control (docs/security/threat_model_dbas_import.md
+# §3.5 D2 / checklist 5): they are enforced by iterating zf.infolist() BEFORE any
+# zf.read(), so the bomb member is never decompressed. Values mirror the
+# checklist's ratified defaults (A4): 100x per-entry ratio, 1 GiB cumulative
+# uncompressed, 10,000 entries.
+_ARTIFACT_MAX_ENTRIES = 10_000
+_ARTIFACT_MAX_TOTAL_UNCOMPRESSED = 1 * 1024 * 1024 * 1024  # 1 GiB cumulative
+_ARTIFACT_MAX_ENTRY_RATIO = 100  # max decompressed:compressed per entry
+# A small stored entry (e.g. a 12-byte manifest) has a degenerate ratio; only
+# entries whose compressed size exceeds this floor are ratio-checked, so a tiny
+# stored file is not falsely flagged. The cumulative + per-entry-size caps still
+# bound everything below the floor.
+_ARTIFACT_RATIO_MIN_COMPRESSED = 1024  # 1 KiB
 
 # Headroom multiplier for the pre-build free-disk check. The redacted source
 # (logos + journal.db) is read once into a compressed ZIP; we conservatively
@@ -804,6 +823,68 @@ def validate_restore_schema_version(manifest) -> None:
     )
 
 
+def guard_artifact_against_zip_bomb(zf: zipfile.ZipFile) -> None:
+    """Refuse a decompression-bomb archive BEFORE any member is ``zf.read()``.
+
+    Implements the threat-model D2 control
+    (``docs/security/threat_model_dbas_import.md`` §3.5 / checklist 5). The 2 GiB
+    upload cap bounds only the COMPRESSED bytes; a small high-ratio ZIP can still
+    expand to gigabytes and OOM the single-process container. This guard iterates
+    ``zf.infolist()`` (header metadata only — it never decompresses) and refuses
+    the archive if any of the D2 caps is exceeded:
+
+    * entry count   > :data:`_ARTIFACT_MAX_ENTRIES`
+    * per-entry decompressed:compressed ratio > :data:`_ARTIFACT_MAX_ENTRY_RATIO`
+      (only for entries whose compressed size exceeds
+      :data:`_ARTIFACT_RATIO_MIN_COMPRESSED`, so a tiny stored file is not
+      falsely flagged), and
+    * cumulative declared uncompressed size > :data:`_ARTIFACT_MAX_TOTAL_UNCOMPRESSED`.
+
+    This is the SINGLE shared guard called at the start of validation
+    (:func:`validate_artifact_manifest`) AND at the start of decode
+    (:func:`dbas.restore_artifact.decode_artifact_to_plan`) so both read sites are
+    protected from one place. The refusal message is GENERIC — it leaks no sizes,
+    ratios, or member names to the caller; the specifics are logged server-side.
+
+    Note: ``ZipInfo.file_size`` is the archive's own DECLARED uncompressed size and
+    is attacker-controlled, but that is exactly the point — a bomb DECLARES a huge
+    size, so refusing on the declared size stops the read before CPython would
+    decompress to discover the real size. A liar that under-declares to slip past
+    the ratio/cumulative check is still bounded by the per-entry write loop in the
+    importers (D8 one-at-a-time decode) and the 2 GiB compressed cap.
+    """
+    infos = zf.infolist()
+    if len(infos) > _ARTIFACT_MAX_ENTRIES:
+        logger.warning(
+            "[BACKUP] Refusing restore: archive has %d entries (max %d)",
+            len(infos), _ARTIFACT_MAX_ENTRIES,
+        )
+        raise HTTPException(status_code=400, detail="Backup archive rejected")
+
+    total_uncompressed = 0
+    for info in infos:
+        uncompressed = info.file_size
+        compressed = info.compress_size
+        total_uncompressed += uncompressed
+        if total_uncompressed > _ARTIFACT_MAX_TOTAL_UNCOMPRESSED:
+            logger.warning(
+                "[BACKUP] Refusing restore: cumulative uncompressed size exceeds "
+                "%d bytes (member %s)",
+                _ARTIFACT_MAX_TOTAL_UNCOMPRESSED, info.filename,
+            )
+            raise HTTPException(status_code=400, detail="Backup archive rejected")
+        if compressed > _ARTIFACT_RATIO_MIN_COMPRESSED:
+            ratio = uncompressed / compressed
+            if ratio > _ARTIFACT_MAX_ENTRY_RATIO:
+                logger.warning(
+                    "[BACKUP] Refusing restore: member %s compression ratio %.1f "
+                    "exceeds %dx (%d -> %d bytes)",
+                    info.filename, ratio, _ARTIFACT_MAX_ENTRY_RATIO,
+                    compressed, uncompressed,
+                )
+                raise HTTPException(status_code=400, detail="Backup archive rejected")
+
+
 def _verify_artifact_member_integrity(zf: zipfile.ZipFile, manifest: dict) -> None:
     """Verify each manifest-listed member's SHA-256 against the ZIP bytes.
 
@@ -862,6 +943,10 @@ def validate_artifact_manifest(zf: zipfile.ZipFile) -> dict:
     refusal message is EXACTLY :data:`UNSUPPORTED_BACKUP_VERSION_MESSAGE`. All
     detail is logged server-side.
     """
+    # D2 zip-bomb guard FIRST — before any zf.read(), including the manifest read
+    # below. A high-ratio member must be refused before it can be decompressed.
+    guard_artifact_against_zip_bomb(zf)
+
     if ARTIFACT_MANIFEST_NAME not in zf.namelist():
         logger.warning("[BACKUP] Refusing restore: artifact missing %s", ARTIFACT_MANIFEST_NAME)
         raise HTTPException(status_code=400, detail="Not a valid ECM backup artifact")
@@ -1245,6 +1330,56 @@ async def restore_backup_initial(file: UploadFile = File(...)):
 DBAS_RESTORE_TASK_ID = "dbas_restore"
 _DBAS_RESTORE_TMP_DIR = CONFIG_DIR / "dbas" / "restore_uploads"
 
+# Age after which an abandoned restore temp is swept (O8TBV-4). The DbasRestoreTask
+# normally deletes its own temp in a finally; this only catches temps orphaned
+# when the fire-and-forget coroutine returns BEFORE execute() runs (task-not-found
+# or an ALREADY_RUNNING concurrency reject — neither reaches the task's finally).
+# A few hours is comfortably longer than the longest realistic restore, so the
+# sweep never races a live run that still owns its temp.
+_DBAS_RESTORE_TMP_MAX_AGE_SECONDS = 6 * 60 * 60  # 6 hours
+
+
+def _sweep_stale_restore_temps(dest_dir: Path) -> None:
+    """Best-effort removal of abandoned restore temp artifacts (O8TBV-4).
+
+    The DbasRestoreTask owns teardown of its own temp in a ``finally`` block, so
+    the common path leaves nothing behind. But the trigger endpoint schedules the
+    task fire-and-forget via ``asyncio.create_task``; if that coroutine returns
+    before ``execute()`` ever runs — ``run_task`` returns ``None`` (task id not
+    registered) or an ``ALREADY_RUNNING`` result for a concurrent run — the task's
+    ``finally`` never fires and the 0600 temp ZIP is orphaned. This sweep, run at
+    the START of each restore trigger, removes temps older than
+    :data:`_DBAS_RESTORE_TMP_MAX_AGE_SECONDS` so an orphan cannot accumulate.
+
+    It never deletes a fresh temp (a live run still owns it — the age floor is far
+    longer than any realistic restore) and never double-deletes (a finished task
+    already unlinked its own). Any error is swallowed with a WARN — a sweep
+    failure must never block a legitimate restore.
+    """
+    if not dest_dir.exists():
+        return
+    cutoff = time.time() - _DBAS_RESTORE_TMP_MAX_AGE_SECONDS
+    removed = 0
+    try:
+        candidates = list(dest_dir.glob("ecm-restore-*.zip"))
+    except OSError as exc:
+        logger.warning("[BACKUP] Could not list restore temp dir for sweep: %s", exc)
+        return
+    for candidate in candidates:
+        try:
+            if candidate.stat().st_mtime < cutoff:
+                candidate.unlink()
+                removed += 1
+        except FileNotFoundError:
+            # Already gone (raced with a task's own finally) — fine.
+            continue
+        except OSError as exc:
+            logger.warning(
+                "[BACKUP] Failed to sweep stale restore temp %s: %s", candidate, exc
+            )
+    if removed:
+        logger.info("[BACKUP] Swept %d stale restore temp artifact(s)", removed)
+
 
 async def _stream_upload_to_temp(file: UploadFile, dest_dir: Path) -> Path:
     """Stream an uploaded artifact to a 0600 temp file, chunk by chunk.
@@ -1334,6 +1469,10 @@ async def restore_dbas_artifact(
         "[BACKUP] DBAS restore requested (filename=%s, confirm_apply=%s)",
         file.filename, confirm_apply,
     )
+
+    # Sweep any temp orphaned by a previous fire-and-forget run that returned
+    # before its task's finally could clean up (task-not-found / ALREADY_RUNNING).
+    _sweep_stale_restore_temps(_DBAS_RESTORE_TMP_DIR)
 
     tmp_path = await _stream_upload_to_temp(file, _DBAS_RESTORE_TMP_DIR)
 

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -4,6 +4,7 @@ Backup & Restore router — create and restore ECM configuration backups.
 Backs up: settings.json, journal.db, uploads/logos/, tls/, m3u_uploads/
 YAML export: settings + DB tables + Dispatcharr state in a single file.
 """
+import asyncio
 import hashlib
 import io
 import json
@@ -12,6 +13,7 @@ import os
 import re
 import shutil
 import sqlite3
+import stat
 import tempfile
 import zipfile
 from datetime import datetime, timezone
@@ -359,6 +361,18 @@ ARTIFACT_BINARY_URL_MAPPINGS = "binary/url-mappings.json"
 
 # Streaming chunk size for SHA-256 computation over the finished artifact.
 _SHA256_CHUNK = 1024 * 1024  # 1 MiB
+
+# Restore-upload streaming chunk size — the uploaded artifact is streamed to a
+# temp file ONE chunk at a time (never read whole-in-RAM, mirrors the .7/.15
+# streaming discipline; ADR-008 D8). 1 MiB chunks keep the per-read buffer small.
+_RESTORE_UPLOAD_CHUNK = 1024 * 1024  # 1 MiB
+
+# Hard cap on an uploaded restore artifact (the binary logo subtree can be large,
+# but a multi-GB upload is an abuse signal / DoS surface). The stream loop aborts
+# and cleans up the moment cumulative bytes exceed this — it never buffers the
+# whole upload to discover the size. 2 GiB is generous headroom over a realistic
+# redacted artifact while still bounding the temp-file write.
+_RESTORE_MAX_UPLOAD_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
 
 # Headroom multiplier for the pre-build free-disk check. The redacted source
 # (logos + journal.db) is read once into a compressed ZIP; we conservatively
@@ -1209,6 +1223,153 @@ async def restore_backup_initial(file: UploadFile = File(...)):
         "backup_version": manifest.get("version", "unknown"),
         "backup_date": manifest.get("created_at", "unknown"),
         "restored_files": restored,
+    }
+
+
+# ---------------------------------------------------------------------------
+# DBAS async restore-trigger endpoint (bead enhancedchannelmanager-o8tbv)
+#
+# The new-format DBAS artifact restore — the async, progress-emitting path that
+# makes restore user-triggerable. UNTRUSTED-ARTIFACT-UPLOAD surface:
+#   * admin-auth only (RequireAdminIfEnabled, like every restore endpoint here),
+#   * the upload is STREAMED to a temp file on the CONFIG partition one chunk at
+#     a time (never read whole-in-RAM — ADR-008 D8), mode 0600,
+#   * a hard size cap aborts + cleans up an oversize upload mid-stream,
+#   * validation (.17 version + integrity) runs INSIDE the task BEFORE any
+#     mutation, and the orchestrator's default-ON dry-run guardrail means APPLY
+#     requires an explicit confirm flag.
+# The endpoint kicks the DbasRestoreTask in the background and returns its
+# task id immediately; the frontend polls /api/tasks/{id} for per-stage progress.
+# ---------------------------------------------------------------------------
+
+DBAS_RESTORE_TASK_ID = "dbas_restore"
+_DBAS_RESTORE_TMP_DIR = CONFIG_DIR / "dbas" / "restore_uploads"
+
+
+async def _stream_upload_to_temp(file: UploadFile, dest_dir: Path) -> Path:
+    """Stream an uploaded artifact to a 0600 temp file, chunk by chunk.
+
+    NEVER reads the whole upload into RAM (ADR-008 D8) — it copies
+    ``_RESTORE_UPLOAD_CHUNK`` bytes at a time and enforces
+    :data:`_RESTORE_MAX_UPLOAD_BYTES`, aborting + unlinking the partial temp the
+    moment the cumulative size exceeds the cap (so an oversize upload can never
+    fill the partition). The temp file is created mode 0600 (owner-only) because
+    the artifact may carry credential-bearing material (journal.db) even though
+    it is redacted-by-default.
+
+    Returns the temp file path on success. Raises ``HTTPException(413)`` on
+    oversize and ``HTTPException(400)`` on a read error — the partial temp is
+    cleaned up in both cases.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix="ecm-restore-", suffix=".zip", dir=str(dest_dir))
+    tmp_path = Path(tmp_name)
+    # Owner read/write only — the artifact may carry sensitive (if redacted) data.
+    try:
+        os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:  # pragma: no cover — platform without fchmod
+        pass
+
+    total = 0
+    try:
+        with os.fdopen(fd, "wb") as out:
+            while True:
+                try:
+                    chunk = await file.read(_RESTORE_UPLOAD_CHUNK)
+                except Exception as exc:  # noqa: BLE001 - any read error is a 400
+                    raise HTTPException(status_code=400, detail="Failed to read uploaded artifact") from exc
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > _RESTORE_MAX_UPLOAD_BYTES:
+                    logger.warning(
+                        "[BACKUP] Refusing restore: upload exceeded size cap (%d bytes max)",
+                        _RESTORE_MAX_UPLOAD_BYTES,
+                    )
+                    raise HTTPException(
+                        status_code=413, detail="Uploaded artifact is too large"
+                    )
+                out.write(chunk)
+    except Exception:
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError as exc:
+            logger.warning("[BACKUP] Failed to clean up partial restore upload: %s", exc)
+        raise
+
+    if total == 0:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise HTTPException(status_code=400, detail="Uploaded artifact is empty")
+
+    logger.info("[BACKUP] Streamed restore artifact to temp (%d bytes)", total)
+    return tmp_path
+
+
+@router.post("/restore-dbas")
+async def restore_dbas_artifact(
+    file: UploadFile = File(...),
+    confirm_apply: bool = Query(
+        default=False,
+        description="False (default) runs a counts-only dry-run; True runs the apply.",
+    ),
+    _admin=RequireAdminIfEnabled,
+):
+    """Trigger an async DBAS artifact restore. Admin only.
+
+    Streams the uploaded artifact to a temp file on the CONFIG partition, then
+    kicks the :class:`tasks.dbas_restore.DbasRestoreTask` in the background and
+    returns its ``task_id`` so the frontend can poll ``/api/tasks/{task_id}`` for
+    per-stage progress and the terminal ``RestoreReport``.
+
+    DRY-RUN is default-ON: without ``confirm_apply=True`` the run is a counts-only
+    plan that makes ZERO mutation (the orchestrator's .16 guardrail enforces this
+    even if this flag were bypassed). Validation (.17 version + integrity) runs
+    inside the task BEFORE any decode or importer.
+    """
+    logger.info(
+        "[BACKUP] DBAS restore requested (filename=%s, confirm_apply=%s)",
+        file.filename, confirm_apply,
+    )
+
+    tmp_path = await _stream_upload_to_temp(file, _DBAS_RESTORE_TMP_DIR)
+
+    # Configure + kick the restore task. The task owns temp-artifact teardown
+    # (cleanup_artifact=True) so the file never outlives the run.
+    parameters = {
+        "artifact_path": str(tmp_path),
+        "confirm_apply": bool(confirm_apply),
+        "cleanup_artifact": True,
+    }
+
+    try:
+        from task_engine import get_engine
+
+        engine = get_engine()
+        # Fire-and-forget: run_task awaits to completion, so schedule it as a
+        # background asyncio task and return the task id immediately. The
+        # frontend polls /api/tasks/{id} for live progress. The task's own
+        # finally-block cleans up the temp artifact on success AND failure.
+        asyncio.create_task(
+            engine.run_task(DBAS_RESTORE_TASK_ID, parameters=parameters)
+        )
+    except Exception as exc:
+        logger.exception("[BACKUP] Failed to schedule DBAS restore task: %s", exc)
+        # Scheduling failed before the task could own cleanup — remove the temp.
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
+        raise HTTPException(status_code=500, detail="Failed to start restore")
+
+    return {
+        "status": "started",
+        "task_id": DBAS_RESTORE_TASK_ID,
+        "is_dry_run": not confirm_apply,
     }
 
 

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -10,12 +10,22 @@ from typing import Literal, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, model_validator
 
+from auth import ResolveIsAdminIfEnabled
 from database import get_session
 from dispatcharr_client import get_client
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Tasks"])
+
+# Task ids that may ONLY be driven by an admin (or in auth-disabled setup mode).
+# These tasks restore/produce credential-bearing backup artifacts and reach the
+# same destructive restore path as the admin-gated /restore-dbas endpoint. The
+# generic POST /api/tasks/{task_id}/run endpoint is reachable by ordinary users
+# for ordinary tasks, so it must NOT carry a blanket admin dependency — instead
+# it admin-gates exactly these privileged ids (O8TBV-1). Keep this set in sync
+# with any new privileged task registered in backend/tasks/.
+PRIVILEGED_TASK_IDS = frozenset({"dbas_restore", "dbas_backup"})
 
 
 # -------------------------------------------------------------------------
@@ -543,9 +553,23 @@ async def update_task(task_id: str, config: TaskConfigUpdate):
 
 
 @router.post("/api/tasks/{task_id}/run", tags=["Tasks"])
-async def run_task(task_id: str, request: Optional[TaskRunRequest] = None):
-    """Manually trigger a task execution."""
+async def run_task(
+    task_id: str,
+    request: Optional[TaskRunRequest] = None,
+    is_admin: bool = ResolveIsAdminIfEnabled,
+):
+    """Manually trigger a task execution.
+
+    Ordinary, user-triggerable tasks are unchanged. Privileged tasks
+    (:data:`PRIVILEGED_TASK_IDS` — the DBAS backup/restore tasks that reach the
+    admin-gated restore path) are refused for authenticated non-admins (O8TBV-1).
+    """
     logger.debug("[TASKS] POST /api/tasks/%s/run", task_id)
+    if task_id in PRIVILEGED_TASK_IDS and not is_admin:
+        logger.warning(
+            "[TASKS] Refusing privileged task run for non-admin: task=%s", task_id
+        )
+        raise HTTPException(status_code=403, detail="Admin access required")
     try:
         from task_engine import get_engine
         engine = get_engine()
@@ -565,9 +589,19 @@ async def run_task(task_id: str, request: Optional[TaskRunRequest] = None):
 
 
 @router.post("/api/tasks/{task_id}/cancel", tags=["Tasks"])
-async def cancel_task(task_id: str):
-    """Cancel a running task."""
+async def cancel_task(task_id: str, is_admin: bool = ResolveIsAdminIfEnabled):
+    """Cancel a running task.
+
+    Privileged tasks (:data:`PRIVILEGED_TASK_IDS`) are refused for non-admins,
+    mirroring :func:`run_task` (O8TBV-1) so a non-admin can neither start nor
+    interfere with a privileged task.
+    """
     logger.debug("[TASKS] POST /api/tasks/%s/cancel", task_id)
+    if task_id in PRIVILEGED_TASK_IDS and not is_admin:
+        logger.warning(
+            "[TASKS] Refusing privileged task cancel for non-admin: task=%s", task_id
+        )
+        raise HTTPException(status_code=403, detail="Admin access required")
     try:
         from task_engine import get_engine
         engine = get_engine()

--- a/backend/tasks/__init__.py
+++ b/backend/tasks/__init__.py
@@ -19,6 +19,7 @@ from tasks.black_screen_scan import BlackScreenScanTask
 from tasks.export_publish import ExportPublishTask
 from tasks.yaml_backup import YamlBackupTask
 from tasks.dbas_backup import DbasBackupTask
+from tasks.dbas_restore import DbasRestoreTask
 from tasks.stats_v2_rollup import StatsV2RollupTask
 
 __all__ = [
@@ -36,5 +37,6 @@ __all__ = [
     "ExportPublishTask",
     "YamlBackupTask",
     "DbasBackupTask",
+    "DbasRestoreTask",
     "StatsV2RollupTask",
 ]

--- a/backend/tasks/dbas_restore.py
+++ b/backend/tasks/dbas_restore.py
@@ -1,0 +1,333 @@
+"""DBAS Restore Task (bead ``enhancedchannelmanager-o8tbv``).
+
+The async, progress-emitting restore that makes a new-format DBAS artifact
+user-triggerable and observable — the missing integration piece for the
+v0.18.0 full round-trip. Mirrors :class:`tasks.dbas_backup.DbasBackupTask`: a
+``TaskScheduler`` subclass whose ``execute()`` runs the whole restore pipeline
+and emits ``_set_progress`` at each of the 13 canonical stages
+(``frontend/src/utils/restoreStages.ts``) so the frontend can poll
+``/api/tasks/{id}`` and render "Stage N of M".
+
+Pipeline (validate -> decode -> dry-run-default -> orchestrate)
+---------------------------------------------------------------
+1. Open the streamed-to-disk artifact (the restore endpoint streamed the upload
+   to a temp file on the CONFIG partition; this task never sees the raw upload).
+2. ``routers.backup.validate_artifact_manifest`` — the .17 gate (version +
+   per-member SHA-256) runs BEFORE any decode or mutation. A refusal returns a
+   failed ``TaskResult`` with ZERO importer ever called.
+3. ``dbas.restore_artifact.decode_artifact_to_plan`` — turn the validated ZIP
+   into the orchestrator's :class:`~dbas.preflight.ImportPlan` (per-category
+   records + the binary logo subtree decoded into .15 logo records).
+4. Run the orchestrator. **Dry-run is default-ON** (.16): the task calls
+   :func:`dbas.restore_orchestrator.run_dry_run` UNLESS the task config carries
+   ``confirm_apply=True``, in which case it calls ``run_restore(...,
+   confirm_apply=True)`` with the apply registry. The orchestrator's own
+   guardrail is the final, unbypassable enforcement — even a misconfigured task
+   degrades to a counts-only dry-run rather than mutating.
+5. Return the :class:`~dbas.restore_contracts.RestoreReport` in the
+   ``TaskResult.details`` so the frontend's ``.20`` summary can render it.
+
+Temp-artifact cleanup
+---------------------
+The task deletes the temp artifact on BOTH success and failure (the endpoint
+owns creation; the task owns teardown so the file does not outlive the run).
+``cleanup_artifact`` defaults to True; the restore endpoint sets it.
+
+Security (untrusted upload — security-review surface)
+-----------------------------------------------------
+Validate-before-mutate is structural: ``validate_artifact_manifest`` runs before
+``decode_artifact_to_plan``, which runs before the orchestrator. The decode
+itself never extracts to disk (zip-slip safe — see ``dbas.restore_artifact``).
+Logging is credential-clean: only safe fields (filename, schema_version, counts,
+outcome) are logged; never an artifact path that could embed a token, never an
+upstream SDK body. The temp artifact is the endpoint's concern for mode/cleanup.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from task_registry import register_task
+from task_scheduler import ScheduleConfig, ScheduleType, TaskResult, TaskScheduler
+
+logger = logging.getLogger(__name__)
+
+
+# The canonical stage keys, in order, aligned 1:1 with the keys in
+# ``frontend/src/utils/restoreStages.ts`` (RESTORE_STAGES). The frontend maps a
+# ``current_item`` string back to "Stage N of M" by these keys, so they MUST
+# match. ``preflight`` is the entry stage; ``finalize`` is the terminal stage.
+_STAGE_KEYS: tuple[str, ...] = (
+    "preflight",
+    "m3u_account",
+    "epg_source",
+    "channel_group",
+    "channel_profile",
+    "stream_profile",
+    "user_agent",
+    "user",
+    "channel",
+    "stream",
+    "logo",
+    "deferred",
+    "finalize",
+)
+_TOTAL_STAGES = len(_STAGE_KEYS)
+
+
+@register_task
+class DbasRestoreTask(TaskScheduler):
+    """Run a new-format DBAS artifact restore as an async, progress-emitting task.
+
+    Configuration options (stored on the instance via ``update_config`` — the
+    restore endpoint passes them as ad-hoc run parameters):
+
+    - ``artifact_path``: str — the temp artifact the endpoint streamed the upload
+      to. Required; an absent/empty path is a hard failure (nothing to restore).
+    - ``confirm_apply``: bool — ``False`` (default) runs a counts-only DRY-RUN;
+      ``True`` runs the destructive APPLY through the orchestrator's apply
+      registry. The orchestrator re-enforces this (.16 guardrail), so a stale
+      ``True`` against an unsupported plan still degrades safely to a dry-run.
+    - ``cleanup_artifact``: bool — delete the temp artifact on completion
+      (default ``True``).
+    """
+
+    task_id = "dbas_restore"
+    task_name = "DBAS Restore"
+    task_description = (
+        "Restore a new-format DBAS backup artifact (validate -> decode -> "
+        "dry-run by default; apply only when confirmed). Emits per-stage progress."
+    )
+    default_enabled = False
+
+    def __init__(self, schedule_config: Optional[ScheduleConfig] = None):
+        if schedule_config is None:
+            schedule_config = ScheduleConfig(schedule_type=ScheduleType.MANUAL)
+        super().__init__(schedule_config)
+
+        self.artifact_path: Optional[str] = None
+        self.confirm_apply: bool = False
+        self.cleanup_artifact: bool = True
+
+    def get_config(self) -> dict:
+        return {
+            "artifact_path": self.artifact_path,
+            "confirm_apply": self.confirm_apply,
+            "cleanup_artifact": self.cleanup_artifact,
+        }
+
+    def update_config(self, config: dict) -> None:
+        if "artifact_path" in config:
+            val = config["artifact_path"]
+            self.artifact_path = str(val) if val is not None else None
+        if "confirm_apply" in config:
+            self.confirm_apply = bool(config["confirm_apply"])
+        if "cleanup_artifact" in config:
+            self.cleanup_artifact = bool(config["cleanup_artifact"])
+
+    # -- progress helpers ----------------------------------------------------
+
+    def _stage(self, key: str, *, success: int = 0, failed: int = 0, skipped: int = 0) -> None:
+        """Advance progress to a named stage (current_item = the restoreStages key)."""
+        idx = _STAGE_KEYS.index(key)
+        self._set_progress(
+            total=_TOTAL_STAGES,
+            current=idx + 1,
+            status="running",
+            current_item=key,
+            success_count=success,
+            failed_count=failed,
+            skipped_count=skipped,
+        )
+
+    async def execute(self) -> TaskResult:
+        started_at = datetime.now(timezone.utc)
+        self._set_progress(
+            total=_TOTAL_STAGES, current=0, status="starting",
+            current_item="preflight",
+        )
+
+        artifact = self.artifact_path
+        if not artifact:
+            return self._fail(started_at, "No artifact_path configured for restore")
+
+        artifact_path = Path(artifact)
+        try:
+            return await self._run_restore(started_at, artifact_path)
+        finally:
+            self._cleanup(artifact_path)
+
+    async def _run_restore(self, started_at: datetime, artifact_path: Path) -> TaskResult:
+        # Local imports keep the heavy backup router / orchestrator off this
+        # module's import-time path (mirrors DbasBackupTask's deferred imports).
+        from dispatcharr_client import get_client
+        from routers.backup import validate_artifact_manifest
+        from dbas.restore_artifact import decode_artifact_to_plan
+        from dbas.restore_orchestrator import run_dry_run, run_restore, new_restore_id
+        from dbas.restore_contracts import IdRemapTable, RestoreReport, RollbackLedger
+        from dbas.restore_orchestrator import default_importer_steps
+
+        from fastapi import HTTPException
+
+        if not artifact_path.exists():
+            return self._fail(started_at, "Restore artifact is missing")
+
+        # --- Stage 0: pre-flight (validate-before-mutate). -----------------
+        # validate_artifact_manifest is the .17 gate: version + per-member
+        # SHA-256, BEFORE any decode or importer. A refusal here means ZERO
+        # mutation ever happened.
+        self._stage("preflight")
+        try:
+            with zipfile.ZipFile(artifact_path, "r") as zf:
+                validate_artifact_manifest(zf)   # .17 — raises HTTPException(400) on refusal
+                plan = decode_artifact_to_plan(zf)  # decode the validated ZIP
+        except zipfile.BadZipFile:
+            return self._fail(started_at, "Uploaded artifact is not a valid archive")
+        except HTTPException as exc:
+            # .17 refused (version/integrity). NO importer ran. Surface the
+            # sanitized message; never leak schema internals.
+            return self._fail(started_at, str(exc.detail))
+
+        is_apply = bool(self.confirm_apply)
+        client = get_client()
+
+        try:
+            if is_apply:
+                report = await run_restore(
+                    plan=plan,
+                    client=client,
+                    steps=default_importer_steps(),
+                    report=RestoreReport(is_dry_run=False),
+                    ledger=RollbackLedger(restore_id=new_restore_id()),
+                    remap=plan.existing_remap or IdRemapTable(),
+                    confirm_apply=True,
+                )
+            else:
+                report = await run_dry_run(plan=plan, client=client)
+        except Exception as exc:  # noqa: BLE001 - any orchestration error is a sanitized failure
+            logger.exception("[DBAS-RESTORE] Restore orchestration failed: %s", exc)
+            return self._fail(started_at, "Restore failed during orchestration")
+
+        # --- Per-category stages: emit one tick per restoreStages key with the
+        #     category's realized (apply) or planned (dry-run) counts. ---------
+        self._emit_category_stages(report)
+
+        # --- Deferred + finalize. ------------------------------------------
+        self._stage("deferred")
+        self._set_progress(current=_TOTAL_STAGES, status="completed", current_item="finalize")
+
+        outcome = report.outcome.value if report.outcome else "dry_run"
+        mode = "apply" if is_apply else "dry-run"
+        logger.info(
+            "[DBAS-RESTORE] Restore task complete (mode=%s, outcome=%s, %d categories)",
+            mode, outcome, len(report.categories),
+        )
+        return TaskResult(
+            success=self._report_succeeded(report, is_apply),
+            message=self._summary_message(report, is_apply),
+            started_at=started_at,
+            completed_at=datetime.now(timezone.utc),
+            total_items=_TOTAL_STAGES,
+            success_count=_TOTAL_STAGES,
+            details={
+                "is_dry_run": report.is_dry_run,
+                "outcome": outcome,
+                "restore_report": report.model_dump(mode="json"),
+            },
+        )
+
+    # -- stage emission ------------------------------------------------------
+
+    def _emit_category_stages(self, report) -> None:
+        """Emit a ``_set_progress`` tick for each per-category restoreStages key.
+
+        Each category's counts come straight from the orchestrator's report (the
+        same counts the .20 summary renders), so the per-stage progress is a true
+        reflection of what happened, not a parallel counter.
+        """
+        # entity_type.value already equals the restoreStages key for every
+        # category EntityType (m3u_account, epg_source, …, channel, logo).
+        by_type = {cat.entity_type.value: cat for cat in report.categories}
+        for key in _STAGE_KEYS:
+            if key in ("preflight", "deferred", "finalize"):
+                continue
+            cat = by_type.get(key)
+            if cat is None:
+                # A stage with no category in the report (e.g. user_agent seam,
+                # stream) still advances the bar so the UI shows linear motion.
+                self._stage(key)
+                continue
+            if report.is_dry_run:
+                self._stage(
+                    key,
+                    success=cat.would_create + cat.would_update,
+                    skipped=cat.would_skip,
+                )
+            else:
+                self._stage(
+                    key,
+                    success=cat.created + cat.updated,
+                    failed=cat.failed,
+                    skipped=cat.skipped,
+                )
+
+    # -- result shaping ------------------------------------------------------
+
+    @staticmethod
+    def _report_succeeded(report, is_apply: bool) -> bool:
+        """A dry-run always 'succeeds' (it produced a plan); an apply succeeds
+        only on a clean SUCCESS outcome (never on a rolled-back/incomplete state)."""
+        from dbas.restore_contracts import RestoreOutcome
+
+        if not is_apply or report.is_dry_run:
+            return True
+        return report.outcome == RestoreOutcome.SUCCESS
+
+    @staticmethod
+    def _summary_message(report, is_apply: bool) -> str:
+        if report.is_dry_run or not is_apply:
+            total_create = sum(c.would_create for c in report.categories)
+            total_update = sum(c.would_update for c in report.categories)
+            total_skip = sum(c.would_skip for c in report.categories)
+            return (
+                "Dry-run complete: would create %d, update %d, skip %d "
+                "across %d categories" % (
+                    total_create, total_update, total_skip, len(report.categories),
+                )
+            )
+        outcome = report.outcome.value if report.outcome else "unknown"
+        total_created = sum(c.created for c in report.categories)
+        total_failed = sum(c.failed for c in report.categories)
+        return (
+            "Restore %s: created %d, failed %d across %d categories" % (
+                outcome, total_created, total_failed, len(report.categories),
+            )
+        )
+
+    def _fail(self, started_at: datetime, message: str) -> TaskResult:
+        """Build a failed TaskResult and mark progress failed (sanitized message)."""
+        logger.warning("[DBAS-RESTORE] %s", message)
+        self._set_progress(status="failed", current_item="finalize")
+        return TaskResult(
+            success=False,
+            message=message,
+            error=message,
+            started_at=started_at,
+            completed_at=datetime.now(timezone.utc),
+            failed_count=1,
+        )
+
+    def _cleanup(self, artifact_path: Path) -> None:
+        """Delete the temp artifact on completion/failure (best-effort)."""
+        if not self.cleanup_artifact:
+            return
+        try:
+            if artifact_path.exists():
+                artifact_path.unlink()
+                logger.info("[DBAS-RESTORE] Cleaned up temp artifact")
+        except OSError as exc:
+            logger.warning("[DBAS-RESTORE] Failed to clean up temp artifact: %s", exc)

--- a/backend/tests/dbas/test_restore_artifact_decode.py
+++ b/backend/tests/dbas/test_restore_artifact_decode.py
@@ -1,0 +1,181 @@
+"""Tests for the DBAS artifact decoder (bead enhancedchannelmanager-o8tbv).
+
+Covers ``dbas.restore_artifact.decode_artifact_to_plan`` — the glue that turns a
+validated new-format DBAS artifact ZIP into the orchestrator's
+:class:`~dbas.preflight.ImportPlan`:
+
+  * per-category YAML (``categories/<section>.yaml``) -> PlanCategory entities,
+  * the binary logo subtree (``binary/logos/<rel>``) -> .15 logo records
+    (``name`` / ``filename`` / ``content_b64`` / ``size``),
+  * the cleartext manifest carried through for pre-flight's version gate,
+  * zip-slip / path-traversal member-name safety.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+import zipfile
+
+import yaml
+
+from dbas.restore_artifact import (
+    _is_safe_member,
+    decode_artifact_to_plan,
+)
+from dbas.restore_contracts import EntityType
+
+
+def _category_yaml(section_key: str, rows: list[dict], container: str = "dispatcharr") -> bytes:
+    """Build a category YAML the way build_yaml_export does (section under a container)."""
+    data = {
+        "ecm_export": {"version": "0.17.6-test", "sections_included": [section_key]},
+        container: {section_key: rows},
+    }
+    return yaml.dump(data, sort_keys=False).encode("utf-8")
+
+
+# 1x1 PNG so the logos importer's later magic-byte check would pass.
+_PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+def _build_artifact(
+    *,
+    m3u=None,
+    epg=None,
+    groups=None,
+    logos=None,
+    schema_version=1,
+    extra_members=None,
+) -> bytes:
+    """Build a new-format artifact ZIP with chosen categories + logo files."""
+    members: dict[str, bytes] = {}
+    if m3u is not None:
+        members["categories/m3u_accounts.yaml"] = _category_yaml("m3u_accounts", m3u)
+    if epg is not None:
+        members["categories/epg_sources.yaml"] = _category_yaml("epg_sources", epg)
+    if groups is not None:
+        members["categories/channel_groups.yaml"] = _category_yaml("channel_groups", groups)
+    for filename, blob in (logos or {}).items():
+        members["binary/logos/%s" % filename] = blob
+    if extra_members:
+        members.update(extra_members)
+
+    import hashlib
+
+    file_hashes = {p: hashlib.sha256(b).hexdigest() for p, b in members.items()}
+    manifest = {
+        "schema_version": schema_version,
+        "app_version": "0.17.6-test",
+        "files": [{"path": p, "sha256": h} for p, h in sorted(file_hashes.items())],
+    }
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(manifest))
+        for path, blob in members.items():
+            zf.writestr(path, blob)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def _open(zip_bytes: bytes) -> zipfile.ZipFile:
+    return zipfile.ZipFile(io.BytesIO(zip_bytes), "r")
+
+
+class TestCategoryDecode:
+    def test_decodes_m3u_accounts(self):
+        art = _build_artifact(m3u=[{"id": 1, "name": "Provider A"}, {"id": 2, "name": "Provider B"}])
+        with _open(art) as zf:
+            plan = decode_artifact_to_plan(zf)
+        cat = plan.category(EntityType.M3U_ACCOUNT)
+        assert cat is not None
+        assert [e["name"] for e in cat.entities] == ["Provider A", "Provider B"]
+
+    def test_decodes_multiple_categories(self):
+        art = _build_artifact(
+            m3u=[{"id": 1, "name": "P"}],
+            epg=[{"id": 5, "name": "XMLTV"}],
+            groups=[{"id": 10, "name": "Sports"}],
+        )
+        with _open(art) as zf:
+            plan = decode_artifact_to_plan(zf)
+        assert len(plan.category(EntityType.M3U_ACCOUNT).entities) == 1
+        assert len(plan.category(EntityType.EPG_SOURCE).entities) == 1
+        assert plan.category(EntityType.CHANNEL_GROUP).entities[0]["name"] == "Sports"
+
+    def test_missing_category_is_empty_not_crash(self):
+        art = _build_artifact(m3u=[{"id": 1, "name": "P"}])
+        with _open(art) as zf:
+            plan = decode_artifact_to_plan(zf)
+        # EPG was not in the artifact — present in the plan but empty.
+        epg = plan.category(EntityType.EPG_SOURCE)
+        assert epg is not None and epg.entities == []
+
+    def test_manifest_carried_through(self):
+        art = _build_artifact(m3u=[{"id": 1, "name": "P"}], schema_version=1)
+        with _open(art) as zf:
+            plan = decode_artifact_to_plan(zf)
+        assert plan.manifest.get("schema_version") == 1
+
+    def test_database_container_section(self):
+        # A section emitted under `database` (ECM DB) is also extracted.
+        members = {
+            "categories/channel_groups.yaml": _category_yaml(
+                "channel_groups", [{"id": 7, "name": "DB-sourced"}], container="database"
+            )
+        }
+        art = _build_artifact(extra_members=members)
+        with _open(art) as zf:
+            plan = decode_artifact_to_plan(zf)
+        assert plan.category(EntityType.CHANNEL_GROUP).entities[0]["name"] == "DB-sourced"
+
+
+class TestLogoDecode:
+    def test_decodes_logo_records(self):
+        art = _build_artifact(logos={"espn.png": _PNG_BYTES})
+        with _open(art) as zf:
+            plan = decode_artifact_to_plan(zf)
+        logos = plan.category(EntityType.LOGO).entities
+        assert len(logos) == 1
+        rec = logos[0]
+        assert rec["filename"] == "espn.png"
+        assert rec["name"] == "espn"
+        assert rec["size"] == len(_PNG_BYTES)
+        # content_b64 round-trips to the original bytes (the .15 importer decodes it).
+        assert base64.b64decode(rec["content_b64"]) == _PNG_BYTES
+
+    def test_nested_logo_basename(self):
+        art = _build_artifact(logos={"sub/dir/cnn.png": _PNG_BYTES})
+        with _open(art) as zf:
+            plan = decode_artifact_to_plan(zf)
+        logos = plan.category(EntityType.LOGO).entities
+        # The decoder records the basename, not the nested path.
+        assert logos[0]["filename"] == "cnn.png"
+
+    def test_no_logos_is_empty_category(self):
+        art = _build_artifact(m3u=[{"id": 1, "name": "P"}])
+        with _open(art) as zf:
+            plan = decode_artifact_to_plan(zf)
+        assert plan.category(EntityType.LOGO).entities == []
+
+
+class TestZipSlipSafety:
+    def test_is_safe_member_rejects_traversal(self):
+        assert not _is_safe_member("../etc/passwd")
+        assert not _is_safe_member("/abs/path")
+        assert not _is_safe_member("binary/logos/../../x")
+        assert not _is_safe_member("binary\\logos\\x.png")
+        assert _is_safe_member("binary/logos/ok.png")
+        assert _is_safe_member("categories/m3u_accounts.yaml")
+
+    def test_malicious_logo_member_skipped(self):
+        # A crafted entry escaping the logos subtree must not become a record.
+        members = {"binary/logos/../../evil.png": _PNG_BYTES}
+        art = _build_artifact(logos={"good.png": _PNG_BYTES}, extra_members=members)
+        with _open(art) as zf:
+            plan = decode_artifact_to_plan(zf)
+        names = {r["filename"] for r in plan.category(EntityType.LOGO).entities}
+        assert "good.png" in names
+        assert "evil.png" not in names

--- a/backend/tests/dbas/test_restore_roundtrip.py
+++ b/backend/tests/dbas/test_restore_roundtrip.py
@@ -1,0 +1,132 @@
+"""Round-trip integration test (bead enhancedchannelmanager-o8tbv).
+
+Proves the full v0.18.0 round-trip seam at mock level:
+
+    build_backup_artifact  ->  validate_artifact_manifest (.17)
+        ->  decode_artifact_to_plan  ->  run_dry_run (.16)  ->  RestoreReport
+
+The Dispatcharr client is mocked at module level (no live upstream). The LIVE
+round-trip against a real Dispatcharr is the DEFERRED success-signal verification
+flagged in the bead — this asserts the wiring produces a coherent RestoreReport
+with sane per-category counts.
+"""
+from __future__ import annotations
+
+import sqlite3
+import zipfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from routers import backup as backup_mod
+from routers.backup import build_backup_artifact, validate_artifact_manifest
+from dbas.restore_artifact import decode_artifact_to_plan
+from dbas.restore_contracts import EntityType
+from dbas.restore_orchestrator import run_dry_run
+
+
+def _mock_engine():
+    engine = MagicMock()
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = (0,)
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=conn)
+    cm.__exit__ = MagicMock(return_value=False)
+    engine.connect.return_value = cm
+    return engine
+
+
+def _seed_journal_db(path):
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+async def _build_real_artifact(tmp_path):
+    """Build a real artifact carrying two M3U accounts + one logo."""
+    config_dir = tmp_path
+    journal = config_dir / "journal.db"
+    _seed_journal_db(journal)
+    (config_dir / "settings.json").write_text("{}")
+    logos = config_dir / "uploads" / "logos"
+    logos.mkdir(parents=True)
+    # 1x1 PNG so the logos importer's magic-byte check passes downstream.
+    import base64
+    png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+    )
+    (logos / "espn.png").write_bytes(png)
+
+    client = MagicMock()
+    client.get_m3u_accounts = AsyncMock(
+        return_value=[
+            {"id": 1, "name": "Provider A"},
+            {"id": 2, "name": "Provider B"},
+        ]
+    )
+    client.get_epg_sources = AsyncMock(return_value=[])
+    client.get_channel_groups = AsyncMock(return_value=[])
+    client.get_channel_profiles = AsyncMock(return_value=[])
+    client.get_stream_profiles = AsyncMock(return_value=[])
+
+    session = MagicMock()
+    session.query.return_value.all.return_value = []
+    session.query.return_value.filter_by.return_value.all.return_value = []
+    session.query.return_value.filter_by.return_value.order_by.return_value.all.return_value = []
+    session.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+
+    settings = MagicMock()
+    settings.model_dump.return_value = {"url": "http://x", "username": "a"}
+
+    with patch.object(backup_mod, "CONFIG_DIR", config_dir), \
+         patch.object(backup_mod, "CONFIG_FILE", config_dir / "settings.json"), \
+         patch.object(backup_mod, "JOURNAL_DB_FILE", journal), \
+         patch.object(backup_mod, "get_engine", return_value=_mock_engine()), \
+         patch.object(backup_mod, "get_settings", return_value=settings), \
+         patch.object(backup_mod, "get_session", return_value=session), \
+         patch.object(backup_mod, "get_client", return_value=client):
+        return await build_backup_artifact(dest_dir=config_dir)
+
+
+def _restore_client():
+    """An empty-destination AsyncMock client — every archived entity is a create."""
+    client = AsyncMock()
+    client.get_m3u_accounts = AsyncMock(return_value=[])
+    client.get_epg_sources = AsyncMock(return_value=[])
+    client.get_channel_groups = AsyncMock(return_value=[])
+    client.get_channel_profiles = AsyncMock(return_value=[])
+    client.get_stream_profiles = AsyncMock(return_value=[])
+    client.get_users = AsyncMock(return_value=[])
+    client.get_current_user = AsyncMock(return_value={"id": 1, "username": "op"})
+    client.get_user_schema_write_fields = AsyncMock(return_value={"username"})
+    client.get_channels = AsyncMock(return_value={"results": [], "count": 0})
+    client.get_streams = AsyncMock(return_value={"results": [], "count": 0})
+    client.get_all_logos_paginated = AsyncMock(return_value=[])
+    return client
+
+
+@pytest.mark.asyncio
+async def test_build_then_decode_then_dry_run(tmp_path):
+    art = await _build_real_artifact(tmp_path)
+
+    with zipfile.ZipFile(art.zip_path, "r") as zf:
+        # .17 validation passes on a freshly built artifact (version + integrity).
+        validate_artifact_manifest(zf)
+        plan = decode_artifact_to_plan(zf)
+
+    # The decoded plan carries the two M3U accounts the builder gathered...
+    assert len(plan.category(EntityType.M3U_ACCOUNT).entities) == 2
+    # ...and the one logo from the binary subtree.
+    assert len(plan.category(EntityType.LOGO).entities) == 1
+
+    report = await run_dry_run(plan=plan, client=_restore_client())
+
+    # Dry-run produced a coherent plan (no mutation, no realized outcome).
+    assert report.is_dry_run is True
+    assert report.outcome is None
+    m3u = report.category(EntityType.M3U_ACCOUNT)
+    # Both M3U accounts would be created against the empty destination.
+    assert m3u.would_create == 2

--- a/backend/tests/routers/test_o8tbv_privileged_task_authz.py
+++ b/backend/tests/routers/test_o8tbv_privileged_task_authz.py
@@ -1,0 +1,163 @@
+"""Privileged-task admin gate on the generic task-run endpoint (O8TBV-1).
+
+Security review of the DBAS restore work (bead enhancedchannelmanager-o8tbv)
+found that ``POST /api/tasks/{task_id}/run`` had NO admin gate — the global auth
+middleware only validates the token, it does not check admin. A non-admin (or an
+MCP-key holder) could therefore ``POST /api/tasks/dbas_restore/run`` with apply
+parameters and drive a destructive restore, bypassing the admin-gated
+``/restore-dbas`` upload endpoint. The same gap exposed ``dbas_backup``.
+
+The fix admin-gates exactly the privileged task ids
+(``routers.tasks.PRIVILEGED_TASK_IDS``) on the generic run/cancel endpoints,
+WITHOUT putting a blanket admin dependency on the endpoint (that would regress
+ordinary user-triggerable tasks). These tests prove:
+
+  * a non-admin POST to a privileged task's run/cancel -> 403,
+  * an admin (or auth-disabled setup mode) POST -> allowed (reaches the engine),
+  * an ordinary non-privileged task is UNCHANGED for a non-admin.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from auth import resolve_is_admin_if_enabled
+from routers.tasks import PRIVILEGED_TASK_IDS
+
+
+def _override_admin(app, is_admin: bool):
+    """Override the admin-resolver dependency to simulate an authenticated user
+    of the given privilege. Returns a cleanup callable."""
+    # Override the *factory-produced* dependency callable registered on the
+    # endpoints (ResolveIsAdminIfEnabled = Depends(resolve_is_admin_if_enabled())).
+    async def _resolved() -> bool:
+        return is_admin
+
+    # The prebuilt Depends wraps a single shared inner callable; override that.
+    from auth import ResolveIsAdminIfEnabled as _prebuilt
+
+    app.dependency_overrides[_prebuilt.dependency] = _resolved
+    return lambda: app.dependency_overrides.pop(_prebuilt.dependency, None)
+
+
+@pytest.mark.asyncio
+class TestPrivilegedTaskRunGate:
+    async def test_privileged_run_ids_are_dbas(self):
+        assert PRIVILEGED_TASK_IDS == frozenset({"dbas_restore", "dbas_backup"})
+
+    @pytest.mark.parametrize("task_id", ["dbas_restore", "dbas_backup"])
+    async def test_non_admin_run_privileged_task_forbidden(self, async_client, task_id):
+        from main import app
+
+        cleanup = _override_admin(app, is_admin=False)
+        engine = MagicMock()
+        engine.run_task = AsyncMock(return_value=MagicMock())
+        try:
+            with patch("task_engine.get_engine", return_value=engine):
+                resp = await async_client.post(f"/api/tasks/{task_id}/run")
+        finally:
+            cleanup()
+
+        assert resp.status_code == 403
+        # The engine must never have been reached for a refused privileged task.
+        engine.run_task.assert_not_called()
+
+    @pytest.mark.parametrize("task_id", ["dbas_restore", "dbas_backup"])
+    async def test_admin_run_privileged_task_allowed(self, async_client, task_id):
+        from main import app
+
+        cleanup = _override_admin(app, is_admin=True)
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {"success": True}
+        engine = MagicMock()
+        engine.run_task = AsyncMock(return_value=mock_result)
+        try:
+            with patch("task_engine.get_engine", return_value=engine):
+                resp = await async_client.post(f"/api/tasks/{task_id}/run")
+        finally:
+            cleanup()
+
+        assert resp.status_code == 200
+        engine.run_task.assert_called_once()
+
+    async def test_non_admin_ordinary_task_unchanged(self, async_client):
+        """An ordinary non-privileged task is NOT gated by the privileged check —
+        a non-admin can still run it (this preserves existing behaviour)."""
+        from main import app
+
+        cleanup = _override_admin(app, is_admin=False)
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {"success": True}
+        engine = MagicMock()
+        engine.run_task = AsyncMock(return_value=mock_result)
+        try:
+            with patch("task_engine.get_engine", return_value=engine):
+                resp = await async_client.post("/api/tasks/stream_probe/run")
+        finally:
+            cleanup()
+
+        assert resp.status_code == 200
+        engine.run_task.assert_called_once()
+
+    async def test_setup_mode_run_privileged_task_allowed(self, async_client):
+        """Auth-disabled (setup) mode: the resolver yields admin=True, so the
+        privileged task runs exactly as the rest of the app behaves in setup
+        mode. This is the default test fixture state (no override)."""
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {"success": True}
+        engine = MagicMock()
+        engine.run_task = AsyncMock(return_value=mock_result)
+        with patch("task_engine.get_engine", return_value=engine):
+            resp = await async_client.post("/api/tasks/dbas_restore/run")
+        assert resp.status_code == 200
+        engine.run_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestPrivilegedTaskCancelGate:
+    @pytest.mark.parametrize("task_id", ["dbas_restore", "dbas_backup"])
+    async def test_non_admin_cancel_privileged_task_forbidden(self, async_client, task_id):
+        from main import app
+
+        cleanup = _override_admin(app, is_admin=False)
+        engine = MagicMock()
+        engine.cancel_task = AsyncMock(return_value={"status": "cancelled"})
+        try:
+            with patch("task_engine.get_engine", return_value=engine):
+                resp = await async_client.post(f"/api/tasks/{task_id}/cancel")
+        finally:
+            cleanup()
+
+        assert resp.status_code == 403
+        engine.cancel_task.assert_not_called()
+
+    async def test_admin_cancel_privileged_task_allowed(self, async_client):
+        from main import app
+
+        cleanup = _override_admin(app, is_admin=True)
+        engine = MagicMock()
+        engine.cancel_task = AsyncMock(return_value={"status": "cancelled"})
+        try:
+            with patch("task_engine.get_engine", return_value=engine):
+                resp = await async_client.post("/api/tasks/dbas_restore/cancel")
+        finally:
+            cleanup()
+
+        assert resp.status_code == 200
+        engine.cancel_task.assert_called_once()
+
+    async def test_non_admin_cancel_ordinary_task_unchanged(self, async_client):
+        from main import app
+
+        cleanup = _override_admin(app, is_admin=False)
+        engine = MagicMock()
+        engine.cancel_task = AsyncMock(return_value={"status": "cancelled"})
+        try:
+            with patch("task_engine.get_engine", return_value=engine):
+                resp = await async_client.post("/api/tasks/stream_probe/cancel")
+        finally:
+            cleanup()
+
+        assert resp.status_code == 200
+        engine.cancel_task.assert_called_once()

--- a/backend/tests/routers/test_o8tbv_restore_dbas_endpoint.py
+++ b/backend/tests/routers/test_o8tbv_restore_dbas_endpoint.py
@@ -1,0 +1,172 @@
+"""Tests for the async DBAS restore-trigger endpoint (bead enhancedchannelmanager-o8tbv).
+
+Covers ``POST /api/backup/restore-dbas`` and the streaming helper
+``routers.backup._stream_upload_to_temp``:
+
+  * the upload is STREAMED to a temp file ONE chunk at a time (never read
+    whole-in-RAM) and the temp file is mode 0600;
+  * a hard size cap rejects an oversize upload (413) and cleans up the partial;
+  * an empty upload is rejected (400);
+  * admin-auth is required (403 for a non-admin);
+  * a valid upload returns a task id and schedules the restore task in the
+    background (the endpoint does NOT block on the restore completing);
+  * dry-run is the default (confirm_apply omitted -> is_dry_run True).
+"""
+from __future__ import annotations
+
+import io
+import os
+import stat
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from routers import backup as backup_mod
+from routers.backup import _stream_upload_to_temp
+
+
+class _FakeUpload:
+    """Minimal UploadFile stand-in that yields its body in chunks (proves the
+    streaming read path: the helper calls .read(chunk) repeatedly)."""
+
+    def __init__(self, body: bytes, filename="artifact.zip"):
+        self._buf = io.BytesIO(body)
+        self.filename = filename
+        self.read_calls = 0
+
+    async def read(self, size: int = -1) -> bytes:
+        self.read_calls += 1
+        return self._buf.read(size)
+
+
+@pytest.mark.asyncio
+class TestStreamUploadToTemp:
+    async def test_streams_in_chunks_not_whole_in_ram(self, tmp_path):
+        # A body larger than one chunk forces multiple .read() calls.
+        body = b"PK\x03\x04" + os.urandom(backup_mod._RESTORE_UPLOAD_CHUNK * 2)
+        upload = _FakeUpload(body)
+        out = await _stream_upload_to_temp(upload, tmp_path)
+        try:
+            # >1 data read + the terminating empty read == streamed, not one slurp.
+            assert upload.read_calls >= 3
+            assert out.read_bytes() == body
+        finally:
+            out.unlink(missing_ok=True)
+
+    async def test_temp_file_is_mode_0600(self, tmp_path):
+        upload = _FakeUpload(b"PK\x03\x04 small")
+        out = await _stream_upload_to_temp(upload, tmp_path)
+        try:
+            mode = stat.S_IMODE(out.stat().st_mode)
+            assert mode == 0o600
+        finally:
+            out.unlink(missing_ok=True)
+
+    async def test_oversize_rejected_and_cleaned_up(self, tmp_path, monkeypatch):
+        # Shrink the cap so the test stays small.
+        monkeypatch.setattr(backup_mod, "_RESTORE_MAX_UPLOAD_BYTES", 1024)
+        monkeypatch.setattr(backup_mod, "_RESTORE_UPLOAD_CHUNK", 256)
+        upload = _FakeUpload(os.urandom(4096))
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as ei:
+            await _stream_upload_to_temp(upload, tmp_path)
+        assert ei.value.status_code == 413
+        # No partial temp left behind.
+        assert list(tmp_path.glob("ecm-restore-*")) == []
+
+    async def test_empty_upload_rejected(self, tmp_path):
+        upload = _FakeUpload(b"")
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as ei:
+            await _stream_upload_to_temp(upload, tmp_path)
+        assert ei.value.status_code == 400
+        assert list(tmp_path.glob("ecm-restore-*")) == []
+
+
+@pytest.mark.asyncio
+class TestRestoreDbasEndpoint:
+    async def _valid_artifact_bytes(self) -> bytes:
+        import hashlib
+        import json
+        import zipfile
+        import yaml
+
+        cat = {"dispatcharr": {"m3u_accounts": [{"id": 1, "name": "P"}]}}
+        members = {"categories/m3u_accounts.yaml": yaml.dump(cat).encode("utf-8")}
+        fh = {p: hashlib.sha256(b).hexdigest() for p, b in members.items()}
+        manifest = {"schema_version": 1, "files": [{"path": p, "sha256": h} for p, h in fh.items()]}
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("manifest.json", json.dumps(manifest))
+            for p, b in members.items():
+                zf.writestr(p, b)
+        return buf.getvalue()
+
+    async def test_returns_task_id_and_schedules_background(self, async_client, tmp_path, monkeypatch):
+        monkeypatch.setattr(backup_mod, "_DBAS_RESTORE_TMP_DIR", tmp_path)
+
+        engine = MagicMock()
+        engine.run_task = AsyncMock(return_value=None)
+        captured = {}
+
+        # Patch asyncio.create_task so the coroutine is observed (and not left
+        # pending) without actually running the restore task.
+        def _fake_create_task(coro):
+            captured["coro"] = coro
+            coro.close()  # don't leave it un-awaited
+            return MagicMock()
+
+        with patch("task_engine.get_engine", return_value=engine), \
+             patch("asyncio.create_task", side_effect=_fake_create_task):
+            files = {"file": ("artifact.zip", await self._valid_artifact_bytes(), "application/zip")}
+            resp = await async_client.post("/api/backup/restore-dbas", files=files)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["task_id"] == "dbas_restore"
+        assert body["is_dry_run"] is True
+        assert body["status"] == "started"
+        assert "coro" in captured
+
+    async def test_confirm_apply_flag_marks_not_dry_run(self, async_client, tmp_path, monkeypatch):
+        monkeypatch.setattr(backup_mod, "_DBAS_RESTORE_TMP_DIR", tmp_path)
+        engine = MagicMock()
+        engine.run_task = AsyncMock(return_value=None)
+
+        def _fake_create_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch("task_engine.get_engine", return_value=engine), \
+             patch("asyncio.create_task", side_effect=_fake_create_task):
+            files = {"file": ("artifact.zip", await self._valid_artifact_bytes(), "application/zip")}
+            resp = await async_client.post(
+                "/api/backup/restore-dbas?confirm_apply=true", files=files
+            )
+        assert resp.status_code == 200
+        assert resp.json()["is_dry_run"] is False
+
+    async def test_empty_upload_rejected(self, async_client, tmp_path, monkeypatch):
+        monkeypatch.setattr(backup_mod, "_DBAS_RESTORE_TMP_DIR", tmp_path)
+        files = {"file": ("artifact.zip", b"", "application/zip")}
+        resp = await async_client.post("/api/backup/restore-dbas", files=files)
+        assert resp.status_code == 400
+
+    async def test_admin_guarded(self, async_client, tmp_path, monkeypatch):
+        monkeypatch.setattr(backup_mod, "_DBAS_RESTORE_TMP_DIR", tmp_path)
+        from fastapi import HTTPException, status
+        from main import app
+        from auth import RequireAdminIfEnabled as _prebuilt
+
+        async def _reject() -> None:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
+
+        app.dependency_overrides[_prebuilt.dependency] = _reject
+        try:
+            files = {"file": ("artifact.zip", b"PK\x03\x04 x", "application/zip")}
+            resp = await async_client.post("/api/backup/restore-dbas", files=files)
+        finally:
+            app.dependency_overrides.pop(_prebuilt.dependency, None)
+        assert resp.status_code == 403

--- a/backend/tests/routers/test_o8tbv_temp_sweep.py
+++ b/backend/tests/routers/test_o8tbv_temp_sweep.py
@@ -1,0 +1,112 @@
+"""Stale restore-temp sweep (O8TBV-4).
+
+The restore-trigger endpoint schedules ``DbasRestoreTask`` fire-and-forget via
+``asyncio.create_task``. If that coroutine returns BEFORE ``execute()`` runs —
+``run_task`` returns ``None`` (task not registered) or an ``ALREADY_RUNNING``
+result for a concurrent run — the task's ``finally`` cleanup never fires and the
+0600 temp ZIP is orphaned. ``routers.backup._sweep_stale_restore_temps`` runs at
+the start of every restore trigger and removes temps older than the age floor.
+
+These tests prove the sweep removes a stale temp, never deletes a fresh one (a
+live run still owns it), and is wired into the endpoint.
+"""
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from routers import backup as backup_mod
+from routers.backup import _sweep_stale_restore_temps
+
+
+def _make_temp(dest_dir, age_seconds):
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    p = dest_dir / "ecm-restore-abc123.zip"
+    p.write_bytes(b"PK\x03\x04 stale")
+    past = time.time() - age_seconds
+    os.utime(p, (past, past))
+    return p
+
+
+class TestSweepStaleRestoreTemps:
+    def test_removes_stale_temp(self, tmp_path):
+        stale = _make_temp(
+            tmp_path, backup_mod._DBAS_RESTORE_TMP_MAX_AGE_SECONDS + 60
+        )
+        assert stale.exists()
+        _sweep_stale_restore_temps(tmp_path)
+        assert not stale.exists()
+
+    def test_keeps_fresh_temp(self, tmp_path):
+        # A temp younger than the floor belongs to a possibly-live run.
+        fresh = _make_temp(tmp_path, 10)
+        _sweep_stale_restore_temps(tmp_path)
+        assert fresh.exists()
+
+    def test_no_dir_is_noop(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        # Must not raise when the dir has never been created.
+        _sweep_stale_restore_temps(missing)
+
+    def test_only_touches_restore_temps(self, tmp_path):
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        other = tmp_path / "unrelated.txt"
+        other.write_text("keep me")
+        past = time.time() - (backup_mod._DBAS_RESTORE_TMP_MAX_AGE_SECONDS + 60)
+        os.utime(other, (past, past))
+        _sweep_stale_restore_temps(tmp_path)
+        assert other.exists()
+
+
+@pytest.mark.asyncio
+class TestEndpointSweepsOnTrigger:
+    async def test_trigger_sweeps_stale_temp(self, async_client, tmp_path, monkeypatch):
+        """An early scheduling/fire-and-forget failure that orphaned a previous
+        temp is cleaned up on the next restore trigger."""
+        import hashlib
+        import io
+        import json
+        import zipfile
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import yaml
+
+        monkeypatch.setattr(backup_mod, "_DBAS_RESTORE_TMP_DIR", tmp_path)
+
+        # Seed an orphaned (stale) temp from a hypothetical prior failed run.
+        stale = _make_temp(
+            tmp_path, backup_mod._DBAS_RESTORE_TMP_MAX_AGE_SECONDS + 120
+        )
+        assert stale.exists()
+
+        cat = {"dispatcharr": {"m3u_accounts": [{"id": 1, "name": "P"}]}}
+        members = {"categories/m3u_accounts.yaml": yaml.dump(cat).encode("utf-8")}
+        fh = {p: hashlib.sha256(b).hexdigest() for p, b in members.items()}
+        manifest = {
+            "schema_version": 1,
+            "files": [{"path": p, "sha256": h} for p, h in fh.items()],
+        }
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("manifest.json", json.dumps(manifest))
+            for p, b in members.items():
+                zf.writestr(p, b)
+        artifact = buf.getvalue()
+
+        engine = MagicMock()
+        engine.run_task = AsyncMock(return_value=None)
+
+        def _fake_create_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch("task_engine.get_engine", return_value=engine), \
+             patch("asyncio.create_task", side_effect=_fake_create_task):
+            files = {"file": ("artifact.zip", artifact, "application/zip")}
+            resp = await async_client.post("/api/backup/restore-dbas", files=files)
+
+        assert resp.status_code == 200
+        # The stale orphan from the prior run is gone after this trigger.
+        assert not stale.exists()

--- a/backend/tests/routers/test_o8tbv_zipbomb_guard.py
+++ b/backend/tests/routers/test_o8tbv_zipbomb_guard.py
@@ -1,0 +1,199 @@
+"""Decompression-bomb guard on the DBAS restore read sites (O8TBV-2 / O8TBV-3).
+
+Security review found that the 2 GiB upload cap bounds only the COMPRESSED bytes:
+both ``routers.backup._verify_artifact_member_integrity`` (via
+``validate_artifact_manifest``) and ``dbas.restore_artifact.decode_artifact_to_plan``
+call ``zf.read(member)`` with no decompressed-size guard. A small ZIP with a
+high-ratio member could OOM the single-process container, reachable even on the
+admin dry-run path.
+
+The fix is a SINGLE shared guard, ``routers.backup.guard_artifact_against_zip_bomb``,
+imported by both read sites and run BEFORE any ``zf.read()``. It enforces the
+threat-model D2 caps (docs/security/threat_model_dbas_import.md §3.5 D2):
+
+  * per-entry decompressed:compressed ratio (100x),
+  * cumulative declared uncompressed size (1 GiB), and
+  * entry count (10,000).
+
+A violation refuses with a GENERIC message (no sizes/internals leaked); the
+specifics go to the server log only. These tests prove a crafted high-ratio,
+over-cumulative, and over-count archive are each refused BEFORE the bomb member
+is read, and that a normal artifact still passes.
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from routers import backup as backup_mod
+from routers.backup import guard_artifact_against_zip_bomb
+
+
+def _zip_from_infos(entries):
+    """Build an in-memory ZIP from (name, uncompressed_size, compressed_size)
+    tuples by directly fabricating ZipInfo records — lets us declare a high
+    ratio without actually allocating gigabytes."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, file_size, compress_size in entries:
+            info = zipfile.ZipInfo(name)
+            # writestr with real bytes for honest sizes; for the bomb cases we
+            # overwrite the declared sizes on the ZipInfo afterwards.
+            zf.writestr(info, b"x" * 1)
+    buf.seek(0)
+    return buf
+
+
+def _open_with_declared_sizes(entries):
+    """Return an open ZipFile whose infolist() reports the declared
+    (file_size, compress_size) per entry — simulating a bomb's lying header
+    WITHOUT decompressing anything. The guard reads infolist() metadata only."""
+    # Build a minimal real zip, then monkey-build a fake infolist on a real
+    # ZipFile object so guard_artifact_against_zip_bomb sees the declared sizes.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_STORED) as zf:
+        for name, _fs, _cs in entries:
+            zf.writestr(name, b"")
+    buf.seek(0)
+    zf = zipfile.ZipFile(buf, "r")
+    fake_infos = []
+    for name, file_size, compress_size in entries:
+        info = zipfile.ZipInfo(name)
+        info.file_size = file_size
+        info.compress_size = compress_size
+        fake_infos.append(info)
+    zf.infolist = lambda: fake_infos  # type: ignore[assignment]
+    return zf
+
+
+class TestGuardAgainstZipBomb:
+    def test_normal_artifact_passes(self):
+        # Realistic small entries, sane ratios.
+        zf = _open_with_declared_sizes([
+            ("manifest.json", 200, 120),
+            ("categories/m3u_accounts.yaml", 4096, 800),
+            ("binary/logos/a.png", 50_000, 49_000),
+        ])
+        try:
+            guard_artifact_against_zip_bomb(zf)  # must not raise
+        finally:
+            zf.close()
+
+    def test_high_ratio_member_refused(self):
+        # 1 KiB+ compressed expanding 200x -> over the 100x cap.
+        zf = _open_with_declared_sizes([
+            ("manifest.json", 200, 120),
+            ("bomb.bin", 2048 * 200, 2048),
+        ])
+        try:
+            with pytest.raises(HTTPException) as ei:
+                guard_artifact_against_zip_bomb(zf)
+            assert ei.value.status_code == 400
+            # Generic message — no sizes/ratios/member names leaked.
+            assert ei.value.detail == "Backup archive rejected"
+        finally:
+            zf.close()
+
+    def test_tiny_stored_entry_not_falsely_flagged(self):
+        # A 12-byte stored file has a degenerate ratio but is below the compressed
+        # floor, so it must NOT trip the ratio check.
+        zf = _open_with_declared_sizes([
+            ("manifest.json", 12, 12),
+            ("categories/m3u_accounts.yaml", 4096, 4096),
+        ])
+        try:
+            guard_artifact_against_zip_bomb(zf)  # must not raise
+        finally:
+            zf.close()
+
+    def test_over_cumulative_refused(self):
+        # Two entries each under the ratio cap but together over the 1 GiB
+        # cumulative cap.
+        half_plus = (backup_mod._ARTIFACT_MAX_TOTAL_UNCOMPRESSED // 2) + 1024
+        zf = _open_with_declared_sizes([
+            ("a.bin", half_plus, half_plus),
+            ("b.bin", half_plus, half_plus),
+        ])
+        try:
+            with pytest.raises(HTTPException) as ei:
+                guard_artifact_against_zip_bomb(zf)
+            assert ei.value.status_code == 400
+            assert ei.value.detail == "Backup archive rejected"
+        finally:
+            zf.close()
+
+    def test_over_entry_count_refused(self):
+        entries = [
+            (f"f{i}.txt", 10, 10)
+            for i in range(backup_mod._ARTIFACT_MAX_ENTRIES + 1)
+        ]
+        zf = _open_with_declared_sizes(entries)
+        try:
+            with pytest.raises(HTTPException) as ei:
+                guard_artifact_against_zip_bomb(zf)
+            assert ei.value.status_code == 400
+            assert ei.value.detail == "Backup archive rejected"
+        finally:
+            zf.close()
+
+
+class TestGuardWiredIntoReadSites:
+    """The guard must run at BOTH read sites before any zf.read()."""
+
+    def _bomb_artifact_bytes(self):
+        """A real ZIP whose declared header would expand hugely — but we assert
+        the guard refuses it BEFORE the member is read, so we never need to
+        allocate the expanded bytes. We achieve a true high ratio with a highly
+        compressible member."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("manifest.json", b'{"schema_version": 1, "files": []}')
+            # 2 MiB of zeros compresses to a few KiB -> ratio well over 100x.
+            zf.writestr("bomb.bin", b"\x00" * (2 * 1024 * 1024))
+        buf.seek(0)
+        return buf.getvalue()
+
+    def test_validate_manifest_refuses_bomb_before_read(self):
+        from routers.backup import validate_artifact_manifest
+
+        zf = zipfile.ZipFile(io.BytesIO(self._bomb_artifact_bytes()), "r")
+        # Spy on zf.read so we can prove the bomb member is never read.
+        read_targets = []
+        orig_read = zf.read
+
+        def _tracked_read(name, *a, **kw):
+            read_targets.append(name.filename if hasattr(name, "filename") else name)
+            return orig_read(name, *a, **kw)
+
+        zf.read = _tracked_read  # type: ignore[assignment]
+        try:
+            with pytest.raises(HTTPException) as ei:
+                validate_artifact_manifest(zf)
+            assert ei.value.status_code == 400
+            assert "bomb.bin" not in read_targets
+        finally:
+            zf.close()
+
+    def test_decode_refuses_bomb_before_read(self):
+        from dbas.restore_artifact import decode_artifact_to_plan
+
+        zf = zipfile.ZipFile(io.BytesIO(self._bomb_artifact_bytes()), "r")
+        read_targets = []
+        orig_read = zf.read
+
+        def _tracked_read(name, *a, **kw):
+            read_targets.append(name.filename if hasattr(name, "filename") else name)
+            return orig_read(name, *a, **kw)
+
+        zf.read = _tracked_read  # type: ignore[assignment]
+        try:
+            with pytest.raises(HTTPException) as ei:
+                decode_artifact_to_plan(zf)
+            assert ei.value.status_code == 400
+            assert "bomb.bin" not in read_targets
+        finally:
+            zf.close()

--- a/backend/tests/tasks/test_dbas_restore_task.py
+++ b/backend/tests/tasks/test_dbas_restore_task.py
@@ -1,0 +1,227 @@
+"""Tests for the DBAS restore task (bead enhancedchannelmanager-o8tbv).
+
+Covers ``tasks.dbas_restore.DbasRestoreTask`` — the async, progress-emitting
+restore that ties .17 validation -> artifact decode -> .16/.18 orchestrator.
+
+Behavioural contracts under test:
+  * validate-before-mutate: a manifest that fails .17 is refused BEFORE any
+    importer runs (the orchestrator is never called);
+  * dry-run is default-ON: confirm_apply omitted -> run_dry_run; confirm_apply
+    True -> run_restore(confirm_apply=True);
+  * _set_progress fires per stage with current_item keys aligned to
+    restoreStages.ts;
+  * the temp artifact is cleaned up on success AND failure;
+  * the RestoreReport is returned in TaskResult.details for the .20 summary.
+
+The Dispatcharr client and the orchestrator entry points are mocked at module
+level so no live upstream / no real importer runs.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+import zipfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dbas.restore_contracts import (
+    EntityType,
+    RestoreOutcome,
+    RestoreReport,
+)
+from tasks.dbas_restore import _STAGE_KEYS, DbasRestoreTask
+from task_scheduler import ScheduleConfig, ScheduleType
+
+
+_PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+def _write_artifact(tmp_path: Path, *, schema_version=1, newer=False) -> Path:
+    """Write a real, integrity-valid new-format artifact to a temp file."""
+    import hashlib
+    import yaml
+
+    cat = {
+        "ecm_export": {"version": "0.17.6-test", "sections_included": ["m3u_accounts"]},
+        "dispatcharr": {"m3u_accounts": [{"id": 1, "name": "Provider A"}]},
+    }
+    members = {
+        "categories/m3u_accounts.yaml": yaml.dump(cat).encode("utf-8"),
+        "binary/logos/espn.png": _PNG_BYTES,
+    }
+    file_hashes = {p: hashlib.sha256(b).hexdigest() for p, b in members.items()}
+    sv = schema_version + 1 if newer else schema_version
+    manifest = {
+        "schema_version": sv,
+        "app_version": "0.17.6-test",
+        "files": [{"path": p, "sha256": h} for p, h in sorted(file_hashes.items())],
+    }
+    art = tmp_path / "artifact.zip"
+    with zipfile.ZipFile(art, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(manifest))
+        for path, blob in members.items():
+            zf.writestr(path, blob)
+    return art
+
+
+def _make_task(artifact_path: Path, *, confirm_apply=False) -> DbasRestoreTask:
+    task = DbasRestoreTask(ScheduleConfig(schedule_type=ScheduleType.MANUAL))
+    task.update_config(
+        {"artifact_path": str(artifact_path), "confirm_apply": confirm_apply}
+    )
+    return task
+
+
+def _dry_run_report() -> RestoreReport:
+    report = RestoreReport(is_dry_run=True)
+    cat = report.category(EntityType.M3U_ACCOUNT)
+    cat.would_create = 1
+    return report
+
+
+def _apply_report(outcome=RestoreOutcome.SUCCESS) -> RestoreReport:
+    report = RestoreReport(is_dry_run=False, outcome=outcome)
+    cat = report.category(EntityType.M3U_ACCOUNT)
+    cat.created = 1
+    return report
+
+
+@pytest.mark.asyncio
+class TestDryRunDefault:
+    async def test_dry_run_is_default(self, tmp_path):
+        art = _write_artifact(tmp_path)
+        task = _make_task(art, confirm_apply=False)
+
+        dry = AsyncMock(return_value=_dry_run_report())
+        apply = AsyncMock(return_value=_apply_report())
+        with patch("dbas.restore_orchestrator.run_dry_run", dry), \
+             patch("dbas.restore_orchestrator.run_restore", apply), \
+             patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            result = await task.execute()
+
+        dry.assert_awaited_once()
+        apply.assert_not_awaited()
+        assert result.success is True
+        assert result.details["is_dry_run"] is True
+        assert "restore_report" in result.details
+
+    async def test_confirm_apply_runs_apply(self, tmp_path):
+        art = _write_artifact(tmp_path)
+        task = _make_task(art, confirm_apply=True)
+
+        dry = AsyncMock(return_value=_dry_run_report())
+        apply = AsyncMock(return_value=_apply_report())
+        with patch("dbas.restore_orchestrator.run_dry_run", dry), \
+             patch("dbas.restore_orchestrator.run_restore", apply), \
+             patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            result = await task.execute()
+
+        apply.assert_awaited_once()
+        dry.assert_not_awaited()
+        # confirm_apply=True is threaded into run_restore.
+        assert apply.await_args.kwargs["confirm_apply"] is True
+        assert result.details["is_dry_run"] is False
+
+    async def test_apply_failure_outcome_marks_task_failed(self, tmp_path):
+        art = _write_artifact(tmp_path)
+        task = _make_task(art, confirm_apply=True)
+        apply = AsyncMock(return_value=_apply_report(RestoreOutcome.FAILED_ROLLBACK_INCOMPLETE))
+        with patch("dbas.restore_orchestrator.run_restore", apply), \
+             patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            result = await task.execute()
+        # A rolled-back / incomplete apply is NOT a success.
+        assert result.success is False
+
+
+@pytest.mark.asyncio
+class TestValidateBeforeMutate:
+    async def test_newer_schema_refused_before_orchestrator(self, tmp_path):
+        art = _write_artifact(tmp_path, newer=True)  # schema_version too new
+        task = _make_task(art, confirm_apply=True)
+
+        dry = AsyncMock(return_value=_dry_run_report())
+        apply = AsyncMock(return_value=_apply_report())
+        with patch("dbas.restore_orchestrator.run_dry_run", dry), \
+             patch("dbas.restore_orchestrator.run_restore", apply), \
+             patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            result = await task.execute()
+
+        # Refused by .17 BEFORE any importer — neither orchestrator entry ran.
+        dry.assert_not_awaited()
+        apply.assert_not_awaited()
+        assert result.success is False
+
+    async def test_missing_artifact_fails_cleanly(self, tmp_path):
+        task = _make_task(tmp_path / "does-not-exist.zip")
+        with patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            result = await task.execute()
+        assert result.success is False
+        assert "missing" in result.message.lower()
+
+    async def test_no_artifact_path_fails(self):
+        task = DbasRestoreTask(ScheduleConfig(schedule_type=ScheduleType.MANUAL))
+        result = await task.execute()
+        assert result.success is False
+
+
+@pytest.mark.asyncio
+class TestProgressStages:
+    async def test_emits_stage_keys_aligned_to_restore_stages(self, tmp_path):
+        art = _write_artifact(tmp_path)
+        task = _make_task(art, confirm_apply=False)
+
+        emitted: list[str] = []
+        orig = task._set_progress
+
+        def _spy(*args, **kwargs):
+            ci = kwargs.get("current_item")
+            if ci:
+                emitted.append(ci)
+            return orig(*args, **kwargs)
+
+        with patch.object(task, "_set_progress", side_effect=_spy), \
+             patch("dbas.restore_orchestrator.run_dry_run", AsyncMock(return_value=_dry_run_report())), \
+             patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            await task.execute()
+
+        # preflight first, finalize last, every emitted key is a known stage key.
+        assert emitted[0] == "preflight"
+        assert emitted[-1] == "finalize"
+        assert set(emitted).issubset(set(_STAGE_KEYS))
+        # the category stages fired in order
+        assert "m3u_account" in emitted
+
+
+@pytest.mark.asyncio
+class TestTempCleanup:
+    async def test_artifact_removed_on_success(self, tmp_path):
+        art = _write_artifact(tmp_path)
+        task = _make_task(art, confirm_apply=False)
+        with patch("dbas.restore_orchestrator.run_dry_run", AsyncMock(return_value=_dry_run_report())), \
+             patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            await task.execute()
+        assert not art.exists()
+
+    async def test_artifact_removed_on_failure(self, tmp_path):
+        art = _write_artifact(tmp_path)
+        task = _make_task(art, confirm_apply=False)
+        with patch("dbas.restore_orchestrator.run_dry_run",
+                   AsyncMock(side_effect=RuntimeError("boom"))), \
+             patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            result = await task.execute()
+        assert result.success is False
+        assert not art.exists()
+
+    async def test_cleanup_disabled_keeps_artifact(self, tmp_path):
+        art = _write_artifact(tmp_path)
+        task = _make_task(art, confirm_apply=False)
+        task.update_config({"cleanup_artifact": False})
+        with patch("dbas.restore_orchestrator.run_dry_run", AsyncMock(return_value=_dry_run_report())), \
+             patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            await task.execute()
+        assert art.exists()

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3804,6 +3804,47 @@ export async function restoreBackupYaml(file: File, sections: string[]): Promise
   return response.json();
 }
 
+/** Response of the async DBAS restore-trigger endpoint (bead o8tbv). */
+export interface DbasRestoreStartResult {
+  status: string;
+  /** Poll `/api/tasks/{task_id}` for per-stage progress + the terminal report. */
+  task_id: string;
+  /** True when the run is a counts-only dry-run (default; apply requires confirm). */
+  is_dry_run: boolean;
+}
+
+/**
+ * Trigger an async DBAS artifact restore (bead o8tbv).
+ *
+ * Streams the new-format artifact (.zip) to the backend, which kicks the
+ * `dbas_restore` task in the background and returns its `task_id`. The caller
+ * polls `/api/tasks/{task_id}` (see `useRestoreProgress`) for the 13-stage
+ * progress and the terminal `RestoreReport`.
+ *
+ * Dry-run is default-ON: pass `confirmApply=true` for the destructive apply.
+ */
+export async function startDbasRestore(
+  file: File,
+  confirmApply = false
+): Promise<DbasRestoreStartResult> {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const query = buildQuery({ confirm_apply: confirmApply });
+  const response = await fetch(`${API_BASE}/backup/restore-dbas${query}`, {
+    method: 'POST',
+    body: formData,
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: 'Restore failed' }));
+    throw new Error(error.detail || 'Restore failed');
+  }
+
+  return response.json();
+}
+
 // ── Status / Monitoring API ────────────────────────────────────────
 
 import type { ServiceWithStatus, ServiceAlertRule } from '../types';


### PR DESCRIPTION
## Bead
enhancedchannelmanager-o8tbv — the integration capstone that makes the DBAS restore user-triggerable (wires .17 validation + .18 orchestrator + .16 dry-run + importers + the g5xv7/.20/.19 UI).

## What
- **`DbasRestoreTask`** (`tasks/dbas_restore.py`, mirrors `.6` DbasBackupTask): open artifact → `validate_artifact_manifest` (.17, before any mutation) → `decode_artifact_to_plan` → `run_dry_run` (default) / `run_restore(confirm_apply=True)` → `RestoreReport`. `_set_progress` per stage, keys 1:1 with `restoreStages.ts` (13 stages). Temp cleaned up in `finally`.
- **Endpoint** `POST /api/backup/restore-dbas` (admin-auth): streams the upload to a 0600 temp on the CONFIG partition (chunked, never whole-in-RAM), 2 GiB cap mid-stream, fires the task in the background, returns the task id the frontend polls. Dry-run default; `confirm_apply` is a typed bool query (malformed → 422, never accidental apply).
- **Safe decode** (`dbas/restore_artifact.py`): no `extractall`, no member written to disk; `_is_safe_member` rejects absolute/`..`/backslash entries; binary subtree → the base64 logo records `.15` consumes.

## Security (independent review: found 1 HIGH + 2 MED + 1 LOW — ALL FIXED in this PR)
- **O8TBV-1 (HIGH auth bypass)**: the generic `POST /api/tasks/{id}/run` had no admin gate → a non-admin could trigger an apply-mode restore. Fixed: `PRIVILEGED_TASK_IDS = {dbas_restore, dbas_backup}` gated with a non-raising admin resolver in `run_task`/`cancel_task` (403 for non-admin; setup-mode + ordinary tasks unchanged). Also closes the same gap for `.6`'s backup task.
- **O8TBV-2/3 (MED zip-bomb DoS)**: shared `guard_artifact_against_zip_bomb` iterates `infolist()` (no decompress) before any `zf.read` at both validation + decode sites; D2 caps (100× ratio, 1 GiB cumulative, 10k entries); generic refusal.
- **O8TBV-4 (LOW temp leak)**: stale-temp sweep (6h) at trigger time for fire-and-forget early-failure orphans.
- Validate-before-mutate, zip-slip, streamed/0600/capped upload, dry-run-default, no-secret-leak invariants all verified by the review.

## Tests
52 tests (decode, privileged-task 403s, endpoint streaming/auth/oversize, zip-bomb refused-before-read, temp sweep, task validate→dry-run/apply + cleanup, mock round-trip build→restore). Full suite green (5878 passed).

## Follow-ups (filed)
- The `.7` builder's `RESTORABLE_SECTIONS` doesn't yet emit channels/users sections → those importers run against empty data (producer-side round-trip gap).
- Frontend `BackupRestoreModal` `.zip` + dry-run/apply toggle + poll-to-terminal wiring (g5xv7 `restoreTaskId` / .20 `restoreReport` seams) — backend done, frontend activation is a small follow-up.
- Live round-trip vs a real Dispatcharr is the deferred success-signal verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)