### PR TITLE
fix(dbas): emit channels+users producers for full round-trip (7i8rf) + builder-owned artifact name (e0r3h)

### DIFF
--- a/backend/dbas/restore_artifact.py
+++ b/backend/dbas/restore_artifact.py
@@ -77,6 +77,12 @@ _SECTION_TO_ENTITY: dict[str, EntityType] = {
     "channel_groups": EntityType.CHANNEL_GROUP,
     "channel_profiles": EntityType.CHANNEL_PROFILE,
     "stream_profiles": EntityType.STREAM_PROFILE,
+    # 7i8rf — the producer now emits these categories, so the decoder maps them
+    # to the EntityTypes the WIRED apply importers consume (channels: 4vouz,
+    # dispatcharr_users: l1p4p). Without these two rows the producer's bytes
+    # decoded to nothing and restore was a silent no-op.
+    "channels": EntityType.CHANNEL,
+    "dispatcharr_users": EntityType.USER,
 }
 
 # Where in the parsed category YAML each section's entity list lives. The

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -142,6 +142,18 @@ _REDACT_KEYS = frozenset(
     }
 )
 
+# Stream-record keys that are credential-class for an EMBEDDED channel stream and
+# must NEVER be carried in the channels producer (7i8rf). A Dispatcharr/IPTV
+# stream URL embeds provider credentials in its path/query
+# (``.../<user>/<pass>/<id>``); ``stream_hash`` / ``custom_url`` are equivalent
+# leak vectors. The channels producer embeds each stream as ID + the SAFE match
+# fields the restore matcher uses (name + m3u_account) ONLY — see
+# ``_safe_embedded_stream``. ``url`` is intentionally NOT added to the global
+# ``_REDACT_KEYS`` denylist because the M3U/EPG/settings categories legitimately
+# carry an operator-typed instance ``url`` that the restore needs; URL handling
+# for streams is therefore scoped to the producer that emits them.
+_STREAM_CREDENTIAL_FIELDS = frozenset({"url", "custom_url", "stream_hash"})
+
 
 def _redact_credentials_deep(obj, preserve_keys: frozenset = frozenset()):
     """Recursively replace any value whose key (case-insensitive) is in the
@@ -705,9 +717,22 @@ async def build_backup_artifact(
     categories = await _gather_redacted_categories(include_credentials=include_credentials)
     logo_entries, logo_metadata, url_mappings = _gather_logo_binary_subtree()
 
-    fd, tmp_zip_name = tempfile.mkstemp(prefix="ecm-artifact-", suffix=".zip", dir=str(dest_dir))
-    os.close(fd)
-    zip_path = Path(tmp_zip_name)
+    # e0r3h — the producer owns the CANONICAL timestamped name
+    # ``ecm-backup-<UTC ts>.zip`` (no post-build rename in the task layer). This is
+    # the name retention's ``_BACKUP_ZIP_FILENAME_RE`` allowlist + filename
+    # timestamp-sort require. ``_get_backup_filename`` is the single source of that
+    # shape. On the rare same-second collision (two runs in the same UTC second)
+    # we suffix a short uniquifier so we never clobber an existing artifact; the
+    # base name still matches the retention regex's ``\d{6}`` second field is the
+    # canonical case, and the collision fallback degrades retention discoverability
+    # of the SECOND file only (same trade-off the old rename made).
+    zip_path = dest_dir / _get_backup_filename()
+    if zip_path.exists():
+        fd, tmp_zip_name = tempfile.mkstemp(
+            prefix="ecm-backup-", suffix=".zip", dir=str(dest_dir)
+        )
+        os.close(fd)
+        zip_path = Path(tmp_zip_name)
     sidecar_path = Path(str(zip_path) + ".sha256")
     scrubbed_db_path: Optional[Path] = None
     file_hashes: dict[str, str] = {}
@@ -1754,6 +1779,107 @@ def _gather_db_tables() -> dict:
         session.close()
 
 
+# Channel-list pagination cap for the channels producer. Dispatcharr's channel
+# list is paginated; the producer walks every page so the backup carries the FULL
+# channel set (a partial channel export would silently lose channels on restore).
+_CHANNELS_PAGE_SIZE = 1000
+_CHANNELS_MAX_PAGES = 1000  # hard stop so a misbehaving upstream cannot loop forever
+
+
+def _safe_embedded_stream(stream: dict) -> dict:
+    """Reduce a Dispatcharr stream record to the SAFE fields a channel embeds.
+
+    The DBAS round-trip restore (``dbas/importers/channels.py``) matches each
+    embedded stream against the destination's streams using the 4-tier matcher
+    (``dbas/stream_matcher.py``): name + provider (``m3u_account``) on Tiers 2-4.
+    Tier 1 (exact URL) is deliberately UNavailable here — a stream URL embeds
+    provider credentials (``_STREAM_CREDENTIAL_FIELDS``) and is NEVER carried in
+    the artifact (7i8rf redaction contract). We emit ONLY the stream id (for the
+    operator-facing label / ordering) and the credential-free match fields. The
+    non-bypassable deep redactor still runs over the result as defense in depth.
+    """
+    out: dict = {}
+    sid = stream.get("id")
+    if sid is not None:
+        out["id"] = sid
+    name = stream.get("name")
+    if name is not None:
+        out["name"] = name
+    # ``m3u_account`` is an integer FK (the provider id), not a credential — it is
+    # the matcher's "same provider" signal (Tier 2). Carried for match fidelity.
+    if "m3u_account" in stream:
+        out["m3u_account"] = stream.get("m3u_account")
+    return out
+
+
+async def _gather_channels_with_streams(client) -> list[dict]:
+    """Fetch every channel with its embedded streams reduced to SAFE fields.
+
+    A Dispatcharr channel's ``streams`` field is a list of stream IDs. For the
+    round-trip restore matcher to do better than a blind custom-stream synthesis,
+    each embedded stream is enriched to ``{id, name, m3u_account}`` (NEVER the
+    URL — see :func:`_safe_embedded_stream`) by joining against the stream records
+    fetched once for the whole export. A channel whose streams cannot be enriched
+    still carries its ordered ``[{id}, ...]`` so ordering and count survive.
+    """
+    # 1) Walk all channel pages.
+    channels: list[dict] = []
+    page = 1
+    while page <= _CHANNELS_MAX_PAGES:
+        resp = await client.get_channels(page=page, page_size=_CHANNELS_PAGE_SIZE)
+        if isinstance(resp, dict):
+            results = resp.get("results", []) or []
+            channels.extend(r for r in results if isinstance(r, dict))
+            if not resp.get("next"):
+                break
+        elif isinstance(resp, list):
+            channels.extend(r for r in resp if isinstance(r, dict))
+            break
+        else:
+            break
+        page += 1
+
+    if not channels:
+        return []
+
+    # 2) Build a stream-id -> safe-record index from the full stream list (one
+    #    paginated walk; the matcher only needs name + provider).
+    stream_index: dict = {}
+    spage = 1
+    while spage <= _CHANNELS_MAX_PAGES:
+        sresp = await client.get_streams(page=spage, page_size=_CHANNELS_PAGE_SIZE)
+        if isinstance(sresp, dict):
+            sresults = sresp.get("results", []) or []
+        elif isinstance(sresp, list):
+            sresults = sresp
+        else:
+            sresults = []
+        for s in sresults:
+            if isinstance(s, dict) and s.get("id") is not None:
+                stream_index[s["id"]] = _safe_embedded_stream(s)
+        if not (isinstance(sresp, dict) and sresp.get("next")):
+            break
+        spage += 1
+
+    # 3) Replace each channel's stream-id list with the enriched safe records,
+    #    preserving order. An id absent from the index degrades to {"id": id}.
+    enriched: list[dict] = []
+    for ch in channels:
+        out = dict(ch)
+        raw_streams = ch.get("streams")
+        if isinstance(raw_streams, list):
+            embedded = []
+            for sid in raw_streams:
+                if isinstance(sid, dict):
+                    # Already an object (some endpoints embed); reduce to safe.
+                    embedded.append(_safe_embedded_stream(sid))
+                else:
+                    embedded.append(stream_index.get(sid, {"id": sid}))
+            out["streams"] = embedded
+        enriched.append(out)
+    return enriched
+
+
 async def _gather_dispatcharr_sections(selected: set[str]) -> dict:
     """Fetch full Dispatcharr data for selected sections.
 
