### PR TITLE
docs: DBAS operator guide — full Backup & Restore article set (bead sxx9x)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -939,18 +939,101 @@ Names are unique. Each table is capped at 10 000 entries.
 | `DELETE /api/export/publish-history` | Clear publish history |
 | `DELETE /api/export/publish-history/{id}` | Delete publish history entry |
 
-## Backup
+## Backup & Restore
+
+The Backup & Restore subsystem (v0.18.0, ADR-012) exposes two tiers of endpoints: the **DBAS artifact** path (new-format v0.18.0, full 12-category round-trip) and the **legacy ZIP/YAML** path (pre-v0.18.0, ECM-config-only). All endpoints require admin authentication unless noted.
+
+### DBAS artifact endpoints (v0.18.0+)
+
+These endpoints operate on the new-format `.zip` artifacts produced by the `dbas_backup` task. They cover the full 12-category Dispatcharr + ECM configuration.
 
 | Endpoint | Description |
 |-|-|
-| `GET /api/backup/create` | Download backup zip of all configuration |
-| `POST /api/backup/restore` | Restore from uploaded backup zip |
-| `POST /api/backup/restore-initial` | Restore from backup during initial setup (no auth) |
-| `GET /api/backup/export-sections` | List available YAML export sections |
-| `POST /api/backup/export` | Export selected sections as YAML |
-| `POST /api/backup/import` | Import from YAML backup |
-| `GET /api/backup/saved` | List saved YAML backup files |
-| `DELETE /api/backup/saved/{filename}` | Delete a saved YAML backup file |
+| `POST /api/backup/restore-dbas` | Upload and restore a DBAS artifact (streaming, max 2 GiB). Validates integrity, schema version, and decompression-bomb checks before any mutation. Runs a **dry-run by default** (`confirm_apply=false`); pass `confirm_apply=true` to apply. Returns a `RestoreReport` with per-category `created/updated/skipped/failed` counts and `outcome` (tri-state: `success`, `partial_failed_rolled_back`, `failed_rollback_incomplete`). |
+| `POST /api/backup/restore-dbas-saved` | Restore a saved DBAS artifact by filename (artifact must be in `/config/backups/`). Same dry-run/apply semantics as `/restore-dbas`. The saved file is not deleted. |
+| `GET /api/backup/saved` | List saved DBAS backup artifacts under `/config/backups/`. Returns filename, size, and creation time. |
+| `GET /api/backup/saved/{filename}` | Download a saved backup artifact (streamed). |
+| `DELETE /api/backup/saved/{filename}` | Delete a saved backup artifact. |
+
+#### Key restore parameters (`POST /api/backup/restore-dbas`)
+
+| Parameter | Type | Default | Description |
+|-|-|-|-|
+| `file` | multipart file | required | The `.zip` backup artifact (plain or encrypted). |
+| `confirm_apply` | bool | `false` | Set `true` to apply mutations. `false` (default) runs a counts-only dry-run; no changes are made. |
+| `passphrase` | string | — | Required when the artifact is encrypted (detected from the file header). **Never logged or echoed.** |
+| `selected_categories` | string (JSON array) | all categories | Comma-separated or JSON list of category keys to restore (e.g. `["m3u_accounts","channels"]`). Omit to restore all. |
+
+#### RestoreReport response shape
+
+```json
+{
+  "is_dry_run": true,
+  "outcome": null,
+  "categories": [
+    {
+      "entity_type": "m3u_account",
+      "created": 0, "updated": 0, "skipped": 0, "failed": 0,
+      "would_create": 3, "would_update": 0, "would_skip": 1,
+      "skip_details": [
+        { "reason": "already_exists_identical", "label": "My Provider", "source_export_id": 42 }
+      ],
+      "failure_details": []
+    }
+  ],
+  "logo_misses": 0,
+  "started_at": "2026-06-28T12:00:00Z",
+  "completed_at": "2026-06-28T12:00:05Z",
+  "notes": ["apply not confirmed — produced a counts-only dry-run; no mutation performed."]
+}
+```
+
+- `is_dry_run: true` → `would_*` counts are populated; `created/updated/skipped/failed` are zero.
+- `is_dry_run: false` → `created/updated/skipped/failed` counts are populated.
+- `outcome` is `null` on a dry-run (a plan has no realized outcome). On an apply: `success`, `partial_failed_rolled_back`, or `failed_rollback_incomplete`.
+- `logo_misses` is an aggregate count of logos that could not be matched or applied.
+
+#### Error responses
+
+| Status | Detail | When |
+|-|-|-|
+| 400 | `"Unsupported backup version"` | Artifact `schema_version` is newer than this ECM build supports. |
+| 400 | `"Backup integrity check failed"` | A member's SHA-256 does not match the manifest. |
+| 400 | `"Backup archive rejected"` | Decompression-bomb check failed (too many entries, too high a ratio, or excessive uncompressed size). |
+| 400 | `"Not a valid ECM backup artifact"` | The artifact is missing `manifest.json`. |
+| 400 | `"Could not decrypt artifact: wrong passphrase or corrupted artifact"` | Passphrase is wrong, or the encrypted artifact is corrupted. The same message is returned for both cases (no oracle). |
+
+### Legacy ZIP/YAML endpoints (pre-v0.18.0 compatibility)
+
+These endpoints operate on the pre-v0.18.0 format (ECM settings + `journal.db` only, no full Dispatcharr configuration round-trip). They remain available for compatibility and are used by the legacy restore-on-first-run wizard.
+
+| Endpoint | Description |
+|-|-|
+| `GET /api/backup/create` | Download a legacy ZIP backup (settings + journal.db + logos). |
+| `POST /api/backup/restore` | Restore from an uploaded legacy ZIP backup. |
+| `POST /api/backup/restore-initial` | Restore from a legacy backup during first-run setup (no auth required). |
+| `GET /api/backup/export-sections` | List available YAML export sections. |
+| `POST /api/backup/export` | Export selected sections as a YAML file. |
+| `POST /api/backup/import` | Import from a YAML backup file. |
+| `POST /api/backup/validate` | Validate a YAML export file and return section item counts. |
+| `POST /api/backup/restore-yaml` | Restore from a YAML export (selective-section restore). |
+| `POST /api/backup/save` | Save a legacy ZIP backup to `/config/backups/`. |
+| `POST /api/backup/restore-saved` | Restore from a saved legacy ZIP backup by filename. |
+
+### Cloud destination endpoints
+
+| Endpoint | Description |
+|-|-|
+| `GET /api/cloud-targets` | List configured cloud storage targets (credentials masked). |
+| `POST /api/cloud-targets` | Create a cloud storage target. |
+| `GET /api/cloud-targets/{id}` | Get a cloud storage target. |
+| `PUT /api/cloud-targets/{id}` | Update a cloud storage target. |
+| `DELETE /api/cloud-targets/{id}` | Delete a cloud storage target. |
+| `POST /api/cloud-targets/{id}/test` | Test connectivity to a cloud storage target. |
+
+**Supported provider types in v0.18.0:** `s3` (AWS S3, MinIO, Backblaze B2), `gdrive` (Google Drive), `webdav`. Adapters for `onedrive` and `dropbox` exist in the codebase but are deferred — a configured target of a deferred provider type produces a per-target failure on each backup run.
+
+See the [user guide](user_guide/backup-restore/configure-cloud-destinations.md) for per-provider credential fields.
 
 ## Authentication
 

