### PR TITLE
DBAS logos follow-ups: BMP magic hardening (q15hs) + per-channel logo-miss detail (qhui4)

### DIFF
--- a/backend/dbas/importers/logos.py
+++ b/backend/dbas/importers/logos.py
@@ -67,6 +67,11 @@ never writes/uploads anything:
    are ELF/PE/script is a disguised binary and is REJECTED — the extension and
    the declared content-type are NEVER trusted. Magic checks are byte
    comparisons / membership tests (no regex on dynamic input — Semgrep clean).
+   BMP is validated more strictly than a 2-byte prefix: it must carry the "BM"
+   signature AND a little-endian file-size dword (offset 2) that equals the
+   decoded byte length (LOW-1 hardening — a bare "BM…" blob is rejected). SVG is
+   NOT an allowed type: it is XML/script-bearing, has no raster magic number, and
+   does not match the allowlist, so it is rejected.
 
 ----------------------------------------------------------------------------
 BULK-DELETE PRE-STEP (destructive — opt-in, never silent, never in dry-run)
@@ -104,6 +109,7 @@ from dbas.restore_contracts import (
     FailureDetail,
     FailureReason,
     IdRemapTable,
+    LogoMissDetail,
     RestoreReport,
     RollbackLedger,
     SkipDetail,
@@ -121,14 +127,29 @@ MAX_LOGO_BYTES = 50 * 1024 * 1024
 # pair the decoded payload must start with at the given offset. These are plain
 # byte comparisons — NO regex on dynamic input (Semgrep-clean magic check).
 # WebP and (some) AVIF carry their tag at offset 8 inside a RIFF/ISO-BMFF box.
+#
+# BMP is NOT in this table: a 2-byte "BM" prefix is too weakly discriminating
+# (LOW-1 from the .15 security review — any non-image "BM…" blob would pass). It
+# is validated separately in :func:`_bmp_ok`, which also checks the BMP header's
+# little-endian file-size dword, so a real BMP (size dword == byte length) is
+# accepted while a "BM"-prefixed junk blob is rejected.
 _MAGIC_PREFIXES: tuple[tuple[bytes, int], ...] = (
     (b"\x89PNG\r\n\x1a\n", 0),   # PNG
     (b"\xff\xd8\xff", 0),         # JPEG (JFIF/EXIF)
     (b"GIF87a", 0),              # GIF87a
     (b"GIF89a", 0),              # GIF89a
-    (b"BM", 0),                  # BMP
     (b"WEBP", 8),               # WebP (RIFF....WEBP)
 )
+
+# The BMP header is: 2-byte "BM" signature + a 4-byte little-endian file-size
+# dword at offset 2 that equals the TOTAL file length. A genuine BMP writer fills
+# this in; a non-image blob that merely starts with "BM" almost never has a size
+# dword that matches its own length, so this is a far stronger discriminator than
+# the 2-byte prefix alone (LOW-1). 14 bytes is the smallest valid BMP file
+# header (BITMAPFILEHEADER), so anything shorter cannot be a BMP.
+_BMP_SIGNATURE = b"BM"
+_BMP_MIN_HEADER_LEN = 14
+_BMP_SIZE_DWORD_OFFSET = 2
 
 # The smallest leading slice we must inspect to decide every magic above. Kept
 # small so we never read more than necessary to classify.
@@ -297,17 +318,36 @@ def _decode_logo_bytes(archive_logo: dict) -> bytes:
         raise ValueError("undecodable logo content") from exc
 
 
+def _bmp_ok(data: bytes) -> bool:
+    """True if ``data`` is a plausible BMP: "BM" signature AND a little-endian
+    file-size dword (offset 2) that equals the total byte length (LOW-1).
+
+    The 2-byte "BM" prefix on its own is too weak — a non-image blob can start
+    with it. A genuine BMP also stores its total file size as a 4-byte
+    little-endian dword at offset 2, so we require that dword to match the actual
+    decoded length. Pure byte/int comparison — no regex on dynamic input.
+    """
+    if len(data) < _BMP_MIN_HEADER_LEN or data[:2] != _BMP_SIGNATURE:
+        return False
+    declared_size = int.from_bytes(
+        data[_BMP_SIZE_DWORD_OFFSET:_BMP_SIZE_DWORD_OFFSET + 4], "little"
+    )
+    return declared_size == len(data)
+
+
 def _magic_ok(data: bytes) -> bool:
     """True if the decoded bytes start with a known IMAGE magic number.
 
     Pure byte-prefix membership test (no regex). Rejects disguised binaries
     (ELF/PE/script) whose extension or declared content-type claims an image.
+    BMP is validated by :func:`_bmp_ok` (signature + size dword), not by the
+    prefix table, because a bare "BM" prefix is too weakly discriminating.
     """
     head = data[:_MAGIC_INSPECT_LEN]
     for prefix, offset in _MAGIC_PREFIXES:
         if head[offset:offset + len(prefix)] == prefix:
             return True
-    return False
+    return _bmp_ok(data)
 
 
 def _sanitize_failure(exc: Exception | str) -> str:
@@ -505,7 +545,12 @@ async def import_logos(
 
         # A valid miss feeds the logo-miss aggregate (D9 red banner) regardless of
         # dry-run vs. apply — it is a logo the destination did not already have.
+        # It also records a per-logo detail row (id + name) for the drill-down
+        # behind the aggregate count (bead qhui4) — additive to the D9 banner.
         report.logo_misses += 1
+        report.logo_miss_details.append(
+            LogoMissDetail(source_export_id=source_id, label=label)
+        )
         result.misses += 1
 
         if is_dry_run:

--- a/backend/dbas/restore_contracts.py
+++ b/backend/dbas/restore_contracts.py
@@ -193,6 +193,25 @@ class FailureDetail(BaseModel):
     source_export_id: int | None = Field(default=None)
 
 
+class LogoMissDetail(BaseModel):
+    """One logo that could not be matched/applied on restore (bead ``…-qhui4``).
+
+    The per-logo drill-down behind the aggregate :attr:`RestoreReport.logo_misses`
+    count (ADR-012 D9). The aggregate count + red banner stay as-is; this list
+    ADDS the affected-logo identities so the restore-complete UX can enumerate
+    *which* logos are missing, not just *how many*.
+
+    ``label`` is the operator-facing logo display name — never a path, byte
+    payload, or secret (same hygiene as :class:`SkipDetail` / :class:`FailureDetail`).
+    """
+
+    source_export_id: int | None = Field(
+        default=None,
+        description="The logo's id in the export archive, when known.",
+    )
+    label: str = Field(description="Operator-facing logo name — never a path or secret.")
+
+
 class EntityCategoryReport(BaseModel):
     """Per-entity-category counts for ONE category.
 
@@ -267,6 +286,16 @@ class RestoreReport(BaseModel):
     logo_misses: int = Field(
         default=0,
         description="Aggregate count of unresolved logo references (.15 / .19 consume this).",
+    )
+
+    # Per-logo drill-down behind the aggregate count (bead …-qhui4). ADDITIVE: the
+    # aggregate count + red banner are unchanged; this list lets the UX enumerate
+    # WHICH logos are missing. Populated by the logos importer (.15) on each miss;
+    # ``len(logo_miss_details)`` tracks :attr:`logo_misses`. Empty on a clean
+    # restore — a renderer keys off the aggregate count for the banner gate.
+    logo_miss_details: list[LogoMissDetail] = Field(
+        default_factory=list,
+        description="Per-logo detail (id + name) for each unresolved logo (…-qhui4).",
     )
 
     started_at: datetime | None = Field(default=None)

--- a/backend/tests/dbas/test_logos_importer.py
+++ b/backend/tests/dbas/test_logos_importer.py
@@ -44,10 +44,15 @@ from dbas.restore_contracts import (
     EntityType,
     FailureReason,
     IdRemapTable,
+    LogoMissDetail,
     RestoreReport,
     RollbackLedger,
     SkipReason,
 )
+
+# Reference the symbol so linters don't flag the import as unused; the model is
+# exercised via report.logo_miss_details entries (Pydantic instances).
+assert LogoMissDetail is not None
 
 
 # ---------------------------------------------------------------------------
@@ -65,6 +70,17 @@ _WEBP = b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 8
 _ELF = b"\x7fELF" + b"\x00" * 16          # Linux executable
 _PE = b"MZ\x90\x00" + b"\x00" * 16        # Windows executable
 _SHELL = b"#!/bin/sh\nrm -rf /\n"          # shell script
+_SVG = b'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+
+
+def _bmp(extra: bytes = b"\x00" * 20) -> bytes:
+    """A spec-correct BMP: 'BM' + a 4-byte little-endian file-size dword that
+    equals the total byte length (LOW-1: the size dword is validated, so the
+    declared size must match the real length for the magic check to pass).
+    """
+    body = b"BM" + b"\x00\x00\x00\x00" + extra  # placeholder size dword
+    total = len(body)
+    return b"BM" + total.to_bytes(4, "little") + extra
 
 
 def _b64(raw: bytes) -> str:
@@ -228,6 +244,55 @@ async def test_miss_increments_logo_misses_aggregate():
         client=client, selected=True, report=report, ledger=ledger, remap=remap,
     )
     assert report.logo_misses == 1
+
+
+@pytest.mark.asyncio
+async def test_miss_records_per_channel_detail():
+    """qhui4: a miss ALSO records a per-logo detail (id + name) alongside the
+    aggregate count, so the banner can drill down into the affected logos.
+    """
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    await import_logos(
+        archive_logos=[_logo(src_id=42, name="ESPN HD")],
+        client=client, selected=True, report=report, ledger=ledger, remap=remap,
+    )
+    assert report.logo_misses == 1
+    assert len(report.logo_miss_details) == 1
+    detail = report.logo_miss_details[0]
+    assert detail.source_export_id == 42
+    assert detail.label == "ESPN HD"
+
+
+@pytest.mark.asyncio
+async def test_miss_detail_count_matches_aggregate_for_multiple():
+    """The per-logo detail list stays consistent with the aggregate count."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    await import_logos(
+        archive_logos=[
+            _logo(src_id=1, name="A"),
+            _logo(src_id=2, name="B"),
+            _logo(src_id=3, name="C"),
+        ],
+        client=client, selected=True, report=report, ledger=ledger, remap=remap,
+    )
+    assert report.logo_misses == 3
+    assert len(report.logo_miss_details) == 3
+    assert [d.label for d in report.logo_miss_details] == ["A", "B", "C"]
+
+
+@pytest.mark.asyncio
+async def test_matched_logo_does_not_record_miss_detail():
+    """A tier-matched logo is NOT a miss — no detail row, no aggregate bump."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[{"id": 801, "name": "ESPN"}])
+    await import_logos(
+        archive_logos=[_logo(src_id=7, name="ESPN")],
+        client=client, selected=True, report=report, ledger=ledger, remap=remap,
+    )
+    assert report.logo_misses == 0
+    assert report.logo_miss_details == []
 
 
 # ===========================================================================
@@ -500,7 +565,8 @@ async def test_attack_mime_spoof_shell_script_rejected():
 async def test_valid_image_types_accepted():
     """PNG / JPEG / GIF / WebP magic bytes are all accepted and uploaded."""
     for raw, ct in [(_PNG, "image/png"), (_JPEG, "image/jpeg"),
-                    (_GIF, "image/gif"), (_WEBP, "image/webp")]:
+                    (_GIF, "image/gif"), (_WEBP, "image/webp"),
+                    (_bmp(), "image/bmp")]:
         report, ledger, remap = _ctx()
         client = _client(dest_logos=[])
         await import_logos(
@@ -510,6 +576,92 @@ async def test_valid_image_types_accepted():
         )
         client.upload_logo_file.assert_awaited_once()
         assert report.category(EntityType.LOGO).created == 1
+
+
+@pytest.mark.asyncio
+async def test_valid_bmp_with_correct_size_dword_accepted():
+    """A spec-correct BMP (LE size dword == byte length) is accepted (LOW-1)."""
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    await import_logos(
+        archive_logos=[_logo(src_id=1, name="Bmp", filename="ok.bmp",
+                             content=_bmp(), content_type="image/bmp")],
+        client=client, selected=True, report=report, ledger=ledger, remap=remap,
+    )
+    client.upload_logo_file.assert_awaited_once()
+    assert report.category(EntityType.LOGO).created == 1
+
+
+@pytest.mark.asyncio
+async def test_attack_bmp_magic_only_two_bytes_rejected():
+    """LOW-1: a non-image blob that merely starts with 'BM' (no valid BMP size
+    dword) is REJECTED. The 2-byte 'BM' prefix alone is too weak a signal — a
+    real BMP also carries a little-endian file-size dword at offset 2 that must
+    match the actual byte length.
+    """
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    # 'BM' followed by an arbitrary non-BMP payload whose offset-2 dword does
+    # NOT equal the total length.
+    spoof = b"BM" + b"this is not really a bitmap, just BM-prefixed junk"
+    logo = _logo(src_id=1, name="Spoof", filename="evil.bmp",
+                 content=spoof, content_type="image/bmp")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=1)
+
+
+@pytest.mark.asyncio
+async def test_attack_svg_rejected():
+    """INFO-3: an SVG (XML, script-executable in a browser) is NOT an allowed
+    raster image type — its magic does not match the allowlist, so it is
+    rejected even though it is a legitimate image format elsewhere. Locks the
+    behaviour that the importer never accepts script-bearing SVG.
+    """
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=1, name="Svg", filename="evil.svg",
+                 content=_SVG, content_type="image/svg+xml")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=1)
+
+
+@pytest.mark.asyncio
+async def test_attack_path_traversal_windows_drive_letter_rejected():
+    """INFO-3: a Windows drive-letter absolute path (C:\\Windows\\...) is
+    rejected by the basename guard before any decode/upload. Locks the
+    drive-letter branch of _safe_basename against regression.
+    """
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=1, name="Drive",
+                 filename="C:\\Windows\\System32\\evil.png")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=1)
+
+
+@pytest.mark.asyncio
+async def test_attack_path_traversal_drive_letter_relative_rejected():
+    """INFO-3: a drive-relative path (C:evil.png — no separator, but a drive
+    letter prefix) is also rejected. This is the case the bare embedded-
+    separator rule would MISS, so the explicit drive-letter rule must catch it.
+    """
+    report, ledger, remap = _ctx()
+    client = _client(dest_logos=[])
+    logo = _logo(src_id=1, name="DriveRel", filename="C:evil.png")
+    await import_logos(
+        archive_logos=[logo], client=client, selected=True,
+        report=report, ledger=ledger, remap=remap,
+    )
+    _assert_rejected(report, client, source_id=1)
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/LogoMissBanner.css
+++ b/frontend/src/components/LogoMissBanner.css
@@ -46,6 +46,23 @@
   line-height: 1.4;
 }
 
+.logo-miss-detail-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  max-height: 12rem;
+  overflow-y: auto;
+  list-style: disc;
+}
+
+.logo-miss-detail-row {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
 .logo-miss-link {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/components/LogoMissBanner.test.tsx
+++ b/frontend/src/components/LogoMissBanner.test.tsx
@@ -2,15 +2,14 @@
  * Tests for LogoMissBanner — the restore-complete logo-miss RED banner
  * (bead 0i2vt.19, ADR-012 D9 "unmissable surfacing").
  *
- * Contract note: the merged `RestoreReport` (docs/dbas_restore_contracts.md)
- * carries the logo-miss signal as an AGGREGATE count only — `logo_misses: number`
- * — not a per-channel list. ADR-012 D9 mandates exactly that: "a WARN log + an
- * aggregate count + a prominent red banner". So the banner names the count and
- * links to the Dispatcharr Channels page where the operator fixes the logos
- * one-off; it does NOT (because it cannot) enumerate per-channel rows — there is
- * no per-channel data in the contract. The "detail view" the banner offers is
- * the Dispatcharr Channels admin page, reached via the same `${dispatcharrUrl}/…`
- * link pattern the rest of the app uses (ChannelsPane).
+ * Contract note: ADR-012 D9 mandates "a WARN log + an aggregate count + a
+ * prominent red banner". The aggregate `logo_misses: number` still gates the red
+ * banner. Bead qhui4 ADDED an optional per-logo detail list
+ * (`logo_miss_details: LogoMissDetail[]`, each id + name) — when present and
+ * non-empty the banner enumerates which logos are missing as a drill-down; when
+ * absent (legacy report) it falls back to the aggregate-only behaviour. The
+ * banner also links to the Dispatcharr Channels page (same `${dispatcharrUrl}/…`
+ * pattern the rest of the app uses, ChannelsPane) for the one-off fix.
  */
 import { describe, it, expect } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
@@ -107,6 +106,59 @@ describe('LogoMissBanner — detail/fix link to the Dispatcharr Channels page', 
     expect(screen.getByTestId('logo-miss-banner')).toBeInTheDocument();
     expect(within(screen.getByTestId('logo-miss-banner')).getByText(/7 channels/i)).toBeInTheDocument();
     expect(screen.queryByTestId('logo-miss-detail-link')).not.toBeInTheDocument();
+  });
+});
+
+describe('LogoMissBanner — per-logo detail drill-down (bead qhui4)', () => {
+  it('lists each affected logo by name when logo_miss_details is present', () => {
+    render(
+      <LogoMissBanner
+        report={report({
+          logo_misses: 2,
+          logo_miss_details: [
+            { source_export_id: 10, label: 'ESPN HD' },
+            { source_export_id: 11, label: 'Disney Channel' },
+          ],
+        })}
+        dispatcharrUrl={DISPATCHARR_URL}
+      />,
+    );
+    const list = screen.getByTestId('logo-miss-detail-list');
+    expect(within(list).getByText('ESPN HD')).toBeInTheDocument();
+    expect(within(list).getByText('Disney Channel')).toBeInTheDocument();
+    // One row per affected logo.
+    expect(within(list).getAllByTestId('logo-miss-detail-row')).toHaveLength(2);
+  });
+
+  it('does NOT render the detail list when logo_miss_details is absent (legacy report)', () => {
+    render(<LogoMissBanner report={report({ logo_misses: 3 })} dispatcharrUrl={DISPATCHARR_URL} />);
+    // Banner still warns with the aggregate count + fix link.
+    expect(screen.getByTestId('logo-miss-banner')).toBeInTheDocument();
+    expect(screen.queryByTestId('logo-miss-detail-list')).not.toBeInTheDocument();
+  });
+
+  it('does NOT render the detail list when logo_miss_details is empty', () => {
+    render(
+      <LogoMissBanner
+        report={report({ logo_misses: 1, logo_miss_details: [] })}
+        dispatcharrUrl={DISPATCHARR_URL}
+      />,
+    );
+    expect(screen.queryByTestId('logo-miss-detail-list')).not.toBeInTheDocument();
+  });
+
+  it('renders a fallback label for a logo with a blank name', () => {
+    render(
+      <LogoMissBanner
+        report={report({
+          logo_misses: 1,
+          logo_miss_details: [{ source_export_id: 99, label: '' }],
+        })}
+        dispatcharrUrl={DISPATCHARR_URL}
+      />,
+    );
+    const list = screen.getByTestId('logo-miss-detail-list');
+    expect(within(list).getByText(/unnamed logo/i)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/LogoMissBanner.tsx
+++ b/frontend/src/components/LogoMissBanner.tsx
@@ -10,13 +10,14 @@
  * act on it.
  *
  * Contract: the merged {@link RestoreReport} carries the logo-miss signal as an
- * AGGREGATE COUNT only — `logo_misses: number` (see
- * docs/dbas_restore_contracts.md; the per-logo detail "lives in the logo beads'
- * own surface", not in the wire contract). There is no per-channel list in the
- * report, so the banner cannot enumerate per-channel rows. Instead it names the
- * count and links to the Dispatcharr **Channels** admin page, where the operator
- * fixes the affected channels one-off. The link is built with the same
- * `${dispatcharrUrl}/…` pattern the rest of the app uses (see ChannelsPane).
+ * AGGREGATE COUNT (`logo_misses: number`) AND — since bead qhui4 — an OPTIONAL
+ * per-logo detail list (`logo_miss_details: LogoMissDetail[]`, each id + name).
+ * The aggregate count gates the red banner (D9, unchanged); when the detail list
+ * is present and non-empty the banner ADDS a drill-down enumerating which logos
+ * are missing. The banner also names the count and links to the Dispatcharr
+ * **Channels** admin page, where the operator fixes the affected channels
+ * one-off. The link is built with the same `${dispatcharrUrl}/…` pattern the rest
+ * of the app uses (see ChannelsPane).
  *
  * Colorblind-safe (WCAG 1.4.1): the meaning is carried by an icon + the word
  * "missing" in the copy, not by red colour alone. `role="alert"` so assistive
@@ -61,6 +62,11 @@ export function LogoMissBanner({ report, dispatcharrUrl }: LogoMissBannerProps) 
   const base = dispatcharrUrl?.replace(/\/+$/, '');
   const channelsHref = base ? `${base}/channels` : null;
 
+  // Optional per-logo drill-down (bead qhui4). Additive to the aggregate count:
+  // present + non-empty => enumerate which logos are missing.
+  const details = report.logo_miss_details ?? [];
+  const hasDetails = details.length > 0;
+
   return (
     <div className="logo-miss-banner" data-testid="logo-miss-banner" role="alert">
       <span className="material-icons logo-miss-icon" data-testid="logo-miss-icon" aria-hidden="true">
@@ -71,6 +77,19 @@ export function LogoMissBanner({ report, dispatcharrUrl }: LogoMissBannerProps) 
         <span className="logo-miss-detail">
           These channels were restored without a logo. Open them in Dispatcharr to set a logo on each.
         </span>
+        {hasDetails && (
+          <ul className="logo-miss-detail-list" data-testid="logo-miss-detail-list">
+            {details.map((miss, index) => (
+              <li
+                className="logo-miss-detail-row"
+                data-testid="logo-miss-detail-row"
+                key={miss.source_export_id ?? `idx-${index}`}
+              >
+                {miss.label?.trim() || 'Unnamed logo'}
+              </li>
+            ))}
+          </ul>
+        )}
         {channelsHref && (
           <a
             className="logo-miss-link"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3707,6 +3707,16 @@ export interface EntityCategoryReport {
   failure_details: RestoreFailureDetail[];
 }
 
+/**
+ * One logo that could not be matched/applied on restore (bead qhui4) — the
+ * per-logo drill-down behind the aggregate `logo_misses` count. `label` is the
+ * operator-facing logo name; never a path or secret.
+ */
+export interface LogoMissDetail {
+  source_export_id?: number | null;
+  label: string;
+}
+
 /** The one restore response schema — dry-run, apply, and summary. */
 export interface RestoreReport {
   contract_version: number;
@@ -3715,6 +3725,12 @@ export interface RestoreReport {
   categories: EntityCategoryReport[];
   /** Aggregate count of unresolved logo references — bead .19 surfaces a red banner when > 0. */
   logo_misses: number;
+  /**
+   * Per-logo detail (id + name) for each unresolved logo (bead qhui4). Additive
+   * to the aggregate count: the banner enumerates these as a drill-down list.
+   * May be absent on reports produced before this field existed.
+   */
+  logo_miss_details?: LogoMissDetail[];
   started_at?: string | null;
   completed_at?: string | null;
   notes: string[];


### PR DESCRIPTION
Closes the two DBAS logos follow-up beads (`enhancedchannelmanager-q15hs`, `enhancedchannelmanager-qhui4`). Both touch the logos importer, so they ship as one unit.

## q15hs — .15 logos security follow-ups
- **LOW-1 (BMP magic hardening):** the BMP magic check was a bare 2-byte `"BM"` prefix — weakly discriminating (any `BM…` blob passed). BMP is moved out of the prefix allowlist into a dedicated `_bmp_ok()` that also validates the BMP header's little-endian file-size dword (offset 2) equals the decoded byte length, with a 14-byte minimum-header floor. A genuine BMP is accepted; a `"BM"`-prefixed junk blob is rejected.
- **INFO-3 (test coverage):** added explicit **SVG-rejection** and **Windows drive-letter** path-traversal test cases (both absolute `C:\…` and drive-relative `C:rel`), plus a valid-BMP accept test and a `"BM"`-prefixed-junk reject test.

## qhui4 — .19 follow-up: per-channel logo-miss detail
- Added `LogoMissDetail` (id + name) and `RestoreReport.logo_miss_details` to the kxuj2 contract (`restore_contracts.py`). **Additive and minimal** — the D9 aggregate count + red banner are unchanged; this only adds the affected-logo identities.
- The logos importer now populates `logo_miss_details` on each miss.
- `LogoMissBanner` renders the drill-down list, with a graceful fallback when the field is absent (legacy reports) or empty. Type mirrored in `api.ts`.

## Conflict-risk flag
This PR **does modify `backend/dbas/restore_contracts.py`** (the shared kxuj2 contract). The change is intentionally minimal/additive (one new model + one new optional field). If another in-flight PR also edits this file, expect a small additive merge conflict there.

## Gates (run in worktree)
- Backend pytest: **6209 passed, 3 skipped**
- Frontend vitest: **1666 passed** (90 files); LogoMissBanner suite 15 passed
- `tsc --noEmit`: clean
- `eslint frontend/src --max-warnings 0`: clean
- `vite build`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)