@@ -1786,6 +1912,17 @@ async def _gather_dispatcharr_sections(selected: set[str]) -> dict:
         if "stream_profiles" in needed:
             profiles = await client.get_stream_profiles()
             result["stream_profiles"] = profiles or []
+        if "channels" in needed:
+            # Channels carry embedded streams reduced to credential-free match
+            # fields (7i8rf). This is the producer the restore channels importer
+            # (dbas/importers/channels.py) consumes.
+            result["channels"] = await _gather_channels_with_streams(client)
+        if "dispatcharr_users" in needed:
+            # Dispatcharr user accounts (Django auth). A GET never returns a
+            # password/hash (see dbas/importers/users.py policy 1); the deep
+            # redactor scrubs any credential-class field as a backstop.
+            users = await client.get_users()
+            result["dispatcharr_users"] = users or []
 
         return result
     except Exception as e:
@@ -1806,9 +1943,18 @@ async def build_yaml_export(
     passphrase-encrypted migration path; it is only ever True from
     :func:`build_backup_artifact`. The user-facing ``/export`` endpoint never
     sets it (always redacts).
+
+    The default set (``sections=None``) excludes ``artifact_only`` categories
+    (channels / dispatcharr_users — 7i8rf): those are restorable only via the
+    DBAS artifact path, not the legacy YAML export/restore, so the user-facing
+    full YAML export keeps its pre-7i8rf shape. The artifact builder
+    (:func:`_gather_redacted_categories`) requests each category by its EXPLICIT
+    key, so it still emits the artifact_only producers.
     """
-    all_keys = set(RESTORABLE_SECTIONS.keys())
-    selected = sections if sections else all_keys
+    legacy_keys = {
+        k for k, v in RESTORABLE_SECTIONS.items() if not v.get("artifact_only")
+    }
+    selected = sections if sections else legacy_keys
 
     export_data: dict = {
         "ecm_export": {
@@ -1837,10 +1983,16 @@ async def build_yaml_export(
 
 @router.get("/export-sections")
 async def get_export_sections(_admin=RequireAdminIfEnabled):
-    """Return available section keys and labels for selective export."""
+    """Return available section keys and labels for selective export.
+
+    ``artifact_only`` categories (channels / dispatcharr_users — 7i8rf) are
+    omitted: they are restorable only through the DBAS artifact path, not the
+    legacy per-section YAML restore this list drives.
+    """
     return [
         {"key": key, "label": info["label"]}
         for key, info in RESTORABLE_SECTIONS.items()
+        if not info.get("artifact_only")
     ]
 
 
@@ -1896,6 +2048,26 @@ RESTORABLE_SECTIONS = {
     "channel_groups": {"label": "Channel Groups", "dispatcharr": True},
     "channel_profiles": {"label": "Channel Profiles", "dispatcharr": True},
     "stream_profiles": {"label": "Stream Profiles", "dispatcharr": True},
+    # 7i8rf — the v0.18.0 round-trip producers. The restore importers
+    # (dbas/importers/channels.py + users.py) existed but the builder did not
+    # emit these categories, so restoring channels/users was a no-op against a
+    # real backup. ``channels`` carries embedded streams reduced to
+    # credential-free match fields (id + name + m3u_account, NEVER the URL).
+    # ``dispatcharr_users`` is the Dispatcharr (Django) user category — distinct
+    # from ECM's own users; a GET never returns a password/hash.
+    #
+    # ``artifact_only`` (7i8rf): these categories are PRODUCED into the DBAS
+    # artifact (consumed by the Phase-2 restore importers via
+    # decode_artifact_to_plan -> orchestrator) but are NOT restorable through the
+    # LEGACY per-section YAML restore endpoint (/restore-yaml), which has no
+    # channel/user restorer. They are therefore hidden from the legacy
+    # export-sections / validate UI so an operator cannot select a section the
+    # legacy path cannot apply. The artifact builder still emits them (the gather
+    # pipeline iterates every RESTORABLE_SECTIONS key).
+    "channels": {"label": "Channels", "dispatcharr": True, "artifact_only": True},
+    "dispatcharr_users": {
+        "label": "Dispatcharr Users", "dispatcharr": True, "artifact_only": True,
+    },
 }
 
 
@@ -1950,6 +2122,10 @@ async def validate_yaml_export(file: UploadFile = File(...), _admin=RequireAdmin
     export_meta = data.get("ecm_export", {})
     sections = []
     for key, info in RESTORABLE_SECTIONS.items():
+        # artifact_only categories (channels / dispatcharr_users — 7i8rf) are not
+        # restorable via the legacy YAML path this validate drives; hide them.
+        if info.get("artifact_only"):
+            continue
         count = _count_section_items(data, key)
         sections.append({
             "key": key,
@@ -1997,6 +2173,20 @@ async def restore_from_yaml(
     invalid = [s for s in selected_sections if s not in RESTORABLE_SECTIONS]
     if invalid:
         raise HTTPException(status_code=400, detail="Unknown sections: %s" % ", ".join(invalid))
+
+    # artifact_only categories (channels / dispatcharr_users — 7i8rf) have no
+    # legacy per-section restorer; they are restorable only via the DBAS artifact
+    # path. Reject them here rather than letting _restore_section raise.
+    artifact_only = [
+        s for s in selected_sections
+        if RESTORABLE_SECTIONS[s].get("artifact_only")
+    ]
+    if artifact_only:
+        raise HTTPException(
+            status_code=400,
+            detail="Sections not restorable via YAML (use a DBAS backup): %s"
+            % ", ".join(artifact_only),
+        )
 
     content = await file.read()
     data = _parse_yaml_export(content)

--- a/backend/tasks/dbas_backup.py
+++ b/backend/tasks/dbas_backup.py
@@ -76,7 +76,6 @@ import journal
 import observability
 from dbas import retention
 from routers.backup import (
-    _get_backup_filename,
     build_backup_artifact,
     verify_artifact_sha256,
 )
@@ -246,15 +245,11 @@ class DbasBackupTask(TaskScheduler):
                 acknowledge_unrecoverable=self.acknowledge_unrecoverable,
             )
 
-            # Give the artifact its CANONICAL, timestamped, allowlist-matching
-            # name (ecm-backup-<ts>.zip) so it is discoverable, sortable by the
-            # filename timestamp, and prunable by the retention policy. The
-            # builder writes a mkstemp temp name (ecm-artifact-<rand>.zip) which
-            # has no timestamp and does not match _BACKUP_ZIP_FILENAME_RE; the
-            # retention canonical-sort + allowlist both require the timestamped
-            # shape (bead 0i2vt.9).
-            artifact = self._canonicalize_artifact_name(artifact)
-
+            # The artifact already carries its CANONICAL, timestamped,
+            # allowlist-matching name (ecm-backup-<ts>.zip): the builder owns it
+            # directly (bead e0r3h) — there is no post-build rename. The retention
+            # canonical-sort + _BACKUP_ZIP_FILENAME_RE allowlist both match the
+            # builder-produced shape.
             filename = artifact.zip_path.name
             logger.info(
                 "[DBAS_BACKUP] Built artifact %s "
@@ -662,50 +657,6 @@ class DbasBackupTask(TaskScheduler):
                 )
             )
         return None
-
-    @staticmethod
-    def _canonicalize_artifact_name(artifact):
-        """Rename the built artifact (and its .sha256 sidecar) to the canonical
-        timestamped name ``ecm-backup-<UTC ts>.zip`` so it matches the retention
-        allowlist and is sortable by the filename timestamp.
-
-        The sidecar's first line is ``<sha>  <zip-name>``; it is rewritten so the
-        named file inside the sidecar tracks the renamed ZIP. On any failure the
-        original artifact is left untouched and returned (the backup still
-        succeeds — only retention discoverability is affected).
-        """
-        from routers.backup import BackupArtifact
-
-        try:
-            dest_dir = artifact.zip_path.parent
-            new_name = _get_backup_filename()  # ecm-backup-<UTC ts>.zip
-            new_zip = dest_dir / new_name
-            # Extremely unlikely collision (same-second run); fall back to the
-            # original name rather than clobber an existing artifact.
-            if new_zip.exists():
-                return artifact
-            new_sidecar = Path(str(new_zip) + ".sha256")
-            artifact.zip_path.rename(new_zip)
-            try:
-                artifact.sidecar_path.rename(new_sidecar)
-                new_sidecar.write_text(
-                    "%s  %s\n" % (artifact.sha256, new_zip.name), encoding="utf-8"
-                )
-            except OSError:
-                new_sidecar = artifact.sidecar_path  # keep whatever exists
-            return BackupArtifact(
-                zip_path=new_zip,
-                sidecar_path=new_sidecar,
-                schema_version=artifact.schema_version,
-                sha256=artifact.sha256,
-                file_count=artifact.file_count,
-            )
-        except OSError as e:
-            logger.warning(
-                "[DBAS_BACKUP] Could not canonicalize artifact name "
-                "(retention discoverability reduced): %s", e,
-            )
-            return artifact
 
     @staticmethod
     def _remote_paths(upload_path: str, artifact) -> tuple[str, str]:

--- a/backend/tests/dbas/test_restore_roundtrip.py
+++ b/backend/tests/dbas/test_restore_roundtrip.py
@@ -46,7 +46,8 @@ def _seed_journal_db(path):
 
 
 async def _build_real_artifact(tmp_path):
-    """Build a real artifact carrying two M3U accounts + one logo."""
+    """Build a real artifact carrying two M3U accounts + one logo + one channel
+    (with embedded streams) + one dispatcharr user — the full 7i8rf producer set."""
     config_dir = tmp_path
     journal = config_dir / "journal.db"
     _seed_journal_db(journal)
@@ -71,6 +72,25 @@ async def _build_real_artifact(tmp_path):
     client.get_channel_groups = AsyncMock(return_value=[])
     client.get_channel_profiles = AsyncMock(return_value=[])
     client.get_stream_profiles = AsyncMock(return_value=[])
+    # 7i8rf — channels (with embedded stream IDs) + the stream records to enrich
+    # them, and a dispatcharr user. The stream url (provider creds) must be
+    # dropped by the producer.
+    client.get_channels = AsyncMock(
+        return_value={
+            "count": 1, "next": None,
+            "results": [{"id": 5, "name": "CNN", "channel_number": 1, "streams": [11]}],
+        }
+    )
+    client.get_streams = AsyncMock(
+        return_value={
+            "count": 1, "next": None,
+            "results": [{"id": 11, "name": "CNN HD", "m3u_account": 1,
+                         "url": "http://prov/secret/cnn.ts"}],
+        }
+    )
+    client.get_users = AsyncMock(
+        return_value=[{"id": 7, "username": "alice", "is_superuser": False}]
+    )
 
     session = MagicMock()
     session.query.return_value.all.return_value = []
@@ -121,6 +141,18 @@ async def test_build_then_decode_then_dry_run(tmp_path):
     assert len(plan.category(EntityType.M3U_ACCOUNT).entities) == 2
     # ...and the one logo from the binary subtree.
     assert len(plan.category(EntityType.LOGO).entities) == 1
+    # ...and (7i8rf) the channel + dispatcharr user the producers now emit, which
+    # used to decode to EMPTY because no producer wrote those categories.
+    channel_cat = plan.category(EntityType.CHANNEL)
+    assert channel_cat is not None and len(channel_cat.entities) == 1
+    assert channel_cat.entities[0]["id"] == 5
+    # The channel embeds its stream by id + safe match fields, NEVER the url.
+    embedded = channel_cat.entities[0]["streams"]
+    assert [s["id"] for s in embedded] == [11]
+    assert "url" not in embedded[0]
+    user_cat = plan.category(EntityType.USER)
+    assert user_cat is not None and len(user_cat.entities) == 1
+    assert user_cat.entities[0]["username"] == "alice"
 
     report = await run_dry_run(plan=plan, client=_restore_client())
 
@@ -130,3 +162,42 @@ async def test_build_then_decode_then_dry_run(tmp_path):
     m3u = report.category(EntityType.M3U_ACCOUNT)
     # Both M3U accounts would be created against the empty destination.
     assert m3u.would_create == 2
+    # 7i8rf round-trip: channels + users are now non-empty all the way through to
+    # the dry-run report (they would be created against the empty destination).
+    assert report.category(EntityType.CHANNEL).would_create == 1
+    assert report.category(EntityType.USER).would_create == 1
+
+
+def test_producer_importer_category_parity():
+    """REGRESSION GUARD (7i8rf): every Dispatcharr-managed RESTORABLE_SECTIONS
+    key the restore decoder maps to an EntityType MUST be emitted by the producer,
+    and every importer-consumed Dispatcharr section MUST be both produced AND
+    decodable. This is the parity that, when broken, made restoring channels/users
+    a silent no-op against a real backup.
+    """
+    from routers.backup import RESTORABLE_SECTIONS
+    from dbas.restore_artifact import _SECTION_TO_ENTITY
+
+    produced_dispatcharr = {
+        k for k, v in RESTORABLE_SECTIONS.items() if v.get("dispatcharr")
+    }
+    decodable = set(_SECTION_TO_ENTITY)
+
+    # Every Dispatcharr section the decoder knows how to turn into a restore
+    # category must be produced by the builder (no decode target without a
+    # producer => silent no-op).
+    missing_producer = decodable - produced_dispatcharr
+    assert not missing_producer, (
+        "decoder maps sections with no producer: %s" % sorted(missing_producer)
+    )
+
+    # channels + dispatcharr_users are the 7i8rf round-trip categories — assert
+    # both ends explicitly so a future edit that drops either is caught.
+    for section, entity in (
+        ("channels", EntityType.CHANNEL),
+        ("dispatcharr_users", EntityType.USER),
+    ):
+        assert section in produced_dispatcharr, "producer dropped %s" % section
+        assert _SECTION_TO_ENTITY.get(section) is entity, (
+            "decoder mapping for %s changed" % section
+        )

--- a/backend/tests/routers/test_0i2vt_backup_artifact.py
+++ b/backend/tests/routers/test_0i2vt_backup_artifact.py
@@ -353,6 +353,149 @@ class TestFreeDiskGuard:
             with pytest.raises(RuntimeError, match="Insufficient free disk"):
                 asyncio.get_event_loop().run_until_complete(build_backup_artifact())
 
-        # No partial artifacts left in the dest dir.
-        leftovers = list(config_dir.glob("ecm-artifact-*"))
+        # No partial artifacts left in the dest dir. The builder now owns the
+        # canonical ecm-backup-<ts>.zip name directly (bead e0r3h), so a failed
+        # build must leave no ecm-backup-* (and no legacy ecm-artifact-*) residue.
+        leftovers = (
+            list(config_dir.glob("ecm-backup-*.zip"))
+            + list(config_dir.glob("ecm-backup-*.zip.sha256"))
+            + list(config_dir.glob("ecm-artifact-*"))
+        )
         assert leftovers == [], "partial artifact left behind: %s" % leftovers
+
+
+# A stream URL embeds IPTV provider credentials; it must NEVER appear in the
+# artifact (7i8rf). Distinctive sentinel so a leak is unambiguous in a byte scan.
+SECRET_STREAM_URL = "http://prov/user/STREAM_SECRET_url_ZZZ666/cnn.ts"
+
+
+def _build_with_channels_and_users(tmp_path, *, dest_dir=None):
+    """Build a real artifact whose Dispatcharr client returns channels (with
+    embedded stream IDs), the matching stream records (carrying a SECRET URL the
+    producer must drop), and a dispatcharr user. Used to prove the 7i8rf
+    producer-side round-trip + the stream-URL redaction contract."""
+    config_dir = tmp_path
+    journal = config_dir / "journal.db"
+    _seed_journal_db(journal)
+    (config_dir / "settings.json").write_text("{}")
+
+    client = MagicMock()
+    client.get_m3u_accounts = AsyncMock(return_value=[])
+    client.get_epg_sources = AsyncMock(return_value=[])
+    client.get_channel_groups = AsyncMock(return_value=[])
+    client.get_channel_profiles = AsyncMock(return_value=[])
+    client.get_stream_profiles = AsyncMock(return_value=[])
+    # A Dispatcharr channel's ``streams`` field is a list of stream IDs.
+    client.get_channels = AsyncMock(
+        return_value={
+            "count": 1,
+            "next": None,
+            "results": [
+                {"id": 5, "name": "CNN", "channel_number": 1, "streams": [11, 12]},
+            ],
+        }
+    )
+    # The stream records the producer joins against — each carries a SECRET url
+    # (provider creds) that must be dropped, plus the safe match fields.
+    client.get_streams = AsyncMock(
+        return_value={
+            "count": 2,
+            "next": None,
+            "results": [
+                {"id": 11, "name": "CNN HD", "m3u_account": 1, "url": SECRET_STREAM_URL},
+                {"id": 12, "name": "CNN SD", "m3u_account": 1, "url": SECRET_STREAM_URL},
+            ],
+        }
+    )
+    client.get_users = AsyncMock(
+        return_value=[{"id": 7, "username": "alice", "is_superuser": False}]
+    )
+
+    session = MagicMock()
+    session.query.return_value.all.return_value = []
+    session.query.return_value.filter_by.return_value.all.return_value = []
+    session.query.return_value.filter_by.return_value.order_by.return_value.all.return_value = []
+    session.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+
+    with patch.object(backup_mod, "CONFIG_DIR", config_dir), \
+         patch.object(backup_mod, "CONFIG_FILE", config_dir / "settings.json"), \
+         patch.object(backup_mod, "JOURNAL_DB_FILE", journal), \
+         patch.object(backup_mod, "get_engine", return_value=_mock_engine()), \
+         patch.object(backup_mod, "get_settings", return_value=_mock_settings_with_secrets()), \
+         patch.object(backup_mod, "get_session", return_value=session), \
+         patch.object(backup_mod, "get_client", return_value=client):
+        import asyncio
+        return asyncio.get_event_loop().run_until_complete(
+            build_backup_artifact(dest_dir=dest_dir)
+        )
+
+
+class TestChannelsUsersProducers:
+    """7i8rf — the builder must emit the channels + dispatcharr_users categories
+    the restore importers consume (was a no-op before this bead)."""
+
+    def test_restorable_sections_include_channels_and_users(self):
+        assert "channels" in backup_mod.RESTORABLE_SECTIONS
+        assert "dispatcharr_users" in backup_mod.RESTORABLE_SECTIONS
+        assert backup_mod.RESTORABLE_SECTIONS["channels"]["dispatcharr"] is True
+        assert backup_mod.RESTORABLE_SECTIONS["dispatcharr_users"]["dispatcharr"] is True
+
+    def test_channels_category_emitted_with_embedded_streams(self, tmp_path):
+        art = _build_with_channels_and_users(tmp_path)
+        with zipfile.ZipFile(art.zip_path) as zf:
+            parsed = yaml.safe_load(zf.read("categories/channels.yaml"))
+        rows = parsed["dispatcharr"]["channels"]
+        assert len(rows) == 1
+        ch = rows[0]
+        assert ch["id"] == 5
+        # Embedded streams are enriched to id + safe match fields, in order.
+        streams = ch["streams"]
+        assert [s["id"] for s in streams] == [11, 12]
+        assert streams[0]["name"] == "CNN HD"
+        assert streams[0]["m3u_account"] == 1
+
+    def test_users_category_emitted(self, tmp_path):
+        art = _build_with_channels_and_users(tmp_path)
+        with zipfile.ZipFile(art.zip_path) as zf:
+            parsed = yaml.safe_load(zf.read("categories/dispatcharr_users.yaml"))
+        rows = parsed["dispatcharr"]["dispatcharr_users"]
+        assert [u["username"] for u in rows] == ["alice"]
+
+    def test_embedded_stream_url_never_in_artifact(self, tmp_path):
+        """The stream URL (provider creds) must not appear in ANY byte of the
+        artifact — the producer drops it, never carries it."""
+        art = _build_with_channels_and_users(tmp_path)
+        raw = art.zip_path.read_bytes()
+        assert SECRET_STREAM_URL.encode("utf-8") not in raw
+        with zipfile.ZipFile(art.zip_path) as zf:
+            for name in zf.namelist():
+                assert SECRET_STREAM_URL.encode("utf-8") not in zf.read(name)
+
+    def test_embedded_stream_carries_no_url_key(self, tmp_path):
+        art = _build_with_channels_and_users(tmp_path)
+        with zipfile.ZipFile(art.zip_path) as zf:
+            parsed = yaml.safe_load(zf.read("categories/channels.yaml"))
+        for s in parsed["dispatcharr"]["channels"][0]["streams"]:
+            assert "url" not in s
+            assert "custom_url" not in s
+            assert "stream_hash" not in s
+
+
+class TestCanonicalArtifactName:
+    """e0r3h — the builder owns the canonical timestamped name directly."""
+
+    def test_zip_name_matches_retention_allowlist(self, tmp_path):
+        art = _patched_build(tmp_path)
+        assert backup_mod._BACKUP_ZIP_FILENAME_RE.fullmatch(art.zip_path.name), (
+            "builder zip name %r does not match retention allowlist" % art.zip_path.name
+        )
+
+    def test_no_legacy_artifact_name(self, tmp_path):
+        art = _patched_build(tmp_path)
+        assert not art.zip_path.name.startswith("ecm-artifact-")
+        assert art.zip_path.name.startswith("ecm-backup-")
+
+    def test_sidecar_name_tracks_canonical_zip(self, tmp_path):
+        art = _patched_build(tmp_path)
+        assert art.sidecar_path.name == art.zip_path.name + ".sha256"
+        assert art.zip_path.name in art.sidecar_path.read_text()

--- a/backend/tests/routers/test_backup.py
+++ b/backend/tests/routers/test_backup.py
@@ -474,7 +474,9 @@ class TestExportYaml:
         mock_settings.model_dump.return_value = {"url": "http://test:9191", "username": "admin", "password": "secret"}
 
         mock_client = AsyncMock()
-        mock_client.get_channels.return_value = [{"id": 1}]
+        mock_client.get_channels.return_value = {"count": 1, "next": None, "results": [{"id": 1, "streams": []}]}
+        mock_client.get_streams.return_value = {"count": 0, "next": None, "results": []}
+        mock_client.get_users.return_value = [{"id": 1, "username": "admin"}]
         mock_client.get_channel_groups.return_value = [{"id": 1, "name": "News"}]
         mock_client.get_m3u_accounts.return_value = [{"id": 1, "name": "Provider", "url": "http://m3u"}]
         mock_client.get_epg_sources.return_value = [{"id": 1, "name": "EPG1", "url": "http://epg"}]
@@ -619,6 +621,8 @@ class TestExportSections:
         response = await async_client.get("/api/backup/export-sections")
         assert response.status_code == 200
         sections = response.json()
+        # artifact_only categories (channels / dispatcharr_users) are excluded
+        # from the legacy export-sections list (7i8rf), so the count stays 13.
         assert len(sections) == 13
         keys = {s["key"] for s in sections}
         assert "settings" in keys
@@ -665,6 +669,8 @@ class TestSelectiveExport:
         data = yaml.safe_load(response.text)
         assert "settings" in data
         assert "database" in data
+        # The legacy /export default excludes artifact_only categories (channels /
+        # dispatcharr_users — 7i8rf), so the section count stays 13.
         assert len(data["ecm_export"]["sections_included"]) == 13
 
     @pytest.mark.asyncio
@@ -1052,6 +1058,8 @@ class TestValidateYaml:
         data = response.json()
         assert data["valid"] is True
         assert data["version"] == "0.16.0"
+        # artifact_only categories (channels / dispatcharr_users) are hidden from
+        # the legacy validate list (7i8rf), so the count stays 13.
         assert len(data["sections"]) == 13
 
         # Check a few sections

--- a/backend/tests/tasks/test_dbas_backup_retention.py
+++ b/backend/tests/tasks/test_dbas_backup_retention.py
@@ -54,13 +54,15 @@ def _make_target(session, **overrides) -> CloudStorageTarget:
 
 
 def _fake_artifact_factory(dest_dir: Path) -> BackupArtifact:
-    """A built artifact with the mkstemp-style name (pre-canonicalization), plus
-    a sidecar whose hash matches the bytes so verify_artifact_sha256 passes."""
+    """A built artifact with the CANONICAL timestamped name (the builder now owns
+    it directly — bead e0r3h; there is no post-build rename), plus a sidecar whose
+    hash matches the bytes so verify_artifact_sha256 passes."""
     import hashlib
+    from routers.backup import _get_backup_filename
 
     dest_dir = Path(dest_dir)
     dest_dir.mkdir(parents=True, exist_ok=True)
-    zip_path = dest_dir / "ecm-artifact-rand123.zip"
+    zip_path = dest_dir / _get_backup_filename()  # ecm-backup-<UTC ts>.zip
     data = b"PK\x03\x04realish-artifact-bytes"
     zip_path.write_bytes(data)
     sha = hashlib.sha256(data).hexdigest()
@@ -103,12 +105,14 @@ async def _run(dbas_backup, DbasBackupTask, backups_dir, config, adapters):
 
 
 # ---------------------------------------------------------------------------
-# Canonical artifact rename.
+# Canonical artifact name (builder-owned — bead e0r3h).
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_artifact_renamed_to_canonical_timestamped_name(_wire_db, _reset_metrics, tmp_path):
-    """The built ecm-artifact-<rand>.zip is renamed to the canonical
-    ecm-backup-<ts>.zip so it matches the retention allowlist + is sortable."""
+async def test_artifact_has_canonical_timestamped_name(_wire_db, _reset_metrics, tmp_path):
+    """The artifact carries the canonical ecm-backup-<ts>.zip name (produced by
+    the builder directly — bead e0r3h, no post-build rename) so it matches the
+    retention allowlist + is sortable. No ecm-artifact-<rand> temp name is ever
+    left behind."""
     from tasks import dbas_backup
     from tasks.dbas_backup import DbasBackupTask
 
@@ -119,9 +123,9 @@ async def test_artifact_renamed_to_canonical_timestamped_name(_wire_db, _reset_m
     assert result.success is True
     on_disk = list(backups.glob("ecm-backup-*.zip"))
     assert len(on_disk) == 1
-    # The mkstemp temp name must be gone.
+    # No mkstemp temp name is ever created/left behind by the builder.
     assert not list(backups.glob("ecm-artifact-*.zip"))
-    # The sidecar tracks the renamed zip.
+    # The sidecar tracks the canonical zip.
     sidecar = Path(str(on_disk[0]) + ".sha256")
     assert sidecar.exists()
     assert on_disk[0].name in sidecar.read_text()


### PR DESCRIPTION
## Summary

Closes the **v0.18.0 DBAS round-trip blocker** (`7i8rf`) and the small
behavior-preserving naming refactor (`e0r3h`), both in the same backup builder.

### 7i8rf — producer-side round-trip gap

The DBAS backup builder did **not** emit the `channels` or `dispatcharr_users`
categories, even though the Phase-2 restore importers
(`dbas/importers/channels.py` + `users.py`, both **WIRED** in
`default_importer_steps`) consume them. Restoring channels/users against a real
backup was therefore a silent no-op. Two ends were broken:

1. **Producer** — `RESTORABLE_SECTIONS` (which drives
   `_gather_redacted_categories` → `build_yaml_export`) had no channels/users.
2. **Decoder** — `_SECTION_TO_ENTITY` in `dbas/restore_artifact.py` had no
   `channels`/`dispatcharr_users` mapping, so even produced bytes decoded to
   empty `PlanCategory` objects.

**Changes:**
- Add `channels` + `dispatcharr_users` to `RESTORABLE_SECTIONS`, flagged
  `artifact_only`: produced into the DBAS artifact (consumed by the Phase-2
  importers via `decode_artifact_to_plan` → orchestrator) but **not** restorable
  through the legacy per-section YAML restore (which has no channel/user
  restorer). They are hidden from `/export-sections` + `/validate`, rejected by
  `/restore-yaml`, and excluded from the legacy full `/export` default so its
  shape is unchanged.
- `_gather_dispatcharr_sections` fetches channels (paginated) with **embedded
  streams reduced to credential-free match fields** — `id + name + m3u_account`,
  **never the URL** (a stream URL embeds IPTV provider credentials; the 4-tier
  restore matcher matches on name + provider, not URL). Also fetches dispatcharr
  users (a GET never returns a password/hash; the non-bypassable deep redactor is
  the backstop).
- Decoder maps `channels` → `CHANNEL` and `dispatcharr_users` → `USER`.

### e0r3h — builder owns the canonical artifact name

`build_backup_artifact` now writes `ecm-backup-<UTC ts>.zip` directly (matching
retention's `_BACKUP_ZIP_FILENAME_RE` + filename timestamp-sort), removing the
post-build `_canonicalize_artifact_name` rename in `tasks/dbas_backup.py`. A rare
same-second collision falls back to an mkstemp `ecm-backup-` temp name.

## Tests
- Producer emits channels (with embedded ID-only streams) + users.
- Stream URL (provider creds) never appears in **any** artifact byte; embedded
  stream records carry no `url`/`custom_url`/`stream_hash`.
- Full `build → validate → decode → run_dry_run` round-trip: channels + users
  decode to non-empty categories and report `would_create == 1`.
- **Producer↔decoder category-parity regression guard** so this gap can't
  silently return.
- Builder-owned canonical-name tests; updated retention/free-disk tests.
- Full backend suite: **6210 passed, 3 skipped**.

## Notes / scope decision
`user_agents` / `core_settings` / `dvr` / `comskip` (the `settings_agents`
importer) are **seams in the apply registry** (`importer=None`) and absent from
the decoder, so producing them now would emit data nothing consumes — out of
scope for the round-trip blocker. Flagged here rather than faking producers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)