### PR TITLE
Frontend tests: eliminate suite-wide React act() warnings (bead bmtoc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Fixed
+- **Frontend test suite is now React `act()`-warning clean (bead bmtoc, build 0019).** Internal-only, no user-facing change: cleared ~88 `act()` async-state warnings across 8 test files (`BackupRestoreSection`, `PreviewStreamModal`, `M3UChangesTab`, `BackupRestoreModal`, `DbasRestoreModal`, `BandwidthPanel`, `EnhancedStatsPanel`, `WatchHistoryPanel`) by awaiting the trailing mount-effect state updates with `waitFor` (the same pattern as the earlier `PopularityPanel` fix). No production code touched, no assertions weakened, all 1665 tests still pass — the warnings no longer bury real signal in CI output. (bead bmtoc)
 - **Frontend dev-quality cleanup (beads 2gg44/v7oql/qpw9a, build 0018).** Internal-only, no user-facing behavior change: (1) `.dist_root` (a local frontend build-output dir) is now git-ignored and excluded from eslint, so a stray local build can no longer flood root-level `npm run lint` with errors from minified bundles; (2) removed the `act()` async-state warnings from `PopularityPanel.test.tsx` by awaiting the settling state updates (all tests still pass); (3) memoized the `epgSourcePriority` map in `EditChannelModal` for consistency with `BulkEPGAssignModal`. (beads 2gg44 / v7oql / qpw9a)
 
 ### Security

--- a/backend/main.py
+++ b/backend/main.py
@@ -132,7 +132,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0018",
+    version="0.17.6-0019",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -74,7 +74,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0018"
+APP_VERSION = "0.17.6-0019"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0018",
+  "version": "0.17.6-0019",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/BackupRestoreModal.test.tsx
+++ b/frontend/src/components/BackupRestoreModal.test.tsx
@@ -51,21 +51,38 @@ describe('BackupRestoreModal', () => {
   });
 
   describe('upload step', () => {
-    it('renders dropzone', () => {
+    it('renders dropzone', async () => {
       render(<BackupRestoreModal onClose={mockClose} />);
       expect(screen.getByText(/drag & drop/i)).toBeInTheDocument();
       expect(screen.getByText('.yaml or .yml files')).toBeInTheDocument();
+
+      // Let the mount-time getSettings() fetch settle so the resulting state
+      // update (setDispatcharrUrl) happens inside act() — otherwise React logs
+      // an act() warning for the un-awaited promise resolution.
+      await waitFor(() => {
+        expect(api.getSettings).toHaveBeenCalled();
+      });
     });
 
-    it('renders cancel button', () => {
+    it('renders cancel button', async () => {
       render(<BackupRestoreModal onClose={mockClose} />);
       expect(screen.getByText('Cancel')).toBeInTheDocument();
+
+      // Let the mount-time getSettings() fetch settle.
+      await waitFor(() => {
+        expect(api.getSettings).toHaveBeenCalled();
+      });
     });
 
-    it('calls onClose when cancel clicked', () => {
+    it('calls onClose when cancel clicked', async () => {
       render(<BackupRestoreModal onClose={mockClose} />);
       fireEvent.click(screen.getByText('Cancel'));
       expect(mockClose).toHaveBeenCalled();
+
+      // Let the mount-time getSettings() fetch settle.
+      await waitFor(() => {
+        expect(api.getSettings).toHaveBeenCalled();
+      });
     });
 
     it('shows error for non-yaml file', async () => {

--- a/frontend/src/components/DbasRestoreModal.test.tsx
+++ b/frontend/src/components/DbasRestoreModal.test.tsx
@@ -60,9 +60,16 @@ describe('DbasRestoreModal', () => {
     (api.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue({ url: 'http://disp:9191' });
   });
 
-  it('renders the upload dropzone first', () => {
+  it('renders the upload dropzone first', async () => {
     render(<DbasRestoreModal onClose={vi.fn()} />);
     expect(screen.getByText(/drag & drop a backup artifact/i)).toBeInTheDocument();
+
+    // Let the mount-time getSettings() fetch settle so the resulting state
+    // update (setDispatcharrUrl) happens inside act() — otherwise React logs
+    // an act() warning for the un-awaited promise resolution.
+    await waitFor(() => {
+      expect(api.getSettings).toHaveBeenCalled();
+    });
   });
 
   it('a plain .zip goes to configure with no passphrase field', async () => {

--- a/frontend/src/components/PreviewStreamModal.test.tsx
+++ b/frontend/src/components/PreviewStreamModal.test.tsx
@@ -23,6 +23,8 @@ vi.mock('../services/api', async () => {
   };
 });
 
+import * as api from '../services/api';
+
 describe('PreviewStreamModal', () => {
   const mockStream: Stream = {
     id: 1,
@@ -70,26 +72,39 @@ describe('PreviewStreamModal', () => {
       expect(container.firstChild).toBeNull();
     });
 
-    it('returns null when no stream or channel provided', () => {
+    it('returns null when no stream or channel provided', async () => {
       const { container } = render(
         <PreviewStreamModal {...defaultProps} />
       );
       expect(container.firstChild).toBeNull();
+
+      // Let the mount-time getSettings() fetch settle so the resulting state
+      // update (setPreviewMode) happens inside act() — otherwise React logs
+      // an act() warning for the un-awaited promise resolution.
+      await waitFor(() => {
+        expect(api.getSettings).toHaveBeenCalled();
+      });
     });
   });
 
   describe('rendering - stream preview', () => {
-    it('renders modal when isOpen is true with stream', () => {
+    it('renders modal when isOpen is true with stream', async () => {
       render(<PreviewStreamModal {...defaultProps} stream={mockStream} />);
       expect(screen.getByText('Stream Preview')).toBeInTheDocument();
+
+      // Let the mount-time getSettings() fetch settle so the resulting state
+      // update (setPreviewMode) happens inside act().
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('renders stream name', () => {
+    it('renders stream name', async () => {
       render(<PreviewStreamModal {...defaultProps} stream={mockStream} />);
       expect(screen.getByText('Test Stream')).toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('renders channel name when provided', () => {
+    it('renders channel name when provided', async () => {
       render(
         <PreviewStreamModal
           {...defaultProps}
@@ -98,19 +113,25 @@ describe('PreviewStreamModal', () => {
         />
       );
       expect(screen.getByText('My Channel')).toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('renders TVG-ID metadata', () => {
+    it('renders TVG-ID metadata', async () => {
       render(<PreviewStreamModal {...defaultProps} stream={mockStream} />);
       expect(screen.getByText('TVG-ID: test.stream')).toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('renders channel group metadata', () => {
+    it('renders channel group metadata', async () => {
       render(<PreviewStreamModal {...defaultProps} stream={mockStream} />);
       expect(screen.getByText('Sports')).toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('renders provider name when provided', () => {
+    it('renders provider name when provided', async () => {
       render(
         <PreviewStreamModal
           {...defaultProps}
@@ -119,55 +140,77 @@ describe('PreviewStreamModal', () => {
         />
       );
       expect(screen.getByText('My IPTV Provider')).toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('renders video player', () => {
+    it('renders video player', async () => {
       render(<PreviewStreamModal {...defaultProps} stream={mockStream} />);
       expect(screen.getByTestId('mock-video-player')).toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('renders fallback options for streams', () => {
+    it('renders fallback options for streams', async () => {
       render(<PreviewStreamModal {...defaultProps} stream={mockStream} />);
       expect(screen.getByText('Open in VLC')).toBeInTheDocument();
       expect(screen.getByText('Download M3U')).toBeInTheDocument();
       expect(screen.getByText('Copy URL')).toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
   });
 
   describe('rendering - channel preview', () => {
-    it('renders channel preview title', () => {
+    it('renders channel preview title', async () => {
       render(<PreviewStreamModal {...defaultProps} channel={mockChannel} />);
       expect(screen.getByText('Channel Preview')).toBeInTheDocument();
+
+      // Let the mount-time getSettings() fetch settle so the resulting state
+      // update (setPreviewMode) happens inside act().
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('renders channel name', () => {
+    it('renders channel name', async () => {
       render(<PreviewStreamModal {...defaultProps} channel={mockChannel} />);
       expect(screen.getByText('Test Channel')).toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('renders channel number metadata', () => {
+    it('renders channel number metadata', async () => {
       render(<PreviewStreamModal {...defaultProps} channel={mockChannel} />);
       expect(screen.getByText('Channel 101')).toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('renders stream count metadata', () => {
+    it('renders stream count metadata', async () => {
       render(<PreviewStreamModal {...defaultProps} channel={mockChannel} />);
       expect(screen.getByText('2 streams')).toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('renders TVG-ID for channel', () => {
+    it('renders TVG-ID for channel', async () => {
       render(<PreviewStreamModal {...defaultProps} channel={mockChannel} />);
       expect(screen.getByText('TVG-ID: test.channel')).toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('renders channel preview note', () => {
+    it('renders channel preview note', async () => {
       render(<PreviewStreamModal {...defaultProps} channel={mockChannel} />);
       expect(screen.getByText(/channel output as it would appear to clients/)).toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('does not render fallback options for channels', () => {
+    it('does not render fallback options for channels', async () => {
       render(<PreviewStreamModal {...defaultProps} channel={mockChannel} />);
       expect(screen.queryByText('Open in VLC')).not.toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
   });
 
@@ -195,21 +238,30 @@ describe('PreviewStreamModal', () => {
   });
 
   describe('close functionality', () => {
-    it('renders close button', () => {
+    it('renders close button', async () => {
       render(<PreviewStreamModal {...defaultProps} stream={mockStream} />);
       expect(screen.getByText('close')).toBeInTheDocument();
+
+      // Let the mount-time getSettings() fetch settle.
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('calls onClose when close button clicked', () => {
+    it('calls onClose when close button clicked', async () => {
       render(<PreviewStreamModal {...defaultProps} stream={mockStream} />);
       fireEvent.click(screen.getByText('close'));
       expect(defaultProps.onClose).toHaveBeenCalled();
+
+      // Let the mount-time getSettings() fetch settle.
+      await waitFor(() => expect(api.getSettings).toHaveBeenCalled());
     });
 
-    it('does not close when overlay clicked', () => {
+    it('does not close when overlay clicked', async () => {
       render(<PreviewStreamModal {...defaultProps} stream={mockStream} />);
       fireEvent.click(document.querySelector('.modal-overlay')!);
       expect(defaultProps.onClose).not.toHaveBeenCalled();
+
+      // Let the mount-time getSettings() fetch settle.
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
     it('does not close when modal content clicked', async () => {
@@ -226,15 +278,21 @@ describe('PreviewStreamModal', () => {
       expect(defaultProps.onClose).not.toHaveBeenCalled();
     });
 
-    it('renders footer close button', () => {
+    it('renders footer close button', async () => {
       render(<PreviewStreamModal {...defaultProps} stream={mockStream} />);
       expect(screen.getByText('Close')).toBeInTheDocument();
+
+      // Let the mount-time getSettings() fetch settle.
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('calls onClose when footer close button clicked', () => {
+    it('calls onClose when footer close button clicked', async () => {
       render(<PreviewStreamModal {...defaultProps} stream={mockStream} />);
       fireEvent.click(screen.getByText('Close'));
       expect(defaultProps.onClose).toHaveBeenCalled();
+
+      // Let the mount-time getSettings() fetch settle.
+      await waitFor(() => expect(api.getSettings).toHaveBeenCalled());
     });
   });
 
@@ -289,10 +347,13 @@ describe('PreviewStreamModal', () => {
       expect(screen.getByText('Playback Error')).toBeInTheDocument();
     });
 
-    it('shows alternative options section for streams', () => {
+    it('shows alternative options section for streams', async () => {
       render(<PreviewStreamModal {...defaultProps} stream={mockStream} />);
       // The "Alternative Options" header should be visible for streams
       expect(screen.getByText('Alternative Options')).toBeInTheDocument();
+
+      // Let the mount-time getSettings() fetch settle.
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
   });
 
@@ -328,20 +389,26 @@ describe('PreviewStreamModal', () => {
   });
 
   describe('preview URL generation', () => {
-    it('generates stream preview URL for streams', () => {
+    it('generates stream preview URL for streams', async () => {
       render(<PreviewStreamModal {...defaultProps} stream={mockStream} />);
 
       // Check the src that was passed to VideoPlayer via the stored window value
       const passedSrc = (window as unknown as { __videoPlayerSrc: string }).__videoPlayerSrc;
       expect(passedSrc).toContain('/api/stream-preview/1');
+
+      // Let the mount-time getSettings() fetch settle.
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
 
-    it('generates channel preview URL for channels', () => {
+    it('generates channel preview URL for channels', async () => {
       render(<PreviewStreamModal {...defaultProps} channel={mockChannel} />);
 
       // Check the src that was passed to VideoPlayer via the stored window value
       const passedSrc = (window as unknown as { __videoPlayerSrc: string }).__videoPlayerSrc;
       expect(passedSrc).toContain('/api/channel-preview/1');
+
+      // Let the mount-time getSettings() fetch settle.
+      await waitFor(() => expect(screen.getByText('Transcode')).toBeInTheDocument());
     });
   });
 });

--- a/frontend/src/components/settings/BackupRestoreSection.test.tsx
+++ b/frontend/src/components/settings/BackupRestoreSection.test.tsx
@@ -65,48 +65,90 @@ describe('BackupRestoreSection', () => {
   });
 
   describe('when admin', () => {
-    it('renders all sections', () => {
+    it('renders all sections', async () => {
       render(<BackupRestoreSection isAdmin={true} />);
       expect(screen.getByText('Export Configuration (YAML)')).toBeInTheDocument();
       expect(screen.getByText('Restore from YAML Export')).toBeInTheDocument();
       expect(screen.getByText('Create Full Backup')).toBeInTheDocument();
       expect(screen.getByText('Restore Full Backup')).toBeInTheDocument();
+
+      // Let the mount-time fetch settle (getExportSections + listSavedBackups) so
+      // the resulting state updates happen inside act() — otherwise React logs an
+      // act() warning for the un-awaited effects that run after the test body.
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+      });
     });
 
-    it('renders page header', () => {
+    it('renders page header', async () => {
       render(<BackupRestoreSection isAdmin={true} />);
       expect(screen.getByText('Backup & Restore')).toBeInTheDocument();
+
+      // Let mount-time fetches settle.
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+      });
     });
 
-    it('renders YAML export button', () => {
+    it('renders YAML export button', async () => {
       render(<BackupRestoreSection isAdmin={true} />);
       expect(screen.getByText('Export YAML')).toBeInTheDocument();
+
+      // Let mount-time fetches settle.
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+      });
     });
 
-    it('renders full backup download button', () => {
+    it('renders full backup download button', async () => {
       render(<BackupRestoreSection isAdmin={true} />);
       expect(screen.getByText('Download Full Backup')).toBeInTheDocument();
+
+      // Let mount-time fetches settle.
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+      });
     });
 
-    it('shows sensitive data warning on YAML export', () => {
+    it('shows sensitive data warning on YAML export', async () => {
       render(<BackupRestoreSection isAdmin={true} />);
       expect(screen.getByText(/redacted in the export/i)).toBeInTheDocument();
+
+      // Let mount-time fetches settle.
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+      });
     });
 
-    it('shows sensitive data warning on full backup', () => {
+    it('shows sensitive data warning on full backup', async () => {
       render(<BackupRestoreSection isAdmin={true} />);
       expect(screen.getByText(/contains sensitive data/i)).toBeInTheDocument();
+
+      // Let mount-time fetches settle.
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+      });
     });
 
-    it('renders file input for zip files', () => {
+    it('renders file input for zip files', async () => {
       render(<BackupRestoreSection isAdmin={true} />);
       const fileInput = document.querySelector('input[type="file"][accept=".zip"]');
       expect(fileInput).toBeInTheDocument();
+
+      // Let mount-time fetches settle.
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+      });
     });
 
-    it('shows warning about full restore replacing data', () => {
+    it('shows warning about full restore replacing data', async () => {
       render(<BackupRestoreSection isAdmin={true} />);
       expect(screen.getByText(/replace all current settings/i)).toBeInTheDocument();
+
+      // Let mount-time fetches settle.
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+      });
     });
   });
 
@@ -170,19 +212,29 @@ describe('BackupRestoreSection', () => {
   });
 
   describe('YAML restore modal', () => {
-    it('opens restore modal on button click', () => {
+    it('opens restore modal on button click', async () => {
       render(<BackupRestoreSection isAdmin={true} />);
       fireEvent.click(screen.getByText('Restore from YAML...'));
 
       expect(screen.getByTestId('backup-restore-modal')).toBeInTheDocument();
+
+      // Let mount-time fetches settle (getExportSections + listSavedBackups).
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+      });
     });
 
-    it('closes restore modal', () => {
+    it('closes restore modal', async () => {
       render(<BackupRestoreSection isAdmin={true} />);
       fireEvent.click(screen.getByText('Restore from YAML...'));
       fireEvent.click(screen.getByText('Close Modal'));
 
       expect(screen.queryByTestId('backup-restore-modal')).not.toBeInTheDocument();
+
+      // Let mount-time fetches settle.
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+      });
     });
   });
 

--- a/frontend/src/components/tabs/BandwidthPanel.test.tsx
+++ b/frontend/src/components/tabs/BandwidthPanel.test.tsx
@@ -71,6 +71,13 @@ describe('BandwidthPanel', () => {
       render(<BandwidthPanel />);
 
       expect(screen.getByText('Loading bandwidth data...')).toBeInTheDocument();
+
+      // Let the mount-time fetch settle so the resulting state updates happen
+      // inside act() (otherwise React logs an act() warning for the
+      // un-awaited fetchData() that flips loading off after this test body).
+      await waitFor(() => {
+        expect(screen.queryByText('Loading bandwidth data...')).not.toBeInTheDocument();
+      });
     });
 
     it('fetches data on mount', async () => {

--- a/frontend/src/components/tabs/EnhancedStatsPanel.test.tsx
+++ b/frontend/src/components/tabs/EnhancedStatsPanel.test.tsx
@@ -74,6 +74,13 @@ describe('EnhancedStatsPanel', () => {
       render(<EnhancedStatsPanel />);
 
       expect(screen.getByText('Loading enhanced statistics...')).toBeInTheDocument();
+
+      // Let the mount-time fetch settle so the resulting state updates happen
+      // inside act() (otherwise React logs an act() warning for the
+      // un-awaited fetchData() that flips loading off after this test body).
+      await waitFor(() => {
+        expect(screen.queryByText('Loading enhanced statistics...')).not.toBeInTheDocument();
+      });
     });
 
     it('fetches data on mount', async () => {

--- a/frontend/src/components/tabs/M3UChangesTab.test.tsx
+++ b/frontend/src/components/tabs/M3UChangesTab.test.tsx
@@ -97,12 +97,26 @@ describe('M3UChangesTab', () => {
       renderWithProviders(<M3UChangesTab />);
 
       expect(screen.getByText('M3U Changes')).toBeInTheDocument();
+
+      // Let the mount-time fetch settle so the resulting state updates happen
+      // inside act() (otherwise React logs an act() warning for the
+      // un-awaited fetchData() that flips loading off after this test body).
+      await waitFor(() => {
+        expect(screen.queryByText('Loading changes...')).not.toBeInTheDocument();
+      });
     });
 
     it('shows loading state initially', async () => {
       renderWithProviders(<M3UChangesTab />);
 
       expect(screen.getByText('Loading changes...')).toBeInTheDocument();
+
+      // Let the mount-time fetch settle so the resulting state updates happen
+      // inside act() (otherwise React logs an act() warning for the
+      // un-awaited fetchData() that flips loading off after this test body).
+      await waitFor(() => {
+        expect(screen.queryByText('Loading changes...')).not.toBeInTheDocument();
+      });
     });
 
     it('fetches accounts, changes, and summary on mount', async () => {

--- a/frontend/src/components/tabs/WatchHistoryPanel.test.tsx
+++ b/frontend/src/components/tabs/WatchHistoryPanel.test.tsx
@@ -92,6 +92,13 @@ describe('WatchHistoryPanel', () => {
       render(<WatchHistoryPanel />);
 
       expect(screen.getByText('Loading watch history...')).toBeInTheDocument();
+
+      // Let the mount-time fetch settle so the resulting state updates happen
+      // inside act() (otherwise React logs an act() warning for the
+      // un-awaited fetchData() that flips loading off after this test body).
+      await waitFor(() => {
+        expect(screen.queryByText('Loading watch history...')).not.toBeInTheDocument();
+      });
     });
 
     it('fetches data on mount with default params', async () => {


### PR DESCRIPTION
**Internal-only, no user-facing change.** Drives the frontend vitest suite's ~88 React `act()` async-state warnings to **zero**.

Same class as the earlier `PopularityPanel` fix (v7oql), now extended suite-wide. Every offender fetched async data in a mount `useEffect`; tests that asserted only synchronous initial state exited before those effects resolved, firing state updates outside `act()`. Fixed by awaiting the settled UI with `waitFor` after the existing assertions.

### Files (test-only, 8)
`BackupRestoreSection` (~15), `PreviewStreamModal` (~24), `M3UChangesTab` (~12), `BackupRestoreModal` (3), `DbasRestoreModal` (1), `BandwidthPanel` (2), `EnhancedStatsPanel` (4), `WatchHistoryPanel` (2).

### Rules honored
No production code touched · no assertions weakened · no console silencing · test count unchanged (1665).

### Verification (independently re-run)
- Full vitest: **1665 passed**, and `grep -c "not wrapped in act"` on the run output → **0**
- `tsc` clean · `eslint src` clean
- Version consistency: all 3 touchpoints at `0.17.6-0019`

Bead: `bmtoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)