### PR TITLE
[bd-fqur1] feat(auto-creation): surface capped/abandoned statuses + circuit-breaker reset UI

### DIFF
--- a/frontend/src/components/autoCreation/AutoCreationTab.test.tsx
+++ b/frontend/src/components/autoCreation/AutoCreationTab.test.tsx
@@ -17,9 +17,14 @@ import {
 } from '../../test/mocks/server';
 import { AutoCreationTab } from './AutoCreationTab';
 import { NotificationProvider } from '../../contexts/NotificationContext';
+import { AuthProvider } from '../../hooks/useAuth';
 
 const renderWithProviders = (ui: React.JSX.Element) =>
-  render(<NotificationProvider>{ui}</NotificationProvider>);
+  render(
+    <AuthProvider>
+      <NotificationProvider>{ui}</NotificationProvider>
+    </AuthProvider>
+  );
 
 // Setup MSW server
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));

--- a/frontend/src/components/autoCreation/AutoCreationTab.tsx
+++ b/frontend/src/components/autoCreation/AutoCreationTab.tsx
@@ -12,10 +12,13 @@ import type {
   RestoreSnapshotResponse,
   FailedChannel,
 } from '../../types/autoCreation';
+import type { CircuitBreakerState } from '../../services/autoCreationApi';
+import { useAuth } from '../../hooks/useAuth';
 import { useAutoCreationRules } from '../../hooks/useAutoCreationRules';
 import { useAutoCreationExecution } from '../../hooks/useAutoCreationExecution';
 import { RuleBuilder } from './RuleBuilder';
 import { BulkRuleSettingsModal } from './BulkRuleSettingsModal';
+import { CircuitBreakerBanner } from './CircuitBreakerBanner';
 import * as autoCreationApi from '../../services/autoCreationApi';
 import { copyToClipboard } from '../../utils/clipboard';
 import { getDateLocale } from '../../utils/formatting';
@@ -31,8 +34,16 @@ const getStatusBadgeClass = (status: string) => {
     enabled: 'badge-success', completed: 'badge-success',
     disabled: '', failed: 'badge-error',
     running: 'badge-info', rolled_back: 'badge-warning',
+    capped: 'badge-warning', abandoned: 'badge-error',
   };
   return `badge badge-sm badge-uppercase ${map[status] || ''}`;
+};
+
+/** Human-readable label for execution statuses that need one (others are fine as-is). */
+const EXECUTION_STATUS_LABEL: Partial<Record<string, string>> = {
+  rolled_back: 'Rolled Back',
+  capped: 'Capped',
+  abandoned: 'Abandoned',
 };
 
 /** Categorize a log action into a filter bucket. */
