### PR TITLE
46pkq: two-instance sync test harness (mocks-only fast tier)

### DIFF
--- a/backend/tests/fixtures/sync_harness.py
+++ b/backend/tests/fixtures/sync_harness.py
@@ -1,0 +1,613 @@
+"""Stateful two-instance (source-A → dest-B) cross-instance sync TEST HARNESS.
+
+Bead ``enhancedchannelmanager-46pkq`` (epic ``i39wu``). This is the reusable,
+shareable harness the convergence / idempotency / partial-failure keystone tests
+rest on (``tests/tasks/test_sync_roundtrip.py``), the sync-test analogue of the
+DBAS restore round-trip anchor (``tests/dbas/test_restore_roundtrip.py``).
+
+What problem this solves
+------------------------
+The pre-existing sync engine tests (``test_dbas_sync_engine.py``) mock dest-B as a
+bag of independent ``AsyncMock`` create/get methods and then assert on **call
+counts** (``create_m3u_account.assert_awaited()``). That proves the engine *calls*
+B, but it cannot prove B *converged*: a stateless mock's ``get_*`` always returns
+the same canned list regardless of what was just created, so a second ``run_sync``
+re-creates everything and "idempotency" can only be asserted against a *different*
+hand-built "already converged" mock — not against the real apply.
+
+This harness instead models **B as a real instance**: a :class:`StatefulDispatcharrFake`
+that APPLIES the writes it receives. ``create_*`` stores the entity and returns it
+with a NEW server-assigned id; a duplicate ``create_*`` (same natural key) raises a
+**409 conflict** exactly like Dispatcharr; ``update_*`` mutates the stored row;
+``delete_*`` (the rollback compensator) removes it (404 when already gone). That
+statefulness is what makes the assertions REAL:
+
+* **Convergence** — after ``run_sync(confirm_apply=True)`` against an empty B you
+  can assert ``B.state() == A.state()`` *by natural key*, not by call count.
+* **Idempotency** — a SECOND ``run_sync`` against the SAME (now-populated) B is a
+  genuine no-op: B's own ``get_*`` now returns what was created, so the importers
+  match → ``ALREADY_EXISTS_IDENTICAL`` and zero creates fire. No second mock.
+* **Partial failure** — inject a mid-sync write error on B; because B actually
+  stored the earlier creates, you can assert the rollback compensated them and B
+  is left consistent, then that a clean re-run converges.
+
+Write-API contract fidelity (the bead's least-validated surface)
+----------------------------------------------------------------
+The dest-B fake models the Dispatcharr WRITE contract the sync path depends on,
+captured as fixtures here because no live Dispatcharr-B is reachable in this
+environment (see ``docs/testing/dbas-test-env.md`` → cross-instance section):
+
+* ``create_*`` returns the created object echoing the payload PLUS a NEW
+  server-assigned ``id`` (B assigns ids; A's ids are never reused on B).
+* a DUPLICATE ``create_*`` (same natural key already present) surfaces a **409
+  conflict** — :class:`FakeConflictError`, a ``httpx.HTTPStatusError`` carrying a
+  real 409 ``Response`` so the importers' status classifiers (which call
+  ``raise_for_status`` semantics / parse ``"<thing> failed: <status> - <body>"``)
+  treat it correctly.
+* ``update_*`` mutates the stored row in place and returns it.
+* ``delete_*`` removes the row; deleting an absent id raises a 404
+  (:class:`FakeNotFoundError`) — the orchestrator's ``404-as-success`` rollback
+  path depends on this shape.
+* ``create_channel_group`` takes a NAME STRING (Dispatcharr's quirk); every other
+  ``create_*`` takes a payload DICT — mirrored faithfully so the REUSED importers
+  run unchanged.
+
+Conventions (``docs/style_guide.md``): ``snake_case``; Google-style docstrings;
+lazy ``%``-formatted logging; no secrets in any log line.
+"""
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Write-contract errors — real httpx.HTTPStatusError so the importer / orchestrator
+# status classifiers (raise_for_status semantics, "<thing> failed: <code>" text)
+# bucket them exactly as they would a live Dispatcharr.
+# ---------------------------------------------------------------------------
+
+
+def _http_status_error(status_code: int, detail: str) -> httpx.HTTPStatusError:
+    """Build an httpx.HTTPStatusError carrying a real Response of ``status_code``.
+
+    The DBAS rollback's ``_status_code_of`` reads ``exc.response.status_code`` for
+    an ``httpx.HTTPStatusError`` first (its primary path), and the importers'
+    ``upstream_http_exception`` mapper also recognises this shape. Building a real
+    Response (not a bare ``Exception``) is what makes the 409/404 fidelity REAL.
+    """
+    request = httpx.Request("POST", "http://dest-b.fake/api/")
+    response = httpx.Response(status_code, json={"detail": detail}, request=request)
+    return httpx.HTTPStatusError(detail, request=request, response=response)
+
+
+class FakeConflictError(httpx.HTTPStatusError):
+    """409 raised by a duplicate ``create_*`` (natural key already present on B)."""
+
+    def __init__(self, label: str):
+        request = httpx.Request("POST", "http://dest-b.fake/api/")
+        response = httpx.Response(
+            409, json={"detail": "already exists"}, request=request
+        )
+        # The importers parse "<thing> failed: <status> - <body>" from str(exc) as a
+        # fallback; include the code in the message so BOTH classifier paths work.
+        super().__init__(
+            "create failed: 409 - %s already exists" % label,
+            request=request,
+            response=response,
+        )
+
+
+class FakeNotFoundError(httpx.HTTPStatusError):
+    """404 raised by ``delete_*`` of an absent id — rollback treats it as success."""
+
+    def __init__(self, entity: str, entity_id: int):
+        request = httpx.Request("DELETE", "http://dest-b.fake/api/")
+        response = httpx.Response(404, json={"detail": "not found"}, request=request)
+        super().__init__(
+            "%s delete failed: 404 - id %s not found" % (entity, entity_id),
+            request=request,
+            response=response,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Natural-key helpers — how the REUSED importers decide identity. The fake's
+# duplicate detection MUST use the same key the importer match uses, or the
+# 409 contract would fire on rows the importer considers distinct (and vice
+# versa). Importers match config rows case-insensitively / trimmed on ``name``;
+# channels on ``(name, channel_number)``.
+# ---------------------------------------------------------------------------
+
+
+def _norm_name(value: Any) -> Optional[str]:
+    """Case-insensitive, whitespace-trimmed name key; None when blank/absent."""
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    return text or None
+
+
+def _name_key(row: dict) -> Optional[str]:
+    return _norm_name(row.get("name"))
+
+
+def _channel_key(row: dict) -> tuple:
+    """A channel's natural key — (normalized name, channel_number-or-None).
+
+    Mirrors the importer's ``(name, channel_number)`` identity. A null number is
+    preserved (not coerced) so the collision-safe floor (ruling 1a) — null on BOTH
+    sides == ambiguous — still triggers through the harness.
+    """
+    return (_norm_name(row.get("name")), row.get("channel_number"))
+
+
+def _stream_key(row: dict) -> Optional[str]:
+    """A stream's identity for B — its ``url`` (the matcher's Tier-1 identity)."""
+    url = row.get("url")
+    return str(url) if url else None
+
+
+# ---------------------------------------------------------------------------
+# One entity collection inside a stateful instance.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Store:
+    """A keyed collection of one entity type inside a stateful fake instance.
+
+    Holds rows by server-assigned id and enforces the natural-key uniqueness that
+    drives the 409 contract.
+    """
+
+    name: str
+    key_fn: Callable[[dict], Any]
+    rows: dict[int, dict] = field(default_factory=dict)
+    _next_id: int = 1
+    id_base: int = 1
+
+    def __post_init__(self) -> None:
+        self._next_id = self.id_base
+
+    def list(self) -> list[dict]:
+        return [dict(r) for r in self.rows.values()]
+
+    def _find_by_key(self, key: Any) -> Optional[int]:
+        if key is None:
+            return None
+        for rid, row in self.rows.items():
+            if self.key_fn(row) == key:
+                return rid
+        return None
+
+    def create(self, payload: dict) -> dict:
+        """Store a new row, assigning a fresh id; 409 on a natural-key duplicate."""
+        key = self.key_fn(payload)
+        if self._find_by_key(key) is not None:
+            label = payload.get("name") or self.name
+            raise FakeConflictError(str(label))
+        new_id = self._next_id
+        self._next_id += 1
+        row = {**payload, "id": new_id}
+        self.rows[new_id] = row
+        return dict(row)
+
+    def update(self, entity_id: int, data: dict) -> dict:
+        if entity_id not in self.rows:
+            raise FakeNotFoundError(self.name, entity_id)
+        self.rows[entity_id].update(data)
+        return dict(self.rows[entity_id])
+
+    def delete(self, entity_id: int) -> None:
+        if entity_id not in self.rows:
+            raise FakeNotFoundError(self.name, entity_id)
+        del self.rows[entity_id]
+
+
+# ---------------------------------------------------------------------------
+# The stateful Dispatcharr fake — one per instance (A and B).
+# ---------------------------------------------------------------------------
+
+
+class StatefulDispatcharrFake:
+    """An in-memory, STATEFUL stand-in for a single Dispatcharr instance.
+
+    Exposes the async client method surface the sync gather + the REUSED DBAS
+    importers call (``get_* / create_* / update_* / delete_*``), backed by real
+    per-entity stores. Unlike a bare ``AsyncMock``, every write is APPLIED, so the
+    instance's reads reflect prior writes — the property the convergence /
+    idempotency / partial-failure assertions need.
+
+    Use :meth:`StatefulDispatcharrFake.seeded_source` for a populated source-A and
+    :meth:`StatefulDispatcharrFake.empty_dest` for an empty dest-B. The
+    ``id_base`` per store is offset per instance so A's ids and B's ids never
+    coincide by accident (a test that confused the two would otherwise pass).
+    """
+
+    def __init__(self, *, label: str, id_base: int = 1):
+        self.label = label
+        # Distinct id bases per entity type so a leaked A-id is obvious on B.
+        self.m3u_accounts = _Store("m3u_account", _name_key, id_base=id_base + 100)
+        self.epg_sources = _Store("epg_source", _name_key, id_base=id_base + 200)
+        self.channel_groups = _Store("channel_group", _name_key, id_base=id_base + 300)
+        self.channel_profiles = _Store("channel_profile", _name_key, id_base=id_base + 400)
+        self.stream_profiles = _Store("stream_profile", _name_key, id_base=id_base + 500)
+        self.channels = _Store("channel", _channel_key, id_base=id_base + 600)
+        self.streams = _Store("stream", _stream_key, id_base=id_base + 700)
+
+        # Optional write-fault injection: a callable invoked at the start of every
+        # mutating call with (method_name, payload). If it raises, the fake raises
+        # that error (models a mid-sync upstream failure on B).
+        self._fault: Optional[Callable[[str, Any], None]] = None
+
+    # ----- fault injection -------------------------------------------------
+
+    def inject_fault(self, fault: Optional[Callable[[str, Any], None]]) -> None:
+        """Install (or clear with ``None``) a write-fault hook for B.
+
+        ``fault(method_name, payload)`` runs before each mutating method applies.
+        Raising from it simulates a mid-sync upstream error; the importer/
+        orchestrator then drives its failure + compensating-rollback path against
+        the REAL state already stored, exactly as it would against a live B.
+        """
+        self._fault = fault
+
+    def _check_fault(self, method: str, payload: Any) -> None:
+        if self._fault is not None:
+            self._fault(method, payload)
+
+    # ----- M3U accounts ----------------------------------------------------
+
+    async def get_m3u_accounts(self) -> list:
+        return self.m3u_accounts.list()
+
+    async def create_m3u_account(self, data: dict) -> dict:
+        self._check_fault("create_m3u_account", data)
+        return self.m3u_accounts.create(data)
+
+    async def update_m3u_account(self, account_id: int, data: dict) -> dict:
+        self._check_fault("update_m3u_account", data)
+        return self.m3u_accounts.update(account_id, data)
+
+    async def delete_m3u_account(self, account_id: int) -> None:
+        self.m3u_accounts.delete(account_id)
+
+    async def get_streams(self, page: int = 1, page_size: int = 100, **kwargs) -> dict:
+        # The m3u importer probes get_streams(m3u_account=...) to count streams; and
+        # the channels importer reads B's standalone streams to match. Return the
+        # paginated shape the real client returns.
+        rows = self.streams.list()
+        m3u_account = kwargs.get("m3u_account")
+        if m3u_account is not None:
+            rows = [s for s in rows if s.get("m3u_account") == m3u_account]
+        return {"count": len(rows), "next": None, "previous": None, "results": rows}
+
+    async def create_stream(self, data: dict) -> dict:
+        self._check_fault("create_stream", data)
+        return self.streams.create(data)
+
+    async def update_stream(self, stream_id: int, data: dict) -> dict:
+        self._check_fault("update_stream", data)
+        return self.streams.update(stream_id, data)
+
+    async def delete_stream(self, stream_id: int) -> None:
+        self.streams.delete(stream_id)
+
+    # ----- EPG sources -----------------------------------------------------
+
+    async def get_epg_sources(self) -> list:
+        return self.epg_sources.list()
+
+    async def create_epg_source(self, data: dict) -> dict:
+        self._check_fault("create_epg_source", data)
+        return self.epg_sources.create(data)
+
+    async def update_epg_source(self, source_id: int, data: dict) -> dict:
+        self._check_fault("update_epg_source", data)
+        return self.epg_sources.update(source_id, data)
+
+    async def delete_epg_source(self, source_id: int) -> None:
+        self.epg_sources.delete(source_id)
+
+    # ----- channel groups (create takes a NAME STRING) ---------------------
+
+    async def get_channel_groups(self) -> list:
+        return self.channel_groups.list()
+
+    async def create_channel_group(self, name: str) -> dict:
+        self._check_fault("create_channel_group", name)
+        return self.channel_groups.create({"name": name})
+
+    async def update_channel_group(self, group_id: int, data: dict) -> dict:
+        self._check_fault("update_channel_group", data)
+        return self.channel_groups.update(group_id, data)
+
+    async def delete_channel_group(self, group_id: int) -> None:
+        self.channel_groups.delete(group_id)
+
+    # ----- channel profiles ------------------------------------------------
+
+    async def get_channel_profiles(self) -> list:
+        return self.channel_profiles.list()
+
+    async def create_channel_profile(self, data: dict) -> dict:
+        self._check_fault("create_channel_profile", data)
+        return self.channel_profiles.create(data)
+
+    async def update_channel_profile(self, profile_id: int, data: dict) -> dict:
+        self._check_fault("update_channel_profile", data)
+        return self.channel_profiles.update(profile_id, data)
+
+    async def delete_channel_profile(self, profile_id: int) -> None:
+        self.channel_profiles.delete(profile_id)
+
+    async def update_profile_channel(
+        self, profile_id: int, channel_id: int, data: dict
+    ) -> dict:
+        # Profile-membership toggle — best-effort, no store of its own here.
+        return {"success": True}
+
+    # ----- stream profiles -------------------------------------------------
+
+    async def get_stream_profiles(self) -> list:
+        return self.stream_profiles.list()
+
+    async def create_stream_profile(self, data: dict) -> dict:
+        self._check_fault("create_stream_profile", data)
+        return self.stream_profiles.create(data)
+
+    # ----- channels --------------------------------------------------------
+
+    async def get_channels(
+        self, page: int = 1, page_size: int = 100, **kwargs
+    ) -> dict:
+        rows = self.channels.list()
+        return {"count": len(rows), "next": None, "previous": None, "results": rows}
+
+    async def get_channel_streams(self, channel_id: int) -> list:
+        ch = self.channels.rows.get(channel_id)
+        if not ch:
+            return []
+        stream_ids = ch.get("streams", []) or []
+        return [s for s in self.streams.list() if s.get("id") in stream_ids]
+
+    async def create_channel(self, data: dict) -> dict:
+        self._check_fault("create_channel", data)
+        return self.channels.create(data)
+
+    async def update_channel(self, channel_id: int, data: dict) -> dict:
+        self._check_fault("update_channel", data)
+        return self.channels.update(channel_id, data)
+
+    async def delete_channel(self, channel_id: int) -> None:
+        self.channels.delete(channel_id)
+
+    # ----- users (NEVER synced, but the rollback dispatch references the
+    #        compensator unconditionally) -----------------------------------
+
+    async def delete_user(self, user_id: int) -> None:
+        # Users are never synced (D3) so this is never created, hence never a
+        # rollback target. It exists only because the orchestrator's
+        # ``_delete_dispatch`` builds the FULL EntityType->deleter map eagerly and
+        # references ``client.delete_user``. A 404 is the correct "already gone".
+        raise FakeNotFoundError("user", user_id)
+
+    # ----- state snapshot (the convergence assertion surface) --------------
+
+    def state_by_key(self) -> dict[str, set]:
+        """A natural-key snapshot of THIS instance's syncable config + channels.
+
+        The convergence assertion compares ``B.state_by_key()`` against
+        ``A.state_by_key()``: equality means every source entity exists on B under
+        its natural key (ids differ — B assigns its own — so the comparison is
+        key-based, never id-based). Streams are keyed by url; channels by
+        ``(name, number)``; config rows by normalized name.
+        """
+        return {
+            "m3u_accounts": {_name_key(r) for r in self.m3u_accounts.list()},
+            "epg_sources": {_name_key(r) for r in self.epg_sources.list()},
+            "channel_groups": {_name_key(r) for r in self.channel_groups.list()},
+            "channel_profiles": {_name_key(r) for r in self.channel_profiles.list()},
+            "stream_profiles": {_name_key(r) for r in self.stream_profiles.list()},
+            "channels": {_channel_key(r) for r in self.channels.list()},
+        }
+
+    def total_rows(self) -> int:
+        """Total stored config + channel + stream rows — a quick consistency probe."""
+        return sum(
+            len(s.rows)
+            for s in (
+                self.m3u_accounts,
+                self.epg_sources,
+                self.channel_groups,
+                self.channel_profiles,
+                self.stream_profiles,
+                self.channels,
+                self.streams,
+            )
+        )
+
+    # ----- factories -------------------------------------------------------
+
+    @classmethod
+    def empty_dest(cls, *, label: str = "dest-B") -> "StatefulDispatcharrFake":
+        """An empty dest-B — every source entity is a fresh create."""
+        return cls(label=label, id_base=5000)
+
+    @classmethod
+    def seeded_source(
+        cls,
+        *,
+        label: str = "source-A",
+        m3u_password: str = "SEED-M3U-SECRET",
+        epg_api_key: str = "SEED-EPG-SECRET",
+        with_embedded_streams: bool = False,
+    ) -> "StatefulDispatcharrFake":
+        """A populated source-A holding a production-shaped config + channels.
+
+        Carries plaintext credential fields (``password`` on the M3U account,
+        ``api_key`` on the EPG source) so the redaction end-to-end assertion is
+        REAL: those literal secrets must NEVER reach B (D2). Also seeds a config +
+        one non-colliding channel (``CNN``, number 5) so the channel slice
+        converges.
+
+        Args:
+            with_embedded_streams: when ``True``, the seeded channel carries an
+                embedded stream. NOTE: that stream's ``m3u_account`` FK is A's id,
+                which does not resolve on a fresh B, so the channels importer
+                (correctly, per production behaviour) synthesizes an "ECM Custom
+                Streams" account on B to hold the orphan. That means strict
+                ``A.state_by_key() == B.state_by_key()`` will NOT hold (B has the
+                extra synthetic account) — use ``False`` (the default) for the
+                strict config+channel convergence assertion, and ``True`` only for
+                the dedicated channels+streams slice test that expects the synth.
+        """
+        fake = cls(label=label, id_base=1)
+        # M3U account with a SECRET that must not reach B (D2).
+        fake.m3u_accounts.create(
+            {"name": "Provider A", "username": "operator", "password": m3u_password,
+             "server_url": "http://provider-a.test/playlist.m3u"}
+        )
+        # EPG source with a SECRET api_key (D2).
+        fake.epg_sources.create(
+            {"name": "EPG One", "source_type": "xmltv", "m3u_account": None,
+             "api_key": epg_api_key, "url": "http://epg-one.test/guide.xml"}
+        )
+        fake.channel_groups.create({"name": "News"})
+        fake.channel_groups.create({"name": "Sports"})
+        fake.channel_profiles.create({"name": "Default Profile"})
+        fake.stream_profiles.create({"name": "Proxy Profile", "command": "ffmpeg"})
+
+        if with_embedded_streams:
+            stream = fake.streams.create(
+                {"name": "CNN HD", "url": "http://provider-a.test/cnn.m3u8",
+                 "m3u_account": 101}
+            )
+            fake.channels.create(
+                {"name": "CNN", "channel_number": 5, "streams": [stream["id"]]}
+            )
+        else:
+            # A non-colliding channel (non-null number) with NO embedded streams,
+            # so strict state equality holds (no synthetic-account side effect).
+            fake.channels.create(
+                {"name": "CNN", "channel_number": 5, "streams": []}
+            )
+        return fake
+
+
+# ---------------------------------------------------------------------------
+# SyncTarget stand-in.
+# ---------------------------------------------------------------------------
+
+
+def make_sync_target(
+    *, credential_version: int = 1, fuzzy_stream_matching: bool = False
+) -> MagicMock:
+    """A fake ``SyncTarget`` row — enabled, fresh, never-insecure.
+
+    Mirrors the shape ``run_sync`` reads (``id``/``name``/``base_url``/
+    ``credentials``/``enabled``/``token_revoked_at``/``credential_version``/
+    ``insecure``/``fuzzy_stream_matching``).
+    """
+    target = MagicMock()
+    target.id = 7
+    target.name = "DR Box"
+    target.base_url = "http://dr-box.lan:9191"
+    target.enabled = True
+    target.insecure = False
+    target.token_revoked_at = None
+    target.credential_version = credential_version
+    target.credentials = "encrypted-blob"
+    target.fuzzy_stream_matching = fuzzy_stream_matching
+    return target
+
+
+# ---------------------------------------------------------------------------
+# The harness — wires A + B into run_sync and applies the right patch seams.
+# ---------------------------------------------------------------------------
+
+
+class SyncHarness:
+    """A reusable stateful two-instance (A → B) sync driver.
+
+    Wires a seeded source-A and a stateful dest-B into the REAL engine seam:
+
+    * the LOCAL gather (``routers.backup.get_client``) is patched to return A, so
+      ``build_live_source_plan`` reads A's real config + channels;
+    * the remote-client factory (``dbas_sync_engine.make_remote_client``) is
+      patched to return B, so the REUSED orchestrator + importers run against B's
+      real stateful stores;
+    * the freshness gate (``dbas_sync_engine.sync_freshness_reason``) is patched to
+      whatever ``freshness_reason`` is set (default ``None`` = fresh) so the
+      A/B convergence path is exercised without a DB session.
+
+    Everything else is the UNCHANGED production path: ``run_sync`` → the redacted
+    live-source plan → ``run_restore`` → the importers → B's stateful writes.
+
+    Usage::
+
+        harness = SyncHarness(
+            source=StatefulDispatcharrFake.seeded_source(),
+            dest=StatefulDispatcharrFake.empty_dest(),
+        )
+        report = await harness.run(confirm_apply=True, ledger_dir=tmp_path)
+        assert harness.dest.state_by_key() == harness.source.state_by_key()
+    """
+
+    def __init__(
+        self,
+        *,
+        source: StatefulDispatcharrFake,
+        dest: StatefulDispatcharrFake,
+        target: Optional[MagicMock] = None,
+        freshness_reason: Optional[str] = None,
+    ):
+        self.source = source
+        self.dest = dest
+        self.target = target or make_sync_target(
+            fuzzy_stream_matching=getattr(
+                target, "fuzzy_stream_matching", False
+            ) if target else False
+        )
+        self.freshness_reason = freshness_reason
+
+    @contextmanager
+    def _patched(self):
+        """Apply the three engine seams (local gather / remote factory / freshness)."""
+        # Imported lazily so importing the harness module never drags the engine in
+        # at collection time (keeps the fixture import cheap + cycle-free).
+        from routers import backup as backup_mod
+        from tasks import dbas_sync_engine as engine
+
+        with patch.object(backup_mod, "get_client", return_value=self.source), \
+             patch.object(engine, "make_remote_client", return_value=self.dest), \
+             patch.object(
+                 engine, "sync_freshness_reason", return_value=self.freshness_reason
+             ):
+            yield
+
+    async def run(self, *, confirm_apply: bool = False, ledger_dir=None, **kwargs):
+        """Drive one ``run_sync`` cycle A → B and return the RestoreReport.
+
+        ``confirm_apply=False`` (default) is a counts-only dry-run (zero writes to
+        B); ``True`` applies source-wins. ``ledger_dir`` should be a ``tmp_path`` so
+        the durable rollback ledger never touches the real CONFIG_DIR.
+        """
+        from tasks.dbas_sync_engine import run_sync
+
+        with self._patched():
+            return await run_sync(
+                self.target,
+                confirm_apply=confirm_apply,
+                session=MagicMock(),
+                ledger_dir=ledger_dir,
+                **kwargs,
+            )

--- a/backend/tests/tasks/test_sync_roundtrip.py
+++ b/backend/tests/tasks/test_sync_roundtrip.py
@@ -1,0 +1,362 @@
+"""Cross-instance sync ROUND-TRIP keystone suite (bead enhancedchannelmanager-46pkq).
+
+Epic ``i39wu``. The sync-test analogue of the DBAS restore round-trip anchor
+(``tests/dbas/test_restore_roundtrip.py``): a small, shareable, harness-driven
+keystone suite that future sync beads (``tjaey``, ``kcxie``) extend.
+
+What makes these tests REAL (vs the call-count engine tests)
+------------------------------------------------------------
+``test_dbas_sync_engine.py`` mocks dest-B as independent ``AsyncMock`` methods and
+asserts on CALL COUNTS — it proves the engine *calls* B but not that B *converged*.
+These tests instead use the STATEFUL two-instance harness
+(``tests/fixtures/sync_harness.py``): dest-B APPLIES every write (create → stores +
+returns a new server id; duplicate create → 409; update → mutates), so:
+
+* **convergence** is asserted as ``B.state_by_key() == A.state_by_key()`` — every
+  source entity present on B under its NATURAL key (ids differ; B assigns its own);
+* **idempotency** is a GENUINE second ``run_sync`` against the now-populated B that
+  the importers resolve to ``ALREADY_EXISTS_IDENTICAL`` → zero creates, no second
+  hand-built "already-converged" mock;
+* **partial failure** injects a real mid-sync write error on B and asserts the
+  orchestrator's compensating rollback left B consistent, then that a clean re-run
+  HEALS (converges) — the idempotent-recovery property.
+
+Plus the two security invariants end-to-end through the harness: never-sync-users
+(D3) and redact-by-default (D2 — no seeded secret reaches B).
+
+NO live Dispatcharr. The live two-stack nightly tier is DEFERRED (see
+``docs/testing/dbas-test-env.md`` → "Cross-instance sync test strategy" and
+``tests/dbas-test-env/docker-compose.dbas-sync-test.yml``).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from dbas.restore_contracts import EntityType, RestoreOutcome
+from tests.fixtures.sync_harness import (
+    StatefulDispatcharrFake,
+    SyncHarness,
+    _http_status_error,
+    make_sync_target,
+)
+
+
+# ---------------------------------------------------------------------------
+# (a) CONVERGENCE — empty B → apply → B's config == A's (by natural key).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_convergence_empty_b_matches_a_by_natural_key(tmp_path):
+    """Apply against an empty B makes B's syncable state equal A's (natural key).
+
+    The stateful dest-B applies every create, so after the cycle a key-by-key
+    comparison is meaningful: B holds every config category + the channel A holds.
+    ids differ (B assigns its own) — equality is asserted on natural keys only.
+    """
+    source = StatefulDispatcharrFake.seeded_source()
+    dest = StatefulDispatcharrFake.empty_dest()
+    assert dest.total_rows() == 0  # B starts empty.
+
+    harness = SyncHarness(source=source, dest=dest)
+    report = await harness.run(confirm_apply=True, ledger_dir=tmp_path)
+
+    assert report.outcome == RestoreOutcome.SUCCESS
+    # The whole point: B converged to A's state by natural key.
+    assert dest.state_by_key() == source.state_by_key()
+    # Sanity: every config category + the channel actually got created on B.
+    assert report.category(EntityType.M3U_ACCOUNT).created == 1
+    assert report.category(EntityType.EPG_SOURCE).created == 1
+    assert report.category(EntityType.CHANNEL_GROUP).created == 2
+    assert report.category(EntityType.CHANNEL).created == 1
+
+
+@pytest.mark.asyncio
+async def test_dry_run_default_makes_zero_writes_to_b(tmp_path):
+    """confirm_apply=False (default) is a counts-only preview — B stays empty."""
+    source = StatefulDispatcharrFake.seeded_source()
+    dest = StatefulDispatcharrFake.empty_dest()
+
+    harness = SyncHarness(source=source, dest=dest)
+    report = await harness.run(ledger_dir=tmp_path)  # confirm_apply defaults False
+
+    assert report.is_dry_run is True
+    assert report.outcome is None
+    assert dest.total_rows() == 0  # ZERO writes — B is untouched.
+    assert report.category(EntityType.M3U_ACCOUNT).would_create == 1
+
+
+# ---------------------------------------------------------------------------
+# (b) IDEMPOTENCY — a SECOND run against the now-populated B is a no-op.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idempotency_second_run_is_a_real_noop(tmp_path):
+    """A second cycle against the SAME (populated) B creates nothing.
+
+    Because B is stateful, the second run reads B's OWN now-populated config, so
+    every source entity matches → ALREADY_EXISTS_IDENTICAL. This is idempotency
+    proven against the real apply, not against a separate hand-built mock.
+    """
+    source = StatefulDispatcharrFake.seeded_source()
+    dest = StatefulDispatcharrFake.empty_dest()
+    harness = SyncHarness(source=source, dest=dest)
+
+    first = await harness.run(confirm_apply=True, ledger_dir=tmp_path)
+    assert first.outcome == RestoreOutcome.SUCCESS
+    rows_after_first = dest.total_rows()
+    assert rows_after_first > 0
+
+    second = await harness.run(confirm_apply=True, ledger_dir=tmp_path)
+
+    assert second.outcome == RestoreOutcome.SUCCESS
+    # No new rows on B — the second run is a genuine no-op.
+    assert dest.total_rows() == rows_after_first
+    # Zero creates across EVERY category; every category resolved to a skip.
+    for cat in second.categories:
+        assert cat.created == 0, "category %s re-created on idempotent run" % cat.entity_type
+    assert sum(cat.skipped for cat in second.categories) >= 5
+    # And B still equals A — convergence is stable across runs.
+    assert dest.state_by_key() == source.state_by_key()
+
+
+# ---------------------------------------------------------------------------
+# (c) PARTIAL FAILURE — mid-sync B write error → rollback leaves B consistent;
+#     a clean re-run heals (converges).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_rolls_back_then_reconverges(tmp_path):
+    """A mid-sync write error on B → non-SUCCESS + compensating rollback leaves B
+    consistent; a clean re-run converges.
+
+    The fault fires on the SECOND importer step (``create_epg_source``), so only
+    the M3U account was created before the failure. M3U HAS a registered rollback
+    compensator, so the orchestrator's compensating delete fully undoes it →
+    PARTIAL_FAILED_ROLLED_BACK and B is left EMPTY (consistent — no half-applied
+    residue). Clearing the fault and re-running then converges B to A.
+    """
+    source = StatefulDispatcharrFake.seeded_source()
+    dest = StatefulDispatcharrFake.empty_dest()
+
+    def _fault(method: str, payload) -> None:
+        if method == "create_epg_source":
+            raise _http_status_error(500, "simulated mid-sync upstream error on B")
+
+    dest.inject_fault(_fault)
+    harness = SyncHarness(source=source, dest=dest)
+
+    failed = await harness.run(confirm_apply=True, ledger_dir=tmp_path)
+
+    # Tri-state discipline: NEVER SUCCESS on mixed state.
+    assert failed.outcome != RestoreOutcome.SUCCESS
+    assert failed.outcome == RestoreOutcome.PARTIAL_FAILED_ROLLED_BACK
+    # Rollback compensated the one created entity (M3U) — B is left CONSISTENT
+    # (empty), not half-applied.
+    assert dest.total_rows() == 0
+    assert any("rollback completed" in note for note in failed.notes)
+
+    # Now clear the fault and re-run: the system HEALS — a clean cycle converges.
+    dest.inject_fault(None)
+    healed = await harness.run(confirm_apply=True, ledger_dir=tmp_path)
+
+    assert healed.outcome == RestoreOutcome.SUCCESS
+    assert dest.state_by_key() == source.state_by_key()
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_on_late_step_surfaces_residue(tmp_path):
+    """A LATE-step failure (after categories without a rollback compensator were
+    created) surfaces INCOMPLETE rollback honestly — and a re-run still heals.
+
+    This documents a REAL orchestrator property the harness makes visible: the
+    rollback dispatch (``restore_orchestrator._delete_dispatch``) registers
+    compensators only for M3U / group / profile / channel / stream / user — NOT
+    for ``epg_source`` or ``stream_profile``. So a channel-step failure (the last
+    step) cannot fully undo the EPG source + stream profile created earlier; the
+    outcome is FAILED_ROLLBACK_INCOMPLETE with that residue left on B, reported
+    loudly (never a silent clean-success). A clean re-run still converges (the
+    residue matches → skip), proving the idempotent-recovery floor holds even from
+    an incompletely-rolled-back state.
+    """
+    source = StatefulDispatcharrFake.seeded_source()
+    dest = StatefulDispatcharrFake.empty_dest()
+
+    def _fault(method: str, payload) -> None:
+        if method == "create_channel":
+            raise _http_status_error(500, "simulated channel-write error on B")
+
+    dest.inject_fault(_fault)
+    harness = SyncHarness(source=source, dest=dest)
+
+    failed = await harness.run(confirm_apply=True, ledger_dir=tmp_path)
+
+    assert failed.outcome == RestoreOutcome.FAILED_ROLLBACK_INCOMPLETE
+    assert any("INCOMPLETE" in note for note in failed.notes)
+    # The residue (epg_source + stream_profile — no compensator) is left on B.
+    assert dest.total_rows() > 0
+
+    # A clean re-run heals despite the residue: the leftover rows match → skip,
+    # everything else is created → B converges to A.
+    dest.inject_fault(None)
+    healed = await harness.run(confirm_apply=True, ledger_dir=tmp_path)
+    assert healed.outcome == RestoreOutcome.SUCCESS
+    assert dest.state_by_key() == source.state_by_key()
+
+
+# ---------------------------------------------------------------------------
+# (d) NEVER-SYNC-USERS guard — end-to-end through the harness (D3).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_never_sync_users_end_to_end(tmp_path):
+    """D3: no user is ever created on B, even though source-A could serve them.
+
+    The source fake deliberately exposes a ``get_users`` that, if it were ever
+    reached, would return a superuser. The harness asserts it is NEVER called for
+    plan assembly AND that B's user-creating method is never invoked — the users
+    category is structurally excluded from a sync plan.
+    """
+    from unittest.mock import AsyncMock
+
+    source = StatefulDispatcharrFake.seeded_source()
+    # Wire a users getter + a B-side create that MUST NEVER fire.
+    source.get_users = AsyncMock(
+        return_value=[{"id": 99, "username": "admin", "is_superuser": True}]
+    )
+    dest = StatefulDispatcharrFake.empty_dest()
+    dest.create_user = AsyncMock(return_value={"id": 1, "username": "admin"})
+
+    harness = SyncHarness(source=source, dest=dest)
+    report = await harness.run(confirm_apply=True, ledger_dir=tmp_path)
+
+    assert report.outcome == RestoreOutcome.SUCCESS
+    # The users getter was never reached (structural exclusion, defence in depth).
+    source.get_users.assert_not_called()
+    # No user was ever created on B — the load-bearing D3 invariant.
+    dest.create_user.assert_not_called()
+    # The USER category was never populated (zero creates/would-creates) — the
+    # report auto-materializes a zero-count shell on access, so we assert counts,
+    # not None (the *plan* never carries a USER category — verified directly below).
+    user_cat = report.category(EntityType.USER)
+    assert user_cat.created == 0 and user_cat.would_create == 0
+
+    # And, directly: the assembled sync PLAN structurally excludes the USER
+    # category (it is never even gathered — D3).
+    from tasks.dbas_sync_engine import build_live_source_plan
+    from routers import backup as backup_mod
+    from unittest.mock import patch
+
+    with patch.object(backup_mod, "get_client", return_value=source):
+        plan = await build_live_source_plan()
+    assert plan.category(EntityType.USER) is None
+
+
+# ---------------------------------------------------------------------------
+# (e) REDACTION — no seeded secret reaches B end-to-end (D2).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redaction_no_seeded_secret_reaches_b(tmp_path):
+    """D2: the M3U password + EPG api_key seeded on A never appear in B's rows.
+
+    The whole config pipeline (gather → deep-redact → plan → importer → B write)
+    runs through the harness; we then dump everything B actually STORED and assert
+    neither plaintext secret is present anywhere in it.
+    """
+    leak_m3u = "LEAK-M3U-PASSWORD-XYZ"
+    leak_epg = "LEAK-EPG-APIKEY-XYZ"
+    source = StatefulDispatcharrFake.seeded_source(
+        m3u_password=leak_m3u, epg_api_key=leak_epg
+    )
+    dest = StatefulDispatcharrFake.empty_dest()
+
+    harness = SyncHarness(source=source, dest=dest)
+    report = await harness.run(confirm_apply=True, ledger_dir=tmp_path)
+    assert report.outcome == RestoreOutcome.SUCCESS
+
+    # Everything B stored, serialized — neither plaintext secret may appear.
+    stored = json.dumps(
+        {
+            "m3u_accounts": dest.m3u_accounts.list(),
+            "epg_sources": dest.epg_sources.list(),
+            "channel_groups": dest.channel_groups.list(),
+            "channels": dest.channels.list(),
+            "streams": dest.streams.list(),
+        }
+    )
+    assert leak_m3u not in stored
+    assert leak_epg not in stored
+    # The M3U account DID sync (topology) — but its secret field is redacted.
+    b_m3u = next(a for a in dest.m3u_accounts.list() if a["name"] == "Provider A")
+    assert b_m3u.get("password") != leak_m3u
+
+
+# ---------------------------------------------------------------------------
+# Write-API contract fidelity — the dest-B fake models the Dispatcharr WRITE
+# contract the sync path depends on (the bead's least-validated surface).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dest_create_returns_new_server_id():
+    """create_* echoes the payload PLUS a NEW server-assigned id (B owns ids)."""
+    dest = StatefulDispatcharrFake.empty_dest()
+    created = await dest.create_m3u_account({"name": "Provider A"})
+    assert created["name"] == "Provider A"
+    assert isinstance(created["id"], int)
+    # A second, DIFFERENT account gets a DIFFERENT id.
+    created2 = await dest.create_m3u_account({"name": "Provider B"})
+    assert created2["id"] != created["id"]
+
+
+@pytest.mark.asyncio
+async def test_dest_duplicate_create_raises_409():
+    """A duplicate create (same natural key) surfaces a real 409 conflict."""
+    import httpx
+
+    dest = StatefulDispatcharrFake.empty_dest()
+    await dest.create_channel_group("News")
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        # case-insensitive / trimmed natural key — "  news " collides with "News".
+        await dest.create_channel_group("  news ")
+    assert exc_info.value.response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_dest_update_mutates_stored_row():
+    """update_* mutates the stored row in place and returns it."""
+    dest = StatefulDispatcharrFake.empty_dest()
+    created = await dest.create_channel({"name": "CNN", "channel_number": 5})
+    updated = await dest.update_channel(created["id"], {"channel_number": 7})
+    assert updated["channel_number"] == 7
+    # The store reflects the mutation (read-after-write).
+    page = await dest.get_channels()
+    assert page["results"][0]["channel_number"] == 7
+
+
+@pytest.mark.asyncio
+async def test_dest_delete_absent_id_raises_404():
+    """delete_* of an absent id raises 404 — the rollback 404-as-success shape."""
+    import httpx
+
+    dest = StatefulDispatcharrFake.empty_dest()
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        await dest.delete_m3u_account(99999)
+    assert exc_info.value.response.status_code == 404
+
+
+def test_distinct_id_bases_prevent_a_b_id_collision():
+    """A's ids and B's ids never coincide by accident (a confused test would fail
+    loudly rather than pass on a shared id)."""
+    a = StatefulDispatcharrFake.seeded_source()
+    b = StatefulDispatcharrFake.empty_dest()
+    a_ids = {r["id"] for r in a.m3u_accounts.list()}
+    # B's next-assigned id base is far from A's, so a leaked A-id is detectable.
+    assert b.m3u_accounts._next_id not in a_ids

--- a/docs/testing/dbas-test-env.md
+++ b/docs/testing/dbas-test-env.md
@@ -128,6 +128,99 @@ hard rule (acceptance criterion #3):
 This keeps the per-PR loop fast **and** keeps the fake honest: the fake's
 correctness is *derived from* the live instance, never *assumed*.
 
+## Cross-instance sync test strategy (epic `i39wu`)
+
+Cross-instance live sync (`docs/adr/ADR-013-cross-instance-live-sync.md`) is
+**"restore over HTTP"**: ECM gathers the config of **Dispatcharr-A** and PUSHES
+it to **Dispatcharr-B** through B's WRITE API. The least-validated surface sync
+depends on is exactly that write contract — `create` (returns the created object
+with a NEW id), a **409 conflict** on a duplicate create, `update` mutation,
+async write completion — which the *read*-oriented restore mocks never covered
+(QA panel: the #1 sync test risk). Bead `enhancedchannelmanager-46pkq` builds the
+test substrate for it. **Two-tier gate**, mirroring the restore gate above:
+
+| Tier | What it proves | Where | Status |
+|------|----------------|-------|--------|
+| **Fast (per-PR)** | The sync ENGINE's convergence / idempotency / partial-failure logic against a FAITHFUL fake of B's write contract | `backend/tests/fixtures/sync_harness.py` + `backend/tests/tasks/test_sync_roundtrip.py` | **BUILT** — runs in the normal pytest suite |
+| **Live (nightly / pre-merge)** | That the fake's write-contract fidelity holds against REAL Dispatcharr (the actual 409 shape, async write completion, real id assignment) | `tests/dbas-test-env/docker-compose.dbas-sync-test.yml` (two non-colliding A+B instances) | **DEFERRED** — scaffold only, **not run in CI** |
+
+### Fast tier (BUILT) — the stateful two-instance mock harness
+
+The pre-existing engine tests (`test_dbas_sync_engine.py`) mock dest-B as
+independent `AsyncMock` methods and assert on **call counts** — proving the
+engine *calls* B, but not that B *converged* (a stateless mock's `get_*` ignores
+prior `create_*`, so "idempotency" can only be checked against a *separate*
+hand-built "already-converged" mock).
+
+The harness instead models **B as a real instance**
+(`StatefulDispatcharrFake`): every write is APPLIED — `create_*` stores the row
+and returns it with a NEW server-assigned id; a **duplicate `create_*`** (same
+natural key) raises a real `httpx` **409**; `update_*` mutates; `delete_*` (the
+rollback compensator) removes it, 404 when already gone. That statefulness makes
+the keystone assertions REAL rather than call-count proxies:
+
+- **Convergence** — `B.state_by_key() == A.state_by_key()` after an apply (every
+  source entity present on B under its natural key; ids differ — B owns its own).
+- **Idempotency** — a GENUINE second `run_sync` against the now-populated B is a
+  no-op (importers match B's own state → `ALREADY_EXISTS_IDENTICAL`, zero creates).
+- **Partial failure** — a real injected mid-sync write error on B drives the
+  orchestrator's compensating rollback against the state B actually stored; the
+  suite asserts B is left consistent and that a clean re-run **heals** (converges).
+- **Never-sync-users (D3)** and **redact-by-default (D2)** end-to-end through the
+  whole gather → redact → plan → importer → B-write pipeline.
+
+The harness is the sync analogue of `tests/dbas/test_restore_roundtrip.py` — a
+shareable keystone the downstream sync beads (`tjaey`, `kcxie`) extend.
+
+> **A real orchestrator property the harness surfaces** (documented, not a bug):
+> the rollback dispatch (`restore_orchestrator._delete_dispatch`) registers
+> compensators only for M3U / group / profile / channel / stream / user — **not**
+> `epg_source` or `stream_profile`. So a *late*-step failure can only
+> `FAILED_ROLLBACK_INCOMPLETE` (those earlier-created rows are residue on B), vs
+> an *early* failure that rolls back cleanly. Both are exercised; a clean re-run
+> heals from either. If completeness of cross-instance rollback is later deemed
+> required, registering those two compensators is the fix — tracked as a follow-up.
+
+### Live tier (DEFERRED) — what still needs a reachable Dispatcharr-B
+
+The live two-stack tier is **scaffolded but unbuilt**: no second (or first)
+Dispatcharr is reachable in this environment, so the compose file +
+write-contract fidelity against reality were authored, not run. The fast mock
+tier is the substrate that ships today; the live tier is the honest gap.
+
+**DEFERRED follow-up checklist** (a reachable Dispatcharr-B is the hard
+prerequisite — none of this could be live-validated at authoring time):
+
+- [ ] **Single-instance `zqtjj` first-bring-up checklist closed.** The two-stack
+      compose inherits every assumption in the single-instance stack (seed-admin
+      env names, `entrypoint.celery.sh` path, modular env vars, snapshot tables).
+      Those are still **authored-not-live-validated** — close
+      `tests/dbas-test-env/README.md` → "First-bring-up validation checklist"
+      against a live 0.26.0 BEFORE trusting the two-stack.
+- [ ] **Bring up `docker-compose.dbas-sync-test.yml`** (`-p dbas-sync-testenv`)
+      and confirm A (9601) + B (9602) both reach `healthy`, with B reachable from
+      A at `http://dispatcharr-b-web:9191` (the `SyncTarget.base_url` analogue).
+- [ ] **Capture the WRITE-API contract fixtures** from live B — the shapes the
+      `StatefulDispatcharrFake` reproduces: `create_*` success body (does B echo
+      the payload + a new `id`?), the **409 conflict** body on a duplicate
+      create, `update_*` response, and **async write completion** semantics (does
+      a create return synchronously, or is there a celery-backed settle the
+      importers must poll for?). Pin the fake to these with a contract test, just
+      like the restore fake (above).
+- [ ] **Run the keystone round-trip against live A→B** — seed A, `run_sync`
+      apply, assert B converged; re-run for idempotency; inject a failure
+      (e.g. revoke B mid-run) for the partial-failure path. This is the live
+      analogue of `test_sync_roundtrip.py`.
+- [ ] **Wire the nightly/pre-merge job** that runs the live tier and **fails on
+      drift** between the fake and live B (mirrors the restore two-tier gate).
+- [ ] **SSRF chokepoint, live** — confirm `security/ssrf.py` validates B's
+      `base_url` at execute time against the real in-cluster DNS name, and that
+      the insecure-TLS escape hatch still emits its per-cycle audit row.
+
+Until that checklist is closed, the per-PR mock tier is the **only** validated
+sync gate — honest about what it does and does not cover: it proves the engine's
+logic against a faithful *model* of B's write contract, not against B itself.
+
 ## Status / follow-ups
 
 Authored as infra + tooling. **Not yet live-validated** — no Dispatcharr was
@@ -138,3 +231,8 @@ endpoint/field names, celery entrypoint path, snapshot table names) is in
 `tests/dbas-test-env/README.md`. Building the validated CI fake itself is a
 follow-up (specified above, gated on a first live bring-up to capture the
 contract fixtures).
+
+For cross-instance **sync** specifically: the fast mock tier (the stateful
+two-instance harness) is **BUILT and running per-PR**; the live two-stack tier is
+**DEFERRED** with the explicit checklist above — it needs a reachable
+Dispatcharr-B, which this environment does not have.

--- a/tests/dbas-test-env/README.md
+++ b/tests/dbas-test-env/README.md
@@ -103,3 +103,47 @@ Dispatcharr reachable from the authoring sandbox).
 - [ ] **Snapshot table names** in `capture-snapshot.sh` manifest query reflect
       the real schema (the row-count query is schema-introspecting, so it's
       tolerant, but eyeball the manifest).
+
+---
+
+## Two-instance sync tier (epic `i39wu`) — A + B
+
+Cross-instance live sync (`docs/adr/ADR-013-cross-instance-live-sync.md`) pushes
+the config of **Dispatcharr-A** to **Dispatcharr-B** over B's WRITE API. Testing
+it has **two tiers** (see `docs/testing/dbas-test-env.md` →
+"Cross-instance sync test strategy"):
+
+| Tier | What | Where | Status |
+|------|------|-------|--------|
+| **Fast (per-PR)** | STATEFUL two-instance MOCK harness — convergence / idempotency / partial-failure / never-users / redaction | `backend/tests/fixtures/sync_harness.py` + `backend/tests/tasks/test_sync_roundtrip.py` | **BUILT** (bead `46pkq`) — runs in the normal pytest suite |
+| **Live (nightly)** | Two REAL non-colliding Dispatcharr instances; validates the mock's write-contract fidelity (409 / async write completion) against reality | `docker-compose.dbas-sync-test.yml` (this dir) | **DEFERRED** — scaffold only; **not run in CI** until a reachable Dispatcharr-B image is wired |
+
+### Bring up the live two-stack (DEFERRED tier — not yet validated)
+
+> The fast mock tier is the one that runs today. The block below is the
+> ready-to-wire scaffold for the live tier. Do **not** assume it works until the
+> DEFERRED checklist in `docs/testing/dbas-test-env.md` is closed.
+
+```bash
+cd tests/dbas-test-env
+docker compose -p dbas-sync-testenv -f docker-compose.dbas-sync-test.yml up -d
+docker compose -p dbas-sync-testenv -f docker-compose.dbas-sync-test.yml ps
+# A = source  -> host 9601 (pg 5446);  B = dest -> host 9602 (pg 5447)
+# In-cluster, A reaches B at  http://dispatcharr-b-web:9191  (the SyncTarget base_url
+# analogue — exercises the SSRF chokepoint on B's url).
+
+# Tear down (throwaway):
+docker compose -p dbas-sync-testenv -f docker-compose.dbas-sync-test.yml down -v
+```
+
+### Isolation contract for the sync stack
+
+Same non-negotiable rules as the single-instance stack, with **distinct**
+project name / ports / volumes so all three (ECM, single-instance, two-instance)
+can coexist:
+
+- Project name `-p dbas-sync-testenv`.
+- Host ports **9601/5446** (A) and **9602/5447** (B) — off ECM's 6100/6143/6101,
+  the live 9191, and the single-instance stack's 9591/5436.
+- Volumes/network are project-scoped (`dbas-sync-testenv_*`).
+- Tear down with `-v` — throwaway.

--- a/tests/dbas-test-env/docker-compose.dbas-sync-test.yml
+++ b/tests/dbas-test-env/docker-compose.dbas-sync-test.yml
@@ -1,0 +1,237 @@
+# =============================================================================
+# CROSS-INSTANCE SYNC test stack — TWO non-colliding Dispatcharr instances (A + B)
+# =============================================================================
+#
+# STATUS: SCAFFOLD for the DEFERRED live nightly tier. NOT run in CI, NOT yet
+# live-validated. The per-PR fast tier (the STATEFUL mock harness) is the BUILT
+# half of bead enhancedchannelmanager-46pkq and lives at
+# backend/tests/fixtures/sync_harness.py + backend/tests/tasks/test_sync_roundtrip.py.
+# This file + the README "Two-instance sync tier" section + the
+# docs/testing/dbas-test-env.md "Cross-instance sync test strategy" section are
+# the documented, ready-to-wire scaffold for when a reachable Dispatcharr-B
+# image is wired into CI. See the DEFERRED checklist in dbas-test-env.md.
+#
+# Purpose (when live)
+# -------------------
+# Cross-instance live sync (epic i39wu) is "restore over HTTP": ECM gathers the
+# config of Dispatcharr-A and PUSHES it to Dispatcharr-B via B's WRITE API
+# (create/update/delete, 409 conflict, async write completion). The mock harness
+# validates the engine's convergence/idempotency/partial-failure logic against a
+# FAITHFUL fake of that write contract; THIS stack validates the fake's fidelity
+# against the REAL Dispatcharr write API — the least-validated surface sync
+# depends on (QA panel #1 risk).
+#
+# Extends the single-instance docker-compose.dbas-test.yml to TWO complete,
+# fully-isolated stacks. A = the sync SOURCE, B = the sync DESTINATION (managed
+# replica). One-way only (A -> B); B never writes back to A (ADR-013 S3).
+#
+# Version pin — same as the single-instance stack
+# -----------------------------------------------
+# Both instances pin Dispatcharr ${DISPATCHARR_VERSION:-0.26.0} (the operator's
+# live version). Mixed-version A/B sync is a SEPARATE matrix dimension and is out
+# of scope for this scaffold — A and B are the SAME version here.
+#
+# Isolation contract (NON-NEGOTIABLE — must never touch ecm-ecm-1 OR the single-
+# instance dbas-testenv stack)
+# -----------------------------------------------------------------------------
+#   * ALWAYS run with the distinct project name:  -p dbas-sync-testenv
+#   * Instance A host ports: web 9601, pg 5446.
+#   * Instance B host ports: web 9602, pg 5447.
+#     (Deliberately away from ECM's 6100/6143/6101, the operator's live 9191, AND
+#      the single-instance stack's 9591/5436.)
+#   * Per-instance named volumes + a shared project-scoped network (A reaches B
+#     by service DNS `dispatcharr-b-web:9191` — the in-cluster analogue of the
+#     SyncTarget base_url; the SSRF chokepoint is exercised against that URL).
+#   * Tear DOWN when done:
+#       docker compose -p dbas-sync-testenv -f docker-compose.dbas-sync-test.yml down -v
+# =============================================================================
+
+name: dbas-sync-testenv
+
+x-dispatcharr-web: &dispatcharr-web-base
+  image: dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-0.26.0}
+  restart: "no"
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+
+x-dispatcharr-celery: &dispatcharr-celery-base
+  image: dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-0.26.0}
+  restart: "no"
+  entrypoint: ["/app/docker/entrypoint.celery.sh"]
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+
+services:
+  # ===========================================================================
+  # INSTANCE A — the sync SOURCE (web + celery + postgres + redis).
+  # ===========================================================================
+  dispatcharr-a-web:
+    <<: *dispatcharr-web-base
+    ports:
+      - "${DBAS_SYNC_A_HTTP_PORT:-9601}:9191"
+    depends_on:
+      dispatcharr-a-db:
+        condition: service_healthy
+      dispatcharr-a-redis:
+        condition: service_healthy
+    volumes:
+      - dbas-sync-a-data:/data
+    environment:
+      - DISPATCHARR_ENV=modular
+      - POSTGRES_HOST=dispatcharr-a-db
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=dispatcharr
+      - POSTGRES_USER=dispatch
+      - POSTGRES_PASSWORD=secret
+      - REDIS_HOST=dispatcharr-a-redis
+      - REDIS_PORT=6379
+      - DISPATCHARR_LOG_LEVEL=info
+      - DISPATCHARR_SUPERUSER_USERNAME=${DBAS_SYNC_A_ADMIN_USER:-ecmtest-a}
+      - DISPATCHARR_SUPERUSER_PASSWORD=${DBAS_SYNC_A_ADMIN_PASS:-ecmtestpass-a}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9191/api/core/version/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+
+  dispatcharr-a-celery:
+    <<: *dispatcharr-celery-base
+    depends_on:
+      dispatcharr-a-db:
+        condition: service_healthy
+      dispatcharr-a-redis:
+        condition: service_healthy
+      dispatcharr-a-web:
+        condition: service_started
+    volumes:
+      - dbas-sync-a-data:/data
+    environment:
+      - DISPATCHARR_ENV=modular
+      - DISPATCHARR_PORT=9191
+      - POSTGRES_HOST=dispatcharr-a-db
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=dispatcharr
+      - POSTGRES_USER=dispatch
+      - POSTGRES_PASSWORD=secret
+      - REDIS_HOST=dispatcharr-a-redis
+      - REDIS_PORT=6379
+      - DISPATCHARR_LOG_LEVEL=info
+      - DJANGO_SETTINGS_MODULE=dispatcharr.settings
+      - PYTHONUNBUFFERED=1
+
+  dispatcharr-a-db:
+    image: postgres:17
+    restart: "no"
+    ports:
+      - "${DBAS_SYNC_A_PG_PORT:-5446}:5432"
+    environment:
+      - POSTGRES_DB=dispatcharr
+      - POSTGRES_USER=dispatch
+      - POSTGRES_PASSWORD=secret
+    volumes:
+      - dbas-sync-a-pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dispatch -d dispatcharr"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  dispatcharr-a-redis:
+    image: redis:7
+    restart: "no"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ===========================================================================
+  # INSTANCE B — the sync DESTINATION / managed replica (web + celery + pg + redis).
+  # ===========================================================================
+  dispatcharr-b-web:
+    <<: *dispatcharr-web-base
+    ports:
+      - "${DBAS_SYNC_B_HTTP_PORT:-9602}:9191"
+    depends_on:
+      dispatcharr-b-db:
+        condition: service_healthy
+      dispatcharr-b-redis:
+        condition: service_healthy
+    volumes:
+      - dbas-sync-b-data:/data
+    environment:
+      - DISPATCHARR_ENV=modular
+      - POSTGRES_HOST=dispatcharr-b-db
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=dispatcharr
+      - POSTGRES_USER=dispatch
+      - POSTGRES_PASSWORD=secret
+      - REDIS_HOST=dispatcharr-b-redis
+      - REDIS_PORT=6379
+      - DISPATCHARR_LOG_LEVEL=info
+      - DISPATCHARR_SUPERUSER_USERNAME=${DBAS_SYNC_B_ADMIN_USER:-ecmtest-b}
+      - DISPATCHARR_SUPERUSER_PASSWORD=${DBAS_SYNC_B_ADMIN_PASS:-ecmtestpass-b}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9191/api/core/version/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+
+  dispatcharr-b-celery:
+    <<: *dispatcharr-celery-base
+    depends_on:
+      dispatcharr-b-db:
+        condition: service_healthy
+      dispatcharr-b-redis:
+        condition: service_healthy
+      dispatcharr-b-web:
+        condition: service_started
+    volumes:
+      - dbas-sync-b-data:/data
+    environment:
+      - DISPATCHARR_ENV=modular
+      - DISPATCHARR_PORT=9191
+      - POSTGRES_HOST=dispatcharr-b-db
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=dispatcharr
+      - POSTGRES_USER=dispatch
+      - POSTGRES_PASSWORD=secret
+      - REDIS_HOST=dispatcharr-b-redis
+      - REDIS_PORT=6379
+      - DISPATCHARR_LOG_LEVEL=info
+      - DJANGO_SETTINGS_MODULE=dispatcharr.settings
+      - PYTHONUNBUFFERED=1
+
+  dispatcharr-b-db:
+    image: postgres:17
+    restart: "no"
+    ports:
+      - "${DBAS_SYNC_B_PG_PORT:-5447}:5432"
+    environment:
+      - POSTGRES_DB=dispatcharr
+      - POSTGRES_USER=dispatch
+      - POSTGRES_PASSWORD=secret
+    volumes:
+      - dbas-sync-b-pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dispatch -d dispatcharr"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  dispatcharr-b-redis:
+    image: redis:7
+    restart: "no"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  dbas-sync-a-data:
+  dbas-sync-a-pg:
+  dbas-sync-b-data:
+  dbas-sync-b-pg:


### PR DESCRIPTION
The per-PR fast tier of the sync test harness (i39wu). Mocks-only per the PO directive — live two-stack bring-up is explicitly DEFERRED + documented (no reachable Dispatcharr-B in this environment).

- backend/tests/fixtures/sync_harness.py: a STATEFUL two-instance (source-A + dest-B) mock. dest-B is a real per-entity datastore: create stores + returns a NEW server id (distinct id bases so a leaked A-id is detectable), a duplicate create raises a real 409, update mutates, delete 404s when gone (the orchestrator's 404-as-success path). inject_fault drives mid-sync failure. This statefulness makes convergence/idempotency assertions REAL (B.state == A.state by natural key), not call-count theater.
- backend/tests/tasks/test_sync_roundtrip.py (12, keystone — mirrors the DBAS round-trip test): convergence, dry-run-zero-writes, idempotency (real 2nd run reads B's populated state -> zero creates), two partial-failure paths + re-run heals, never-sync-users (D3) end-to-end, redaction (D2) end-to-end, 5 write-contract assertions.
- tests/dbas-test-env/docker-compose.dbas-sync-test.yml: two-instance A+B compose SCAFFOLD (validates clean; for the deferred live tier, not run in CI).
- docs/testing/dbas-test-env.md: cross-instance sync two-tier strategy — mock fast tier BUILT, live nightly DEFERRED with an explicit follow-up checklist.

FINDING (flagged, not fixed — out of test-infra scope): restore_orchestrator._delete_dispatch registers rollback compensators for m3u/group/profile/channel/stream/user but NOT epg_source/stream_profile, so a LATE-step sync failure can only reach FAILED_ROLLBACK_INCOMPLETE (residue on B); an early failure rolls back clean. Both tested; a clean re-run heals from either. Follow-up bead filed.

Tests: 12 keystone; full suite 6114 passed / 0 fail. Test-infra + docs only (no production code, no version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)