### PR TITLE
[uomwu+lpbjb] DBAS security: GDrive token_uri SSRF, deferred-provider gate, ledger durability

### DIFF
--- a/backend/cloud_storage/__init__.py
+++ b/backend/cloud_storage/__init__.py
@@ -2,7 +2,7 @@
 Cloud storage adapter framework for export distribution.
 Supports S3, Google Drive, OneDrive, Dropbox, and WebDAV.
 """
-from cloud_storage.factory import get_adapter
+from cloud_storage.factory import SUPPORTED_PROVIDERS, get_adapter
 from cloud_storage.types import (
     CloudStorageAdapter,
     ConnectionTestResult,
@@ -14,4 +14,5 @@ __all__ = [
     "UploadResult",
     "ConnectionTestResult",
     "get_adapter",
+    "SUPPORTED_PROVIDERS",
 ]

--- a/backend/cloud_storage/factory.py
+++ b/backend/cloud_storage/factory.py
@@ -11,6 +11,15 @@ from cloud_storage.types import CloudStorageAdapter
 
 logger = logging.getLogger(__name__)
 
+# Providers whose adapters are HARDENED — routed through the SSRF chokepoint
+# (bead 0i2vt.8) and validated at the API boundary. OneDrive and Dropbox are
+# DEFERRED to a v0.18.x follow-up (PO decision 2026-06-17): their adapters still
+# make raw, un-validated outbound calls (see tests/test_ssrf_chokepoint_guard.py
+# baseline), so the config-UI test/upload surfaces must NOT exercise them
+# (SEC-4, bead enhancedchannelmanager-uomwu). This is the single source of truth
+# for "which providers are wired this release"; tasks.dbas_backup imports it.
+SUPPORTED_PROVIDERS = ("s3", "gdrive", "webdav")
+
 
 def get_adapter(provider_type: str, credentials: dict) -> CloudStorageAdapter:
     """Factory function to create the appropriate cloud storage adapter.

--- a/backend/cloud_storage/gdrive_adapter.py
+++ b/backend/cloud_storage/gdrive_adapter.py
@@ -38,6 +38,12 @@ logger = logging.getLogger(__name__)
 # so a poisoned resolver pointing it at an internal address is refused.
 _GOOGLE_API_ENDPOINT = "https://www.googleapis.com/"
 
+# Google's well-known service-account token-exchange endpoint. Used as the
+# default when the service-account JSON omits ``token_uri`` so the SSRF
+# validation always has a concrete host to check (SEC-1, bead
+# enhancedchannelmanager-uomwu).
+_DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token"
+
 
 class GDriveAdapter(CloudStorageAdapter):
     """Adapter for Google Drive via service account.
@@ -53,12 +59,27 @@ class GDriveAdapter(CloudStorageAdapter):
         self.folder_id = credentials["folder_id"]
 
     def _validate_endpoint(self) -> None:
-        """Pre-resolve + denylist-validate the Google API host (.5 chokepoint).
+        """Pre-resolve + denylist-validate both Google API hosts (.5 chokepoint).
 
-        Raises :class:`SSRFError` if the host resolves to a denied address —
-        BEFORE the Drive service / any socket is built.
+        Two hosts must be validated BEFORE the Drive service / any socket is
+        built:
+
+        * ``_GOOGLE_API_ENDPOINT`` — the fixed Drive API host the SDK calls.
+        * ``token_uri`` — the OAuth token-exchange endpoint from the
+          operator-supplied service-account JSON. ``google-auth`` opens an
+          outbound request to THIS host during ``.execute()`` to mint the bearer
+          token, and it is NOT otherwise routed through the chokepoint. A
+          malicious service-account JSON with
+          ``token_uri=http://169.254.169.254/...`` would otherwise trigger an
+          unvalidated request to the cloud-metadata endpoint (SEC-1, bead
+          enhancedchannelmanager-uomwu). Validating it here fails closed before
+          the token exchange runs.
+
+        Raises :class:`SSRFError` if either host resolves to a denied address.
         """
         preresolve_endpoint(_GOOGLE_API_ENDPOINT)
+        token_uri = self.sa_info.get("token_uri") if isinstance(self.sa_info, dict) else None
+        preresolve_endpoint(token_uri or _DEFAULT_TOKEN_URI)
 
     def _get_service(self):
         from google.oauth2 import service_account as sa_module  # ssrf-ok: endpoint pre-validated (.5)