@@ -60,6 +71,9 @@ function getActionCategory(action: ActionLogEntry): string | null {
 }
 
 export function AutoCreationTab() {
+  const { user } = useAuth();
+  const isAdmin = Boolean(user?.is_admin);
+
   // State from hooks
   const {
     rules,
@@ -85,6 +99,9 @@ export function AutoCreationTab() {
     runPipeline: runPipelineApi,
     rollback,
   } = useAutoCreationExecution();
+
+  // Circuit-breaker state (bd-fqur1: abandoned/capped run surfacing)
+  const [circuitBreaker, setCircuitBreaker] = useState<CircuitBreakerState | null>(null);
 
   // Local state
   const [search, setSearch] = useState('');
@@ -132,11 +149,21 @@ export function AutoCreationTab() {
   // Responsive state
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
 
-  // Fetch rules and executions on mount
+  const fetchCircuitBreaker = useCallback(async () => {
+    try {
+      const state = await autoCreationApi.getCircuitBreakerState();
+      setCircuitBreaker(state);
+    } catch {
+      // Non-fatal — banner is informational only; don't surface a toast
+    }
+  }, []);
+
+  // Fetch rules, executions, and circuit-breaker state on mount
   useEffect(() => {
     fetchRules();
     fetchExecutions();
-  }, [fetchRules, fetchExecutions]);
+    fetchCircuitBreaker();
+  }, [fetchRules, fetchExecutions, fetchCircuitBreaker]);
 
   // Handle responsive layout
   useEffect(() => {
@@ -664,6 +691,15 @@ export function AutoCreationTab() {
         </div>
       </header>
 
+      {/* Circuit-breaker banner — shown when run-on-refresh auto-fire is suppressed */}
+      {circuitBreaker && (
+        <CircuitBreakerBanner
+          state={circuitBreaker}
+          isAdmin={isAdmin}
+          onReset={fetchCircuitBreaker}
+        />
+      )}
+
       {/* Statistics Summary */}
       <div className="auto-creation-stats">
         <div className="stat-item">
@@ -936,7 +972,7 @@ export function AutoCreationTab() {
                 <div key={execution.id} className="execution-item" data-testid="execution-item">
                   <div className="execution-info">
                     <span className={getStatusBadgeClass(execution.status)}>
-                      {execution.status === 'rolled_back' ? 'Rolled Back' : execution.status}
+                      {EXECUTION_STATUS_LABEL[execution.status] ?? execution.status}
                     </span>
                     <span className="execution-mode">
                       {execution.mode === 'dry_run' ? 'Dry Run' : 'Execute'}

--- a/frontend/src/components/autoCreation/CircuitBreakerBanner.css
+++ b/frontend/src/components/autoCreation/CircuitBreakerBanner.css
@@ -1,0 +1,97 @@
+/* CircuitBreakerBanner — run-on-refresh circuit breaker status banner */
+
+.circuit-breaker-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-xl);
+  border: 1px solid;
+  margin-bottom: 1rem;
+}
+
+/* abandoned_run variant — amber/warning */
+.circuit-breaker-banner--abandoned {
+  background: var(--warning-bg, rgba(245, 158, 11, 0.1));
+  border-color: rgba(245, 158, 11, 0.3);
+}
+
+.circuit-breaker-banner--abandoned .circuit-breaker-icon {
+  color: var(--status-warning, #f59e0b);
+}
+
+/* manual-disable variant — muted/info */
+.circuit-breaker-banner--manual {
+  background: rgba(99, 102, 241, 0.08);
+  border-color: rgba(99, 102, 241, 0.2);
+}
+
+.circuit-breaker-banner--manual .circuit-breaker-icon {
+  color: #6366f1;
+}
+
+.circuit-breaker-icon {
+  font-size: 20px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.circuit-breaker-text {
+  flex: 1;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+
+.circuit-breaker-reset-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8125rem;
+}
+
+.circuit-breaker-reset-btn .material-icons {
+  font-size: 16px;
+}
+
+/* Confirmation overlay — inline (not full-screen modal) */
+.circuit-breaker-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal, 1000);
+}
+
+.circuit-breaker-confirm-dialog {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-xl);
+  padding: 1.5rem;
+  max-width: 420px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.circuit-breaker-confirm-dialog h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.circuit-breaker-confirm-dialog p {
+  margin: 0 0 1.25rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.circuit-breaker-confirm-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}

--- a/frontend/src/components/autoCreation/CircuitBreakerBanner.test.tsx
+++ b/frontend/src/components/autoCreation/CircuitBreakerBanner.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * TDD Tests for CircuitBreakerBanner component (bd-fqur1).
+ *
+ * Covers:
+ *  - Banner hides when breaker is not tripped
+ *  - Banner shows on abandoned_run with correct message
+ *  - Banner shows for manual-disable without reset button
+ *  - Reset button only for admins on abandoned_run
+ *  - Reset confirmation dialog flow
+ *  - POST /reset-circuit-breaker called on confirm
+ *  - onReset callback invoked after success
+ */
+import type * as React from 'react';
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server, mockDataStore } from '../../test/mocks/server';
+import { CircuitBreakerBanner } from './CircuitBreakerBanner';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+
+// Setup MSW
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const renderBanner = (props: React.ComponentProps<typeof CircuitBreakerBanner>) =>
+  render(
+    <NotificationProvider>
+      <CircuitBreakerBanner {...props} />
+    </NotificationProvider>,
+  );
+
+describe('CircuitBreakerBanner', () => {
+  describe('when breaker is not tripped', () => {
+    it('renders nothing', () => {
+      const { container } = renderBanner({
+        state: { disabled: false, reason: null },
+        isAdmin: true,
+        onReset: vi.fn(),
+      });
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('when tripped by abandoned_run', () => {
+    const trippedState = { disabled: true, reason: 'abandoned_run' as const };
+
+    it('shows the banner', () => {
+      renderBanner({ state: trippedState, isAdmin: false, onReset: vi.fn() });
+      expect(screen.getByTestId('circuit-breaker-banner')).toBeInTheDocument();
+    });
+
+    it('shows abandoned_run message', () => {
+      renderBanner({ state: trippedState, isAdmin: false, onReset: vi.fn() });
+      expect(screen.getByText(/auto-creation suspended/i)).toBeInTheDocument();
+    });
+
+    it('shows reset button for admins', () => {
+      renderBanner({ state: trippedState, isAdmin: true, onReset: vi.fn() });
+      expect(screen.getByTestId('circuit-breaker-reset-btn')).toBeInTheDocument();
+    });
+
+    it('hides reset button for non-admins', () => {
+      renderBanner({ state: trippedState, isAdmin: false, onReset: vi.fn() });
+      expect(screen.queryByTestId('circuit-breaker-reset-btn')).not.toBeInTheDocument();
+    });
+
+    it('opens confirmation dialog on reset click', async () => {
+      const user = userEvent.setup();
+      renderBanner({ state: trippedState, isAdmin: true, onReset: vi.fn() });
+
+      await user.click(screen.getByTestId('circuit-breaker-reset-btn'));
+
+      expect(screen.getByTestId('circuit-breaker-confirm-dialog')).toBeInTheDocument();
+    });
+
+    it('closes confirmation dialog on cancel', async () => {
+      const user = userEvent.setup();
+      renderBanner({ state: trippedState, isAdmin: true, onReset: vi.fn() });
+
+      await user.click(screen.getByTestId('circuit-breaker-reset-btn'));
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(screen.queryByTestId('circuit-breaker-confirm-dialog')).not.toBeInTheDocument();
+    });
+
+    it('calls POST reset-circuit-breaker and invokes onReset on confirm', async () => {
+      const user = userEvent.setup();
+      const onReset = vi.fn();
+      // Wire the mock store so the handler returns was_disabled: true
+      mockDataStore.circuitBreaker = { disabled: true, reason: 'abandoned_run' };
+      renderBanner({ state: trippedState, isAdmin: true, onReset });
+
+      await user.click(screen.getByTestId('circuit-breaker-reset-btn'));
+      await user.click(screen.getByTestId('circuit-breaker-confirm-reset-btn'));
+
+      await waitFor(() => expect(onReset).toHaveBeenCalledTimes(1));
+    });
+
+    it('shows success toast after reset', async () => {
+      const user = userEvent.setup();
+      mockDataStore.circuitBreaker = { disabled: true, reason: 'abandoned_run' };
+      renderBanner({ state: trippedState, isAdmin: true, onReset: vi.fn() });
+
+      await user.click(screen.getByTestId('circuit-breaker-reset-btn'));
+      await user.click(screen.getByTestId('circuit-breaker-confirm-reset-btn'));
+
+      await waitFor(() =>
+        expect(screen.getByText(/circuit breaker cleared/i)).toBeInTheDocument()
+      );
+    });
+
+    it('shows error toast when reset API fails', async () => {
+      const user = userEvent.setup();
+      server.use(
+        http.post('/api/auto-creation/reset-circuit-breaker', () =>
+          // Return a network-level error body with a detail that httpClient surfaces
+          HttpResponse.json({ detail: 'Failed to reset circuit breaker' }, { status: 500 }),
+        ),
+      );
+      renderBanner({ state: trippedState, isAdmin: true, onReset: vi.fn() });
+
+      await user.click(screen.getByTestId('circuit-breaker-reset-btn'));
+      await user.click(screen.getByTestId('circuit-breaker-confirm-reset-btn'));
+
+      await waitFor(() =>
+        expect(screen.getByText(/failed to reset circuit breaker/i)).toBeInTheDocument()
+      );
+    });
+  });
+
+  describe('when tripped manually (reason: null)', () => {
+    const manualState = { disabled: true, reason: null as null };
+
+    it('shows the banner', () => {
+      renderBanner({ state: manualState, isAdmin: true, onReset: vi.fn() });
+      expect(screen.getByTestId('circuit-breaker-banner')).toBeInTheDocument();
+    });
+
+    it('shows manual-disable message', () => {
+      renderBanner({ state: manualState, isAdmin: true, onReset: vi.fn() });
+      expect(screen.getByText(/run-on-refresh is disabled/i)).toBeInTheDocument();
+    });
+
+    it('does NOT show reset button even for admins', () => {
+      renderBanner({ state: manualState, isAdmin: true, onReset: vi.fn() });
+      expect(screen.queryByTestId('circuit-breaker-reset-btn')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/autoCreation/CircuitBreakerBanner.tsx
+++ b/frontend/src/components/autoCreation/CircuitBreakerBanner.tsx
@@ -1,0 +1,143 @@
+/**
+ * Circuit-breaker banner for the Auto-Creation Pipeline tab.
+ *
+ * Shown when the run-on-refresh circuit breaker is tripped. Distinguishes two
+ * cases:
+ *   - reason === 'abandoned_run': tripped automatically after an abandoned
+ *     (OOM-killed) run. Shows a reset button for admins.
+ *   - reason === null / other: tripped manually by the user. No reset button
+ *     (user disabled it intentionally; they re-enable via the run-on-refresh
+ *     toggle in the rule settings).
+ *
+ * Manual "Run Now" is never gated by the circuit breaker — only the automatic
+ * post-refresh trigger is affected.
+ */
+import { useState } from 'react';
+import { useNotifications } from '../../contexts/NotificationContext';
+import type { CircuitBreakerState } from '../../services/autoCreationApi';
+import * as autoCreationApi from '../../services/autoCreationApi';
+import './CircuitBreakerBanner.css';
+
+export interface CircuitBreakerBannerProps {
+  /** Current state from GET /api/auto-creation/circuit-breaker */
+  state: CircuitBreakerState;
+  /** Whether the current user is an admin (and can reset the breaker) */
+  isAdmin: boolean;
+  /** Called after a successful reset so the parent can refresh state */
+  onReset: () => void;
+}
+
+export function CircuitBreakerBanner({ state, isAdmin, onReset }: CircuitBreakerBannerProps) {
+  const notifications = useNotifications();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [resetting, setResetting] = useState(false);
+
+  // Only render when the breaker is actually tripped
+  if (!state.disabled) return null;
+
+  const isAbandonedRun = state.reason === 'abandoned_run';
+  const canReset = isAdmin && isAbandonedRun;
+
+  const handleConfirmReset = async () => {
+    setResetting(true);
+    try {
+      await autoCreationApi.resetCircuitBreaker();
+      notifications.success(
+        'Circuit breaker cleared — auto-creation will run after M3U refresh again.',
+        'Auto-Creation',
+      );
+      setConfirmOpen(false);
+      onReset();
+    } catch (err) {
+      notifications.error(
+        err instanceof Error ? err.message : 'Failed to reset circuit breaker',
+        'Auto-Creation',
+      );
+    } finally {
+      setResetting(false);
+    }
+  };
+
+  return (
+    <>
+      <div
+        className={`circuit-breaker-banner ${isAbandonedRun ? 'circuit-breaker-banner--abandoned' : 'circuit-breaker-banner--manual'}`}
+        data-testid="circuit-breaker-banner"
+        role="alert"
+      >
+        <span className="material-icons circuit-breaker-icon">
+          {isAbandonedRun ? 'warning' : 'pause_circle'}
+        </span>
+        <div className="circuit-breaker-text">
+          {isAbandonedRun ? (
+            <>
+              <strong>Auto-creation suspended</strong> — the previous run was abandoned
+              (likely an OOM crash). Run-on-refresh is disabled until an operator resets
+              the circuit breaker. Manual &quot;Run Now&quot; is unaffected.
+            </>
+          ) : (
+            <>
+              <strong>Run-on-refresh is disabled</strong> — auto-creation will not fire
+              automatically after M3U refresh. Manual &quot;Run Now&quot; is unaffected.
+            </>
+          )}
+        </div>
+        {canReset && (
+          <button
+            className="btn-secondary circuit-breaker-reset-btn"
+            onClick={() => setConfirmOpen(true)}
+            data-testid="circuit-breaker-reset-btn"
+            aria-label="Reset circuit breaker"
+          >
+            <span className="material-icons">restart_alt</span>
+            Reset
+          </button>
+        )}
+      </div>
+
+      {/* Reset confirmation dialog */}
+      {confirmOpen && (
+        <div
+          className="circuit-breaker-confirm-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="cb-confirm-title"
+          data-testid="circuit-breaker-confirm-dialog"
+        >
+          <div className="circuit-breaker-confirm-dialog">
+            <h3 id="cb-confirm-title">Reset Circuit Breaker</h3>
+            <p>
+              This will re-enable automatic auto-creation after every M3U refresh.
+              Only reset if the previous abandoned run has been investigated.
+            </p>
+            <div className="circuit-breaker-confirm-footer">
+              <button
+                className="btn-secondary"
+                onClick={() => setConfirmOpen(false)}
+                disabled={resetting}
+              >
+                Cancel
+              </button>
+              <button
+                className="btn-primary"
+                onClick={handleConfirmReset}
+                disabled={resetting}
+                data-testid="circuit-breaker-confirm-reset-btn"
+                aria-label="Confirm reset"
+              >
+                {resetting ? (
+                  <>
+                    <span className="material-icons spinning" style={{ fontSize: '16px', marginRight: '4px' }}>sync</span>
+                    Resetting...
+                  </>
+                ) : (
+                  'Reset Circuit Breaker'
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/hooks/useAutoCreationExecution.test.ts
+++ b/frontend/src/hooks/useAutoCreationExecution.test.ts
@@ -637,6 +637,62 @@ describe('useAutoCreationExecution', () => {
     });
   });
 
+  // bd-fqur1: capped and abandoned must be treated as terminal statuses so the
+  // poll in pollExecutionUntilTerminal never hangs on these new backend values.
+  describe('terminal status set (bd-fqur1)', () => {
+    async function verifyStatusIsTerminal(status: 'capped' | 'abandoned') {
+      server.use(
+        http.post('/api/auto-creation/run', () => {
+          const exec = createMockAutoCreationExecution({ status, channels_created: 0 });
+          mockDataStore.autoCreationExecutions.unshift(exec);
+          return HttpResponse.json(
+            { execution_id: exec.id, status: 'running', message: 'started' },
+            { status: 202 },
+          );
+        }),
+      );
+      const { result } = renderHook(() => useAutoCreationExecution());
+      let resolved: RunPipelineResponse | undefined;
+      await act(async () => {
+        resolved = await result.current.runPipeline();
+      });
+      expect(resolved).toBeDefined();
+      expect(resolved!.status).toBe(status);
+    }
+
+    it('treats "capped" as terminal so the poll resolves', async () => {
+      await verifyStatusIsTerminal('capped');
+    });
+
+    it('treats "abandoned" as terminal so the poll resolves', async () => {
+      await verifyStatusIsTerminal('abandoned');
+    });
+  });
+
+  describe('getExecutionsByStatus with capped and abandoned (bd-fqur1)', () => {
+    it('filters by capped', async () => {
+      mockDataStore.autoCreationExecutions.push(
+        createMockAutoCreationExecution({ status: 'capped' }),
+        createMockAutoCreationExecution({ status: 'completed' }),
+      );
+      const { result } = renderHook(() => useAutoCreationExecution());
+      await act(async () => { await result.current.fetchExecutions(); });
+      const capped = result.current.getExecutionsByStatus('capped');
+      expect(capped).toHaveLength(1);
+    });
+
+    it('filters by abandoned', async () => {
+      mockDataStore.autoCreationExecutions.push(
+        createMockAutoCreationExecution({ status: 'abandoned' }),
+        createMockAutoCreationExecution({ status: 'failed' }),
+      );
+      const { result } = renderHook(() => useAutoCreationExecution());
+      await act(async () => { await result.current.fetchExecutions(); });
+      const abandoned = result.current.getExecutionsByStatus('abandoned');
+      expect(abandoned).toHaveLength(1);
+    });
+  });
+
   describe('autoRefresh option', () => {
     it('re-fetches executions when the interval fires', async () => {
       vi.useFakeTimers();

--- a/frontend/src/hooks/useAutoCreationExecution.ts
+++ b/frontend/src/hooks/useAutoCreationExecution.ts
@@ -135,7 +135,7 @@ export function useAutoCreationExecution(
     // Tunables — small and steady; backend status writes are cheap GETs.
     const POLL_INTERVAL_MS = 1000;
     const MAX_POLL_DURATION_MS = 30 * 60 * 1000; // 30 minutes safety cap
-    const TERMINAL: ExecutionStatus[] = ['completed', 'failed', 'rolled_back'];
+    const TERMINAL: ExecutionStatus[] = ['completed', 'failed', 'rolled_back', 'capped', 'abandoned'];
     const startedAt = Date.now();
 
     while (true) {

--- a/frontend/src/services/autoCreationApi.ts
+++ b/frontend/src/services/autoCreationApi.ts
@@ -281,6 +281,42 @@ export async function importAutoCreationRulesYAML(
 }
 
 // =============================================================================
+// Circuit breaker (bd-exo4j / GH #473)
+// =============================================================================
+
+/**
+ * State of the run-on-refresh circuit breaker.
+ *
+ * - disabled: true → auto-creation will NOT fire after M3U refresh.
+ * - reason: 'abandoned_run' → tripped automatically by startup crash-sentinel;
+ *   null → manually disabled by the user (or not disabled at all).
+ */
+export interface CircuitBreakerState {
+  disabled: boolean;
+  reason: 'abandoned_run' | null;
+}
+
+/**
+ * Get the current run-on-refresh circuit-breaker state.
+ */
+export async function getCircuitBreakerState(): Promise<CircuitBreakerState> {
+  return fetchJson<CircuitBreakerState>(`${API_BASE}/auto-creation/circuit-breaker`);
+}
+
+/**
+ * Reset (clear) the run-on-refresh circuit breaker. Admin-only.
+ *
+ * Re-enables the post-refresh auto-fire chain. Returns ``was_disabled`` so the
+ * caller can distinguish a no-op reset from an active one.
+ */
+export async function resetCircuitBreaker(): Promise<{ success: boolean; was_disabled: boolean; disabled: boolean }> {
+  return fetchJson<{ success: boolean; was_disabled: boolean; disabled: boolean }>(
+    `${API_BASE}/auto-creation/reset-circuit-breaker`,
+    { method: 'POST' },
+  );
+}
+
+// =============================================================================
 // Debug bundle (bd-cns7j: 202+poll, replaces the old single-shot GET that
 // timed out on large catalogs)
 // =============================================================================

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -335,7 +335,7 @@ interface MockAutoCreationExecution {
   started_at: string
   completed_at: string | null
   duration_seconds: number | null
-  status: 'running' | 'completed' | 'failed' | 'rolled_back'
+  status: 'running' | 'completed' | 'failed' | 'rolled_back' | 'capped' | 'abandoned'
   streams_evaluated: number
   streams_matched: number
   channels_created: number
@@ -389,6 +389,8 @@ interface MockDataStore {
   popularityScores: MockPopularityScore[]
   autoCreationRules: MockAutoCreationRule[]
   autoCreationExecutions: MockAutoCreationExecution[]
+  /** Circuit-breaker state (bd-fqur1). Default: not tripped. */
+  circuitBreaker: { disabled: boolean; reason: 'abandoned_run' | null }
   settings: object
 }
 
@@ -402,6 +404,7 @@ export const mockDataStore: MockDataStore = {
   popularityScores: [],
   autoCreationRules: [],
   autoCreationExecutions: [],
+  circuitBreaker: { disabled: false, reason: null },
   settings: {
     configured: true,
     url: 'http://dispatcharr.test',
@@ -452,6 +455,7 @@ export function resetMockDataStore(): void {
   mockDataStore.popularityScores = []
   mockDataStore.autoCreationRules = []
   mockDataStore.autoCreationExecutions = []
+  mockDataStore.circuitBreaker = { disabled: false, reason: null }
   resetIdCounter()
 }
 
@@ -460,6 +464,29 @@ export function resetMockDataStore(): void {
 // =============================================================================
 
 export const handlers = [
+  // -------------------------------------------------------------------------
+  // Auth (no-auth mode — tests run with require_auth=false so no user is needed)
+  // -------------------------------------------------------------------------
+
+  http.get(`${API_BASE}/auth/status`, () => {
+    return HttpResponse.json({
+      require_auth: false,
+      setup_complete: true,
+      dispatcharr_enabled: false,
+    })
+  }),
+
+  http.get(`${API_BASE}/auth/me`, () => {
+    // Return 401 — unauthenticated in no-auth mode tests
+    return HttpResponse.json({ detail: 'Not authenticated' }, { status: 401 })
+  }),
+
+  // ── Normalization (required by RuleBuilder, which is lazy-loaded in AutoCreationTab) ──
+
+  http.get(`${API_BASE}/normalization/rules`, () => {
+    return HttpResponse.json({ groups: [] })
+  }),
+
   // -------------------------------------------------------------------------
   // Health & Settings
   // -------------------------------------------------------------------------
@@ -1182,6 +1209,18 @@ export const handlers = [
       restored_channels: 10,
       failed_channels: [],
     })
+  }),
+
+  // ── Circuit breaker (bd-fqur1) ──
+
+  http.get(`${API_BASE}/auto-creation/circuit-breaker`, () => {
+    return HttpResponse.json(mockDataStore.circuitBreaker)
+  }),
+
+  http.post(`${API_BASE}/auto-creation/reset-circuit-breaker`, () => {
+    const was_disabled = mockDataStore.circuitBreaker.disabled
+    mockDataStore.circuitBreaker = { disabled: false, reason: null }
+    return HttpResponse.json({ success: true, was_disabled, disabled: false })
   }),
 
   http.get(`${API_BASE}/auto-creation/export/yaml`, () => {

--- a/frontend/src/types/autoCreation.ts
+++ b/frontend/src/types/autoCreation.ts
@@ -307,8 +307,13 @@ export interface BulkUpdateRulesResponse {
 
 /**
  * Status of a pipeline execution.
+ *
+ * Terminal statuses: completed, failed, rolled_back, capped, abandoned.
+ * - capped: the pipeline hit the per-run created-channel cap and stopped early.
+ * - abandoned: the pipeline was abandoned (e.g. OOM crash); trips the
+ *   run-on-refresh circuit breaker until an operator resets it.
  */
-export type ExecutionStatus = 'running' | 'completed' | 'failed' | 'rolled_back';
+export type ExecutionStatus = 'running' | 'completed' | 'failed' | 'rolled_back' | 'capped' | 'abandoned';
 
 /**
  * How a pipeline was triggered.


### PR DESCRIPTION
## [bd-fqur1] Auto-creation: capped/abandoned status surfacing + circuit-breaker reset UI

### What

Frontend fast-follow to the 0.17.6 patch (PR #505). The backend now sets `status='abandoned'` (crash-sentinel) and `status='capped'` (created-channel cap), and exposes circuit-breaker endpoints. This PR wires up all the frontend pieces:

1. **`ExecutionStatus` type** — additive only: added `'capped'` and `'abandoned'` to the union in `autoCreation.ts`. No other changes to this type.
2. **`TERMINAL` set** — added `'capped'` and `'abandoned'` to `pollExecutionUntilTerminal`'s terminal list in `useAutoCreationExecution.ts` so a capped/abandoned run doesn't hang the poll.
3. **Badge display** — `capped` renders as `badge-warning`, `abandoned` as `badge-error`, with correct human-readable labels.
4. **`CircuitBreakerBanner` component** — new component that:
   - Fetches `GET /api/auto-creation/circuit-breaker` on tab mount
   - Is hidden when the breaker is not tripped
   - Shows an amber warning for `reason: 'abandoned_run'` (auto-tripped by crash-sentinel) with a **Reset** button for admins
   - Shows a muted info banner for manual-disable (no reset button — user controls that via the rule toggle)
   - Reset button opens a confirmation dialog → calls `POST /api/auto-creation/reset-circuit-breaker` → fires `onReset` callback to refresh state
5. **API layer** — `getCircuitBreakerState()` and `resetCircuitBreaker()` added to `autoCreationApi.ts`
6. **Pre-existing gap fix** — `GET /api/normalization/rules` and auth endpoints were unhandled in MSW, causing 46 `AutoCreationTab` tests to time out. Added the missing handlers. All 1703 tests now pass.

### Why

Surfaces two new backend states that were silently swallowed by the UI, and gives operators a clear recovery path when an OOM crash trips the circuit breaker.

### How to Test

1. Open the Auto-Creation tab with a tripped circuit breaker (`auto_creation_run_on_refresh_disabled: true` in settings)
2. Verify the amber banner appears with "Auto-creation suspended" text
3. As an admin, click Reset → confirm → banner disappears and circuit breaker clears
4. Trigger a `capped` or `abandoned` execution — verify the badge shows the correct color and label

### autoCreation.ts edits (conflict flag)

**Minimal and additive only** — the single change is appending `| 'capped' | 'abandoned'` to the `ExecutionStatus` type union at line ~311. No other fields, no interface changes. Safe to merge alongside e8p1h's work as long as that bead doesn't touch the `ExecutionStatus` line.

### Security
- [x] No hardcoded secrets
- [x] Admin gate enforced: reset button only shown to `user.is_admin === true`; backend enforces `RequireAdminIfEnabled` independently

### Deployment
- [x] No infrastructure changes
- [x] No database migration
- [x] Frontend-only; backend endpoints already shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)