--- a/docs/runbooks/disaster-recovery-restore.md
+++ b/docs/runbooks/disaster-recovery-restore.md
@@ -1,0 +1,227 @@
+# Runbook: Disaster Recovery — ECM Configuration Restore
+
+> Restore ECM + Dispatcharr configuration from a DBAS backup artifact after host failure, data loss, or a corrupt Dispatcharr instance.
+
+- **Severity**: P1 (complete configuration loss) / P2 (partial data loss, instance degraded)
+- **Owner**: SRE / Operator
+- **Last reviewed**: 2026-06-28
+- **Related beads**: `enhancedchannelmanager-0i2vt` (epic), `enhancedchannelmanager-sxx9x` (this doc)
+- **Related ADR**: ADR-012 (`docs/adr/ADR-012-dbas-absorption-approach.md`)
+
+---
+
+## Alert / Trigger
+
+- **Manual trigger**: Host failure, container loss, or accidental bulk-deletion that destroyed Dispatcharr configuration.
+- **Manual trigger**: Post-migration: need to restore an archived configuration onto a freshly installed Dispatcharr.
+- **Alert**: If `ECMSyncStalledTargetDrift` fires and the standby instance needs to be promoted, use this runbook to restore the latest backup onto the standby before treating it as primary.
+
+---
+
+## Symptoms
+
+- Dispatcharr has no channels, M3U accounts, or EPG sources (fresh/wiped instance).
+- ECM has lost its `journal.db`, settings, or logo files.
+- The `/api/health/ready` endpoint returns unhealthy due to missing Dispatcharr configuration.
+- Channels were bulk-deleted accidentally and the instance needs to be rolled back.
+
+---
+
+## Diagnosis
+
+### Step 1 — Confirm you have a usable backup
+
+```bash
+ls -lh /config/backups/ecm-backup-*.zip
+```
+
+Expected: one or more `.zip` files sorted by timestamp. The most recent is the best candidate.
+
+If no local backup exists, check your configured cloud destinations (S3 bucket, WebDAV server, GDrive folder) for the most recent artifact.
+
+### Step 2 — Verify the artifact integrity
+
+```bash
+sha256sum -c /config/backups/ecm-backup-YYYY-MM-DD_HHMMSS.zip.sha256
+```
+
+Expected output: `ecm-backup-YYYY-MM-DD_HHMMSS.zip: OK`
+
+If the sidecar is absent or the hash does not match, the artifact is corrupted. Use an earlier backup.
+
+### Step 3 — Check ECM is running and can reach Dispatcharr
+
+```bash
+docker exec ecm-ecm-1 curl -s http://localhost:8080/api/health/ready | python3 -m json.tool
+```
+
+Expected: `"dispatcharr": "ok"` (or equivalent healthy state). If Dispatcharr is unreachable, resolve that first — the restore pipeline writes directly to the Dispatcharr API.
+
+### Step 4 — Determine if the artifact is encrypted
+
+```bash
+python3 -c "
+import sys
+with open('/config/backups/ecm-backup-YYYY-MM-DD_HHMMSS.zip','rb') as f:
+    print('ENCRYPTED' if f.read(8)==b'ECMBKENC' else 'PLAINTEXT')
+"
+```
+
+If `ENCRYPTED`: have the passphrase ready before proceeding. If the passphrase is lost, you cannot decrypt this artifact — go to an older unencrypted backup.
+
+---
+
+## Resolution
+
+### Phase 1 — Pre-restore (5 minutes)
+
+**1.1 Take a fresh backup of current state (if any state exists).**
+
+If the Dispatcharr instance still has any configuration (even partial), snapshot it first:
+
+```bash
+# Trigger a manual backup via the API
+curl -s -X POST http://localhost:8080/api/backup/save \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+Or use the UI: **Settings → Backup & Restore → Back Up Now**.
+
+**1.2 Open the Restore DBAS Backup modal.**
+
+Go to **Settings → Backup & Restore → Restore DBAS Backup** in the ECM UI.
+
+### Phase 2 — Upload and validate (2 minutes)
+
+**2.1** Upload the backup `.zip` artifact. If it is encrypted, enter the passphrase when prompted.
+
+ECM validates:
+- Decompression-bomb check (header scan only — nothing decompressed).
+- `manifest.json` presence and integrity.
+- `schema_version` compatibility (artifact must not be newer than this ECM build).
+- Per-member SHA-256 verification.
+
+If validation fails, stop and use an older backup.
+
+**2.2** Note the reported `schema_version` and `app_version` from the manifest display.
+
+### Phase 3 — Dry-run preview (3 minutes)
+
+**3.1** Click **Preview** (default mode — no changes are written).
+
+**3.2** Review the per-category counts:
+
+| Category | Expected count | What to check |
+|-|-|-|
+| M3U accounts | Matches source instance | Wrong count = wrong backup |
+| Channel groups | Matches source instance | |
+| Channels | Matches source instance | |
+| Logos | Any non-zero count | Logo misses acceptable; channels still work |
+| Users | 0 (not selected by default) | Enable explicitly if needed |
+
+**3.3** If counts look wrong: verify you uploaded the correct artifact. Do not apply if the category counts are significantly lower than expected.
+
+**3.4** Check for pre-flight problems in the report notes. Common ones:
+- `unresolved_fk_reference` — the backup's channels reference groups/profiles not in the archive. Ensure channel groups are in the restore selection.
+- `duplicate_unique_name` — duplicate names in one category. Contact support — this should not occur in an ECM-produced artifact.
+
+### Phase 4 — Apply (15–30 minutes depending on logo count)
+
+**4.1** Click **Apply these changes**.
+
+**4.2** Confirm the dialog.
+
+**4.3** Monitor live progress. The restore runs in the fixed order:
+
+1. M3U accounts (with deferred auto-sync)
+2. EPG sources
+3. Channel groups
+4. Channel profiles
+5. Stream profiles
+6. User agents
+7. Users (if selected)
+8. Channels (with 4-tier stream matching)
+9. Logos
+10. Deferred auto-sync settings (applied last)
+
+**4.4** Wait for the restore-complete report.
+
+### Phase 5 — Interpret the result
+
+| Outcome | Action |
+|-|-|
+| **Success** | Go to Phase 6 — verification. |
+| **Restore failed — state rolled back** | The rollback ran cleanly. Instance is at pre-restore state. Diagnose the failure reason in the report notes and retry. See Phase 5a. |
+| **Restore failed — rollback incomplete** | **Critical — stop.** See Phase 5b. |
+
+**Phase 5a — Rolled-back failure:**
+
+Read the notes section. Common causes:
+- Dispatcharr returned an API error for a specific entity. Check Dispatcharr logs: `docker logs dispatcharr 2>&1 | tail -100`.
+- Network timeout. Confirm ECM→Dispatcharr connectivity: `docker exec ecm-ecm-1 curl -s http://dispatcharr:8080/api/health`.
+- Name conflict on the destination. If the destination has existing entities with conflicting names, the restore skips or fails them. Consider wiping the destination first if this is a fresh install.
+
+After resolving the cause, re-attempt from Phase 3.
+
+**Phase 5b — Rollback incomplete (instance in partial state):**
+
+The restore created some entities and could not roll them back. The report lists the entity IDs.
+
+```bash
+# Get the residue list from the restore report (displayed in the UI)
+# Manually delete each listed entity via the Dispatcharr UI or API
+# Example: delete a channel group by its destination ID
+curl -s -X DELETE http://dispatcharr:8080/api/channel-groups/ID \
+  -H "Authorization: Bearer DISPATCHARR_TOKEN"
+```
+
+Repeat for each listed entity type and ID. Once all residue is deleted, take a fresh local backup and retry the restore from Phase 3.
+
+### Phase 6 — Verification (5 minutes)
+
+**6.1** Navigate to **Channels** in ECM and confirm the channel count matches the backup.
+
+**6.2** Check channel groups are present: **Settings → Channel Groups**.
+
+**6.3** Run an M3U refresh to confirm streams are populating:
+```bash
+curl -s -X POST http://localhost:8080/api/tasks/m3u_refresh/run \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+**6.4** Run an EPG refresh if guide data is absent.
+
+**6.5** Test playback on one channel per M3U provider to confirm stream assignment worked.
+
+**6.6** If logos are missing (red banner on restore-complete), this is a warning — channels work. Re-upload logos manually or re-run an EPG logo match.
+
+---
+
+## Escalation
+
+If the restore repeatedly fails or if the rollback-incomplete state cannot be resolved within 30 minutes:
+
+1. Preserve the restore-complete report (screenshot or copy the text).
+2. Note the restore ID from the ledger filename: `ls /config/dbas/restore_ledger_*.json`.
+3. File an incident bead with: artifact name, schema_version, failure notes, and the entity residue list.
+
+---
+
+## Post-incident
+
+- [ ] Take a fresh backup from the recovered instance once verification passes.
+- [ ] If you used an old backup, file a bead to investigate why newer backups were not available.
+- [ ] If the restore pipeline itself failed (not a data issue), attach logs and file a bead.
+- [ ] Update cloud destination configuration if the incident exposed a gap in off-host storage coverage.
+- [ ] Consider enabling [Cross-Instance Sync](../user_guide/backup-restore/cross-instance-sync.md) for a standing DR standby.
+- [ ] Schedule a postmortem if this was P1 (use `/postmortem` skill).
+
+---
+
+## References
+
+- [Backup & Restore overview](../user_guide/backup-restore/backup-overview.md)
+- [Restore a backup — user guide](../user_guide/backup-restore/restore-a-backup.md)
+- [Troubleshoot a restore](../user_guide/backup-restore/troubleshoot-restore.md)
+- ADR-012 (`docs/adr/ADR-012-dbas-absorption-approach.md`) — the restore pipeline design
+- Threat model (`docs/security/threat_model_dbas_import.md`) — restore security controls

--- a/docs/user_guide/backup-restore/backup-overview.md
+++ b/docs/user_guide/backup-restore/backup-overview.md
@@ -1,0 +1,126 @@
+# Backup & Restore — Overview
+
+> **Audience:** Operator who wants to understand what a backup contains, what it protects, and how to think about cadence and retention before configuring anything.
+>
+> **Status:** Shipped in v0.18.0 (epic `0i2vt`, ADR-012).
+
+---
+
+## What a backup is
+
+A **Backup & Restore** backup is a single `.zip` artifact that captures your complete Dispatcharr + ECM configuration. It contains everything needed to bring a fresh Dispatcharr instance to the same operational state as the one that produced it — or to recover from accidental data loss on the same instance.
+
+Backups are built by the `dbas_backup` task (scheduled or on-demand) and stored locally under `/config/backups/`. They can optionally be uploaded to off-host cloud storage for durability.
+
+---
+
+## What a backup contains (12 categories)
+
+A backup covers the following configuration categories. All are included by default; a selective restore can opt individual categories out.
+
+| Category | What is included |
+|-|-|
+| **M3U accounts** | Source URLs and account settings. Credentials are redacted by default (see [Credentials and passphrase encryption](#credentials-and-passphrase-encryption)). |
+| **EPG sources** | Source URLs and refresh settings. Credentials are redacted by default. |
+| **Channel groups** | Group names and structure. |
+| **Channel profiles** | All channel profile definitions. |
+| **Stream profiles** | All stream profile definitions. |
+| **User agents** | Configured user-agent strings. |
+| **Core settings** | ECM settings (`settings.json`). |
+| **DVR rules** | Any configured DVR recording rules. |
+| **Comskip config** | Comskip commercial-detection configuration. |
+| **Users** | Dispatcharr user accounts (opt-in — see [User restore semantics](#user-restore-semantics)). |
+| **Channels (with embedded streams)** | The full channel list, with their embedded stream assignments. |
+| **Logos** | Logo image files from `/config/uploads/logos/`, plus their URL-mapping inventory. |
+
+> **Plugins are not backed up.** Plugin state is excluded from v0.18.0 backups. This is a deliberate safety decision — plugin restore semantics are not yet defined. If you rely on plugins, document your plugin configuration separately.
+
+---
+
+## What a backup does not contain
+
+- **Live stream content** — a backup captures *definitions* (which streams are assigned to which channels), not the streams themselves.
+- **The SQLite WAL file** — ECM checkpoints the write-ahead log before building the artifact, so `journal.db` in the archive is self-contained, but the WAL itself is not included.
+- **Dispatcharr's own database** — ECM backs up the configuration it manages. Dispatcharr's internal database (viewer history, its own task state, etc.) is outside ECM's scope.
+- **Credentials in a standard backup** — M3U/EPG passwords and similar secrets are replaced with a `REDACTED` placeholder. See [Credentials and passphrase encryption](#credentials-and-passphrase-encryption) for the migration path that does carry credentials.
+
+---
+
+## The artifact format
+
+Each backup is a `.zip` file containing:
+
+- `manifest.json` — a cleartext header with `schema_version`, `app_version`, creation timestamp, and a per-member SHA-256 hash list.
+- `categories/<name>.yaml` — one YAML file per configuration category.
+- `journal.db` — a scrubbed copy of the ECM SQLite database (alert-method credential fields redacted).
+- `binary/logos/<file>` — per-image logo files, streamed one at a time.
+- `binary/metadata.json` — logo inventory.
+- `binary/url-mappings.json` — logo filename to source-URL map.
+
+A `.sha256` sidecar file is written alongside the ZIP, containing the SHA-256 of the whole artifact. ECM verifies this hash before any restore begins.
+
+### Schema version and forward compatibility
+
+The `manifest.json` contains a `schema_version` integer (distinct from the ECM app version string). A restore that receives an artifact whose `schema_version` is newer than the running ECM build refuses with "Unsupported backup version" — it does not attempt a partial restore of an incompatible artifact.
+
+When restoring a backup produced by an older ECM onto a newer ECM, the schema version is accepted (older ≤ current = accepted). This means backups are forward-compatible: an artifact from ECM v0.18.0 can be restored onto a later ECM build.
+
+---
+
+## Credentials and passphrase encryption
+
+By default, all backups are **redact-by-default**: credential fields (M3U passwords, EPG passwords, API keys, SMTP passwords, etc.) are replaced with a `REDACTED` sentinel. A restore from this artifact re-uses whatever credentials are already configured on the destination, or leaves the credential blank on a fresh install.
+
+If you are migrating to a new install and want credentials to travel with the backup, use the **Encrypted Backup** option:
+
+1. In **Settings → Backup & Restore**, open the **Encrypted Backup** card.
+2. Check the **"I understand a lost passphrase makes this artifact permanently unrecoverable"** acknowledgement.
+3. Set a passphrase of at least 12 characters. The passphrase is never stored — keep it somewhere safe.
+4. Enable **Include credentials** to carry M3U/EPG passwords and alert-method credentials alongside the encrypted artifact.
+
+An encrypted backup uses scrypt (N=2¹⁵) for key derivation and ChaCha20-Poly1305 for authenticated encryption, applied as a chunked streaming pass over the whole artifact. The passphrase is never logged or stored.
+
+> **Warning: lost passphrase = permanently unrecoverable artifact.** There is no recovery path. Store your passphrase in a password manager before taking an encrypted backup.
+
+Encrypted backups are manual-only — a passphrase is never persisted in the task schedule store.
+
+---
+
+## Retention model
+
+ECM automatically prunes old local backups (and old off-host copies at each configured cloud destination) after each verified-successful backup run. The default policy is:
+
+- **Keep the newest 7 backups**, regardless of age.
+- **Additionally prune** any backup beyond the newest 7 that is older than 30 days.
+
+The newest-N floor is always respected: even if a backup is older than 30 days, it is kept if it is within the newest 7. A failed or partial backup run never prunes anything — retention only runs when a verified-successful new backup has been written.
+
+---
+
+## User restore semantics
+
+Restoring user accounts is **opt-in** — users are not selected by default in the restore modal. When you do restore users:
+
+- The **current admin account** is never overwritten. ECM detects the currently authenticated admin and skips it during restore, so you cannot lock yourself out via a restore.
+- A user account that already exists on the destination with the same username is updated (not duplicated).
+
+See [Restore a backup](restore-a-backup.md) for the full restore flow.
+
+---
+
+## Recommended backup cadence
+
+- **Daily scheduled backup** — sufficient for most operators. Configure a `dbas_backup` task schedule in **Settings → Task Schedules**.
+- **Before any major change** — take a manual backup before reconfiguring M3U sources, bulk-editing channels, or running a major auto-creation rule change.
+- **Before a restore** — always take a fresh backup of the current state before restoring an older artifact, so you can roll back if the restore does not produce the result you expected.
+
+---
+
+## Going deeper
+
+- [Take a backup](take-a-backup.md) — step-by-step backup workflow.
+- [Verify a backup](verify-a-backup.md) — dry-run preview before committing.
+- [Restore a backup](restore-a-backup.md) — full restore flow with safety semantics.
+- [Configure cloud destinations](configure-cloud-destinations.md) — off-host storage for durability.
+- [Migrate to a new install](migrate-to-a-new-install.md) — end-to-end migration walkthrough.
+- [`docs/security/threat_model_dbas_import.md`](../../security/threat_model_dbas_import.md) — security context for import and restore, for operators evaluating the trust boundary.

--- a/docs/user_guide/backup-restore/configure-cloud-destinations.md
+++ b/docs/user_guide/backup-restore/configure-cloud-destinations.md
@@ -1,0 +1,172 @@
+# Configure Cloud Destinations
+
+> **Audience:** Operator who wants backup artifacts uploaded to off-host storage automatically after each backup run.
+>
+> **Status:** Shipped in v0.18.0. **S3 (including S3-compatible), Google Drive, and WebDAV are fully shipped. Dropbox and OneDrive adapters exist in the codebase but are deferred — see the per-provider notes below.**
+
+---
+
+## Why configure a cloud destination
+
+A local backup protects you from accidental ECM misconfiguration or data loss within your host. It does not protect you from host failure, disk failure, or container loss. Configuring a cloud destination sends each backup artifact to durable, off-host storage automatically after every successful backup run.
+
+You can configure multiple cloud destinations. Each destination applies the retention policy independently: a failed upload to one destination does not prune backups at another destination, and a failed upload never prunes the local copy.
+
+---
+
+## All providers: common SSRF security behavior
+
+Every cloud destination URL passes through ECM's SSRF (Server-Side Request Forgery) chokepoint before any connection is made. This is a non-bypassable security control:
+
+- **Always-blocked addresses** (in both LAN-friendly and public-only mode): loopback (`127.x.x.x`), link-local (`169.254.x.x` — includes the AWS/cloud metadata endpoint), CGNAT (`100.64.x.x/10`), multicast, IPv6 ULA/link-local, and non-http(s) URL schemes.
+- **LAN-friendly mode (default):** RFC 1918 private addresses (`192.168.x.x`, `10.x.x.x`, `172.16-31.x.x`) are allowed. Use this when your WebDAV server or S3-compatible endpoint is on a local NAS.
+- **Public-only mode:** RFC 1918 addresses are blocked. Switch to this mode if your threat model requires it (Settings → Security → SSRF policy, if exposed in the UI).
+
+DNS-rebinding is mitigated by resolving the endpoint hostname before connecting and then connecting by the resolved IP address, not by re-resolving at connection time.
+
+---
+
+## S3 and S3-compatible (MinIO, Backblaze B2)
+
+**Status: Shipped (v0.18.0)**
+
+The S3 adapter supports AWS S3, MinIO, and Backblaze B2. Any service that implements the S3 API is supported via a custom endpoint URL.
+
+### Required credentials
+
+| Field | Description |
+|-|-|
+| **Bucket name** | The S3 bucket to upload artifacts to. |
+| **Access key ID** | AWS/MinIO/B2 access key. |
+| **Secret access key** | AWS/MinIO/B2 secret key. |
+
+### Optional credentials
+
+| Field | Description |
+|-|-|
+| **Endpoint URL** | Custom endpoint for MinIO, B2, or any S3-compatible service. Omit for AWS (the standard AWS regional endpoints are used). |
+| **Region** | AWS region (default: `us-east-1`). Ignored for custom endpoint services. |
+
+### Security notes
+
+- A custom `endpoint_url` is pre-resolved and validated through the SSRF denylist before the S3 client is built. An endpoint pointing at `169.254.169.254` (the cloud-metadata service) is refused before any socket opens.
+- For AWS, the standard regional endpoints are public AWS infrastructure and are not operator-influenced, so they are not pre-resolved.
+
+### Setup walkthrough
+
+1. Go to **Settings → Backup & Restore → Cloud Destinations**.
+2. Click **Add destination**.
+3. Select **S3 / S3-compatible**.
+4. Fill in the required fields.
+5. Click **Test connection** to confirm ECM can reach the bucket.
+6. Click **Save**.
+
+On the next scheduled backup, ECM uploads the artifact to this bucket and verifies the upload before applying the retention policy.
+
+---
+
+## WebDAV
+
+**Status: Shipped (v0.18.0)**
+
+The WebDAV adapter works with any RFC 4918 WebDAV server: Nextcloud, ownCloud, Apache `mod_dav`, `rclone serve webdav`, a NAS's built-in WebDAV service, and others.
+
+### Required credentials
+
+| Field | Description |
+|-|-|
+| **Base URL** | The base URL of the WebDAV endpoint (e.g., `http://192.168.1.50/webdav/backups`). |
+| **Username** | Basic auth username (leave blank if the server requires no auth). |
+| **Password** | Basic auth password. |
+
+### Optional
+
+| Field | Description |
+|-|-|
+| **Allow insecure TLS** | Disable TLS certificate verification. Use only on isolated LANs where you control both endpoints. Every upload using this setting is logged. |
+
+### Security notes
+
+- The base URL is validated through the SSRF chokepoint before any connection is made.
+- Uploads are streamed from disk — the artifact is never read whole into RAM.
+- The `Authorization` header value is masked before logging.
+
+### Setup walkthrough
+
+1. Go to **Settings → Backup & Restore → Cloud Destinations**.
+2. Click **Add destination**.
+3. Select **WebDAV**.
+4. Enter the base URL and optional credentials.
+5. Click **Test connection**.
+6. Click **Save**.
+
+---
+
+## Google Drive
+
+**Status: Shipped (v0.18.0)**
+
+The Google Drive adapter uses service account (app-only) authentication.
+
+### Required credentials
+
+| Field | Description |
+|-|-|
+| **Service account key** | The JSON service account key file contents from the Google Cloud Console. |
+| **Folder ID** | The Google Drive folder ID where artifacts will be uploaded (from the folder's URL). |
+
+### Setup notes
+
+- Create a service account in the Google Cloud Console, enable the Drive API, and download a JSON key file.
+- Share the target folder with the service account's email address (give it Editor access).
+- Paste the full contents of the JSON key file into the **Service account key** field.
+
+### Setup walkthrough
+
+1. Go to **Settings → Backup & Restore → Cloud Destinations**.
+2. Click **Add destination**.
+3. Select **Google Drive**.
+4. Paste the service account JSON and fill in the folder ID.
+5. Click **Test connection**.
+6. Click **Save**.
+
+---
+
+## OneDrive / SharePoint
+
+**Status: Code exists but DEFERRED in v0.18.0. Configuring an OneDrive target will produce a per-target failure on each backup run without uploading anything.**
+
+OneDrive support using the Microsoft Graph API (client credentials OAuth2 flow) is planned but not wired for upload in v0.18.0. The adapter code is present (`backend/cloud_storage/onedrive_adapter.py`) and will be connected in a follow-up release.
+
+Do not configure an OneDrive cloud destination in v0.18.0. If you have one configured, remove it or switch to a different provider until this is resolved.
+
+---
+
+## Dropbox
+
+**Status: Code exists but DEFERRED in v0.18.0. Configuring a Dropbox target will produce a per-target failure on each backup run without uploading anything.**
+
+Dropbox support is planned but not wired for upload in v0.18.0. The adapter code is present (`backend/cloud_storage/dropbox_adapter.py`) and will be connected in a follow-up release.
+
+Do not configure a Dropbox cloud destination in v0.18.0. If you have one configured, remove it or switch to a different provider until this is resolved.
+
+---
+
+## Retention at cloud destinations
+
+After a verified-successful upload to a cloud destination, ECM applies the same retention policy used for local backups:
+
+- Keep the newest N backups (default: 7).
+- Additionally prune any backup beyond the newest N that is older than the maximum age (default: 30 days).
+
+Retention is applied independently per cloud destination. A failed upload to one destination does not prune artifacts there (no pruning without a verified-successful new upload).
+
+---
+
+## Testing and troubleshooting
+
+- **Test connection button** — use this before saving a new destination. It confirms ECM can reach the endpoint and authenticate.
+- **Task history** — after a backup run, check **Settings → Task History** for per-destination upload results.
+- **Notifications** — a failure notification is emitted when an upload fails. The notification includes the destination name (never the URL or credentials).
+
+See [Troubleshoot a restore](troubleshoot-restore.md) for further diagnostic patterns.

--- a/docs/user_guide/backup-restore/index.md
+++ b/docs/user_guide/backup-restore/index.md
@@ -2,46 +2,50 @@
 
 > **Audience:** Operator setting up backups, migrating to a new install, or recovering from a failure.
 >
-> **Status:** In progress. Cross-instance sync shipped in v0.18.1. Earlier DBAS articles (backup, restore, migration) are planned; see the articles table below. UX has confirmed the in-UI label is **Backup & Restore** — the internal acronym DBAS only appears in dev docs and the threat model.
+> **Status:** Shipped in v0.18.0 (epic `0i2vt`, ADR-012). Cross-instance sync shipped in v0.18.1. UX label is **Backup & Restore** — the internal acronym DBAS only appears in dev docs and the threat model.
 
-## Section purpose (planned)
+---
 
-Cover everything an operator needs to:
+## Start here
 
-1. Take a backup of their ECM configuration on a regular cadence.
-2. Verify a backup is valid before they need it.
-3. Restore a backup to a fresh install or recover from accidental data loss.
-4. Understand the safety semantics of import (what is overwritten, what is merged, what is rejected).
+| I want to… | Go to |
+|-|-|
+| Understand what a backup contains | [Backup & Restore overview](backup-overview.md) |
+| Take a backup right now | [Take a backup](take-a-backup.md) |
+| Confirm a backup is valid before I need it | [Verify a backup](verify-a-backup.md) |
+| Restore from a backup | [Restore a backup](restore-a-backup.md) |
+| Move to a new host | [Migrate to a new install](migrate-to-a-new-install.md) |
+| Upload backups to S3, WebDAV, or Google Drive | [Configure cloud destinations](configure-cloud-destinations.md) |
+| Diagnose a failed restore | [Troubleshoot a restore](troubleshoot-restore.md) |
+| Keep a standby instance automatically in sync | [Cross-Instance Sync](cross-instance-sync.md) |
 
-This section is unusually high-stakes — restore is a one-way door for the configuration that ends up in place — so the articles will lean heavily on dry-run workflows, conflict resolution semantics, and recovery patterns.
-
-## Intended audience
-
-- **Operator** setting up routine backups (read once, configure, forget until needed).
-- **Operator** in the middle of a recovery (read under pressure — clarity matters).
-- **Operator** migrating ECM to new hardware or a new container.
-
-End users do not read this section, but they care intensely about the outcome (their channels still working after a restore).
+---
 
 ## Articles
 
 | Article | Purpose | Status |
 |-|-|-|
-| [`cross-instance-sync.md`](cross-instance-sync.md) | One-way A→B config replication for DR standbys and multi-instance setups. Covers setup, semantics, credential handling, and troubleshooting. | **Shipped — v0.18.1** |
-| `backup-overview.md` | What a backup contains, what it does **not** contain (e.g., the SQLite journal vs. config), recommended backup frequency. | Planned |
-| `take-a-backup.md` | The Backup & Restore tab — exporting a backup, where the file lives, naming conventions. | Planned |
-| `verify-a-backup.md` | The dry-run workflow before restoring, what the dry-run output tells you. | Planned |
-| `restore-a-backup.md` | The actual restore flow, conflict resolution semantics, category ordering, what to expect post-restore. **Step-by-step, written for the operator under pressure.** | Planned |
-| `migrate-to-a-new-install.md` | End-to-end migration: backup on old install, install on new host, restore, verify. | Planned |
-| `import-from-elsewhere.md` | Importing configuration that didn't come from an ECM backup (DBAS import; see threat model for security context). | Planned |
-| `troubleshoot-restore.md` | "The restore reported conflicts" / "the restore appeared to succeed but my channels are different" — diagnostic patterns. | Planned |
+| [`backup-overview.md`](backup-overview.md) | What a backup contains, what it does not contain (plugins excluded), credentials and passphrase encryption, retention model. | **Shipped — v0.18.0** |
+| [`take-a-backup.md`](take-a-backup.md) | Manual and scheduled backup workflows, encrypted backup walkthrough. | **Shipped — v0.18.0** |
+| [`verify-a-backup.md`](verify-a-backup.md) | Dry-run preview; what the preview report tells you; counts-only limit. | **Shipped — v0.18.0** |
+| [`restore-a-backup.md`](restore-a-backup.md) | Full restore flow, category ordering, 4-tier stream matching, rollback/partial-state callout, user restore semantics. | **Shipped — v0.18.0** |
+| [`configure-cloud-destinations.md`](configure-cloud-destinations.md) | Per-provider setup: S3/S3-compatible (shipped), WebDAV (shipped), Google Drive (shipped), OneDrive (deferred), Dropbox (deferred). | **Shipped — v0.18.0** |
+| [`troubleshoot-restore.md`](troubleshoot-restore.md) | Failure modes, log patterns, rollback-incomplete recovery, logo misses. | **Shipped — v0.18.0** |
+| [`migrate-to-a-new-install.md`](migrate-to-a-new-install.md) | End-to-end migration: backup on old install, install on new host, restore, verify. | **Shipped — v0.18.0** |
+| [`cross-instance-sync.md`](cross-instance-sync.md) | One-way A→B config replication for DR standbys and multi-instance setups. | **Shipped — v0.18.1** |
 
-## Going deeper (for now)
+---
 
-- [`docs/security/threat_model_dbas_import.md`](../../security/threat_model_dbas_import.md) — security context for the import flow. Operators evaluating restore safety should be aware this exists.
-- [`docs/database_migrations.md`](../../database_migrations.md) — the migration story for the underlying SQLite schema, relevant when restoring across versions.
+## One thing you must know about encrypted backups
 
-## Tracking
+If you create an encrypted backup, **a lost passphrase makes the artifact permanently unrecoverable**. There is no reset, no recovery path, and no way to extract the plaintext without the passphrase. Store your passphrase in a password manager before creating an encrypted backup. This acknowledgement is required in the UI before an encrypted backup can be produced.
 
-- bd-gb5r5.3 — *DBAS import / restore* — the first user-facing article in this section. **Blocked by this scaffolding bead (bd-f1wnt).**
-- bd-0i2vt — *Backup & Restore epic* — fills in the rest of the section in v0.18.0.
+---
+
+## Going deeper (for operators and security evaluators)
+
+- [`docs/security/threat_model_dbas_import.md`](../../security/threat_model_dbas_import.md) — STRIDE analysis of the restore pipeline and cloud upload surface. Operators evaluating the trust boundary of a restore should read this.
+- [`docs/adr/ADR-012-dbas-absorption-approach.md`](../../adr/ADR-012-dbas-absorption-approach.md) — the design decisions behind the backup/restore subsystem (D1–D12).
+- [`docs/runbooks/disaster-recovery-restore.md`](../../runbooks/disaster-recovery-restore.md) — the SRE runbook for a full configuration restore under incident conditions.
+- [`docs/api.md`](../../api.md#backup--restore) — HTTP API reference for the Backup & Restore endpoints.
+- [`docs/database_migrations.md`](../../database_migrations.md) — the migration story for the underlying SQLite schema, relevant when restoring across ECM versions.

--- a/docs/user_guide/backup-restore/migrate-to-a-new-install.md
+++ b/docs/user_guide/backup-restore/migrate-to-a-new-install.md
@@ -1,0 +1,141 @@
+# Migrate to a New Install
+
+> **Audience:** Operator who wants to move their ECM + Dispatcharr configuration from one host to another — for example, moving to new hardware, migrating to a different container runtime, or rebuilding after a host failure.
+>
+> **Status:** Shipped in v0.18.0.
+
+---
+
+## Overview
+
+A migration is a backup on the old install, followed by a restore on the new install. Because the backup captures the full Dispatcharr configuration (M3U accounts, EPG sources, channels, groups, profiles, logos, and ECM settings), a restore on a fresh Dispatcharr instance brings it to the same operational state as the source.
+
+This walkthrough assumes:
+- The old install is still running (or was running long enough to take a backup).
+- You have a new host ready with ECM and Dispatcharr installed but not yet configured.
+- You want to carry your M3U/EPG credentials (if so, you need the encrypted backup path).
+
+---
+
+## Step 1 — Take a backup on the old install
+
+Take a **manual encrypted backup** so credentials travel with the artifact. If you are OK re-entering credentials on the new install, a standard (unencrypted) backup is sufficient.
+
+### Encrypted backup (recommended for migration)
+
+1. On the old install, go to **Settings → Backup & Restore → Encrypted Backup**.
+2. Check the acknowledgement: *"I understand a lost passphrase makes this artifact permanently unrecoverable."*
+3. Enter a passphrase of at least 12 characters. **Write it down in a password manager right now.** You need this passphrase on the new install. There is no recovery path if you lose it.
+4. Enable **Include credentials** to include M3U/EPG passwords, SMTP passwords, and alert-method credentials in the artifact.
+5. Click **Create encrypted backup**.
+
+Wait for the backup to complete (a notification appears). Then go to **Settings → Backup & Restore → Saved Backups** and download the `.zip` to your workstation.
+
+### Standard backup (if re-entering credentials is acceptable)
+
+1. On the old install, go to **Settings → Backup & Restore → Back Up Now**.
+2. Wait for completion, then download the artifact from **Saved Backups**.
+
+---
+
+## Step 2 — Install ECM and Dispatcharr on the new host
+
+Follow your normal installation procedure. At first run, ECM will show a setup wizard. You can skip the manual configuration steps — the backup will replace them.
+
+Make sure the new Dispatcharr instance is:
+- Running and reachable from ECM.
+- Not yet configured (a clean install). If it already has some configuration, the restore will merge — existing entities with the same names will be updated, not duplicated.
+
+---
+
+## Step 3 — Connect ECM to the new Dispatcharr instance
+
+Complete the initial setup in ECM to point it at the new Dispatcharr API. The restore needs a working Dispatcharr connection to apply channel and stream configuration.
+
+---
+
+## Step 4 — Run a dry-run preview
+
+Before applying the restore, run a preview to confirm the backup artifact is valid and the expected counts look right.
+
+1. On the new install, go to **Settings → Backup & Restore → Restore DBAS Backup**.
+2. Upload the `.zip` artifact you downloaded from the old install.
+3. If the artifact is encrypted, enter the passphrase when prompted.
+4. ECM validates the artifact (integrity, schema version).
+5. Click **Preview** (dry-run, the default).
+6. Review the per-category counts: M3U accounts, EPG sources, channels, etc.
+
+If the counts look wrong (too few channels, unexpected skip count), do not apply yet. Check the notes in the report for skip reasons.
+
+---
+
+## Step 5 — Apply the restore
+
+If the preview looks correct:
+
+1. Click **Apply these changes**.
+2. Confirm the dialog.
+3. Watch the live progress for each of the 13 restore stages.
+4. Review the restore-complete report.
+
+The restore applies categories in the fixed hard order: M3U accounts → EPG sources → channel groups/profiles/stream profiles → user agents/settings → users → channels → logos.
+
+### What to watch for
+
+- **Users** are not restored by default. If you want to restore user accounts, explicitly enable the users category in the restore modal before applying.
+- **The current admin account is always preserved** — the account you used to log in to the new ECM cannot be overwritten by the restore.
+- **Logo misses** appear as a red banner if any logos could not be matched. This is a warning, not a failure — channels work, logos may be absent.
+
+---
+
+## Step 6 — Re-enter credentials (standard backup only)
+
+If you used a standard (unencrypted) backup, M3U account passwords, EPG passwords, and similar credentials were redacted. On the new install:
+
+1. Go to **Settings → M3U Accounts**.
+2. Edit each M3U account and re-enter the password.
+3. Go to **Settings → EPG Sources**.
+4. Edit each EPG source and re-enter the password (if applicable).
+5. Run an M3U refresh and an EPG refresh to populate the new Dispatcharr with streams and guide data.
+
+If you used an encrypted backup with **Include credentials**, this step is not needed — credentials travel with the artifact and are restored automatically.
+
+---
+
+## Step 7 — Verify the new install
+
+After the restore:
+
+1. Go to **Channels** and confirm your channel list is present.
+2. Check that channel groups, profiles, and stream assignments look correct.
+3. Run an M3U refresh if streams are not populating.
+4. Run an EPG refresh if guide data is absent.
+5. Test playback on a sample channel.
+
+---
+
+## Decommissioning the old install
+
+Once you have verified the new install is working:
+
+1. Take a final backup on the old install (optional, for your records).
+2. Shut down the old ECM and Dispatcharr containers.
+3. Retain the old `/config/` data for at least a week in case you need to reference it.
+
+---
+
+## If the migration restore fails
+
+See [Troubleshoot a restore](troubleshoot-restore.md) for specific failure scenarios.
+
+For a hard failure on a fresh install (rollback incomplete, instance in a bad state), the simplest recovery is to wipe the new Dispatcharr instance entirely (delete all channels and accounts via the Dispatcharr UI or by re-initializing it), and then re-run the restore from scratch.
+
+---
+
+## Alternative: Cross-instance sync for ongoing DR
+
+If your goal is ongoing DR (keeping a standby always in sync with your primary), consider [Cross-Instance Sync](cross-instance-sync.md) (v0.18.1) instead of — or in addition to — manual migration. Sync is not a backup and does not produce a restorable archive, but it keeps a second Dispatcharr instance continuously tracking the primary's configuration.
+
+The recommended pattern for a DR setup:
+1. Migrate the initial configuration to the standby via an encrypted backup restore (this article).
+2. Configure cross-instance sync for ongoing replication after the initial migration.

--- a/docs/user_guide/backup-restore/restore-a-backup.md
+++ b/docs/user_guide/backup-restore/restore-a-backup.md
@@ -1,0 +1,152 @@
+# Restore a Backup
+
+> **Audience:** Operator who needs to restore a Backup & Restore artifact — either after a data loss event, or after migrating to a new install.
+>
+> **Status:** Shipped in v0.18.0.
+
+---
+
+## Before you restore
+
+**Read this section before you click anything.**
+
+1. **Take a fresh backup first.** Before restoring an older artifact onto a running instance, take a fresh backup of the current state. This gives you a way back if the restore does not produce the result you expected.
+2. **Run a dry-run preview.** See [Verify a backup](verify-a-backup.md). The dry-run shows you what will change without making any modifications. Review the counts before applying.
+3. **Have your passphrase ready.** If the artifact is encrypted, you need the passphrase before the restore can proceed. There is no recovery path for a lost passphrase.
+
+---
+
+## The restore flow
+
+### Step 1 — Upload the artifact
+
+1. Go to **Settings → Backup & Restore**.
+2. Find the **Restore DBAS Backup** card.
+3. Click **Upload artifact** and select your `.zip` backup file.
+
+If the artifact is encrypted, ECM detects this automatically (by reading the file's 8-byte magic header) and shows a passphrase prompt. Enter the passphrase before proceeding.
+
+ECM validates the artifact immediately on upload:
+
+- Checks for decompression-bomb characteristics (before decompressing anything).
+- Reads and validates `manifest.json`.
+- Checks `schema_version` — if the artifact was produced by a newer ECM build, the upload is refused with "Unsupported backup version."
+- Verifies each archive member's SHA-256 against the manifest.
+
+If validation fails, ECM shows the error and makes no changes.
+
+### Step 2 — Run a dry-run preview (default)
+
+The restore modal runs a **dry-run by default** — it does not apply anything unless you explicitly confirm. After uploading:
+
+1. Click **Preview** (or the run button, which is in dry-run mode by default).
+2. ECM runs the full importer pipeline in read-only mode against the artifact.
+3. The report shows, for each category: **would create / would update / would skip** counts, with reasons for skips.
+4. Logo misses are reported as an aggregate count. If logos cannot be matched, the report flags them here.
+
+Review the report before applying. A large unexpected "would create" count on an existing instance is a signal to investigate before proceeding.
+
+### Step 3 — Apply
+
+If the preview looks correct:
+
+1. Click **Apply these changes**.
+2. Confirm the dialog.
+3. ECM runs the restore pipeline with live mutations. Live progress is shown for each of the 13 restore stages.
+
+---
+
+## Category restore order
+
+The restore applies categories in a fixed order determined by their dependencies. You cannot change this order:
+
+1. **M3U accounts** — must exist before channels, since channels reference their provider.
+2. **EPG sources** — must exist before channels, since channels can reference EPG sources.
+3. **Channel groups, channel profiles, stream profiles** — must exist before channels, since channels reference them.
+4. **User agents, core settings** — applied alongside other config.
+5. **Users** — opt-in; see [User restore semantics](#user-restore-semantics).
+6. **Channels (with embedded streams)** — applied after all the entities they reference.
+7. **Logos** — applied last; references channels and URL mappings.
+
+This ordering is enforced by the restore orchestrator and cannot be reordered via the UI.
+
+---
+
+## How streams are matched to channels
+
+When restoring channels, ECM must attach each channel's archived streams to streams that already exist on the destination Dispatcharr instance. The archive records which stream URLs were assigned to each channel, but stream IDs differ between instances. ECM uses a four-tier matching ladder to find the right stream on the destination:
+
+**Tier 1 — Exact URL match.** The archived stream URL matches a destination stream URL exactly (case-sensitive). This is the strongest signal: the same provider is serving the same endpoint. A Tier-1 match is never a false positive.
+
+**Tier 2 — Exact name + same provider.** Same display name (after normalization) and same M3U account on both instances. Covers the common case where a provider rotated its stream URLs (token refresh, CDN hostname change) but kept the channel lineup stable.
+
+**Tier 3 — Exact normalized name (any provider).** Same normalized display name, regardless of which M3U account or provider the stream comes from. Useful when restoring onto an instance whose M3U account IDs differ from the source.
+
+**Tier 4 — Fuzzy name match.** A fuzzy normalized name comparison with a similarity floor (≥60%). Catches minor name drift: quality-tag reordering (`HD` vs `FHD`), punctuation differences, minor wording changes. Used as a last resort before declaring a miss.
+
+**If no tier matches (miss):** The stream is synthesized as a custom-stream entry so the channel is still created and visible. A WARN log entry is recorded and the restore-complete report includes an aggregate logo-miss count (for logos) and stream-miss details (for streams). Misses are a signal to check your M3U account configuration on the destination.
+
+When multiple destination streams match the same tier, the one with the lowest stream ID wins. This tie-break is deterministic — the same inputs always produce the same result.
+
+---
+
+## User restore semantics
+
+Users are **opt-in** — they are not selected by default in the restore modal. This is intentional: restoring users onto a running instance can change login credentials and privilege flags for existing accounts.
+
+When you opt in to restoring users:
+
+- **The current admin is always preserved.** The account you are currently authenticated with is detected and skipped, so you cannot lock yourself out via a restore.
+- Existing users with matching usernames are updated, not duplicated.
+- Password hashes are restored if the destination supports the same hash algorithm. If there is a hash-algorithm mismatch, the user is reported as failed (with reason) rather than silently applied with a corrupted password.
+
+---
+
+## Rollback and partial-state recovery
+
+If a restore fails mid-run (a network error, a Dispatcharr API error, or a validation failure on a specific category), ECM runs a **compensating rollback**:
+
+1. Every entity that was created during the current restore run is tracked in a durable on-disk ledger (written to `/config/dbas/restore_ledger_<id>.json`).
+2. On failure, ECM issues delete requests for those entities in reverse creation order (logos first, then channels, then the groups and profiles they referenced, then M3U accounts and EPG sources). Reverse order ensures a parent entity is never deleted before the children that reference it are gone.
+3. A delete that returns 404 (already gone) is counted as success — the rollback is idempotent.
+
+The restore-complete screen reports one of three outcomes:
+
+| Outcome | What happened |
+|-|-|
+| **Success** | All selected categories applied cleanly. No failures, no rollback needed. |
+| **Restore failed — state rolled back** | One or more categories failed; the compensating rollback deleted all entities created in this run. The instance is back to its pre-restore state. |
+| **Restore failed — rollback incomplete** | A failure occurred AND the rollback could not delete one or more entities (a non-404 error on a delete). The instance is in a partially modified state. The report shows which entities remain and their IDs so you can clean them up manually. |
+
+**If you see "rollback incomplete":** Check the Dispatcharr API is reachable and that your admin credentials are valid. Look at the entity IDs listed in the report and delete them manually via the Dispatcharr UI. Then re-attempt the restore from scratch.
+
+---
+
+## Restoring from a saved local backup
+
+If you want to restore a backup that is already stored locally (not re-uploading from your workstation):
+
+1. Go to **Settings → Backup & Restore → Saved Backups**.
+2. Find the backup file you want.
+3. Click **Restore this backup** (or use the `restore_dbas_backup_saved` MCP tool with the filename).
+
+This is the same restore flow as uploading — it runs through the same validation, dry-run, and apply pipeline. The saved file is not deleted by a restore.
+
+---
+
+## Logo misses after restore
+
+If logos could not be matched during restore, the restore-complete screen shows a **red banner** with the aggregate miss count. This is a warning, not a failure: channels are still created and functional, but their logos may be absent or using placeholder images.
+
+Causes of logo misses:
+- The backup was taken on an instance with locally uploaded logos that do not exist on the destination.
+- The logo URL mapping points to a URL that is no longer reachable.
+
+To resolve: re-upload the missing logos manually in **Settings → Channels**, or re-run a channel EPG logo match if the EPG carries logos.
+
+---
+
+## Next steps
+
+- [Troubleshoot a restore](troubleshoot-restore.md) — if the restore produced unexpected results.
+- [Migrate to a new install](migrate-to-a-new-install.md) — the full end-to-end migration walkthrough.

--- a/docs/user_guide/backup-restore/take-a-backup.md
+++ b/docs/user_guide/backup-restore/take-a-backup.md
@@ -1,0 +1,101 @@
+# Take a Backup
+
+> **Audience:** Operator who wants to create a backup of their ECM configuration — either on demand or on a recurring schedule.
+>
+> **Status:** Shipped in v0.18.0.
+
+---
+
+## Before you start
+
+Read [Backup & Restore overview](backup-overview.md) to understand what a backup contains and how credentials are handled. In particular, decide before you start whether you need an **encrypted backup** (to carry M3U/EPG credentials for a migration) or whether a standard redacted backup is sufficient.
+
+---
+
+## Option A — Manual backup (on demand)
+
+Use this when you want a backup right now: before a major change, before a restore, or before migrating to a new install.
+
+1. Go to **Settings → Backup & Restore**.
+2. Find the **Backup** card.
+3. Click **Back Up Now**.
+
+ECM builds the artifact in the background via the `dbas_backup` task. A notification appears when the backup completes. The artifact is saved to `/config/backups/` on the ECM host.
+
+### Taking an encrypted backup
+
+If you need credentials (M3U passwords, EPG passwords, SMTP config) to travel with the artifact:
+
+1. Go to **Settings → Backup & Restore**.
+2. Find the **Encrypted Backup** card.
+3. Check the acknowledgement: *"I understand a lost passphrase makes this artifact permanently unrecoverable."*
+4. Enter a passphrase of at least 12 characters. Write it down somewhere safe before proceeding — ECM never stores the passphrase.
+5. Enable **Include credentials** if you want M3U/EPG passwords included in the encrypted artifact.
+6. Click **Create encrypted backup**.
+
+> **Warning:** A lost passphrase means the encrypted artifact is permanently unrecoverable. There is no reset or recovery path. Store the passphrase in a password manager.
+
+Encrypted backups are always manual — a passphrase cannot be persisted in the task scheduler.
+
+---
+
+## Option B — Scheduled backup (recurring)
+
+Use this for routine protection. A scheduled backup runs automatically and applies the retention policy after each successful run.
+
+1. Go to **Settings → Task Schedules**.
+2. Find the `dbas_backup` task, or create a new schedule for it.
+3. Set the interval (daily is recommended for most operators).
+4. Optionally configure a cloud destination to receive the artifact off-host (see [Configure cloud destinations](configure-cloud-destinations.md)).
+5. Save the schedule.
+
+To verify the schedule is running, check **Settings → Task History** after the first scheduled fire, or look for the notification the task produces on completion.
+
+---
+
+## Where backups are stored
+
+Local backups are saved to `/config/backups/` (under your ECM `CONFIG_DIR`, the same mounted volume as `journal.db`). Filenames follow the pattern:
+
+```
+ecm-backup-YYYY-MM-DD_HHMMSS.zip
+```
+
+All timestamps are UTC.
+
+A `.sha256` sidecar file is written alongside each `.zip`, containing the artifact's SHA-256 hash. ECM verifies this hash before any restore, so do not rename or move the sidecar separately from its `.zip`.
+
+### Listing saved backups
+
+In **Settings → Backup & Restore**, the **Saved Backups** section lists all local backups with their creation time and size. You can download or delete individual backups from this list.
+
+---
+
+## What happens during a backup
+
+When a backup runs, ECM:
+
+1. Checkpoints the SQLite write-ahead log (`PRAGMA wal_checkpoint(TRUNCATE)`) so `journal.db` is self-contained.
+2. Checks available disk space before writing anything.
+3. Gathers all 12 configuration categories from both ECM's own database and the connected Dispatcharr API, applying credential redaction to every category (non-bypassable).
+4. Streams the artifact to a temp file under `/config/` — never buffering the whole artifact in RAM, since logo files can be large.
+5. Writes a SHA-256 sidecar next to the `.zip`.
+6. Optionally uploads to each configured cloud destination and verifies the upload.
+7. Applies the retention policy (prunes old local and cloud copies if a verified-successful backup was produced).
+8. Emits a notification with the result.
+
+---
+
+## Checking backup status
+
+- **Notifications panel** — a success or failure notification is emitted after each backup run.
+- **Settings → Task History** — shows the last run time, duration, and outcome of each task.
+- **Settings → Backup & Restore → Saved Backups** — shows the local artifact list.
+
+---
+
+## Next steps
+
+- [Verify a backup](verify-a-backup.md) — run a dry-run preview to confirm the artifact is restorable before you need it.
+- [Configure cloud destinations](configure-cloud-destinations.md) — add off-host storage for durability.
+- [Restore a backup](restore-a-backup.md) — when you need to recover.

--- a/docs/user_guide/backup-restore/troubleshoot-restore.md
+++ b/docs/user_guide/backup-restore/troubleshoot-restore.md
@@ -1,0 +1,137 @@
+# Troubleshoot a Restore
+
+> **Audience:** Operator who ran a restore and got unexpected results, or who needs to diagnose why a restore failed.
+>
+> **Status:** Shipped in v0.18.0.
+
+---
+
+## "Unsupported backup version"
+
+**Symptom:** The upload step shows "Unsupported backup version" and the restore is refused.
+
+**Cause:** The artifact was produced by a newer ECM build than the one currently running. The schema version inside the artifact is higher than this build supports.
+
+**Fix:** Upgrade ECM to at least the version that produced the backup. Alternatively, if you have an older backup that is still usable, restore from that instead.
+
+---
+
+## "Backup integrity check failed"
+
+**Symptom:** The upload step fails with "Backup integrity check failed."
+
+**Cause:** One or more files inside the artifact do not match their SHA-256 hashes recorded in `manifest.json`. The artifact may have been corrupted during transit, partially overwritten, or tampered with.
+
+**Fix:**
+1. Download the artifact again from its original source.
+2. If you have the `.sha256` sidecar, verify the artifact locally: `sha256sum -c ecm-backup-YYYY-MM-DD_HHMMSS.zip.sha256`.
+3. If the artifact is corrupt, restore from an earlier backup.
+
+---
+
+## "Could not decrypt artifact: wrong passphrase or corrupted artifact"
+
+**Symptom:** After entering a passphrase for an encrypted backup, the restore is refused with this message.
+
+**Cause:** Either the passphrase is wrong, or the encrypted artifact is corrupted. ECM returns the same message for both cases — this is intentional (no oracle).
+
+**Fix:**
+1. Double-check the passphrase. Passphrases are case-sensitive.
+2. If you are confident the passphrase is correct, the artifact may be corrupted — verify the `.sha256` sidecar if available.
+3. If the passphrase is lost: there is no recovery path. The encrypted artifact is permanently unrecoverable. Restore from an unencrypted backup, or from a different encrypted backup for which you have the passphrase.
+
+---
+
+## "Pre-flight refused: ..."
+
+**Symptom:** The restore is refused at the pre-flight stage with one or more problem messages.
+
+Pre-flight runs before any mutation. If it fails, nothing was changed.
+
+Common pre-flight failures:
+
+| Problem kind | Meaning | Fix |
+|-|-|-|
+| `unsupported_schema_version` | Artifact schema version is unsupported (same as above). | Upgrade ECM. |
+| `unresolved_fk_reference` | A channel references a channel group or stream profile that is not in the archive and does not already exist on the destination. | Restore the channel groups and stream profiles first, or include them in the same restore. |
+| `duplicate_unique_name` | The archive contains two M3U accounts, channel groups, or channel profiles with the same name. | The archive is malformed. Contact support if this was produced by ECM's own backup tool. |
+| `count_out_of_bounds` | A category has an implausibly large number of entities (above the sanity ceiling). | The archive may be malformed or from an untrusted source. |
+
+---
+
+## The restore ran but channels look wrong
+
+**Symptom:** The restore reported success, but channel numbers are wrong, channels are missing, or streams are not playing.
+
+**Check 1 — Stream matching tiers.** The restore-complete report shows how many streams were matched at each tier (exact URL, exact name+provider, exact normalized name, fuzzy name). A large number of Tier-4 fuzzy matches or misses means ECM had trouble re-attaching streams from the archive to the streams on this Dispatcharr instance. This happens most often when the M3U provider's stream URLs have changed significantly, or when restoring onto an instance with different M3U accounts.
+
+**Fix for stream misses:** Check that the M3U accounts on the destination instance are configured and active. Run an M3U refresh to make sure all streams are present. Then re-attempt the restore — the stream matcher will have more candidates to match against.
+
+**Check 2 — Did the M3U accounts restore first?** If you ran a partial restore that included channels but excluded M3U accounts, channels cannot be attached to their providers. Restore M3U accounts first, then restore channels.
+
+**Check 3 — Channel number conflicts.** The restore reports a `CONFLICT` (failed with reason) for a channel when the channel has no channel number and an existing channel with the same name and no number is already present. This is ambiguous — ECM cannot determine if they are the same channel or two different ones. The second channel is not created. Assign explicit channel numbers on the source before re-taking the backup to avoid this.
+
+---
+
+## The restore failed part-way — "restore failed, state rolled back"
+
+**Symptom:** The restore-complete screen shows "restore failed — state rolled back."
+
+**What happened:** A failure occurred mid-restore (a Dispatcharr API error, a timeout, or a validation error). ECM ran a compensating rollback: every entity created during this restore run was deleted in reverse order. The instance is back to its pre-restore state.
+
+**Fix:** Investigate the failure reason shown in the report (it appears in the notes section). Common causes:
+- Dispatcharr API returned an error for a specific entity (name conflict, validation failure). Check the Dispatcharr logs.
+- Network timeout between ECM and Dispatcharr. Check connectivity and retry.
+
+After resolving the underlying cause, re-run the restore from scratch.
+
+---
+
+## The restore failed — "rollback incomplete"
+
+**Symptom:** The restore-complete screen shows "restore failed — rollback incomplete."
+
+**What happened:** A failure occurred mid-restore AND the compensating rollback could not delete one or more entities (the delete returned an error that was not 404). The instance is in a partially modified state. The report lists the entity IDs and types that could not be rolled back.
+
+**This is the worst outcome. Take it seriously.** The instance state is indeterminate — some entities from the backup are present, others are not. Do not attempt another restore until you have cleaned up the residue.
+
+**Fix:**
+1. Read the report. Note every entity type and destination ID listed as residue.
+2. Log into the Dispatcharr UI (or use the Dispatcharr API) and manually delete each listed entity.
+3. Confirm the entities are gone.
+4. Take a fresh backup of the current state.
+5. Re-attempt the restore.
+
+If you are on a fresh install and the instance has no channels you care about, a simpler recovery is: delete all channels and M3U accounts via the Dispatcharr UI, then re-run the restore from scratch.
+
+---
+
+## Logo misses — red banner after restore
+
+**Symptom:** After a successful restore, a red banner shows "N logos could not be matched."
+
+**What happened:** One or more logo files in the archive did not match any existing logo on the destination. The channels exist and work — only the logos are affected.
+
+**Fix:** Re-upload the missing logos manually in the Dispatcharr UI, or re-run an EPG logo match if your EPG sources carry logo URLs.
+
+---
+
+## Checking logs
+
+ECM logs all restore activity at the `[DBAS-RESTORE]` log prefix. For detailed diagnostics:
+
+```bash
+docker logs ecm-ecm-1 2>&1 | grep "\[DBAS"
+```
+
+The logs contain entity types, IDs, and outcome codes — never credentials or passphrase values.
+
+The restore ledger is stored at `/config/dbas/restore_ledger_<id>.json` while a restore is in progress, and deleted on clean success. If a ledger file remains after a failed restore, it records the exact entities that were created and (if rollback was incomplete) which ones remain.
+
+---
+
+## Still stuck?
+
+- [Backup & Restore overview](backup-overview.md) — to understand the artifact format and what each category contains.
+- [`docs/security/threat_model_dbas_import.md`](../../security/threat_model_dbas_import.md) — the security analysis of the restore pipeline.
+- [Disaster Recovery runbook](../../runbooks/disaster-recovery-restore.md) — for structured incident response.

--- a/docs/user_guide/backup-restore/verify-a-backup.md
+++ b/docs/user_guide/backup-restore/verify-a-backup.md
@@ -1,0 +1,88 @@
+# Verify a Backup
+
+> **Audience:** Operator who wants to confirm a backup artifact is valid and restorable before they actually need to restore it — or before committing to a restore.
+>
+> **Status:** Shipped in v0.18.0.
+
+---
+
+## Why verify before you restore
+
+A restore is a one-way door: it writes configuration changes to a live Dispatcharr instance. Running a dry-run first tells you exactly what a restore *would* do — how many channels, M3U accounts, EPG sources, and other entities would be created, updated, or skipped — without making any changes. If the preview looks wrong, you can stop before any modification occurs.
+
+Verification is also the right way to confirm that a backup you took last week (or last month) is still usable.
+
+---
+
+## What verification checks
+
+When you upload a backup artifact for verification, ECM performs the following checks **before any mutation**:
+
+1. **Decompression-bomb guard** — the artifact is inspected at header level (not decompressed) and rejected if it contains too many entries, a suspicious compression ratio, or an excessive cumulative declared uncompressed size.
+2. **Manifest presence and integrity** — the `manifest.json` header must be present and parseable.
+3. **Schema version gate** — the artifact's `schema_version` is compared to the running ECM build. An artifact produced by a newer ECM build is refused with "Unsupported backup version" before any further processing.
+4. **Per-member SHA-256** — each file listed in `manifest.json` is verified against its recorded hash. A corrupted or tampered member is refused.
+
+If any check fails, ECM returns a descriptive error and makes no changes.
+
+---
+
+## Running a dry-run preview
+
+A dry-run is **on by default** in the restore modal. You do not need to change any settings — if you upload an artifact and click the run button, you get a preview, not an apply.
+
+1. Go to **Settings → Backup & Restore**.
+2. Find the **Restore DBAS Backup** card.
+3. Upload your `.zip` backup artifact. (If the artifact is encrypted, ECM detects the encryption magic automatically and prompts for the passphrase before proceeding.)
+4. ECM validates the artifact (schema version, integrity) immediately on upload.
+5. Click **Preview** (or the equivalent run button, which is in dry-run mode by default).
+6. ECM runs a counts-only preview and returns a report showing, for each category:
+   - **Would create** — entities in the archive that do not exist on the destination.
+   - **Would update** — entities that exist but differ.
+   - **Would skip** — entities that already exist identically, or that are excluded.
+
+### Reading the dry-run report
+
+The preview report is counts-only — it tells you *how many* entities would be created, updated, or skipped, but not the full diff for each entity. A full per-entity diff view is planned for a future release.
+
+The report covers all 12 backup categories. Pay particular attention to:
+
+- **Channels** — a large "would create" count on an existing instance may indicate the backup is from a different source, or that the categories (M3U accounts, channel groups) those channels reference have not been restored yet.
+- **Users** — users are opt-in. If users are not selected, the user category shows "skipped (excluded by operator)."
+- **Logos** — logo misses (logos in the archive that could not be matched to an existing file) are reported separately as an aggregate count. A non-zero logo-miss count means some logos will be absent after restore; the restore-complete screen shows a prominent warning banner if any logos miss.
+
+### What the preview does not check
+
+- **Whether the Dispatcharr instance is reachable** — the dry-run exercises the importer logic against the archived data, but a subsequent apply will need to reach the Dispatcharr API. Test reachability separately if you are on a new install.
+- **Credential validity** — credentials are redacted in a standard backup, so the preview cannot verify that M3U/EPG credentials will work on the destination.
+
+---
+
+## Counts-only limit
+
+The v0.18.0 dry-run engine reports **counts only** per entity per action (would create / would update / would skip). It does not produce a full entity-level diff listing every individual channel or stream. This is a deliberate scope choice (ADR-012 D7): the count answers the safety question ("am I about to make a large unexpected change?") at low cost. A full diff view is planned for v0.19.x.
+
+---
+
+## After a successful preview
+
+If the preview looks correct — the category counts match your expectations and there are no unexpected "would create" surprises — you can proceed to apply:
+
+1. In the restore modal, review the dry-run report.
+2. Click **Apply these changes** (or the equivalent apply button).
+3. ECM shows a confirmation dialog before executing. Confirm to proceed.
+
+See [Restore a backup](restore-a-backup.md) for the full apply flow, including the ordering of categories and what to do if the restore reports failures.
+
+---
+
+## Verifying a scheduled backup proactively
+
+To confirm that the backup produced last night is healthy without waiting for a failure:
+
+1. Go to **Settings → Backup & Restore → Saved Backups**.
+2. Download the most recent `.zip`.
+3. Upload it in the **Restore DBAS Backup** card and run a dry-run preview (do not apply).
+4. Confirm the report looks reasonable.
+
+Do this before migrating to a new install. A few minutes of verification now prevents a failed restore at the moment you need it most.


### PR DESCRIPTION
## Summary

- Fills the placeholder `docs/user_guide/backup-restore/` section with 7 operator-facing articles grounded in the shipped v0.18.0 code (ADR-012, epic 0i2vt).
- Fixes the stale `index.md` bead ref (bd-gb5r5.3) — the section landing is now a real article table, not a placeholder stub.
- Adds a DR runbook (`docs/runbooks/disaster-recovery-restore.md`) for structured incident response.
- Expands `docs/api.md` Backup section with DBAS artifact endpoints, `RestoreReport` shape, error responses, and cloud destination CRUD.

## Files created / edited

**User guide articles (new):**
- `docs/user_guide/backup-restore/backup-overview.md` — 12 categories, schema_version forward-compat, retention model, encrypted backup warning
- `docs/user_guide/backup-restore/take-a-backup.md` — manual + scheduled + encrypted
- `docs/user_guide/backup-restore/verify-a-backup.md` — dry-run; counts-only D7 limit
- `docs/user_guide/backup-restore/restore-a-backup.md` — hard M3U→EPG→Channels→Logos order; 4-tier stream matching in plain language; rollback/partial-state callout; user opt-in + current-admin-preserved
- `docs/user_guide/backup-restore/configure-cloud-destinations.md` — S3/WebDAV/GDrive (shipped), OneDrive/Dropbox (deferred with operator warning)
- `docs/user_guide/backup-restore/troubleshoot-restore.md` — failure modes, rollback-incomplete recovery
- `docs/user_guide/backup-restore/migrate-to-a-new-install.md` — end-to-end migration

**Runbook (new):**
- `docs/runbooks/disaster-recovery-restore.md` — SRE DR runbook following the project template

**Edited:**
- `docs/user_guide/backup-restore/index.md` — replaces placeholder with section landing + article table
- `docs/api.md` — Backup section expanded with DBAS artifact endpoints

## Code-vs-bead discrepancies found

1. **Category count:** The bead says "12 categories — plugins excluded per D10." ADR-012 context says DBAS originally covered 13 categories (M3U accounts, EPG sources, channel groups, channel profiles, stream profiles, user agents, core settings, plugins, DVR rules, comskip config, users, channels, logos). D10 excluded plugins → shipped set is 12. The docs document 12, which matches `RESTORABLE_SECTIONS` + `EntityType` in the codebase.

2. **Cloud provider deferral:** ADR-012 Q2 (stale note, 2026-06-17) says "Dropbox/OneDrive cloud targets deferred, leaving S3/WebDAV/GDrive." All 5 adapter files exist in `backend/cloud_storage/`. Verified the definitive source: `_SUPPORTED_UPLOAD_PROVIDERS = ("s3", "gdrive", "webdav")` in `backend/tasks/dbas_backup.py` (line 92), with an explicit code comment confirming the deferral. `configure-cloud-destinations.md` documents this accurately and warns operators not to configure a deferred provider.

3. **D12 passphrase encryption:** Ships in v0.18.0 per the ADR-012 amendment (2026-06-16). `backend/dbas/artifact_crypto.py` exists and is wired. `MIN_PASSPHRASE_LENGTH = 12` verified in code. Lost-passphrase warning documented prominently in both `backup-overview.md` and `take-a-backup.md`.

## Test plan

- [ ] Verify all internal links in the new articles resolve to real files.
- [ ] Confirm the category count (12) matches the code: `RESTORABLE_SECTIONS` in `backend/routers/backup.py` lists 13 keys but plugins is excluded per D10 — the 12 categories in `backup-overview.md` match the `EntityType` enum in `backend/dbas/restore_contracts.py`.
- [ ] Confirm `configure-cloud-destinations.md` OneDrive/Dropbox deferral matches `_SUPPORTED_UPLOAD_PROVIDERS` in `backend/tasks/dbas_backup.py`.
- [ ] Confirm `MIN_PASSPHRASE_LENGTH = 12` in `backend/dbas/artifact_crypto.py` matches the "at least 12 characters" stated in the articles.
- [ ] Confirm restore order (M3U → EPG → Channel groups/profiles/stream profiles → user agents → users → channels → logos) matches `default_importer_steps()` in `backend/dbas/restore_orchestrator.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)