--- a/backend/dbas/importers/users.py
+++ b/backend/dbas/importers/users.py
@@ -64,6 +64,7 @@ by deleting them. This importer imports the contracts module READ-ONLY.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 
 from dbas.restore_contracts import (
     EntityType,
@@ -137,29 +138,48 @@ def _sanitize(message: str) -> str:
     return (message or "").strip()
 
 
-def _build_create_payload(archive_user: dict) -> dict:
-    """Build the create_user payload from an archive user record.
+def _build_create_payload(archive_user: dict, write_fields: set[str]) -> dict:
+    """Build the create_user payload from an archive user record (ALLOWLIST).
 
-    Drops every secret/privilege/source-id key (``_DROPPED_KEYS``) and forces the
-    conservative non-privileged defaults. The result NEVER carries a password,
-    a hash, or an elevated privilege flag.
+    Keys are admitted only when they are BOTH (a) in the destination's parsed
+    User-create write-field set (``write_fields`` from ``/api/schema/``) AND
+    (b) not in ``_DROPPED_KEYS`` (secret/privilege/source-id material, dropped as
+    defense-in-depth even if the schema would accept them). An unknown archive
+    key the schema does not list is silently dropped rather than forwarded — an
+    allowlist intersected with the schema's write-fields, not a denylist of known
+    bad keys (bead l1p4p, follow-up 2). The privilege fields are then forced to
+    the conservative non-privileged defaults regardless of the archive.
+
+    The result NEVER carries a password, a hash, or an elevated privilege flag.
+
+    Args:
+        archive_user: One user record from the export archive.
+        write_fields: The destination's writable User-create field names.
+
+    Returns:
+        The create payload — schema-known, non-secret keys plus the forced
+        conservative privilege defaults.
     """
     payload = {
         k: v
         for k, v in archive_user.items()
-        if k not in _DROPPED_KEYS
+        if k in write_fields and k not in _DROPPED_KEYS
     }
     payload.update(_CONSERVATIVE_PRIVILEGE_DEFAULTS)
     return payload
 
 
-async def _assert_capability(client: DispatcharrClient) -> None:
+async def _assert_capability(client: DispatcharrClient) -> set[str]:
     """Fail CLOSED unless the destination User-create schema is safe.
 
     Reads the writable User-create fields from ``/api/schema/``. Raises
     :class:`UsersCapabilityError` if a forbidden pre-hashed-password write field
     is present, OR if no write fields could be parsed at all (cannot confirm
     safety). The message names the issue but carries no secret.
+
+    Returns:
+        The set of writable User-create field names — the allowlist
+        :func:`_build_create_payload` intersects the archive keys against.
     """
     try:
         write_fields = await client.get_user_schema_write_fields()
@@ -170,7 +190,8 @@ async def _assert_capability(client: DispatcharrClient) -> None:
             "(schema unavailable); failing the dispatcharr_users category closed."
         ) from exc
 
-    forbidden = sorted(_FORBIDDEN_SCHEMA_WRITE_FIELDS & set(write_fields))
+    write_fields = set(write_fields)
+    forbidden = sorted(_FORBIDDEN_SCHEMA_WRITE_FIELDS & write_fields)
     if forbidden:
         logger.error(
             "[DBAS-USERS] Capability check FAILED CLOSED: forbidden write field(s) %s "
@@ -193,6 +214,8 @@ async def _assert_capability(client: DispatcharrClient) -> None:
             "dispatcharr_users category closed (cannot confirm safety)."
         )
 
+    return write_fields
+
 
 def _operator_username(operator: dict) -> str | None:
     """Return the auth subject's username, or None if unknowable.
@@ -213,6 +236,7 @@ async def import_users(
     report: RestoreReport,
     ledger: RollbackLedger,
     is_dry_run: bool = False,
+    persist_ledger: Callable[[], None] | None = None,
 ) -> None:
     """Restore the ``dispatcharr_users`` category into the destination instance.
 
@@ -228,6 +252,12 @@ async def import_users(
             for compensating deletes.
         is_dry_run: When ``True``, no user is created — the importer only reports
             ``would_create`` / ``would_skip`` so the operator sees the plan.
+        persist_ledger: Optional durable-flush callback (wired by the
+            orchestrator to ``persist_ledger``). Called IMMEDIATELY after each
+            created user is recorded in the ledger and BEFORE the next create, so
+            a mid-category crash leaves a recoverable record of every user
+            created so far (RollbackLedger durability contract — bead l1p4p). On
+            a dry-run or when ``None`` it is not invoked.
 
     Raises:
         UsersCapabilityError: when the destination User schema is unsafe
@@ -243,8 +273,9 @@ async def import_users(
             _skip(cat, SkipReason.EXCLUDED_BY_OPERATOR, label, archive_user.get("id"), is_dry_run)
         return
 
-    # Policy 6 — capability check FAILS CLOSED before anything is created.
-    await _assert_capability(client)
+    # Policy 6 — capability check FAILS CLOSED before anything is created. It
+    # also returns the schema write-field allowlist the payload builder uses.
+    write_fields = await _assert_capability(client)
 
     # Policy 3 — identify the current operator by AUTH SUBJECT, not archive data.
     operator = await client.get_current_user()
@@ -291,8 +322,9 @@ async def import_users(
             cat.would_create += 1
             continue
 
-        # Policy 1 + 2 — payload omits password/hash; forces non-privileged.
-        payload = _build_create_payload(archive_user)
+        # Policy 1 + 2 — payload is an allowlist (schema write-fields ∩ archive),
+        # omits password/hash, forces non-privileged.
+        payload = _build_create_payload(archive_user, write_fields)
         try:
             created = await client.create_user(payload)
         except Exception as exc:
@@ -313,6 +345,12 @@ async def import_users(
         cat.created += 1
         if dest_id is not None:
             ledger.record_created(EntityType.USER, int(dest_id), label)
+            # Durability contract (bead l1p4p): flush the ledger to disk NOW,
+            # before the next create is issued, so a mid-category crash leaves a
+            # recoverable record of every user created so far — not only those
+            # from completed steps. No-op on dry-run / when unwired.
+            if persist_ledger is not None:
+                persist_ledger()
         # Policy 1 — flag force-reset (usernames only; no secret).
         report.notes.append(
             f"{CATEGORY_LABEL}: '{label}' restored with no usable password — "
@@ -358,7 +396,16 @@ def _failure_reason_for(exc: Exception) -> FailureReason:
 def _sanitize_failure(exc: Exception) -> str:
     """Produce a sanitized, operator-facing failure message with no secrets.
 
-    create_user never sends a password, so an upstream error body cannot echo
-    one back. We still keep the message short and scrubbed.
+    create_user never sends a password, so an upstream error body cannot echo a
+    password back. But a Dispatcharr error CAN echo other request-body material
+    (e.g. an Authorization header, a token, an api_key field) verbatim. Route the
+    message through the shared credential masker so any such echoed secret is
+    redacted before it reaches the operator-facing :class:`FailureDetail`
+    (bead l1p4p, follow-up 3 — defense in depth; not exploitable today).
     """
-    return _sanitize(str(exc)) or "Upstream rejected the user creation request."
+    # Lazy import: keep the dbas importer free of a cloud_storage dependency at
+    # module-import time (same pattern as tasks.dbas_backup). mask_secrets is the
+    # canonical credential masker (precompiled patterns; never raises).
+    from cloud_storage.upload_security import mask_secrets
+
+    return mask_secrets(_sanitize(str(exc))) or "Upstream rejected the user creation request."

--- a/backend/dbas/restore_orchestrator.py
+++ b/backend/dbas/restore_orchestrator.py
@@ -142,6 +142,23 @@ class ApplyContext:
     is_dry_run: bool = False
     # Collected deferred settings (M3U auto-sync, EPG download) — applied LAST.
     deferred: list[dict] = field(default_factory=list)
+    # Durable per-create ledger flush. The orchestrator wires this to
+    # ``persist_ledger`` so an importer can flush the shared ledger to disk
+    # IMMEDIATELY after each ``record_created`` and BEFORE the next upstream
+    # create (the RollbackLedger durability contract — bead l1p4p). On a dry-run
+    # this is a no-op (no entity is created, nothing to persist). Defaults to a
+    # no-op so a test that builds an ApplyContext directly need not wire it.
+    persist_ledger: "Callable[[], None]" = field(default=lambda: None)
+
+    def flush_ledger(self) -> None:
+        """Durably persist the shared ledger (per-create flush; no-op on dry-run).
+
+        Importers call this right after :meth:`RollbackLedger.record_created` and
+        before issuing the next create, so a mid-category ECM crash leaves a
+        recoverable record of every entity created so far — not just those from
+        completed steps.
+        """
+        self.persist_ledger()
 
 
 class ImporterStepError(RuntimeError):
@@ -495,6 +512,18 @@ async def run_restore(
     if plan_is_dry_run := report.is_dry_run:
         logger.info("[DBAS-RESTORE] Dry-run: pre-flight passed; no apply performed.")
 
+    # Per-create durable flush: on a real apply, persist the shared ledger after
+    # each ``record_created`` (importers call ``ctx.flush_ledger()``); on a
+    # dry-run nothing is created, so the flush is a no-op that never touches the
+    # ledger path. This makes the worst-case crash window a single in-flight
+    # create rather than a whole category (RollbackLedger durability contract —
+    # bead l1p4p).
+    if report.is_dry_run:
+        per_create_persist: Callable[[], None] = lambda: None
+    else:
+        def per_create_persist() -> None:
+            persist_ledger(ledger, ledger_dir=ledger_dir)
+
     ctx = ApplyContext(
         plan=plan,
         client=client,
@@ -502,6 +531,7 @@ async def run_restore(
         ledger=ledger,
         remap=remap,
         is_dry_run=report.is_dry_run,
+        persist_ledger=per_create_persist,
     )
 
     # --- 2. Ordered apply (the hard Phase-2 sequence). ---
@@ -761,6 +791,7 @@ def _importer_step_builders() -> dict[str, ImporterCallable]:
             report=ctx.report,
             ledger=ctx.ledger,
             is_dry_run=ctx.is_dry_run,
+            persist_ledger=ctx.flush_ledger,
         )
         return None
 

--- a/backend/routers/export.py
+++ b/backend/routers/export.py
@@ -12,7 +12,7 @@ from typing import Literal, Optional
 from fastapi import APIRouter, HTTPException, Response
 from pydantic import BaseModel, field_validator
 
-from cloud_storage import get_adapter
+from cloud_storage import SUPPORTED_PROVIDERS, get_adapter
 from cloud_storage.crypto import encrypt_credentials, decrypt_credentials
 from cloud_storage.onedrive_adapter import _validate_tenant_id, _validate_drive_id
 from database import get_session
@@ -707,6 +707,28 @@ async def delete_cloud_target(target_id: int):
 # Cloud Storage Test Connection
 # ---------------------------------------------------------------------------
 
+
+def _deferred_provider_result(provider_type: str) -> Optional[dict]:
+    """Fail-closed test result for a DEFERRED (un-hardened) provider, else None.
+
+    OneDrive and Dropbox adapters are not yet routed through the SSRF chokepoint
+    (PO decision 2026-06-17; see ``cloud_storage.SUPPORTED_PROVIDERS``). The
+    config-UI "Test Connection" surface must not exercise a deferred adapter's
+    raw outbound call, so this returns a non-silent "not supported" result for
+    such a provider and ``None`` for a supported one (test proceeds normally).
+    SEC-4, bead enhancedchannelmanager-uomwu.
+    """
+    if provider_type in SUPPORTED_PROVIDERS:
+        return None
+    return {
+        "success": False,
+        "message": (
+            f"Provider '{provider_type}' is not supported in this release "
+            "(deferred to a v0.18.x follow-up)."
+        ),
+    }
+
+
 @router.post("/cloud-targets/{target_id}/test")
 async def test_cloud_target(target_id: int):
     """Test connection to a saved cloud storage target."""
@@ -719,6 +741,11 @@ async def test_cloud_target(target_id: int):
         creds = decrypt_credentials(target.credentials)
     finally:
         db.close()
+
+    deferred = _deferred_provider_result(provider_type)
+    if deferred is not None:
+        logger.info("[EXPORT] Test refused for deferred provider '%s'", provider_type)
+        return deferred
 
     try:
         adapter = get_adapter(provider_type, creds)
@@ -754,6 +781,11 @@ async def test_cloud_target(target_id: int):
 @router.post("/cloud-targets/test")
 async def test_cloud_target_inline(req: CloudTargetTestRequest):
     """Test connection with inline credentials (before saving)."""
+    deferred = _deferred_provider_result(req.provider_type)
+    if deferred is not None:
+        logger.info("[EXPORT] Inline test refused for deferred provider '%s'", req.provider_type)
+        return deferred
+
     try:
         adapter = get_adapter(req.provider_type, req.credentials)
         result = await adapter.test_connection()

--- a/backend/tasks/dbas_backup.py
+++ b/backend/tasks/dbas_backup.py
@@ -67,6 +67,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from cloud_storage import SUPPORTED_PROVIDERS
 from config import CONFIG_DIR
 from services.notification_service import create_notification_internal
 from task_registry import register_task
@@ -88,8 +89,9 @@ BACKUPS_DIR = CONFIG_DIR / "backups"
 # Provider types whose upload path is wired in v0.18.0 (bead 0i2vt.8). Dropbox
 # and OneDrive are DEFERRED to a v0.18.x follow-up (PO decision 2026-06-17) —
 # a configured target of a deferred provider is treated as a non-silent
-# per-target failure rather than silently skipped.
-_SUPPORTED_UPLOAD_PROVIDERS = ("s3", "gdrive", "webdav")
+# per-target failure rather than silently skipped. Single source of truth lives
+# in cloud_storage (also gates the config-UI test surface — SEC-4).
+_SUPPORTED_UPLOAD_PROVIDERS = SUPPORTED_PROVIDERS
 
 
 def _bump_metric(result: str) -> None:

--- a/backend/tests/dbas/test_restore_orchestrator.py
+++ b/backend/tests/dbas/test_restore_orchestrator.py
@@ -413,6 +413,77 @@ async def test_ledger_persisted_during_rollback(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# 9b. Per-create durable flush (bead l1p4p): an importer can flush the shared
+# ledger to disk WITHIN a step (after each record_created, before the next
+# create) via ctx.flush_ledger(), so a mid-category crash leaves a recoverable
+# record — not only after a whole step completes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_create_flush_persists_first_entry_before_second_create(tmp_path):
+    import json as _json
+    from dbas.restore_orchestrator import _ledger_path
+
+    seen_on_disk = []  # ledger entry count observed on disk at each create point
+
+    async def _two_create_step(ctx: ApplyContext):
+        cat = ctx.report.category(EntityType.USER)
+        for dest_id, name in ((201, "alice"), (202, "bob")):
+            # Record what is ALREADY durable before issuing this create.
+            path = _ledger_path(ctx.ledger.restore_id, tmp_path)
+            if path.exists():
+                seen_on_disk.append(len(_json.loads(path.read_text())["entries"]))
+            else:
+                seen_on_disk.append(0)
+            cat.created += 1
+            ctx.ledger.record_created(EntityType.USER, dest_id, name)
+            ctx.flush_ledger()  # durable per-create flush
+        return None
+
+    ledger = _ledger("rid-percreate")
+    await run_restore(
+        plan=_plan(_cat(EntityType.USER, [{"id": 1, "username": "alice"}])),
+        client=_client(),
+        steps=[ImporterStep(EntityType.USER, _two_create_step)],
+        report=_report(),
+        ledger=ledger,
+        remap=IdRemapTable(),
+        confirm_apply=True,
+        ledger_dir=tmp_path,
+    )
+    # Before alice's create: 0 entries durable. Before bob's create: alice (1)
+    # is ALREADY flushed — the durability contract.
+    assert seen_on_disk == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_per_create_flush_is_noop_on_dry_run(tmp_path):
+    from dbas.restore_orchestrator import _ledger_path
+
+    async def _flushing_step(ctx: ApplyContext):
+        # On a dry-run nothing is created; flush must be a no-op that never
+        # writes the ledger path.
+        ctx.flush_ledger()
+        ctx.report.category(EntityType.USER).would_create += 1
+        return None
+
+    report = RestoreReport(is_dry_run=True)
+    ledger = _ledger("rid-dryrun")
+    await run_restore(
+        plan=_plan(_cat(EntityType.USER, [{"id": 1, "username": "alice"}])),
+        client=_client(),
+        steps=[ImporterStep(EntityType.USER, _flushing_step)],
+        report=report,
+        ledger=ledger,
+        remap=IdRemapTable(),
+        confirm_apply=False,
+        ledger_dir=tmp_path,
+    )
+    assert not _ledger_path("rid-dryrun", tmp_path).exists()
+
+
+# ---------------------------------------------------------------------------
 # 6b. EPG_SOURCE + STREAM_PROFILE compensators (enhancedchannelmanager-v1uz9)
 #
 # Before v1uz9 the rollback dispatch had NO compensator for epg_source or

--- a/backend/tests/dbas/test_users_importer.py
+++ b/backend/tests/dbas/test_users_importer.py
@@ -384,6 +384,193 @@ async def test_existing_non_operator_username_skipped_already_exists():
     assert cat.skip_details[0].reason == SkipReason.ALREADY_EXISTS_IDENTICAL
 
 
+# ---------------------------------------------------------------------------
+# l1p4p follow-up 1 (MEDIUM data-integrity): per-create ledger flush.
+# The RollbackLedger durability contract requires the ledger be flushed to disk
+# IMMEDIATELY after each created user is recorded and BEFORE the next create —
+# otherwise a mid-category crash orphans every created user with no recoverable
+# record. The importer accepts a persist_ledger callback (wired by the
+# orchestrator) and must invoke it after each record_created, before the next
+# upstream create.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ledger_flushed_to_disk_before_each_subsequent_create():
+    """The persist callback fires after each create, and the entry for user N is
+    durable BEFORE user N+1's create is issued."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+
+    events = []  # ordered log of (kind, detail)
+
+    original_create = client.create_user.side_effect
+
+    async def _tracked_create(payload):
+        # At the moment we issue this create, snapshot how many entries are
+        # already durably flushed (proxied by the flush call count) and how many
+        # are in the in-memory ledger.
+        events.append(("create", payload.get("username"), flush_calls["n"], len(ledger.entries)))
+        return await original_create(payload)
+
+    client.create_user.side_effect = _tracked_create
+
+    flush_calls = {"n": 0}
+
+    def _persist():
+        # Each flush corresponds to a durable write of the current ledger state.
+        flush_calls["n"] += 1
+        events.append(("flush", len(ledger.entries)))
+
+    await import_users(
+        archive_users=[
+            {"id": 5, "username": "alice"},
+            {"id": 6, "username": "bob"},
+            {"id": 7, "username": "carol"},
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        persist_ledger=_persist,
+    )
+
+    # One flush per created user.
+    assert flush_calls["n"] == 3
+    # Before the 2nd and 3rd create is issued, the prior creation has already
+    # been flushed: the create event for bob/carol carries flush_count >= the
+    # number of prior creates.
+    create_events = [e for e in events if e[0] == "create"]
+    # alice: 0 prior flushes; bob: >=1 prior flush; carol: >=2 prior flushes.
+    assert create_events[0][2] == 0
+    assert create_events[1][2] >= 1
+    assert create_events[2][2] >= 2
+    # The ledger ends with all three entries recorded.
+    assert len(ledger.entries) == 3
+
+
+@pytest.mark.asyncio
+async def test_no_persist_callback_does_not_crash():
+    """The callback is optional — omitting it (e.g. a direct unit call) creates
+    users in-memory without error (durability is the orchestrator's concern)."""
+    client = _client()
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[{"id": 5, "username": "alice"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        # persist_ledger omitted
+    )
+    assert report.category(EntityType.USER).created == 1
+    assert len(ledger.entries) == 1
+
+
+# ---------------------------------------------------------------------------
+# l1p4p follow-up 2 (LOW): allowlist payload, intersected with schema fields.
+# Unknown archive keys the destination schema does not list as write-fields are
+# DROPPED, not forwarded. This is an allowlist (schema ∩ archive), not a denylist
+# of known-bad keys.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_payload_drops_keys_not_in_schema_write_fields():
+    """An archive key absent from the destination's User-create write-fields is
+    NOT forwarded — even though it is not a known secret/privilege key."""
+    client = _client(schema_fields={"username", "email"})
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[
+            {
+                "id": 5,
+                "username": "alice",
+                "email": "alice@example.com",
+                # Not in the schema write-field set -> must be dropped.
+                "some_future_field": "x",
+                "totally_unknown": {"nested": 1},
+            }
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    payload = client.create_user.await_args.args[0]
+    assert payload["username"] == "alice"
+    assert payload["email"] == "alice@example.com"
+    assert "some_future_field" not in payload
+    assert "totally_unknown" not in payload
+
+
+@pytest.mark.asyncio
+async def test_payload_still_drops_secret_keys_present_in_schema():
+    """Defense-in-depth: even if the schema lists a secret/privilege key as
+    writable, the importer still drops it (the drop list overrides the
+    allowlist) and forces conservative privilege defaults."""
+    client = _client(
+        schema_fields={"username", "password", "is_superuser", "is_staff", "user_level"},
+    )
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[
+            {"id": 5, "username": "alice", "password": "hunter2", "is_superuser": True},
+        ],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    payload = client.create_user.await_args.args[0]
+    assert "password" not in payload
+    assert payload["is_superuser"] is False
+
+
+# ---------------------------------------------------------------------------
+# l1p4p follow-up 3 (LOW): _sanitize_failure masks echoed secrets.
+# If Dispatcharr echoes request-body material (a token, an Authorization
+# header) back in an error, the operator-facing failure message must be masked.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failure_message_masks_echoed_secret():
+    """A create_user error whose text carries a secret-looking token is masked
+    in the operator-facing FailureDetail.message — no raw secret survives."""
+    secret = "AKIAIOSFODNN7EXAMPLE"  # AWS access-key shape masked by mask_secrets
+
+    async def _raise_with_secret(payload):
+        raise RuntimeError("upstream rejected; aws_secret_access_key=%s echoed" % secret)
+
+    client = _client(create_side_effect=_raise_with_secret)
+    report = _report()
+    ledger = _ledger()
+
+    await import_users(
+        archive_users=[{"id": 5, "username": "alice"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+    )
+
+    cat = report.category(EntityType.USER)
+    assert cat.failed == 1
+    message = cat.failure_details[0].message
+    assert secret not in message
+    assert "REDACTED" in message
+
+
 @pytest.mark.asyncio
 async def test_create_conflict_recorded_as_failure_conflict():
     """If create_user raises a CONFLICT-shaped upstream error (race: username

--- a/backend/tests/test_cloud_storage.py
+++ b/backend/tests/test_cloud_storage.py
@@ -185,6 +185,105 @@ class TestOneDriveAdapter:
 
 
 # =============================================================================
+# GDrive adapter — token_uri SSRF chokepoint (SEC-1, bead ...-uomwu)
+# =============================================================================
+
+
+class TestGDriveTokenUriSSRF:
+    """The service-account ``token_uri`` is operator-supplied and is hit by
+    google-auth during the token exchange. It MUST be routed through the .5 SSRF
+    chokepoint in ``_validate_endpoint``, BEFORE any service/socket is built —
+    otherwise a malicious SA JSON with token_uri pointing at the cloud-metadata
+    endpoint triggers an unvalidated outbound request (SEC-1)."""
+
+    def _adapter(self, token_uri):
+        sa_info = {
+            "type": "service_account",
+            "client_email": "svc@example.iam.gserviceaccount.com",
+            "private_key": "-----BEGIN PRIVATE KEY-----\\nx\\n-----END PRIVATE KEY-----\\n",
+        }
+        if token_uri is not None:
+            sa_info["token_uri"] = token_uri
+        return get_adapter("gdrive", {
+            "service_account_json": json.dumps(sa_info),
+            "folder_id": "folder123",
+        })
+
+    def test_validate_endpoint_rejects_imds_token_uri(self):
+        """A token_uri pointing at the cloud-metadata IP (169.254.169.254) is
+        denied by the chokepoint before any service is built."""
+        from cloud_storage.upload_security import SSRFError
+
+        adapter = self._adapter("http://169.254.169.254/computeMetadata/v1/token")
+        with pytest.raises(SSRFError):
+            adapter._validate_endpoint()
+
+    def test_validate_endpoint_rejects_imds_token_uri_no_service_built(self):
+        """The SSRF refusal happens BEFORE _get_service — no Google client is
+        ever constructed for a malicious token_uri."""
+        from cloud_storage.upload_security import SSRFError
+
+        adapter = self._adapter("http://169.254.169.254/token")
+        with patch.object(adapter, "_get_service") as mock_get_service:
+            with pytest.raises(SSRFError):
+                adapter._validate_endpoint()
+        mock_get_service.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upload_refuses_malicious_token_uri(self):
+        """End-to-end: upload() surfaces a masked failure (never raises) and
+        never builds the service for a metadata-pointing token_uri."""
+        adapter = self._adapter("http://169.254.169.254/token")
+        with patch.object(adapter, "_get_service") as mock_get_service:
+            from pathlib import Path
+            result = await adapter.upload(Path("/nonexistent"), "exports/x.zip")
+        assert result.success is False
+        mock_get_service.assert_not_called()
+
+    def test_validate_endpoint_allows_default_google_token_uri(self):
+        """A normal SA JSON (well-known Google token_uri, or none) passes the
+        chokepoint — the legitimate path is not broken."""
+        # Explicit well-known token_uri.
+        self._adapter("https://oauth2.googleapis.com/token")._validate_endpoint()
+        # Omitted token_uri -> falls back to the well-known default.
+        self._adapter(None)._validate_endpoint()
+
+
+# =============================================================================
+# Deferred providers gated at the config-UI test surface (SEC-4, bead ...-uomwu)
+# =============================================================================
+
+
+class TestDeferredProviderGate:
+    """OneDrive/Dropbox adapters are DEFERRED (not routed through the SSRF
+    chokepoint). The config-UI Test-Connection surface must not exercise them."""
+
+    def test_supported_providers_excludes_deferred(self):
+        from cloud_storage import SUPPORTED_PROVIDERS
+
+        assert "s3" in SUPPORTED_PROVIDERS
+        assert "gdrive" in SUPPORTED_PROVIDERS
+        assert "webdav" in SUPPORTED_PROVIDERS
+        assert "dropbox" not in SUPPORTED_PROVIDERS
+        assert "onedrive" not in SUPPORTED_PROVIDERS
+
+    @pytest.mark.asyncio
+    async def test_inline_test_refuses_deferred_dropbox(self, async_client):
+        """A 'Test Connection' for a deferred provider returns a non-silent
+        'not supported' result without building/exercising the adapter."""
+        with patch("routers.export.get_adapter") as mock_get_adapter:
+            response = await async_client.post("/api/export/cloud-targets/test", json={
+                "provider_type": "dropbox",
+                "credentials": {"access_token": "tok"},
+            })
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is False
+        assert "not supported" in body["message"].lower()
+        mock_get_adapter.assert_not_called()
+
+
+# =============================================================================
 # Credential encryption
 # =============================================================================
 


### PR DESCRIPTION
## What

Closes two DBAS Phase-1/2 security follow-up beads:

### uomwu — DBAS .8 SEC-1 (MEDIUM): GDrive OAuth token_uri SSRF
`gdrive_adapter._validate_endpoint` previously validated only the hardcoded `www.googleapis.com` host. The service-account token exchange inside `google-auth` opens an outbound request to the `token_uri` field of the **operator-supplied** `service_account_json`, which was NOT routed through the .5 SSRF chokepoint. A malicious SA JSON with `token_uri=http://169.254.169.254/...` would trigger an unvalidated request to the cloud-metadata endpoint during `.execute()`.

**Fix:** `_validate_endpoint` now also runs `preresolve_endpoint(token_uri)` (defaulting to Google's well-known `https://oauth2.googleapis.com/token` when absent). The malicious host is denied by the always-on denylist **before** any service is built or socket opens. Self-SSRF (admin-supplied creds) → MEDIUM.

### uomwu — SEC-4 (INFO): deferred providers gated from the config UI
OneDrive/Dropbox adapters are DEFERRED (per the SSRF chokepoint-guard baseline) — they still make raw, un-validated outbound calls and Dropbox surfaces raw `str(e)`. The config-UI "Test Connection" surfaces (`/cloud-targets/{id}/test` and `/cloud-targets/test`) now fail-closed for a deferred provider instead of building the un-hardened adapter. Introduced `cloud_storage.SUPPORTED_PROVIDERS = ("s3","gdrive","webdav")` as the single source of truth; `tasks.dbas_backup` reuses it (was a private duplicate). OneDrive target *creation* + its boundary tenant/drive-id validation are unchanged.

### lpbjb — DBAS l1p4p follow-ups
- **(a) MEDIUM data-integrity — per-create ledger flush.** The `RollbackLedger` durability contract requires a disk flush after each `record_created` and before the next create; the orchestrator previously flushed only at step boundaries, so a mid-category crash orphaned every user created in that step. `ApplyContext` now exposes `flush_ledger()` (wired by the orchestrator to `persist_ledger`); the users importer flushes after each created user. No-op on dry-run.
- **(b) LOW — allowlist payload.** `_build_create_payload` switched from a `_DROPPED_KEYS` denylist to an allowlist: archive keys ∩ parsed schema write-fields, with the secret/privilege drop-list still applied as defense-in-depth.
- **(c) LOW — sanitize masking.** `_sanitize_failure` now routes upstream error text through `mask_secrets`, so an echoed token/credential is redacted in the operator-facing `FailureDetail.message`.

## How to test
`cd backend && python -m pytest tests/ -p no:warnings`

New/updated tests: GDrive token_uri SSRF regression (IMDS rejected, no service built, legit path allowed); deferred-provider gate; per-create flush ordering (orchestrator + importer); allowlist payload; sanitize masking.

## Security
- [x] No secrets logged; outbound routed through the validated `security.ssrf` chokepoint
- [x] Semgrep `no-bare-re-on-dynamic-pattern`: 0 findings on changed files
- [x] Full backend suite: **6214 passed, 3 skipped** (pre-existing baseline skips)

## Deployment
- [x] No infra changes / no DB migration
- Rollback: revert this commit

Beads: `enhancedchannelmanager-uomwu`, `enhancedchannelmanager-lpbjb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)