### PR TITLE
v0.17.6-0075: Event Sync parse coverage + Channel Group Override fix + master-identity options

### DIFF
--- a/backend/channel_pipeline_engine.py
+++ b/backend/channel_pipeline_engine.py
@@ -2744,6 +2744,58 @@ class ChannelPipelineEngine:
                 if not isinstance(resp, dict) or not resp.get("next"):
                     break
                 page += 1
+
+        # bead 6xxmp: optionally also fetch the MASTER group's own streams as
+        # a secondary source (group_id = master_group_id). The resolver drops
+        # the ones already attached to a master channel, so only a second
+        # provider's unsynced streams in the same-named group survive. Mirrors
+        # the secondary fetch above so preview and run see the same universe.
+        if config.get("include_master_group_streams") and not truncated:
+            master_group_id = config["master_group_id"]
+            mgname = await self.client._channel_group_name_for_id(
+                master_group_id
+            )
+            if not mgname:
+                logger.warning(
+                    "[EVENT-SYNC] Master group %s has no resolvable "
+                    "channel-group name; skipping self-attach fetch",
+                    master_group_id,
+                )
+            else:
+                page = 1
+                while True:
+                    resp = await self.client.get_streams(
+                        page=page, page_size=_EVENT_SYNC_FETCH_PAGE_SIZE,
+                        channel_group_name=mgname,
+                    )
+                    batch = (
+                        resp.get("results", []) if isinstance(resp, dict)
+                        else (resp or [])
+                    )
+                    for s in batch:
+                        if not s.get("name") or s.get("id") is None:
+                            continue
+                        account_id = extract_m3u_account_id(s.get("m3u_account"))
+                        secondary_streams.append(SecondaryStream(
+                            name=s["name"],
+                            group_id=master_group_id,
+                            stream_id=s.get("id"),
+                            provider=account_names.get(account_id),
+                            provider_id=account_id,
+                        ))
+                    if len(secondary_streams) >= EVENT_SYNC_MAX_SECONDARY_STREAMS:
+                        secondary_streams = secondary_streams[
+                            :EVENT_SYNC_MAX_SECONDARY_STREAMS]
+                        logger.warning(
+                            "[EVENT-SYNC] Secondary stream fetch truncated at "
+                            "%s streams (guard, incl. master-group self-attach)"
+                            " — remaining streams picked up next run",
+                            EVENT_SYNC_MAX_SECONDARY_STREAMS,
+                        )
+                        break
+                    if not isinstance(resp, dict) or not resp.get("next"):
+                        break
+                    page += 1
         return secondary_streams
 
     async def _run_event_sync_rules(
@@ -2862,6 +2914,23 @@ class ChannelPipelineEngine:
             )
             accounts = []
         account_names = {a.get("id"): a.get("name") for a in accounts}
+
+        # Channel Group Override resolution (bead override): master channels
+        # for an auto-synced SOURCE group live in its override TARGET group.
+        # Fetch settings ONCE for the whole phase so each rule's master fetch
+        # follows the override instead of coming back empty.
+        from services.event_sync_preflight import (
+            resolve_effective_master_group_id,
+        )
+        try:
+            all_group_settings = await self.client.get_all_m3u_group_settings()
+        except Exception as e:
+            logger.warning(
+                "[EVENT-SYNC] Failed to fetch group settings for override "
+                "resolution (%s) — master fetch uses the configured group id "
+                "as-is", e,
+            )
+            all_group_settings = {}
 
         for rule in event_sync_rules:
             config = rule.get_event_sync_config()
@@ -2987,10 +3056,14 @@ class ChannelPipelineEngine:
                     rule.name, rule.id, e,
                 )
 
+            effective_master_group_id = resolve_effective_master_group_id(
+                all_group_settings, config["master_group_id"]
+            )
             exec_ctx = ExecutionContext(dry_run=dry_run)
             summary = await executor.execute_event_sync_rule(
                 rule.id, rule.name, config, secondary_streams, exec_ctx,
                 decisions=decisions,
+                effective_master_group_id=effective_master_group_id,
             )
 
             # ti939.3.2: persist the run's ambiguous pairings as pending

--- a/backend/channel_pipeline_executor.py
+++ b/backend/channel_pipeline_executor.py
@@ -3372,7 +3372,9 @@ class ActionExecutor:
         return best_channel, provenance
 
     def _resolve_event_sync(self, config: dict, secondary_streams: list,
-                            now=None, decisions=None) -> tuple:
+                            now=None, decisions=None,
+                            effective_master_group_id=None,
+                            master_name_to_id=None) -> tuple:
         """Event-mode candidate resolution (ti939.2.1) — SIBLING of
         :meth:`_resolve_scored_fuzzy`.
 
@@ -3412,22 +3414,46 @@ class ActionExecutor:
         from services.event_sync_resolver import resolve_event_sync
 
         master_group_id = config["master_group_id"]
-        name_to_id: dict[str, int] = {}
+        # Follow a Channel Group Override: master channels live in the
+        # override TARGET group, not the configured source group (bead
+        # override). Falls back to the configured id when unset.
+        channel_group_id = (
+            effective_master_group_id
+            if effective_master_group_id is not None
+            else master_group_id
+        )
+        channel_name_to_id: dict[str, int] = {}
         master_channel_count = 0
+        # bead 6xxmp: stream ids already on a master channel — the resolver
+        # drops these when the master group is a self-attach source so the
+        # auto-synced provider's own streams are never re-offered.
+        attached_stream_ids: set[int] = set()
         for ch in self.existing_channels:
-            if ch.get("channel_group_id") != master_group_id:
+            if ch.get("channel_group_id") != channel_group_id:
                 continue
             master_channel_count += 1
+            for s in ch.get("streams", []):
+                sid = s["id"] if isinstance(s, dict) else s
+                if sid is not None:
+                    attached_stream_ids.add(sid)
             name, cid = ch.get("name"), ch.get("id")
             if not name or cid is None:
                 continue
-            if name not in name_to_id or cid < name_to_id[name]:
-                name_to_id[name] = cid
+            if name not in channel_name_to_id or cid < channel_name_to_id[name]:
+                channel_name_to_id[name] = cid
+        # bead parse-from-stream: master identity may come from the attached
+        # stream names (pre-built async in execute_event_sync_rule) instead of
+        # the channel names. The attach path maps the winning identity back to
+        # its channel id via this same map.
+        name_to_id = (
+            master_name_to_id if master_name_to_id is not None
+            else channel_name_to_id
+        )
         master_names = sorted(name_to_id)
 
         resolution = resolve_event_sync(
             config, master_names, secondary_streams, now=now,
-            decisions=decisions,
+            decisions=decisions, attached_stream_ids=attached_stream_ids,
         )
         return resolution, name_to_id, master_channel_count
 
@@ -3435,7 +3461,8 @@ class ActionExecutor:
                                       rule_name: str, config: dict,
                                       secondary_streams: list,
                                       exec_ctx: ExecutionContext,
-                                      decisions=None) -> dict:
+                                      decisions=None,
+                                      effective_master_group_id=None) -> dict:
         """Execute one event_sync rule's attach path (bead ti939.2.1).
 
         Phase 1B — the FIRST write path for event_sync. Resolves every
@@ -3495,11 +3522,30 @@ class ActionExecutor:
         )
         from concurrency import run_cpu_bound
 
+        # bead parse-from-stream: build the master identity map from attached
+        # stream names (async fetch) BEFORE the CPU-bound resolve. Default
+        # (flag off) keeps channel-name identity built inside _resolve.
+        master_name_to_id = None
+        if config.get("parse_master_from_stream"):
+            from services.event_sync_resolver import build_master_name_to_id
+            cg = (
+                effective_master_group_id
+                if effective_master_group_id is not None
+                else config["master_group_id"]
+            )
+            master_chs = [
+                c for c in self.existing_channels
+                if c.get("channel_group_id") == cg
+            ]
+            master_name_to_id = await build_master_name_to_id(
+                master_chs, self.client, True
+            )
+
         # CPU-bound scoring off the event loop (same treatment as the
         # preview endpoint).
         resolution, name_to_id, master_channel_count = await run_cpu_bound(
             self._resolve_event_sync, config, secondary_streams, None,
-            decisions,
+            decisions, effective_master_group_id, master_name_to_id,
         )
 
         cap = config.get("max_attach_per_run", DEFAULT_MAX_ATTACH_PER_RUN)

--- a/backend/channel_pipeline_schema.py
+++ b/backend/channel_pipeline_schema.py
@@ -787,6 +787,9 @@ _EVENT_SYNC_ALLOWED_KEYS = frozenset({
     "enabled",
     "auto_run",
     "dummy_epg_profile_id",
+    "include_master_group_streams",
+    "assume_current_date",
+    "parse_master_from_stream",
 })
 
 # Ceiling for event_sync_config.max_attach_per_run. The cap is a blast-radius
@@ -1093,6 +1096,57 @@ def validate_event_sync_config(config: Any) -> list[str]:
             "auto_run", auto_run,
             "a boolean (default false) — true opts this rule into "
             "unattended runs on the M3U refresh watermark task",
+        ))
+
+    # Master-group self-attach flag (bead 6xxmp). DEFAULT OFF. When true the
+    # MASTER group's own streams are ALSO fetched as a secondary source and
+    # matched to the master channels — the sanctioned path for the case a
+    # single Dispatcharr channel group (global, unique-by-name) carries
+    # streams from TWO providers, one auto-synced (its streams already on the
+    # master channels) and one not: the unsynced provider's streams attach to
+    # the synced provider's event channels. The master group is NEVER added
+    # to secondary_group_ids (that rail stays); the resolver filters the
+    # master group's already-attached streams so preview/run parity holds and
+    # the auto-synced provider's own streams are not re-offered.
+    include_master = config.get("include_master_group_streams")
+    if include_master is None:
+        config["include_master_group_streams"] = False
+    elif not isinstance(include_master, bool):
+        errors.append(_event_sync_error(
+            "include_master_group_streams", include_master,
+            "a boolean (default false) — true also matches the master "
+            "group's own unattached streams (a second provider sharing the "
+            "master group's name) to the master channels",
+        ))
+
+    # Dateless "today's schedule" opt-in (bead assume-current-date). DEFAULT
+    # OFF — it deliberately relaxes the never-guess-the-date rail (a listing
+    # with a time but no date is placed on the current date), so it must be
+    # an explicit per-rule choice with the cross-day risk understood.
+    assume_current_date = config.get("assume_current_date")
+    if assume_current_date is None:
+        config["assume_current_date"] = False
+    elif not isinstance(assume_current_date, bool):
+        errors.append(_event_sync_error(
+            "assume_current_date", assume_current_date,
+            "a boolean (default false) — true fills the CURRENT date for "
+            "listings that carry a time but no date (dateless live "
+            "schedules), accepting the cross-day match risk",
+        ))
+
+    # Parse master identity from the attached stream (bead parse-from-stream).
+    # DEFAULT OFF. When true the master event's title+time are read from each
+    # master channel's FIRST attached stream name instead of the channel
+    # name, so operators can name master channels freely.
+    parse_master_from_stream = config.get("parse_master_from_stream")
+    if parse_master_from_stream is None:
+        config["parse_master_from_stream"] = False
+    elif not isinstance(parse_master_from_stream, bool):
+        errors.append(_event_sync_error(
+            "parse_master_from_stream", parse_master_from_stream,
+            "a boolean (default false) — true reads each master channel's "
+            "event identity from its attached stream's name instead of the "
+            "channel name, so master channels can be named freely",
         ))
 
     # Dummy EPG auto-assignment (bead ti939.3.3). OPTIONAL — an absent key

--- a/backend/main.py
+++ b/backend/main.py
@@ -140,7 +140,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0074",
+    version="0.17.6-0075",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -74,7 +74,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0074"
+APP_VERSION = "0.17.6-0075"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/routers/channel_pipeline.py
+++ b/backend/routers/channel_pipeline.py
@@ -2425,13 +2425,17 @@ async def preview_event_sync(
     """
     from functools import partial
 
-    from services.event_sync_preflight import check_event_sync_group_settings
+    from services.event_sync_preflight import (
+        check_event_sync_group_settings,
+        resolve_effective_master_group_id,
+    )
     from services.event_sync_resolver import (
         DISPOSITION_AMBIGUOUS,
         DISPOSITION_PARSE_FAILED,
         DISPOSITION_UNMATCHED,
         DISPOSITION_WOULD_ATTACH,
         SecondaryStream,
+        build_master_name_to_id,
         resolve_event_sync,
     )
     from services.event_sync_review import (
@@ -2479,11 +2483,24 @@ async def preview_event_sync(
             session.close()
 
     # --- Pre-flight (READ-ONLY; failures surface, never block) -----------
+    # Fetch group settings ONCE and reuse for both the pre-flight and the
+    # Channel Group Override resolution below (bead override).
     try:
-        preflight = await check_event_sync_group_settings(client, config)
+        all_settings = await client.get_all_m3u_group_settings()
+        preflight = await check_event_sync_group_settings(
+            client, config, all_settings=all_settings
+        )
     except Exception as e:
         logger.warning("[EVENT-SYNC] preview pre-flight failed: %s", e)
         raise HTTPException(status_code=500, detail=str(e))
+
+    # Follow a Channel Group Override: when the master group is an auto-synced
+    # SOURCE, Dispatcharr places its channels in the override TARGET group, so
+    # the master channels must be fetched from there — not the raw
+    # master_group_id, which would come back empty (bead override).
+    effective_master_group_id = resolve_effective_master_group_id(
+        all_settings, master_group_id
+    )
 
     truncated = False
 
@@ -2494,12 +2511,12 @@ async def preview_event_sync(
         while True:
             resp = await client.get_channels(
                 page=cpage, page_size=_PREVIEW_FETCH_PAGE_SIZE,
-                channel_group=master_group_id,
+                channel_group=effective_master_group_id,
             )
             batch = resp.get("results", []) if isinstance(resp, dict) else (resp or [])
             master_channels.extend(
                 ch for ch in batch
-                if ch.get("channel_group_id") == master_group_id
+                if ch.get("channel_group_id") == effective_master_group_id
             )
             if len(master_channels) >= _PREVIEW_MAX_CHANNELS:
                 master_channels = master_channels[:_PREVIEW_MAX_CHANNELS]
@@ -2512,16 +2529,19 @@ async def preview_event_sync(
         logger.warning("[EVENT-SYNC] preview master-channel fetch failed: %s", e)
         raise HTTPException(status_code=500, detail=str(e))
 
-    # Name -> current channel id, re-resolved on THIS call (stateless
-    # recompute; the matcher itself never sees ids). Lowest id wins for
-    # duplicate names — deterministic.
-    name_to_id: dict[str, int] = {}
-    for ch in master_channels:
-        name, cid = ch.get("name"), ch.get("id")
-        if not name or cid is None:
-            continue
-        if name not in name_to_id or cid < name_to_id[name]:
-            name_to_id[name] = cid
+    # Identity name -> current channel id, re-resolved on THIS call (stateless
+    # recompute; the matcher never sees ids). Lowest id wins for duplicate
+    # names — deterministic. bead parse-from-stream: identity is the attached
+    # stream's name when parse_master_from_stream is on, else the channel name.
+    try:
+        name_to_id = await build_master_name_to_id(
+            master_channels, client,
+            bool(config.get("parse_master_from_stream")),
+        )
+    except Exception as e:
+        logger.warning(
+            "[EVENT-SYNC] preview master identity build failed: %s", e)
+        raise HTTPException(status_code=500, detail=str(e))
     master_names = sorted(name_to_id)
 
     # --- Fetch the secondary groups' streams (capped, paginated) ---------
@@ -2573,17 +2593,69 @@ async def preview_event_sync(
                 if not isinstance(resp, dict) or not resp.get("next"):
                     break
                 spage += 1
+        # bead 6xxmp: optionally fetch the MASTER group's own streams as a
+        # self-attach source (group_id = master_group_id). Mirrors the
+        # secondary fetch above so preview matches the run; the resolver drops
+        # the ones already attached to a master channel below.
+        if config.get("include_master_group_streams") and not truncated:
+            mgname = await client._channel_group_name_for_id(master_group_id)
+            # Record the master group's name so its own streams (and any
+            # parse-failure rows they produce) render with a group name in
+            # the preview, not a blank.
+            group_names[master_group_id] = mgname
+            if not mgname:
+                logger.warning(
+                    "[EVENT-SYNC] preview: master group %s has no resolvable "
+                    "channel-group name; skipping self-attach fetch",
+                    master_group_id,
+                )
+            else:
+                spage = 1
+                while True:
+                    resp = await client.get_streams(
+                        page=spage, page_size=_PREVIEW_FETCH_PAGE_SIZE,
+                        channel_group_name=mgname,
+                    )
+                    batch = resp.get("results", []) if isinstance(resp, dict) else (resp or [])
+                    for s in batch:
+                        if not s.get("name") or s.get("id") is None:
+                            continue
+                        account_id = extract_m3u_account_id(s.get("m3u_account"))
+                        secondary_streams.append(SecondaryStream(
+                            name=s["name"],
+                            group_id=master_group_id,
+                            stream_id=s.get("id"),
+                            provider=account_names.get(account_id),
+                            provider_id=account_id,
+                        ))
+                    if len(secondary_streams) >= _PREVIEW_MAX_STREAMS:
+                        secondary_streams = secondary_streams[:_PREVIEW_MAX_STREAMS]
+                        truncated = True
+                        break
+                    if not isinstance(resp, dict) or not resp.get("next"):
+                        break
+                    spage += 1
     except HTTPException:
         raise
     except Exception as e:
         logger.warning("[EVENT-SYNC] preview stream fetch failed: %s", e)
         raise HTTPException(status_code=500, detail=str(e))
 
+    # bead 6xxmp: stream ids already on a master channel — the resolver uses
+    # these to drop the master group's own already-attached streams so the
+    # preview's would-attach count matches the run's attach count.
+    attached_stream_ids: set[int] = set()
+    for ch in master_channels:
+        for s in ch.get("streams", []):
+            sid = s["id"] if isinstance(s, dict) else s
+            if sid is not None:
+                attached_stream_ids.add(sid)
+
     # --- Resolve (CPU-bound scoring off the event loop) ------------------
     resolution = await run_cpu_bound(
         partial(
             resolve_event_sync, config, master_names, secondary_streams,
-            decisions=decisions,
+            decisions=decisions, attached_stream_ids=attached_stream_ids,
         )
     )
 

--- a/backend/services/event_sync_matcher.py
+++ b/backend/services/event_sync_matcher.py
@@ -203,41 +203,95 @@ _TEAM_AGREE_FLOOR: float = 0.90
 # score. The escape hatch for such providers is a per-rule pattern
 # override (event_sync_config.patterns / group_patterns).
 #
-# Date-delimiter "@" vs team-separator "@" (PR #611 review, finding 2): a
-# title may itself contain "@" as a home/away separator ("Rangers @
-# Islanders @ 11 Jul 07:00 PM ET"), so the title capture is ".+?" bounded
-# by an explicitly DATE-SHAPED tail — the "@" followed by
+# Date-delimiter "@"/"|" vs team-separator "@" (PR #611 review, finding 2;
+# broadened for the live "|"-delimited + trailing-suffix shapes, bead
+# 9c9j7): a title may itself contain "@" as a home/away separator ("Rangers
+# @ Islanders @ 11 Jul 07:00 PM ET"), so the title capture is ".+?" bounded
+# by an explicitly DATE-SHAPED tail — the delimiter followed by
 # "<day> <month> <h:mm>" or "<month> <day> [year] <h:mm>" — not by the
-# first "@" in the name. A team-separator "@" can never satisfy the date
+# first delimiter in the name. A team-separator can never satisfy the date
 # shape (it is never followed by "<h:mm>" immediately after the day/month
 # tokens), so the title extends through it.
+#
+# Three broadenings over the original "@ <date> <time>$" shape, each driven
+# by live provider names that were producing "Incomplete date/time" parse
+# FAILURES (bead 9c9j7):
+#   1. TRAILING SUFFIX after the time — a slot/provider label the provider
+#      appends AFTER the date ("... @ Jul 11 9:30 AM :Flo Racing 03",
+#      "... | Sun 12 Jul 02:00 EDT (US) | | US: ESPN+ PPV 40"). Fixed by
+#      folding the CAPTURED time into the date pattern (``_TIME_CAPTURE``)
+#      so hour/minute are positionally locked to the date and the pattern
+#      stops at the timezone instead of having to reach end-of-string.
+#   2. "|" DELIMITER as well as "@" (``_DATE_DELIM``), for pipe-delimited
+#      listing formats.
+#   3. Optional leading WEEKDAY token before the date (``_WEEKDAY_PREFIX``),
+#      e.g. "| Sun 12 Jul 02:00 EDT". Weekday abbreviations never collide
+#      with month abbreviations, so this is unambiguous before either shape.
 # ---------------------------------------------------------------------------
 
-_TITLE_PATTERN = (
-    r"^(?:[^@:]{0,40}?(?<!\d)\d{2}\s*:\s*)?"
-    r"\s*(?P<title>.+?)\s*"
-    r"(?:@\s*(?:\d{1,2}\s+[A-Za-z]{3,9}\s+\d{1,2}:\d{2}"
-    r"|[A-Za-z]{3,9}\.?\s+\d{1,2}(?:\s*,?\s*\d{4})?\s+\d{1,2}:\d{2}).*)?$"
+# Date delimiter: "@" (most providers), "|" (pipe-delimited listings), or
+# "(" (parenthesized dates, e.g. "Title (7.12 9:15 AM ET)" — bead for the
+# numeric-date shape).
+_DATE_DELIM = r"(?:@|\||\()"
+
+# Optional leading weekday token ("Sun", "Sunday", "Mon,") before the date.
+_WEEKDAY_PREFIX = r"(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[A-Za-z]*\.?,?\s+)?"
+
+# Time-of-day CAPTURED, folded into the date pattern so hour/minute are
+# positionally locked to the date tokens (never re-searched across the whole
+# name) — this is what lets a trailing suffix after the time be ignored.
+# 12h with AM/PM ("06:00 PM ET") or 24h ("02:00 EDT"); optional ET/EST/EDT.
+_TIME_CAPTURE = (
+    r"(?P<hour>\d{1,2}):(?P<minute>\d{2})"
+    r"(?:\s*(?P<ampm>[AaPp])\.?[Mm]?\.?)?"
+    r"(?:\s*E[SD]?T)?"
 )
 
-# Time-of-day at the end of the name: 12h with AM/PM ("06:00 PM ET",
-# "02:45 PM ET") or 24h without ("18:30 ET"). Optional ET/EST/EDT suffix.
+# Non-capturing time shape — bounds the title's date tail only.
+_TIME_SHAPE = r"\d{1,2}:\d{2}(?:\s*[AaPp]\.?[Mm]?\.?)?(?:\s*E[SD]?T)?"
+
+_TITLE_PATTERN = (
+    r"^(?:[^@:|(]{0,40}?(?<!\d)\d{2}\s*:\s*)?"
+    + r"\s*(?P<title>.+?)\s*"
+    + r"(?:" + _DATE_DELIM + r"\s*" + _WEEKDAY_PREFIX + r"(?:"
+    + r"\d{1,2}\s+[A-Za-z]{3,9}\.?\s+" + _TIME_SHAPE
+    + r"|[A-Za-z]{3,9}\.?\s+\d{1,2}(?:\s*,?\s*\d{4})?\s+" + _TIME_SHAPE
+    + r"|\d{1,2}[./]\d{1,2}\s+" + _TIME_SHAPE
+    + r").*)?$"
+)
+
+# End-anchored FALLBACK time source for names whose date pattern does not
+# itself capture the time; the date pattern's captured time wins on merge
+# (``extract_groups`` applies ``date_pattern`` last). 12h with AM/PM
+# ("06:00 PM ET") or 24h without ("18:30 ET"). Optional ET/EST/EDT suffix.
 _TIME_PATTERN = (
     r"(?P<hour>\d{1,2}):(?P<minute>\d{2})"
     r"(?:\s*(?P<ampm>[AaPp])\.?[Mm]?\.?)?"
     r"\s*(?:E[SD]?T)?\s*$"
 )
 
-# Date shape 1 (observed): "@ 11 Jul 06:00 PM ET" — day first.
+# Date shape 1 (observed): "@ 11 Jul 06:00 PM ET" / "| Sun 12 Jul 02:00
+# EDT" — day first, captured time.
 _DATE_PATTERN_DAY_FIRST = (
-    r"@\s*(?P<day>\d{1,2})\s+(?P<month>[A-Za-z]{3,9})\s+\d{1,2}:\d{2}"
+    _DATE_DELIM + r"\s*" + _WEEKDAY_PREFIX
+    + r"(?P<day>\d{1,2})\s+(?P<month>[A-Za-z]{3,9})\.?\s+" + _TIME_CAPTURE
 )
 
 # Date shape 2 (observed): "@ Jan 17 02:45 PM ET" — month first, optional
-# explicit 4-digit year ("@ Jan 17 2027 02:45 PM ET").
+# explicit 4-digit year ("@ Jan 17 2027 02:45 PM ET"), captured time.
 _DATE_PATTERN_MONTH_FIRST = (
-    r"@\s*(?P<month>[A-Za-z]{3,9})\.?\s+(?P<day>\d{1,2})"
-    r"(?:\s*,?\s*(?P<year>\d{4}))?\s+\d{1,2}:\d{2}"
+    _DATE_DELIM + r"\s*" + _WEEKDAY_PREFIX
+    + r"(?P<month>[A-Za-z]{3,9})\.?\s+(?P<day>\d{1,2})"
+    + r"(?:\s*,?\s*(?P<year>\d{4}))?\s+" + _TIME_CAPTURE
+)
+
+# Date shape 3 (observed): "(7.12 9:15 AM ET)" — NUMERIC month-first date,
+# "." or "/" separated, month-first (US convention, matching the ET default
+# timezone). A provider that lists numeric dates day-first needs a per-rule
+# override. Captured time; the parenthesis opener is one of the delimiters.
+_DATE_PATTERN_NUMERIC = (
+    _DATE_DELIM + r"\s*" + _WEEKDAY_PREFIX
+    + r"(?P<month>\d{1,2})[./](?P<day>\d{1,2})\s+" + _TIME_CAPTURE
 )
 
 DEFAULT_EVENT_PATTERNS: tuple[dict, ...] = (
@@ -252,6 +306,69 @@ DEFAULT_EVENT_PATTERNS: tuple[dict, ...] = (
         "title_pattern": _TITLE_PATTERN,
         "time_pattern": _TIME_PATTERN,
         "date_pattern": _DATE_PATTERN_MONTH_FIRST,
+    },
+    {
+        "name": "slot-title-numeric-date",
+        "title_pattern": _TITLE_PATTERN,
+        "time_pattern": _TIME_PATTERN,
+        "date_pattern": _DATE_PATTERN_NUMERIC,
+    },
+)
+
+# ---------------------------------------------------------------------------
+# Dateless "today's live schedule" support (bead assume-current-date).
+#
+# OPT-IN ONLY, via the per-rule ``assume_current_date`` flag. Some providers
+# list a live schedule with a TIME but NO date ("Boxing 05 : FURY vs HALL
+# 6PM", "LIVE EVENT 05 - 4:15pm Zenith Racing Series"). The never-guess rail
+# rejects these by default (a time with no date is unmatchable). When the
+# flag is on, :func:`parse_event_name` fills the CURRENT date so the time
+# becomes matchable — accepting the cross-day risk the operator opted into.
+#
+# These variants are tried ONLY on the opt-in path (never in
+# DEFAULT_EVENT_PATTERNS), so the shipped defaults' precision is untouched. A
+# bare time REQUIRES a colon (``H:MM``) or an am/pm marker, so a lone number
+# in a title is never mistaken for a time. A slightly broader slot strip
+# handles the 1-digit / colon-less slots common in these PPV feeds.
+# ---------------------------------------------------------------------------
+
+_BARE_SLOT = r"(?:[^@:|(]{0,40}?(?<!\d)\d{1,2}\s*[:\-]\s*)?"
+
+_ASSUME_DATE_PATTERNS: tuple[dict, ...] = (
+    # Time-of-day at the END, am/pm form: "6PM" / "4:15pm" / "12am".
+    {
+        "name": "dateless-title-time-ampm",
+        "title_pattern": (
+            r"^" + _BARE_SLOT + r"\s*(?P<title>.+?)\s+"
+            r"\d{1,2}(?::\d{2})?\s*[AaPp]\.?[Mm]?\.?(?:\s*E[SD]?T)?\s*$"
+        ),
+        "time_pattern": (
+            r"(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?"
+            r"\s*(?P<ampm>[AaPp])\.?[Mm]?\.?(?:\s*E[SD]?T)?\s*$"
+        ),
+    },
+    # Time-of-day at the END, 24h form: "19:00" / "18:30 ET".
+    {
+        "name": "dateless-title-time-24h",
+        "title_pattern": (
+            r"^" + _BARE_SLOT + r"\s*(?P<title>.+?)\s+"
+            r"\d{1,2}:\d{2}(?:\s*E[SD]?T)?\s*$"
+        ),
+        "time_pattern": r"(?P<hour>\d{1,2}):(?P<minute>\d{2})(?:\s*E[SD]?T)?\s*$",
+    },
+    # Time-of-day FIRST after a "-"/"|" separator: "LIVE EVENT 05 - 4:15pm
+    # <title>". am/pm required here (a leading 24h "HH:MM" is too easily a
+    # score/round number).
+    {
+        "name": "dateless-time-first",
+        "title_pattern": (
+            r"^.*?[-|]\s*\d{1,2}(?::\d{2})?\s*[AaPp]\.?[Mm]?\.?\s+"
+            r"(?P<title>.+?)\s*$"
+        ),
+        "time_pattern": (
+            r"[-|]\s*(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?"
+            r"\s*(?P<ampm>[AaPp])\.?[Mm]?\.?"
+        ),
     },
 )
 
@@ -427,6 +544,7 @@ def parse_event_name(
     *,
     event_timezone: str = DEFAULT_EVENT_TIMEZONE,
     now: datetime | None = None,
+    assume_current_date: bool = False,
 ) -> ParsedEvent:
     """Parse one provider event name into a :class:`ParsedEvent`.
 
@@ -439,6 +557,12 @@ def parse_event_name(
 
     ``now`` (tz-aware) anchors year inference for the observed yearless
     date shapes and defaults to the current time in ``event_timezone``.
+
+    ``assume_current_date`` (bead assume-current-date, OPT-IN) relaxes the
+    never-guess rail for dateless "today's schedule" listings: when no
+    variant yields a complete date but the name carries a bare time-of-day,
+    the CURRENT date (in ``event_timezone``) is filled so the time is
+    matchable. Default False preserves the never-guess behavior exactly.
     """
     variants = patterns if patterns is not None else DEFAULT_EVENT_PATTERNS
     tz = pytz.timezone(event_timezone)
@@ -470,6 +594,26 @@ def parse_event_name(
             fallback_title = groups["title"]
             fallback_variant = variant.get("name") or title_pattern
 
+    # Dateless opt-in: no complete date parsed, but with assume_current_date
+    # a bare time-of-day is placed on TODAY (event_timezone). Tried only here
+    # so the shipped defaults never inherit the "guess the date" behavior.
+    if complete_groups is None and assume_current_date:
+        now_local = now.astimezone(tz)
+        for variant in _ASSUME_DATE_PATTERNS:
+            groups = extract_groups(
+                name, variant["title_pattern"], variant.get("time_pattern"),
+            )
+            if groups is None or groups.get("hour") is None:
+                continue
+            complete_groups = {
+                **groups,
+                "day": str(now_local.day),
+                "month": str(now_local.month),
+                "year": str(now_local.year),
+            }
+            complete_variant = variant["name"]
+            break
+
     if complete_groups is None:
         title = _cap_title(fallback_title)
         return ParsedEvent(
@@ -497,7 +641,9 @@ def _build_start(groups: dict, tz, event_timezone: str, now: datetime) -> dateti
     try:
         day = int(groups.get("day"))
         hour = int(groups.get("hour"))
-        minute = int(groups.get("minute"))
+        # Bare am/pm times ("6PM") carry no minutes — default to :00.
+        minute_raw = groups.get("minute")
+        minute = int(minute_raw) if minute_raw is not None else 0
     except (TypeError, ValueError):
         return None
     if month is None:
@@ -530,7 +676,9 @@ def _build_start(groups: dict, tz, event_timezone: str, now: datetime) -> dateti
     except (ValueError, OverflowError):
         return None
 
-    groups = {**groups, "year": str(year)}
+    # Normalize the delegated groups: fill the defaulted minute (bare am/pm
+    # times have none) so compute_event_times never sees ``minute=None``.
+    groups = {**groups, "year": str(year), "minute": str(minute)}
 
     # Delegate the actual datetime construction (incl. 12h→24h and DST
     # localization) to the shared dummy-EPG machinery so event_sync and
@@ -963,6 +1111,7 @@ def match_streams(
     threshold: float = EVENT_ATTACH_FLOOR,
     event_timezone: str = DEFAULT_EVENT_TIMEZONE,
     now: datetime | None = None,
+    assume_current_date: bool = False,
 ) -> list[StreamMatchResult]:
     """Match every secondary stream name against the master channel names.
 
@@ -991,7 +1140,8 @@ def match_streams(
     )
     parsed_masters = [
         parse_event_name(
-            m, effective_master_patterns, event_timezone=event_timezone, now=now
+            m, effective_master_patterns, event_timezone=event_timezone,
+            now=now, assume_current_date=assume_current_date,
         )
         for m in master_names
     ]
@@ -1003,7 +1153,8 @@ def match_streams(
     results: list[StreamMatchResult] = []
     for stream_name in stream_names:
         parsed = parse_event_name(
-            stream_name, patterns, event_timezone=event_timezone, now=now
+            stream_name, patterns, event_timezone=event_timezone, now=now,
+            assume_current_date=assume_current_date,
         )
         if parsed.title is None:
             results.append(StreamMatchResult(

--- a/backend/services/event_sync_preflight.py
+++ b/backend/services/event_sync_preflight.py
@@ -39,6 +39,57 @@ CHECK_SECONDARY_AUTO_SYNC_OFF = "secondary_auto_sync_off"
 CHECK_GROUP_SETTINGS_FOUND = "group_settings_found"
 
 
+def _build_override_maps(all_settings: dict) -> tuple[dict, dict]:
+    """Resolve Dispatcharr Channel Group Override relationships (bead 6xxmp/override).
+
+    A Channel Group Override never rewrites a STREAM's group, but auto-sync
+    creates the CHANNELS into the override TARGET group, while the
+    ``auto_channel_sync`` setting lives on the ORIGINAL (source) group
+    (``custom_properties.group_override`` holds the target group ID — same
+    shape ``routers/channel_groups.py`` reads for orphan detection). So an
+    operator who points the master at their auto-synced provider group gets
+    an EMPTY master set (its channels are in the target), and an operator who
+    points it at the target hits a group with no direct M3U setting.
+
+    Returns ``(target_to_source_setting, source_to_target_id)``:
+    * ``target_to_source_setting``: override TARGET group id -> the source
+      group's setting dict (preferring an ``auto_channel_sync``-ON source —
+      that is the one actually creating channels into the target).
+    * ``source_to_target_id``: source group id -> its override TARGET id.
+    """
+    target_to_source: dict[int, dict] = {}
+    source_to_target: dict[int, int] = {}
+    for gid, setting in all_settings.items():
+        cp = setting.get("custom_properties")
+        target = cp.get("group_override") if isinstance(cp, dict) else None
+        if not isinstance(target, int):
+            continue
+        source_to_target[gid] = target
+        existing = target_to_source.get(target)
+        if existing is None or (
+            setting.get("auto_channel_sync")
+            and not existing.get("auto_channel_sync")
+        ):
+            target_to_source[target] = setting
+    return target_to_source, source_to_target
+
+
+def resolve_effective_master_group_id(
+    all_settings: dict, master_group_id: int
+) -> int:
+    """Channel-group id where the master group's channels ACTUALLY live.
+
+    Follows a Channel Group Override: if the configured master group is an
+    override SOURCE (an auto-synced group whose channels Dispatcharr places
+    in a different target group), the auto-created master channels live in
+    that TARGET group — so callers must fetch/filter master channels by the
+    returned id, not the raw ``master_group_id``. A group with no override
+    resolves to itself; picking the target directly also resolves to itself.
+    """
+    _target_to_source, source_to_target = _build_override_maps(all_settings)
+    return source_to_target.get(master_group_id, master_group_id)
+
+
 def _failure(
     *, group_id: int, role: str, check: str, expected: str, got: str,
     message: str,
@@ -54,7 +105,9 @@ def _failure(
     }
 
 
-async def check_event_sync_group_settings(client, config: dict) -> dict:
+async def check_event_sync_group_settings(
+    client, config: dict, all_settings: dict | None = None
+) -> dict:
     """Pre-flight an event_sync config against live Dispatcharr group settings.
 
     Args:
@@ -63,6 +116,10 @@ async def check_event_sync_group_settings(client, config: dict) -> dict:
             read-only by contract (see module docstring).
         config: A validated event_sync_config dict (``master_group_id``,
             ``secondary_group_ids``).
+        all_settings: Optional pre-fetched
+            ``get_all_m3u_group_settings()`` result — passed by callers that
+            also resolve the override relationship (preview/run) to avoid a
+            second fetch. Fetched here when omitted.
 
     Returns:
         ``{"ok": bool, "failures": [ ... ]}`` where each failure carries
@@ -75,24 +132,35 @@ async def check_event_sync_group_settings(client, config: dict) -> dict:
     master_group_id = config.get("master_group_id")
     secondary_group_ids = config.get("secondary_group_ids") or []
 
-    all_settings = await client.get_all_m3u_group_settings()
+    if all_settings is None:
+        all_settings = await client.get_all_m3u_group_settings()
+    target_to_source, _source_to_target = _build_override_maps(all_settings)
     failures: list[dict] = []
 
     master_settings = all_settings.get(master_group_id)
     if master_settings is None:
-        failures.append(_failure(
-            group_id=master_group_id,
-            role="master",
-            check=CHECK_GROUP_SETTINGS_FOUND,
-            expected="group present in an M3U account's group settings",
-            got="no settings for this group ID on any account",
-            message=(
-                f"Master group {master_group_id} was not found in any M3U "
-                f"account's group settings — the group may have been "
-                f"removed or renamed by the provider."
-            ),
-        ))
-    elif not master_settings.get("auto_channel_sync"):
+        # A Channel Group Override TARGET has no direct M3U setting of its
+        # own — auto-sync creates its channels from a SOURCE group. Read the
+        # effective auto-sync state through that source instead of failing
+        # "group not found" (bead override).
+        override_source = target_to_source.get(master_group_id)
+        if override_source is not None:
+            master_settings = override_source
+        else:
+            failures.append(_failure(
+                group_id=master_group_id,
+                role="master",
+                check=CHECK_GROUP_SETTINGS_FOUND,
+                expected="group present in an M3U account's group settings",
+                got="no settings for this group ID on any account",
+                message=(
+                    f"Master group {master_group_id} was not found in any "
+                    f"M3U account's group settings — the group may have been "
+                    f"removed or renamed by the provider."
+                ),
+            ))
+    if master_settings is not None and not master_settings.get(
+            "auto_channel_sync"):
         failures.append(_failure(
             group_id=master_group_id,
             role="master",

--- a/backend/services/event_sync_resolver.py
+++ b/backend/services/event_sync_resolver.py
@@ -207,6 +207,59 @@ def effective_patterns(config: dict, group_id: int) -> list[dict] | None:
     return config.get("patterns")
 
 
+async def build_master_name_to_id(
+    channels: list[dict], client, parse_master_from_stream: bool
+) -> dict[str, int]:
+    """Map a master IDENTITY name -> master channel id (bead parse-from-stream).
+
+    Default identity is the channel's OWN name. When
+    ``parse_master_from_stream`` is on, the identity is the name of the
+    channel's FIRST attached stream (fetched by id via ``get_streams_by_ids``)
+    — so operators can name master channels freely while the event title+time
+    are read from the underlying auto-synced stream. Duplicate identity names
+    resolve to the LOWEST channel id (deterministic, mirrors the channel-name
+    path). The matcher is unchanged: it scores whatever identity strings this
+    map's keys carry, and the attach path maps the winning key back to its
+    channel id here.
+    """
+    name_to_id: dict[str, int] = {}
+    if not parse_master_from_stream:
+        for ch in channels:
+            name, cid = ch.get("name"), ch.get("id")
+            if not name or cid is None:
+                continue
+            if name not in name_to_id or cid < name_to_id[name]:
+                name_to_id[name] = cid
+        return name_to_id
+
+    # Stream-identity: the first attached stream per channel.
+    first_stream_id: dict[int, int] = {}
+    for ch in channels:
+        cid = ch.get("id")
+        streams = ch.get("streams") or []
+        if cid is None or not streams:
+            continue
+        first = streams[0]
+        sid = first["id"] if isinstance(first, dict) else first
+        if sid is not None:
+            first_stream_id[cid] = sid
+    if not first_stream_id:
+        return name_to_id
+    stream_objs = await client.get_streams_by_ids(
+        sorted(set(first_stream_id.values()))
+    ) or []
+    sid_to_name = {
+        s.get("id"): s.get("name") for s in stream_objs if s.get("name")
+    }
+    for cid, sid in sorted(first_stream_id.items()):
+        name = sid_to_name.get(sid)
+        if not name:
+            continue
+        if name not in name_to_id or cid < name_to_id[name]:
+            name_to_id[name] = cid
+    return name_to_id
+
+
 def _is_contested(candidates: tuple[MasterCandidate, ...]) -> bool:
     """True when the winner's attach decision is CONTESTED (PR #613 rail).
 
@@ -369,6 +422,7 @@ def resolve_event_sync(
     *,
     now: datetime | None = None,
     decisions: ReviewDecisions | None = None,
+    attached_stream_ids: set[int] | frozenset[int] | None = None,
 ) -> EventSyncResolution:
     """Resolve every secondary stream against the master channel names.
 
@@ -390,6 +444,16 @@ def resolve_event_sync(
             (bead ti939.3.2), fingerprint-keyed — see the module docstring
             and :func:`_resolve_stream` for the application contract.
             ``None`` (or empty) preserves pre-queue behavior exactly.
+        attached_stream_ids: Stream ids already attached to a master
+            channel (bead 6xxmp). Master-group streams (group_id ==
+            master_group_id, present only when
+            ``include_master_group_streams`` is on) whose id is in this set
+            are dropped BEFORE scoring — the auto-synced provider's own
+            streams are already on their channels, so re-offering them would
+            desync preview ("would attach") from the run (an idempotent
+            no-op). Scoped to the master group so every other secondary
+            group's behavior is byte-identical. ``None`` (or empty) filters
+            nothing.
 
     Returns:
         :class:`EventSyncResolution` in a deterministic order — streams
@@ -402,15 +466,32 @@ def resolve_event_sync(
     window_minutes = config.get("time_window_minutes", DEFAULT_TIME_WINDOW_MINUTES)
     threshold = config.get("attach_threshold", EVENT_ATTACH_FLOOR)
     master_patterns = effective_patterns(config, config["master_group_id"])
+    # bead assume-current-date: opt-in dateless matching (both master and
+    # secondary sides share the same "today" so their times compare on one day).
+    assume_current_date = bool(config.get("assume_current_date", False))
 
     # Master-as-ceiling diagnostic: masters with no complete parsed identity
     # can never be candidates (match_streams filters them the same way —
     # same parse function, same patterns, same "now").
     unparsed_masters = tuple(
         name for name in master_names
-        if (parsed := parse_event_name(name, master_patterns, now=now)).title is None
+        if (parsed := parse_event_name(
+                name, master_patterns, now=now,
+                assume_current_date=assume_current_date,
+            )).title is None
         or parsed.start is None
     )
+
+    # bead 6xxmp: drop the master group's already-attached streams (the
+    # auto-synced provider's own streams). Scoped to the master group so
+    # normal secondary groups resolve exactly as before.
+    if attached_stream_ids:
+        master_group_id = config["master_group_id"]
+        secondary_streams = [
+            s for s in secondary_streams
+            if not (s.group_id == master_group_id
+                    and s.stream_id in attached_stream_ids)
+        ]
 
     by_group: dict[int, list[SecondaryStream]] = {}
     for stream in secondary_streams:
@@ -430,6 +511,7 @@ def resolve_event_sync(
             window_minutes=window_minutes,
             threshold=threshold,
             now=now,
+            assume_current_date=assume_current_date,
         )
         for stream, result in zip(streams, results):
             resolved.append(_resolve_stream(stream, result, decisions))

--- a/backend/tests/e2e/test_channel_pipeline_tags.py
+++ b/backend/tests/e2e/test_channel_pipeline_tags.py
@@ -1,7 +1,10 @@
 """
-E2E tests for auto-creation, normalization, tags, and ffmpeg endpoints.
+E2E tests for auto-creation, normalization, and tags endpoints.
 
-Endpoints: /api/auto-creation/*, /api/normalization/*, /api/tags/*, /api/ffmpeg/*
+Endpoints: /api/auto-creation/*, /api/normalization/*, /api/tags/*
+
+The FFMPEG Builder feature (/api/ffmpeg) was removed in build 0062 (beads
+vrrxv/1w428); its e2e coverage was deleted with it (bead 72z02).
 """
 from tests.e2e.conftest import skip_if_not_api
 
@@ -78,22 +81,5 @@ class TestTags:
             "text": "CNN",
             "group_id": group_id,
         })
-        skip_if_not_api(response)
-        assert response.status_code == 200
-
-
-class TestFFmpegProfiles:
-    """Tests for /api/ffmpeg endpoints (may not exist in older versions)."""
-
-    def test_list_profiles(self, e2e_client):
-        """GET /api/ffmpeg/profiles returns profiles."""
-        response = e2e_client.get("/api/ffmpeg/profiles")
-        skip_if_not_api(response)
-        data = response.json()
-        assert "profiles" in data
-
-    def test_capabilities(self, e2e_client):
-        """GET /api/ffmpeg/capabilities returns FFmpeg capabilities."""
-        response = e2e_client.get("/api/ffmpeg/capabilities")
         skip_if_not_api(response)
         assert response.status_code == 200

--- a/backend/tests/routers/test_event_sync_persistence_roundtrip.py
+++ b/backend/tests/routers/test_event_sync_persistence_roundtrip.py
@@ -42,6 +42,12 @@ def _event_sync_config(**overrides) -> dict:
         # ti939.3.1: same default-fill convention for the Phase 2 auto-run
         # opt-in — round-tripped configs carry the explicit false.
         "auto_run": False,
+        # bead 6xxmp: master-group self-attach flag, same default-fill.
+        "include_master_group_streams": False,
+        # bead assume-current-date: dateless opt-in, same default-fill.
+        "assume_current_date": False,
+        # bead parse-from-stream: master-identity-from-stream, same default-fill.
+        "parse_master_from_stream": False,
     }
     config.update(overrides)
     return config

--- a/backend/tests/services/test_event_sync_matcher.py
+++ b/backend/tests/services/test_event_sync_matcher.py
@@ -220,6 +220,126 @@ class TestParseEventName:
         assert parsed.start == _et(2026, 7, 11, 19, 0)
 
     @pytest.mark.parametrize(
+        ("name", "expected_title", "expected_start"),
+        [
+            # bead 9c9j7: a provider/slot label appended AFTER the time used
+            # to break the parse (the end-anchored time pattern rejected the
+            # trailing " :Flo Racing 03"). Folding captured time into the
+            # date pattern lets the tail be ignored. Single-digit hour too.
+            (
+                "Zenith Racing Series at Road America @ Jul 11 9:30 AM :Flo Racing 03",
+                "Zenith Racing Series at Road America",
+                _et(2026, 7, 11, 9, 30),
+            ),
+            # Day-first with a trailing suffix.
+            (
+                "Mercury vs. Aces @ 11 Jul 06:00 PM ET | Peacock 14",
+                "Mercury vs. Aces",
+                _et(2026, 7, 11, 18, 0),
+            ),
+        ],
+    )
+    def test_trailing_suffix_after_time_still_parses(
+        self, name, expected_title, expected_start
+    ):
+        parsed = parse_event_name(name, now=_NOW)
+        assert parsed.title == expected_title
+        assert parsed.start == expected_start
+
+    @pytest.mark.parametrize(
+        ("name", "expected_title", "expected_start"),
+        [
+            # bead: parenthesized NUMERIC month-first date "(7.12 9:15 AM ET)".
+            (
+                "PPV EVENT 01: Zenith Racing Series at Road America "
+                "(7.12 9:15 AM ET)",
+                "Zenith Racing Series at Road America",
+                _et(2026, 7, 12, 9, 15),
+            ),
+            # Slash separator, PM.
+            (
+                "PPV EVENT 10: Redstall vs. Courtney (7/12 12:00 PM ET)",
+                "Redstall vs. Courtney",
+                _et(2026, 7, 12, 12, 0),
+            ),
+        ],
+    )
+    def test_parenthesized_numeric_date_parses(
+        self, name, expected_title, expected_start
+    ):
+        parsed = parse_event_name(name, now=_NOW)
+        assert parsed.title == expected_title
+        assert parsed.start == expected_start
+
+    def test_numeric_date_needs_a_time_after_it(self):
+        # A bare numeric "7.5" with no time must NOT parse a start (never
+        # guessed) — guards the numeric-date pattern against false positives.
+        parsed = parse_event_name("Slot 01: Game 7.5 preview show", now=_NOW)
+        assert parsed.start is None
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Boxing 05 : FURY vs HALL 6PM",
+            "Boxing 6: Fury v Makhmudov 19:00",
+            "LIVE EVENT 05 - 4:15pm Zenith Racing Series Road America",
+        ],
+    )
+    def test_dateless_stays_unmatchable_without_the_flag(self, name):
+        # The never-guess rail: a time with no date is None by default.
+        assert parse_event_name(name, now=_NOW).start is None
+
+    @pytest.mark.parametrize(
+        ("name", "expected_title", "expected_start"),
+        [
+            # am/pm, minutes implied :00, slot stripped.
+            ("Boxing 05 : FURY vs HALL 6PM", "FURY vs HALL",
+             _et(2026, 7, 11, 18, 0)),
+            # 24h, 1-digit colon-less slot stripped.
+            ("Boxing 6: Fury v Makhmudov 19:00", "Fury v Makhmudov",
+             _et(2026, 7, 11, 19, 0)),
+            # time-FIRST layout after "-".
+            ("LIVE EVENT 05 - 4:15pm Zenith Racing Series Road America",
+             "Zenith Racing Series Road America", _et(2026, 7, 11, 16, 15)),
+        ],
+    )
+    def test_dateless_parses_onto_today_with_the_flag(
+        self, name, expected_title, expected_start
+    ):
+        parsed = parse_event_name(name, now=_NOW, assume_current_date=True)
+        assert parsed.title == expected_title
+        assert parsed.start == expected_start
+
+    def test_flag_does_not_override_a_real_parsed_date(self):
+        # A name WITH a date keeps its real date (Jul 11) even when the flag
+        # is on and "today" (Jan 1) is a completely different day.
+        parsed = parse_event_name(
+            "Peacock 14: Mercury vs. Aces @ 11 Jul 06:00 PM ET",
+            now=_et(2026, 1, 1, 12, 0), assume_current_date=True,
+        )
+        assert (parsed.start.month, parsed.start.day) == (7, 11)
+        assert parsed.start.hour == 18
+
+    def test_flag_still_rejects_a_name_with_no_time(self):
+        parsed = parse_event_name(
+            "Boxing 7: Jake Paul vs Anthony Joshua", now=_NOW,
+            assume_current_date=True,
+        )
+        assert parsed.start is None
+
+    def test_pipe_delimited_name_with_weekday_and_region_marker_parses(self):
+        # bead 9c9j7: live pipe-delimited listing shape that produced
+        # "Incomplete date/time" — "|" delimiter, a "Sun" weekday prefix, a
+        # "(US)" region marker after the timezone, and a trailing provider.
+        parsed = parse_event_name(
+            "NEXT | OTAGO NUGGETS VS. AUCKLAND TUATARA (ROUND 14) "
+            "| Sun 12 Jul 02:00 EDT (US) |  | US: ESPN+ PPV 40",
+            now=_NOW,
+        )
+        assert parsed.start == _et(2026, 7, 12, 2, 0)
+        assert "AUCKLAND TUATARA" in parsed.title
+
+    @pytest.mark.parametrize(
         ("name", "expected_title"),
         [
             # PR #611 finding 4: series-identity prefixes are NOT slot
@@ -673,13 +793,16 @@ class TestMatchStreamToMasters:
         # may carry different name shapes. master_patterns parses ONLY the
         # master side; ``patterns`` (here None -> built-in defaults) parses
         # the streams.
+        # Uses a ">>" delimiter the built-in defaults do NOT recognize (the
+        # defaults accept "@" and "|", bead 9c9j7), so the master shape stays
+        # unparseable without master_patterns and the test's intent survives.
         master_patterns = [{
             "name": "master-shape",
-            "title_pattern": r"^MASTER\s*\|\s*(?P<title>.+?)\s*\|.*$",
+            "title_pattern": r"^MASTER\s*>>\s*(?P<title>.+?)\s*>>.*$",
             "time_pattern": r"(?P<hour>\d{1,2}):(?P<minute>\d{2})\s*(?P<ampm>[AP])M\s*$",
-            "date_pattern": r"\|\s*(?P<day>\d{1,2})\s+(?P<month>[A-Za-z]{3})\s+\d{1,2}:\d{2}",
+            "date_pattern": r">>\s*(?P<day>\d{1,2})\s+(?P<month>[A-Za-z]{3})\s+\d{1,2}:\d{2}",
         }]
-        masters = ["MASTER | Mercury vs. Aces | 11 Jul 06:00 PM"]
+        masters = ["MASTER >> Mercury vs. Aces >> 11 Jul 06:00 PM"]
         stream = "Peacock 14: Mercury vs. Aces @ 11 Jul 06:00 PM ET"
 
         # Without master_patterns the default patterns cannot extract a

--- a/backend/tests/services/test_event_sync_resolver.py
+++ b/backend/tests/services/test_event_sync_resolver.py
@@ -20,6 +20,7 @@ Pure module — no Dispatcharr client, no DB, no network.
 from __future__ import annotations
 
 from datetime import datetime
+from unittest.mock import AsyncMock
 
 import pytest
 import pytz
@@ -367,6 +368,133 @@ class TestContestedRail:
         disposition, best, reason = _classify(result)
         assert disposition == DISPOSITION_AMBIGUOUS
         assert reason == AMBIGUOUS_REASON_CONTESTED
+
+
+class TestMasterGroupSelfAttach:
+    """bead 6xxmp: the master group as its own secondary stream source.
+
+    When ``include_master_group_streams`` is on, the fetch layer appends the
+    master group's streams with ``group_id == master_group_id``. The resolver
+    drops those already attached to a master channel (passed via
+    ``attached_stream_ids``) so preview/run parity holds and the auto-synced
+    provider's own streams are not re-offered.
+    """
+
+    # A master-group stream that matches MASTERS[0] (a second provider's copy).
+    MASTER_GROUP_STREAM = "Fubo 09 : Mercury vs. Aces @ 11 Jul 06:00 PM ET"
+
+    def test_already_attached_master_group_stream_is_dropped(self):
+        streams = [SecondaryStream(
+            name=self.MASTER_GROUP_STREAM, group_id=10, stream_id=999,
+        )]
+        resolution = resolve_event_sync(
+            _config(include_master_group_streams=True), MASTERS, streams,
+            now=NOW, attached_stream_ids={999},
+        )
+        # Filtered before scoring -> not in the resolution at all.
+        assert resolution.resolved == ()
+
+    def test_unattached_master_group_stream_still_attaches(self):
+        streams = [SecondaryStream(
+            name=self.MASTER_GROUP_STREAM, group_id=10, stream_id=1000,
+        )]
+        resolution = resolve_event_sync(
+            _config(include_master_group_streams=True), MASTERS, streams,
+            now=NOW, attached_stream_ids={999},  # different id -> not filtered
+        )
+        (resolved,) = resolution.resolved
+        assert resolved.disposition == DISPOSITION_WOULD_ATTACH
+        assert resolved.best.master_name == MASTERS[0]
+
+    def test_filter_is_scoped_to_the_master_group_only(self):
+        # A normal secondary-group stream (group 20) whose id happens to be in
+        # attached_stream_ids must NOT be dropped — the filter is master-group
+        # scoped so every other group behaves exactly as before.
+        streams = [SecondaryStream(
+            name="WNBA TV 01: Mercury vs. Aces @ 11 Jul 06:00 PM ET",
+            group_id=20, stream_id=555,
+        )]
+        resolution = resolve_event_sync(
+            _config(), MASTERS, streams, now=NOW, attached_stream_ids={555},
+        )
+        (resolved,) = resolution.resolved
+        assert resolved.disposition == DISPOSITION_WOULD_ATTACH
+
+    def test_no_attached_ids_filters_nothing(self):
+        streams = [SecondaryStream(
+            name=self.MASTER_GROUP_STREAM, group_id=10, stream_id=999,
+        )]
+        resolution = resolve_event_sync(
+            _config(include_master_group_streams=True), MASTERS, streams,
+            now=NOW,  # attached_stream_ids defaults to None
+        )
+        (resolved,) = resolution.resolved
+        assert resolved.disposition == DISPOSITION_WOULD_ATTACH
+
+
+class TestAssumeCurrentDate:
+    """bead assume-current-date: the flag threads through to BOTH sides.
+
+    A dateless master and a dateless secondary both land on "today", so their
+    times compare on one day and a same-time same-event pair attaches.
+    """
+
+    DATELESS_MASTERS = ["Boxing 01 : Fury vs. Usyk 6PM"]
+
+    def test_dateless_pair_attaches_only_with_the_flag(self):
+        streams = [SecondaryStream(
+            name="PPV 07 : Tyson Fury vs. Oleksandr Usyk 6PM",
+            group_id=20, stream_id=701,
+        )]
+        # OFF: both sides are dateless -> unmatchable, no candidate.
+        off = resolve_event_sync(
+            _config(), self.DATELESS_MASTERS, streams, now=NOW,
+        )
+        assert off.resolved[0].disposition != DISPOSITION_WOULD_ATTACH
+
+        # ON: both land on today at 18:00 -> in-window, attaches.
+        on = resolve_event_sync(
+            _config(assume_current_date=True), self.DATELESS_MASTERS,
+            streams, now=NOW,
+        )
+        assert on.resolved[0].disposition == DISPOSITION_WOULD_ATTACH
+        assert on.resolved[0].best.master_name == self.DATELESS_MASTERS[0]
+
+
+class TestBuildMasterNameToId:
+    """bead parse-from-stream: master identity from channel name vs stream."""
+
+    CHANNELS = [
+        {"id": 100, "name": "Clean Master A", "streams": [9001]},
+        {"id": 101, "name": "Clean Master B", "streams": [{"id": 9002}]},
+        {"id": 102, "name": "No Streams", "streams": []},
+    ]
+
+    async def test_default_uses_channel_names(self):
+        from services.event_sync_resolver import build_master_name_to_id
+        client = AsyncMock()
+        result = await build_master_name_to_id(self.CHANNELS, client, False)
+        assert result == {
+            "Clean Master A": 100,
+            "Clean Master B": 101,
+            "No Streams": 102,
+        }
+        client.get_streams_by_ids.assert_not_awaited()
+
+    async def test_flag_uses_first_attached_stream_name(self):
+        from services.event_sync_resolver import build_master_name_to_id
+        client = AsyncMock()
+        client.get_streams_by_ids.return_value = [
+            {"id": 9001, "name": "Fury vs. Usyk @ 12 Jul 06:00 PM ET"},
+            {"id": 9002, "name": "Canelo vs. GGG @ 12 Jul 09:00 PM ET"},
+        ]
+        result = await build_master_name_to_id(self.CHANNELS, client, True)
+        # Identity is the STREAM name; the channel with no streams drops out.
+        assert result == {
+            "Fury vs. Usyk @ 12 Jul 06:00 PM ET": 100,
+            "Canelo vs. GGG @ 12 Jul 09:00 PM ET": 101,
+        }
+        client.get_streams_by_ids.assert_awaited_once_with([9001, 9002])
 
 
 def _candidate(master_name: str, *, score: float, band: str) -> MasterCandidate:

--- a/backend/tests/unit/test_event_sync_attach_execution.py
+++ b/backend/tests/unit/test_event_sync_attach_execution.py
@@ -770,8 +770,12 @@ class TestEnginePhaseAutoRun:
         )
 
     def test_manual_runs_do_not_preflight(self):
-        """Manual behavior is unchanged: no pre-flight call on the manual
-        path (the operator previews; preview carries the pre-flight)."""
+        """Manual behavior is unchanged: no pre-flight GATE on the manual
+        path (the operator previews; preview carries the pre-flight). Proven
+        by attaching even though the master group's auto_channel_sync is OFF
+        — a state the pre-flight would fail-closed on. (Group settings ARE
+        read once for Channel Group Override resolution — bead override — a
+        read-only lookup, not a gate.)"""
         channels = [_master_channel(100, MASTER_MERCURY, streams=[9001])]
         batch = [{"id": 7001, "name": STREAM_MERCURY, "m3u_account": 1}]
         engine, executor, client = _engine_with_client(channels, batch)
@@ -785,8 +789,51 @@ class TestEnginePhaseAutoRun:
             triggered_by="manual", channels_touched_ids=set(),
         ))
 
-        client.get_all_m3u_group_settings.assert_not_awaited()
+        # Attached despite master auto-sync OFF => the manual path never
+        # pre-flight-gates (the settings read was override resolution only).
         assert results["event_sync"][0]["attached"] == 1
+
+
+class TestParseMasterFromStream:
+    """bead parse-from-stream: master identity read from the attached stream,
+    so a cleanly-named master channel still matches via its timed stream."""
+
+    def test_flag_reads_identity_from_attached_stream_and_attaches(self):
+        # Channel named cleanly (no time); its attached stream 9001 carries
+        # the timed event that the secondary matches.
+        channels = [_master_channel(100, "Mercury Aces (clean)", streams=[9001])]
+        executor, client = _executor(channels)
+        client.get_streams_by_ids = AsyncMock(
+            return_value=[{"id": 9001, "name": MASTER_MERCURY}]
+        )
+        streams = [SecondaryStream(
+            name=STREAM_MERCURY, group_id=20, stream_id=7001, provider="ProvB",
+        )]
+        exec_ctx = ExecutionContext(dry_run=False)
+        summary = _run(executor.execute_event_sync_rule(
+            1, "Event Rule", _config(parse_master_from_stream=True),
+            streams, exec_ctx,
+        ))
+        assert summary["attached"] == 1
+        client.update_channel.assert_awaited_once_with(
+            100, {"streams": [9001, 7001]}
+        )
+        client.get_streams_by_ids.assert_awaited_once_with([9001])
+
+    def test_without_flag_a_clean_named_master_cannot_match(self):
+        # Same clean channel name, flag OFF: the master name has no time, so
+        # it is an unparsed master and nothing attaches — proves the flag is
+        # what enables the match.
+        channels = [_master_channel(100, "Mercury Aces (clean)", streams=[9001])]
+        executor, client = _executor(channels)
+        streams = [SecondaryStream(
+            name=STREAM_MERCURY, group_id=20, stream_id=7001, provider="ProvB",
+        )]
+        exec_ctx = ExecutionContext(dry_run=False)
+        summary = _run(executor.execute_event_sync_rule(
+            1, "Event Rule", _config(), streams, exec_ctx,
+        ))
+        assert summary["attached"] == 0
 
 
 # =============================================================================

--- a/backend/tests/unit/test_event_sync_config_schema.py
+++ b/backend/tests/unit/test_event_sync_config_schema.py
@@ -340,6 +340,91 @@ class TestAutoRunFlag:
         assert stored["auto_run"] is False
 
 
+class TestIncludeMasterGroupStreamsFlag:
+    """include_master_group_streams flag (bead 6xxmp — master self-attach).
+
+    Same default-fill/safety convention as auto_run: absent reads as false,
+    and pre-existing stored configs validate unchanged.
+    """
+
+    def test_default_filled_false(self):
+        config = _valid_config()
+        assert validate_event_sync_config(config) == []
+        assert config["include_master_group_streams"] is False
+
+    @pytest.mark.parametrize("good", [True, False])
+    def test_bool_accepted(self, good):
+        config = _valid_config(include_master_group_streams=good)
+        assert validate_event_sync_config(config) == []
+        assert config["include_master_group_streams"] is good
+
+    @pytest.mark.parametrize("bad", ["true", 1, 0])
+    def test_non_bool_rejected(self, bad):
+        config = _valid_config()
+        config["include_master_group_streams"] = bad
+        errors = validate_event_sync_config(config)
+        assert any("include_master_group_streams" in e for e in errors)
+
+    def test_master_still_forbidden_in_secondary_list(self):
+        # The flag is the sanctioned path — it does NOT relax the rail that
+        # forbids the master id inside secondary_group_ids.
+        config = _valid_config(
+            master_group_id=10,
+            secondary_group_ids=[10, 20],
+            include_master_group_streams=True,
+        )
+        errors = validate_event_sync_config(config)
+        assert any("secondary_group_ids" in e for e in errors)
+
+
+class TestAssumeCurrentDateFlag:
+    """assume_current_date flag (bead assume-current-date — dateless opt-in).
+
+    Same default-fill/safety convention as auto_run: absent reads as false,
+    and pre-existing stored configs validate unchanged.
+    """
+
+    def test_default_filled_false(self):
+        config = _valid_config()
+        assert validate_event_sync_config(config) == []
+        assert config["assume_current_date"] is False
+
+    @pytest.mark.parametrize("good", [True, False])
+    def test_bool_accepted(self, good):
+        config = _valid_config(assume_current_date=good)
+        assert validate_event_sync_config(config) == []
+        assert config["assume_current_date"] is good
+
+    @pytest.mark.parametrize("bad", ["true", 1, 0])
+    def test_non_bool_rejected(self, bad):
+        config = _valid_config()
+        config["assume_current_date"] = bad
+        errors = validate_event_sync_config(config)
+        assert any("assume_current_date" in e for e in errors)
+
+
+class TestParseMasterFromStreamFlag:
+    """parse_master_from_stream flag (bead parse-from-stream)."""
+
+    def test_default_filled_false(self):
+        config = _valid_config()
+        assert validate_event_sync_config(config) == []
+        assert config["parse_master_from_stream"] is False
+
+    @pytest.mark.parametrize("good", [True, False])
+    def test_bool_accepted(self, good):
+        config = _valid_config(parse_master_from_stream=good)
+        assert validate_event_sync_config(config) == []
+        assert config["parse_master_from_stream"] is good
+
+    @pytest.mark.parametrize("bad", ["true", 1, 0])
+    def test_non_bool_rejected(self, bad):
+        config = _valid_config()
+        config["parse_master_from_stream"] = bad
+        errors = validate_event_sync_config(config)
+        assert any("parse_master_from_stream" in e for e in errors)
+
+
 class TestDummyEpgProfileId:
     """dummy_epg_profile_id reference (bead ti939.3.3 — dummy EPG
     auto-assignment for master event channels).

--- a/backend/tests/unit/test_event_sync_preflight.py
+++ b/backend/tests/unit/test_event_sync_preflight.py
@@ -21,6 +21,7 @@ from services.event_sync_preflight import (
     CHECK_MASTER_AUTO_SYNC_ON,
     CHECK_SECONDARY_AUTO_SYNC_OFF,
     check_event_sync_group_settings,
+    resolve_effective_master_group_id,
 )
 
 
@@ -146,3 +147,84 @@ class TestPreflightFailures:
         result = await check_event_sync_group_settings(client, _config())
         assert result["ok"] is False
         assert not hasattr(client, "update_m3u_group_settings")
+
+
+def _source(auto_sync: bool, target: int) -> dict:
+    """An auto-synced SOURCE group whose channels are placed in ``target``."""
+    return {
+        "enabled": True,
+        "auto_channel_sync": auto_sync,
+        "custom_properties": {"group_override": target},
+    }
+
+
+class TestChannelGroupOverride:
+    """Channel Group Override resolution (bead override).
+
+    Auto-created channels land in the override TARGET group while the
+    auto_channel_sync setting lives on the SOURCE group; the pre-flight and
+    the master fetch must follow that relationship.
+    """
+
+    def test_effective_id_follows_source_to_target(self):
+        # Source 95 overrides to target 420 -> master channels live in 420.
+        settings = {95: _source(auto_sync=True, target=420)}
+        assert resolve_effective_master_group_id(settings, 95) == 420
+
+    def test_effective_id_is_identity_without_override(self):
+        settings = {10: _group(auto_sync=True)}
+        assert resolve_effective_master_group_id(settings, 10) == 10
+
+    def test_effective_id_of_target_is_itself(self):
+        # Picking the target directly: it has no override of its own.
+        settings = {95: _source(auto_sync=True, target=420)}
+        assert resolve_effective_master_group_id(settings, 420) == 420
+
+    async def test_master_as_override_target_passes(self):
+        # Operator points master at the TARGET (420) which has no direct
+        # setting; auto-sync ON is read through the source (95).
+        client = _ReadOnlyClient({
+            95: _source(auto_sync=True, target=420),
+            20: _group(auto_sync=False),
+        })
+        result = await check_event_sync_group_settings(
+            client, _config(master=420, secondaries=(20,))
+        )
+        assert result == {"ok": True, "failures": []}
+
+    async def test_master_target_with_source_auto_sync_off_fails(self):
+        client = _ReadOnlyClient({
+            95: _source(auto_sync=False, target=420),
+            20: _group(auto_sync=False),
+        })
+        result = await check_event_sync_group_settings(
+            client, _config(master=420, secondaries=(20,))
+        )
+        assert result["ok"] is False
+        assert any(f["check"] == CHECK_MASTER_AUTO_SYNC_ON
+                   for f in result["failures"])
+
+    async def test_master_as_override_source_still_passes(self):
+        # Operator points master at the auto-synced SOURCE (95) — the natural
+        # pick. Pre-flight passes (auto-sync ON); the master FETCH follows the
+        # override to 420 (covered by resolve_effective_master_group_id).
+        client = _ReadOnlyClient({
+            95: _source(auto_sync=True, target=420),
+            20: _group(auto_sync=False),
+        })
+        result = await check_event_sync_group_settings(
+            client, _config(master=95, secondaries=(20,))
+        )
+        assert result == {"ok": True, "failures": []}
+
+    async def test_prefetched_settings_avoid_a_second_fetch(self):
+        settings = {
+            95: _source(auto_sync=True, target=420),
+            20: _group(auto_sync=False),
+        }
+        client = _ReadOnlyClient(settings)
+        await check_event_sync_group_settings(
+            client, _config(master=420, secondaries=(20,)),
+            all_settings=settings,
+        )
+        client.get_all_m3u_group_settings.assert_not_awaited()

--- a/docs/event_sync.md
+++ b/docs/event_sync.md
@@ -164,15 +164,29 @@ the pipeline-level manual Run, or the single-rule run API):
 
 ## Pattern cookbook
 
-The two built-in patterns cover the majority of live-stream naming shapes
-observed across providers. Below are three verified provider name shapes
+The three built-in patterns cover the majority of live-stream naming shapes
+observed across providers. Below are the verified provider name shapes
 and the pattern that parses each — copy-paste consistent with the shipped
 patterns in `frontend/src/components/channelPipeline/eventSyncShippedPatterns.json`
 and the matcher defaults in `backend/services/event_sync_matcher.py`
 (every regex below was run against its example through the real
 `parse_event_name()` while writing this guide).
 
-### 1. Slot-prefixed, month-first date, with "@" (built-in)
+> **The built-ins are tolerant of real-world noise (beads 9c9j7 + numeric
+> dates).** They accept `@`, `|`, **or** `(` as the title/date delimiter, an
+> optional weekday before the date (`| Sun 12 Jul 02:00 EDT`), a **numeric
+> month-first date** (`(7.12 9:15 AM ET)` / `(7/12 12:00 PM ET)`), and —
+> crucially — **any trailing text after the time** (a provider/slot label
+> like `... @ Jul 11 9:30 AM :Flo Racing 03`, or a region marker like
+> `... | Sun 12 Jul 02:00 EDT (US) | US: ESPN+ PPV 40`). A trailing suffix
+> after the time used to cause an "Incomplete date/time — would be a parse
+> failure"; it no longer does. Single-digit hours (`9:30`) parse too.
+>
+> **Still a parse failure by design:** a listing with a time but **no date**
+> (`Boxing 05 : FURY vs HALL 6PM`, `LIVE EVENT 05 - 4:15pm ...`). Event Sync
+> never guesses the date. See [Dateless live listings](#dateless-live-listings).
+
+### 1. Slot-prefixed, month-first date, "@" or "|" (built-in)
 
 ```
 Fubo Sports Network 07 : Chelsea vs. Brentford @ Jan 17 10:00 AM ET
@@ -183,12 +197,12 @@ is the **`slot-title-month-first-date`** built-in — no configuration
 needed, it's pre-selected by default.
 
 ```
-title_pattern: ^(?:[^@:]{0,40}?(?<!\d)\d{2}\s*:\s*)?\s*(?P<title>.+?)\s*(?:@\s*(?:\d{1,2}\s+[A-Za-z]{3,9}\s+\d{1,2}:\d{2}|[A-Za-z]{3,9}\.?\s+\d{1,2}(?:\s*,?\s*\d{4})?\s+\d{1,2}:\d{2}).*)?$
+title_pattern: ^(?:[^@:|(]{0,40}?(?<!\d)\d{2}\s*:\s*)?\s*(?P<title>.+?)\s*(?:(?:@|\||\()\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[A-Za-z]*\.?,?\s+)?(?:\d{1,2}\s+[A-Za-z]{3,9}\.?\s+\d{1,2}:\d{2}(?:\s*[AaPp]\.?[Mm]?\.?)?(?:\s*E[SD]?T)?|[A-Za-z]{3,9}\.?\s+\d{1,2}(?:\s*,?\s*\d{4})?\s+\d{1,2}:\d{2}(?:\s*[AaPp]\.?[Mm]?\.?)?(?:\s*E[SD]?T)?|\d{1,2}[./]\d{1,2}\s+\d{1,2}:\d{2}(?:\s*[AaPp]\.?[Mm]?\.?)?(?:\s*E[SD]?T)?).*)?$
 time_pattern:  (?P<hour>\d{1,2}):(?P<minute>\d{2})(?:\s*(?P<ampm>[AaPp])\.?[Mm]?\.?)?\s*(?:E[SD]?T)?\s*$
-date_pattern:  @\s*(?P<month>[A-Za-z]{3,9})\.?\s+(?P<day>\d{1,2})(?:\s*,?\s*(?P<year>\d{4}))?\s+\d{1,2}:\d{2}
+date_pattern:  (?:@|\||\()\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[A-Za-z]*\.?,?\s+)?(?P<month>[A-Za-z]{3,9})\.?\s+(?P<day>\d{1,2})(?:\s*,?\s*(?P<year>\d{4}))?\s+(?P<hour>\d{1,2}):(?P<minute>\d{2})(?:\s*(?P<ampm>[AaPp])\.?[Mm]?\.?)?(?:\s*E[SD]?T)?
 ```
 
-### 2. Slot-prefixed, day-first date, with "@" (built-in)
+### 2. Slot-prefixed, day-first date, "@" or "|" (built-in)
 
 ```
 Peacock 14: Mercury vs. Aces @ 11 Jul 06:00 PM ET
@@ -201,12 +215,34 @@ wins, so most rules can leave both on and cover both date shapes without
 any per-provider configuration.
 
 ```
-title_pattern: ^(?:[^@:]{0,40}?(?<!\d)\d{2}\s*:\s*)?\s*(?P<title>.+?)\s*(?:@\s*(?:\d{1,2}\s+[A-Za-z]{3,9}\s+\d{1,2}:\d{2}|[A-Za-z]{3,9}\.?\s+\d{1,2}(?:\s*,?\s*\d{4})?\s+\d{1,2}:\d{2}).*)?$
+title_pattern: ^(?:[^@:|(]{0,40}?(?<!\d)\d{2}\s*:\s*)?\s*(?P<title>.+?)\s*(?:(?:@|\||\()\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[A-Za-z]*\.?,?\s+)?(?:\d{1,2}\s+[A-Za-z]{3,9}\.?\s+\d{1,2}:\d{2}(?:\s*[AaPp]\.?[Mm]?\.?)?(?:\s*E[SD]?T)?|[A-Za-z]{3,9}\.?\s+\d{1,2}(?:\s*,?\s*\d{4})?\s+\d{1,2}:\d{2}(?:\s*[AaPp]\.?[Mm]?\.?)?(?:\s*E[SD]?T)?|\d{1,2}[./]\d{1,2}\s+\d{1,2}:\d{2}(?:\s*[AaPp]\.?[Mm]?\.?)?(?:\s*E[SD]?T)?).*)?$
 time_pattern:  (?P<hour>\d{1,2}):(?P<minute>\d{2})(?:\s*(?P<ampm>[AaPp])\.?[Mm]?\.?)?\s*(?:E[SD]?T)?\s*$
-date_pattern:  @\s*(?P<day>\d{1,2})\s+(?P<month>[A-Za-z]{3,9})\s+\d{1,2}:\d{2}
+date_pattern:  (?:@|\||\()\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[A-Za-z]*\.?,?\s+)?(?P<day>\d{1,2})\s+(?P<month>[A-Za-z]{3,9})\.?\s+(?P<hour>\d{1,2}):(?P<minute>\d{2})(?:\s*(?P<ampm>[AaPp])\.?[Mm]?\.?)?(?:\s*E[SD]?T)?
 ```
 
-### 3. Slot-prefixed, no "@" separator (shipped, not pre-selected)
+### 3. Slot-prefixed, numeric month-first date (built-in)
+
+Some providers list the date **numerically**, often in parentheses:
+
+```
+PPV EVENT 01: Zenith Racing Series at Road America (7.12 9:15 AM ET)
+PPV EVENT 10: Redstall vs. Courtney (7/12 12:00 PM ET)
+```
+
+Parses to title `Zenith Racing Series at Road America` / `Redstall vs.
+Courtney`, start `Jul 12 09:15 AM ET` / `Jul 12 12:00 PM ET`. This is the
+**`slot-title-numeric-date`** built-in (pre-selected). Numeric dates are
+read **month-first** (US convention, matching the ET default timezone) and
+accept `.` or `/` — a provider that lists numeric dates day-first needs a
+per-rule override. `(`, `@`, and `|` all work as the opener.
+
+```
+date_pattern:  (?:@|\||\()\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[A-Za-z]*\.?,?\s+)?(?P<month>\d{1,2})[./](?P<day>\d{1,2})\s+(?P<hour>\d{1,2}):(?P<minute>\d{2})(?:\s*(?P<ampm>[AaPp])\.?[Mm]?\.?)?(?:\s*E[SD]?T)?
+```
+
+(title_pattern and time_pattern are identical across all three built-ins.)
+
+### 4. Slot-prefixed, no "@" separator (shipped, not pre-selected)
 
 Some providers drop the "@" between title and date entirely:
 
@@ -228,10 +264,43 @@ title_pattern (day-first): ^(?:[^@:]{0,40}?(?<!\d)\d{2}\s*:\s*(?!\d))?\s*(?P<tit
 date_pattern (day-first):  (?P<day>\d{1,2})\s+(?P<month>[A-Za-z]{3,9})\s+\d{1,2}:\d{2}
 ```
 
-(time_pattern is the same on all four shipped patterns.) If your
-provider's shape doesn't match any of the four, add a custom shared
+(time_pattern is the same on all five shipped patterns.) If your
+provider's shape doesn't match any of them, add a custom shared
 pattern (or a per-group override) in the rule editor's **Advanced**
 section and verify it with Test Patterns before saving — do not guess.
+
+### Dateless live listings
+
+Some providers list a live "today" schedule with a **time but no date**:
+
+```
+Boxing 05 : FURY vs HALL 6PM
+Boxing 6: Fury v Makhmudov 19:00
+LIVE EVENT 05 - 4:15pm Zenith Racing Series Road America
+```
+
+By default these are a **parse failure** — Event Sync's core safety rail is
+that it **never guesses the date** (otherwise it could match yesterday's
+"6PM" to today's), so a listing that omits the date is shown as "Incomplete
+date/time" in the preview rather than guessed onto "today".
+
+If a group **only ever lists the current day** and you accept the cross-day
+risk, set **`assume_current_date: true`** on the rule (in the editor:
+**"Assume today's date for dateless listings"** under Advanced). With it on,
+a listing that carries a time but no date is placed on the **current date**
+(in the rule's timezone) so it becomes matchable. Both the master and
+secondary sides share the same "today", so their times compare on one day.
+The built-in dateless shapes cover `… TITLE 6PM` / `… TITLE 19:00` (time
+last) and `… - 4:15pm TITLE` (time first); a bare time must carry a colon or
+an am/pm marker so a lone number in a title is never mistaken for a time.
+
+**The risk:** a listing that is really for a *different* day (a replay at the
+same time-of-day tomorrow) can mis-match — the ±`time_window_minutes` window
+still applies, but same-time-of-day collisions can slip through. And even a
+correctly-dated listing only attaches when its time lands within the window
+of the master, so a group whose listed times are unreliable (hours off the
+real start) still won't pair. Leave the flag **off** unless the group is a
+genuine same-day live schedule.
 
 ## Rule configuration (`event_sync_config`)
 
@@ -274,6 +343,9 @@ the rule.
 | `enabled` | no (default true) | Feature toggle within the rule. |
 | `auto_run` | no (default **false**) | Phase 2 opt-in (bead ti939.3.1): when true, the rule also runs **unattended** after each M3U refresh (the watermark task). Absent means false — manual-run-only. See [Automatic runs after refresh](#automatic-runs-after-refresh-phase-2-opt-in). |
 | `dummy_epg_profile_id` | no (absent = off) | Phase 2 (bead ti939.3.3): id of a [dummy EPG profile](template_engine.md) auto-assigned to the master group's channels on every run. Must reference an **existing** profile (teaching error otherwise); the key is never default-filled — omit it to disable. See [Automatic guide data for master channels](#automatic-guide-data-for-master-channels-dummy-epg). |
+| `include_master_group_streams` | no (default **false**) | bead 6xxmp: when true, the **master group's own streams** are also matched to the master channels (streams already attached are skipped). The sanctioned path for a same-named cross-provider group — see [Two providers, one group name](#two-providers-one-group-name) below. |
+| `assume_current_date` | no (default **false**) | When true, a listing that carries a **time but no date** is placed on the **current date** so it becomes matchable — deliberately relaxing the never-guess-the-date rail. Accepts the cross-day match risk. See [Dateless live listings](#dateless-live-listings). |
+| `parse_master_from_stream` | no (default **false**) | When true, each master channel's event identity (title + time) is read from its **first attached stream's name** instead of the channel name — so master channels can be named freely. A master with no attached stream is skipped. See [The master channels' date+time must be in their NAMES](#the-master-channels-datetime-must-be-in-their-names). |
 
 ### Why validation is strict
 
@@ -299,6 +371,34 @@ value you sent, what was expected, and a link back to this document.
   regression corpus only proves the matcher's precision at sane windows.
 * **Unknown keys are rejected**, so a typo'd optional key cannot silently
   fall back to its default.
+
+### Two providers, one group name
+
+Dispatcharr channel groups are **global and unique by name**: if two M3U
+providers both carry a group called `Live Events`, their streams land in the
+*same* channel group — one group ID. That means you cannot pick provider A's
+`Live Events` as the master and provider B's `Live Events` as a secondary;
+the group picker shows one entry, and choosing it as master removes it from
+the secondary list (a group cannot be both — the mandatory-scoping rail).
+
+`include_master_group_streams` is the sanctioned path for exactly this case:
+
+1. Leave the shared group as the **master** (`auto_channel_sync` ON) so
+   Dispatcharr owns one channel per event, built from provider A's streams.
+2. Set `include_master_group_streams: true` (in the rule editor: **"Also
+   attach the master group's own streams"** under Advanced).
+
+On each run the master group's own streams are matched to the master
+channels alongside the secondary groups. Streams **already attached** to a
+master channel — provider A's own — are skipped by the resolver, so only
+provider B's still-unattached streams attach. Preview and run stay in
+lockstep (the preview's *would attach* count already excludes the
+already-attached streams), and the master group is **never** added to
+`secondary_group_ids` — that rail is untouched.
+
+If you would rather keep the two providers fully separate, the alternative
+is to **rename one provider's group** in Dispatcharr (a group override) so
+the two names become distinct IDs that pick independently — no flag needed.
 
 ## Threshold and bands
 
@@ -401,6 +501,45 @@ If this list is large and consistently the same events, it's evidence for
 picking a different (broader) master group, or a future promotion feature
 (tracked under epic `enhancedchannelmanager-ti939.4`, not built yet) — not
 something to work around today.
+
+### The master channels' date+time must be in their NAMES
+
+Event Sync reads a master channel's start time by **parsing the channel's
+name** — it does **not** read the time from the stream attached to the
+channel, nor from EPG. A master channel whose name has no complete
+parseable date+time can never be an attach target (it shows up as an
+*unparsed master* in the preview, and every secondary stream for that event
+lands in the unmatched list).
+
+Auto-synced master channels normally inherit the master provider's **stream
+name**, which already carries the time (`… @ Jul 11 9:30 AM`), so this just
+works. The pitfall is a **normalization or naming rule that strips the
+date-time out of the master channel name** — that makes the masters
+unparseable and nothing attaches.
+
+If you *want* to name the master channels freely (a clean name without the
+time), set **`parse_master_from_stream: true`** on the rule (in the editor:
+**"Read master event time from the attached stream"** under Advanced). With
+it on, each master channel's identity is read from its **first attached
+stream's name** instead of the channel name — so the event title+time come
+from the underlying auto-synced stream, and the channel name is yours to
+choose. A master channel with no attached stream is skipped. Otherwise, keep
+the date+time in the master channel names (verify with the preview: the
+master count should be non-zero and the "unparsed masters" count zero).
+
+### Using a Dispatcharr Channel Group Override
+
+A Dispatcharr **Channel Group Override** on an auto-synced M3U group sends
+the auto-created **channels** into a *different* target group, while the
+group's **streams** stay under the original name. Event Sync follows the
+override automatically: **point the master at your auto-synced provider
+group** (the one you normally pick, where `auto_channel_sync` is ON) and ECM
+fetches the master channels from the override's target group for you — both
+in the preview and the run. (Pointing the master at the override *target*
+group directly also works: the pre-flight reads its auto-sync state through
+the source group.) If the preview shows zero master channels for a group you
+know is auto-synced, confirm the override target group has actually been
+populated by a Dispatcharr auto-sync at least once.
 
 ### Undo a bad event_sync run
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0074",
+  "version": "0.17.6-0075",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
@@ -193,6 +193,150 @@ describe('EventSyncRuleEditor', () => {
     });
   });
 
+  describe('master-group self-attach (bead 6xxmp)', () => {
+    it('defaults OFF and omits include_master_group_streams when never set', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onSave = vi.fn();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
+
+      await user.click(screen.getByText('Advanced'));
+      expect(
+        screen.getByTestId('event-sync-include-master-group-streams')
+      ).not.toBeChecked();
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+      expect(onSave.mock.calls[0][0].event_sync_config).not.toHaveProperty(
+        'include_master_group_streams'
+      );
+    });
+
+    it('emits include_master_group_streams: true when the operator checks the box', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onSave = vi.fn();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
+
+      await user.click(screen.getByText('Advanced'));
+      await user.click(
+        screen.getByTestId('event-sync-include-master-group-streams')
+      );
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+      expect(
+        onSave.mock.calls[0][0].event_sync_config.include_master_group_streams
+      ).toBe(true);
+    });
+
+    it('initializes checked from a stored true and round-trips it', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onSave = vi.fn();
+      const rule = {
+        ...EXISTING_RULE,
+        event_sync_config: {
+          ...EXISTING_RULE.event_sync_config!,
+          include_master_group_streams: true,
+        },
+      };
+      render(<EventSyncRuleEditor rule={rule} onSave={onSave} onCancel={vi.fn()} />);
+
+      await user.click(screen.getByText('Advanced'));
+      expect(
+        screen.getByTestId('event-sync-include-master-group-streams')
+      ).toBeChecked();
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+      expect(
+        onSave.mock.calls[0][0].event_sync_config.include_master_group_streams
+      ).toBe(true);
+    });
+  });
+
+  describe('parse-master-from-stream opt-in', () => {
+    it('defaults OFF and omits the key when never set', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onSave = vi.fn();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
+
+      await user.click(screen.getByText('Advanced'));
+      expect(
+        screen.getByTestId('event-sync-parse-master-from-stream')
+      ).not.toBeChecked();
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+      expect(onSave.mock.calls[0][0].event_sync_config).not.toHaveProperty(
+        'parse_master_from_stream'
+      );
+    });
+
+    it('emits parse_master_from_stream: true when checked', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onSave = vi.fn();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
+
+      await user.click(screen.getByText('Advanced'));
+      await user.click(
+        screen.getByTestId('event-sync-parse-master-from-stream')
+      );
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+      expect(
+        onSave.mock.calls[0][0].event_sync_config.parse_master_from_stream
+      ).toBe(true);
+    });
+  });
+
+  describe('assume-current-date opt-in (dateless listings)', () => {
+    it('defaults OFF and omits assume_current_date when never set', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onSave = vi.fn();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
+
+      await user.click(screen.getByText('Advanced'));
+      expect(
+        screen.getByTestId('event-sync-assume-current-date')
+      ).not.toBeChecked();
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+      expect(onSave.mock.calls[0][0].event_sync_config).not.toHaveProperty(
+        'assume_current_date'
+      );
+    });
+
+    it('emits assume_current_date: true when checked', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onSave = vi.fn();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
+
+      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByTestId('event-sync-assume-current-date'));
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+      expect(
+        onSave.mock.calls[0][0].event_sync_config.assume_current_date
+      ).toBe(true);
+    });
+  });
+
   describe('auto-run opt-in (ti939.3.1)', () => {
     it('defaults OFF and omits auto_run for a rule that never had the key', async () => {
       const user = userEvent.setup();
@@ -496,14 +640,15 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      // Deselect one of the two built-ins
+      // Deselect one of the built-ins; the remaining built-ins are emitted.
       await user.click(screen.getByRole('checkbox', { name: /month-first date \(built-in\)/i }));
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
       await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
       const config = onSave.mock.calls[0][0].event_sync_config;
-      expect(config.patterns).toHaveLength(1);
-      expect(config.patterns[0].name).toBe('slot-title-day-first-date');
+      const names = config.patterns.map((p: { name: string }) => p.name);
+      expect(names).toContain('slot-title-day-first-date');
+      expect(names).not.toContain('slot-title-month-first-date');
       expect(config.patterns[0].title_pattern).toContain('(?P<title>');
     });
 
@@ -702,9 +847,10 @@ describe('EventSyncRuleEditor', () => {
       expect(names).toEqual([
         'slot-title-day-first-date',
         'slot-title-month-first-date',
+        'slot-title-numeric-date',
         'custom-shared',
       ]);
-      expect(saved.patterns[2].title_pattern).toBe('^(?P<title>.+?)\\s*@');
+      expect(saved.patterns[3].title_pattern).toBe('^(?P<title>.+?)\\s*@');
     });
   });
 

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
@@ -231,6 +231,19 @@ export function EventSyncRuleEditor({
   // Phase 2 opt-in (ti939.3.1): unattended auto-run on the refresh
   // watermark. Default OFF — the backend treats an absent key as false.
   const [autoRun, setAutoRun] = useState(config?.auto_run ?? false);
+  // bead 6xxmp: also match the master group's own streams (a second provider
+  // sharing the master group's name) to the master channels.
+  const [includeMasterGroupStreams, setIncludeMasterGroupStreams] = useState(
+    config?.include_master_group_streams ?? false
+  );
+  // bead assume-current-date: fill the current date for dateless listings.
+  const [assumeCurrentDate, setAssumeCurrentDate] = useState(
+    config?.assume_current_date ?? false
+  );
+  // bead parse-from-stream: read master identity from the attached stream.
+  const [parseMasterFromStream, setParseMasterFromStream] = useState(
+    config?.parse_master_from_stream ?? false
+  );
   // Phase 2 (ti939.3.3): optional dummy EPG profile auto-assigned to master
   // channels on every run. null = feature off (key omitted on save).
   const [dummyEpgProfileId, setDummyEpgProfileId] = useState<number | null>(
@@ -476,6 +489,22 @@ export function EventSyncRuleEditor({
     // the key is never emitted as null).
     if (dummyEpgProfileId != null) {
       built.dummy_epg_profile_id = dummyEpgProfileId;
+    }
+    // bead 6xxmp: emit the master self-attach flag when checked; preserve an
+    // explicit stored value (the backend validator fills it on save). Absent
+    // means false on the backend, so an unchecked legacy config stays absent.
+    if (includeMasterGroupStreams || config?.include_master_group_streams != null) {
+      built.include_master_group_streams = includeMasterGroupStreams;
+    }
+    // bead assume-current-date: emit when checked; preserve an explicit
+    // stored value (absent means false on the backend).
+    if (assumeCurrentDate || config?.assume_current_date != null) {
+      built.assume_current_date = assumeCurrentDate;
+    }
+    // bead parse-from-stream: emit when checked; preserve an explicit stored
+    // value (absent means false on the backend).
+    if (parseMasterFromStream || config?.parse_master_from_stream != null) {
+      built.parse_master_from_stream = parseMasterFromStream;
     }
 
     // --- Shared patterns (bead z4y4a: full round-trip) -------------------
@@ -1018,6 +1047,75 @@ export function EventSyncRuleEditor({
                   landing right after a refresh can precede Dispatcharr
                   creating a brand-new event&apos;s master channel — that
                   stream attaches on the next run.
+                </span>
+              </div>
+
+              <div className="form-group">
+                <label className="checkbox-option">
+                  <input
+                    type="checkbox"
+                    checked={includeMasterGroupStreams}
+                    onChange={e => setIncludeMasterGroupStreams(e.target.checked)}
+                    disabled={isLoading}
+                    data-testid="event-sync-include-master-group-streams"
+                  />
+                  <span>Also attach the master group&apos;s own streams</span>
+                </label>
+                <span className="form-hint">
+                  Off by default. Turn this on when a second provider&apos;s
+                  streams live in the <em>same-named</em> channel group as the
+                  master (Dispatcharr merges same-named groups into one, so
+                  they cannot be picked as a separate secondary). When on, the
+                  master group&apos;s streams are matched to the master
+                  channels too; streams already attached (the auto-synced
+                  provider&apos;s own) are skipped, so only the unsynced
+                  provider&apos;s streams attach.
+                </span>
+              </div>
+
+              <div className="form-group">
+                <label className="checkbox-option">
+                  <input
+                    type="checkbox"
+                    checked={parseMasterFromStream}
+                    onChange={e => setParseMasterFromStream(e.target.checked)}
+                    disabled={isLoading}
+                    data-testid="event-sync-parse-master-from-stream"
+                  />
+                  <span>Read master event time from the attached stream</span>
+                </label>
+                <span className="form-hint">
+                  Off by default. Event Sync normally reads a master
+                  channel&apos;s date/time from its <em>name</em>. Turn this on
+                  to read it from the master channel&apos;s <strong>first
+                  attached stream</strong> instead — so you can name the master
+                  channels however you like while the event time still comes
+                  from the underlying auto-synced stream. (If a master channel
+                  has no attached stream, it is skipped.)
+                </span>
+              </div>
+
+              <div className="form-group">
+                <label className="checkbox-option">
+                  <input
+                    type="checkbox"
+                    checked={assumeCurrentDate}
+                    onChange={e => setAssumeCurrentDate(e.target.checked)}
+                    disabled={isLoading}
+                    data-testid="event-sync-assume-current-date"
+                  />
+                  <span>Assume today&apos;s date for dateless listings</span>
+                </label>
+                <span className="form-hint">
+                  Off by default. Some providers list a live schedule with a
+                  time but <em>no date</em> (e.g. &quot;FURY vs HALL 6PM&quot;).
+                  Normally those can&apos;t be matched (the time could be any
+                  day). Turn this on to place such listings on the{' '}
+                  <strong>current date</strong> so they match same-day events.
+                  Risk: a listing that is really for another day (e.g. a replay
+                  at the same time tomorrow) can mis-match — the ±time window
+                  still applies, but same-time-of-day collisions can slip
+                  through. Leave off unless the group only ever lists today.
                 </span>
               </div>
 

--- a/frontend/src/components/channelPipeline/eventSyncShippedPatterns.json
+++ b/frontend/src/components/channelPipeline/eventSyncShippedPatterns.json
@@ -7,25 +7,37 @@
       "id": "slot-title-day-first-date",
       "builtin": true,
       "label": "Title @ Day-first date (built-in)",
-      "description": "Optional \"Slot NN :\" prefix, then title, then \"@ <day> <month> <time>\". Matches the most common live shape.",
+      "description": "Optional \"Slot NN :\" prefix, then title, then \"@ <day> <month> <time>\". Matches the most common live shape. Also accepts a \"|\" delimiter, an optional weekday prefix, and a trailing provider/slot suffix after the time.",
       "example": "Fubo Sports Network 07 : Yankees vs Red Sox @ 11 Jul 06:00 PM ET",
       "expected_title": "Yankees vs Red Sox",
       "expected_start": "2026-07-11T18:00:00-04:00",
-      "title_pattern": "^(?:[^@:]{0,40}?(?<!\\d)\\d{2}\\s*:\\s*)?\\s*(?P<title>.+?)\\s*(?:@\\s*(?:\\d{1,2}\\s+[A-Za-z]{3,9}\\s+\\d{1,2}:\\d{2}|[A-Za-z]{3,9}\\.?\\s+\\d{1,2}(?:\\s*,?\\s*\\d{4})?\\s+\\d{1,2}:\\d{2}).*)?$",
+      "title_pattern": "^(?:[^@:|(]{0,40}?(?<!\\d)\\d{2}\\s*:\\s*)?\\s*(?P<title>.+?)\\s*(?:(?:@|\\||\\()\\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[A-Za-z]*\\.?,?\\s+)?(?:\\d{1,2}\\s+[A-Za-z]{3,9}\\.?\\s+\\d{1,2}:\\d{2}(?:\\s*[AaPp]\\.?[Mm]?\\.?)?(?:\\s*E[SD]?T)?|[A-Za-z]{3,9}\\.?\\s+\\d{1,2}(?:\\s*,?\\s*\\d{4})?\\s+\\d{1,2}:\\d{2}(?:\\s*[AaPp]\\.?[Mm]?\\.?)?(?:\\s*E[SD]?T)?|\\d{1,2}[./]\\d{1,2}\\s+\\d{1,2}:\\d{2}(?:\\s*[AaPp]\\.?[Mm]?\\.?)?(?:\\s*E[SD]?T)?).*)?$",
       "time_pattern": "(?P<hour>\\d{1,2}):(?P<minute>\\d{2})(?:\\s*(?P<ampm>[AaPp])\\.?[Mm]?\\.?)?\\s*(?:E[SD]?T)?\\s*$",
-      "date_pattern": "@\\s*(?P<day>\\d{1,2})\\s+(?P<month>[A-Za-z]{3,9})\\s+\\d{1,2}:\\d{2}"
+      "date_pattern": "(?:@|\\||\\()\\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[A-Za-z]*\\.?,?\\s+)?(?P<day>\\d{1,2})\\s+(?P<month>[A-Za-z]{3,9})\\.?\\s+(?P<hour>\\d{1,2}):(?P<minute>\\d{2})(?:\\s*(?P<ampm>[AaPp])\\.?[Mm]?\\.?)?(?:\\s*E[SD]?T)?"
     },
     {
       "id": "slot-title-month-first-date",
       "builtin": true,
       "label": "Title @ Month-first date (built-in)",
-      "description": "Optional \"Slot NN :\" prefix, then title, then \"@ <month> <day> [year] <time>\".",
+      "description": "Optional \"Slot NN :\" prefix, then title, then \"@ <month> <day> [year] <time>\". Also accepts a \"|\" delimiter, an optional weekday prefix, and a trailing provider/slot suffix after the time.",
       "example": "Peacock 14: Lyon vs Marseille @ Jan 17 02:45 PM ET",
       "expected_title": "Lyon vs Marseille",
       "expected_start": "2026-01-17T14:45:00-05:00",
-      "title_pattern": "^(?:[^@:]{0,40}?(?<!\\d)\\d{2}\\s*:\\s*)?\\s*(?P<title>.+?)\\s*(?:@\\s*(?:\\d{1,2}\\s+[A-Za-z]{3,9}\\s+\\d{1,2}:\\d{2}|[A-Za-z]{3,9}\\.?\\s+\\d{1,2}(?:\\s*,?\\s*\\d{4})?\\s+\\d{1,2}:\\d{2}).*)?$",
+      "title_pattern": "^(?:[^@:|(]{0,40}?(?<!\\d)\\d{2}\\s*:\\s*)?\\s*(?P<title>.+?)\\s*(?:(?:@|\\||\\()\\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[A-Za-z]*\\.?,?\\s+)?(?:\\d{1,2}\\s+[A-Za-z]{3,9}\\.?\\s+\\d{1,2}:\\d{2}(?:\\s*[AaPp]\\.?[Mm]?\\.?)?(?:\\s*E[SD]?T)?|[A-Za-z]{3,9}\\.?\\s+\\d{1,2}(?:\\s*,?\\s*\\d{4})?\\s+\\d{1,2}:\\d{2}(?:\\s*[AaPp]\\.?[Mm]?\\.?)?(?:\\s*E[SD]?T)?|\\d{1,2}[./]\\d{1,2}\\s+\\d{1,2}:\\d{2}(?:\\s*[AaPp]\\.?[Mm]?\\.?)?(?:\\s*E[SD]?T)?).*)?$",
       "time_pattern": "(?P<hour>\\d{1,2}):(?P<minute>\\d{2})(?:\\s*(?P<ampm>[AaPp])\\.?[Mm]?\\.?)?\\s*(?:E[SD]?T)?\\s*$",
-      "date_pattern": "@\\s*(?P<month>[A-Za-z]{3,9})\\.?\\s+(?P<day>\\d{1,2})(?:\\s*,?\\s*(?P<year>\\d{4}))?\\s+\\d{1,2}:\\d{2}"
+      "date_pattern": "(?:@|\\||\\()\\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[A-Za-z]*\\.?,?\\s+)?(?P<month>[A-Za-z]{3,9})\\.?\\s+(?P<day>\\d{1,2})(?:\\s*,?\\s*(?P<year>\\d{4}))?\\s+(?P<hour>\\d{1,2}):(?P<minute>\\d{2})(?:\\s*(?P<ampm>[AaPp])\\.?[Mm]?\\.?)?(?:\\s*E[SD]?T)?"
+    },
+    {
+      "id": "slot-title-numeric-date",
+      "builtin": true,
+      "label": "Title (numeric date) (built-in)",
+      "description": "Optional \"Slot NN :\" prefix, then title, then a parenthesized/\"@\"/\"|\" NUMERIC month-first date: \"Title (7.12 9:15 AM ET)\" or \"(7/12 12:00 PM ET)\". Numeric dates are read month-first (US convention).",
+      "example": "PPV EVENT 01: Zenith Racing Series at Road America (7.12 9:15 AM ET)",
+      "expected_title": "Zenith Racing Series at Road America",
+      "expected_start": "2026-07-12T09:15:00-04:00",
+      "title_pattern": "^(?:[^@:|(]{0,40}?(?<!\\d)\\d{2}\\s*:\\s*)?\\s*(?P<title>.+?)\\s*(?:(?:@|\\||\\()\\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[A-Za-z]*\\.?,?\\s+)?(?:\\d{1,2}\\s+[A-Za-z]{3,9}\\.?\\s+\\d{1,2}:\\d{2}(?:\\s*[AaPp]\\.?[Mm]?\\.?)?(?:\\s*E[SD]?T)?|[A-Za-z]{3,9}\\.?\\s+\\d{1,2}(?:\\s*,?\\s*\\d{4})?\\s+\\d{1,2}:\\d{2}(?:\\s*[AaPp]\\.?[Mm]?\\.?)?(?:\\s*E[SD]?T)?|\\d{1,2}[./]\\d{1,2}\\s+\\d{1,2}:\\d{2}(?:\\s*[AaPp]\\.?[Mm]?\\.?)?(?:\\s*E[SD]?T)?).*)?$",
+      "time_pattern": "(?P<hour>\\d{1,2}):(?P<minute>\\d{2})(?:\\s*(?P<ampm>[AaPp])\\.?[Mm]?\\.?)?\\s*(?:E[SD]?T)?\\s*$",
+      "date_pattern": "(?:@|\\||\\()\\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[A-Za-z]*\\.?,?\\s+)?(?P<month>\\d{1,2})[./](?P<day>\\d{1,2})\\s+(?P<hour>\\d{1,2}):(?P<minute>\\d{2})(?:\\s*(?P<ampm>[AaPp])\\.?[Mm]?\\.?)?(?:\\s*E[SD]?T)?"
     },
     {
       "id": "title-day-first-date-no-at",

--- a/frontend/src/types/eventSync.ts
+++ b/frontend/src/types/eventSync.ts
@@ -59,6 +59,29 @@ export interface EventSyncConfig {
    * never default-fills it). Must reference an existing dummy EPG profile.
    */
   dummy_epg_profile_id?: number;
+  /**
+   * bead 6xxmp: when true, the MASTER group's own streams are also matched
+   * to the master channels (the resolver drops those already attached). The
+   * sanctioned path for a single channel group (global, unique-by-name)
+   * carrying two providers' streams — one auto-synced, one not — so the
+   * unsynced provider's streams attach to the synced provider's channels.
+   * Backend default false.
+   */
+  include_master_group_streams?: boolean;
+  /**
+   * bead assume-current-date: when true, a listing that carries a time but
+   * NO date (a dateless "today's schedule") is placed on the CURRENT date so
+   * it becomes matchable — deliberately relaxing the never-guess-the-date
+   * rail, accepting the cross-day match risk. Backend default false.
+   */
+  assume_current_date?: boolean;
+  /**
+   * bead parse-from-stream: when true, each master channel's event identity
+   * (title + time) is read from its FIRST attached stream's name instead of
+   * the channel name — so master channels can be named freely. Backend
+   * default false.
+   */
+  parse_master_from_stream?: boolean;
 }
 
 // =============================================================================

--- a/mcp-server/tests/test_ti939_event_sync_preview.py
+++ b/mcp-server/tests/test_ti939_event_sync_preview.py
@@ -133,6 +133,28 @@ class TestPreviewEventSync:
         assert "channel 55" in text
 
     @pytest.mark.asyncio
+    async def test_include_master_group_streams_flag_forwarded_verbatim(self):
+        # bead 6xxmp: the tool forwards event_sync_config as-is, so the new
+        # flag reaches the backend validator with no MCP-side handling.
+        mcp = _make_mcp_and_register()
+        bodies = []
+
+        async def call_endpoint_side_effect(endpoint, **kwargs):
+            bodies.append(kwargs.get("body"))
+            return _preview_response()
+
+        client = AsyncMock()
+        client.call_endpoint.side_effect = call_endpoint_side_effect
+        config = {
+            "master_group_id": 10,
+            "secondary_group_ids": [20],
+            "include_master_group_streams": True,
+            "assume_current_date": True,
+        }
+        await _call_tool(mcp, client, {"event_sync_config": config})
+        assert bodies == [{"event_sync_config": config}]
+
+    @pytest.mark.asyncio
     async def test_rule_id_sends_rule_id_body(self):
         mcp = _make_mcp_and_register()
         bodies = []

--- a/mcp-server/tools/channel_pipeline.py
+++ b/mcp-server/tools/channel_pipeline.py
@@ -1533,7 +1533,29 @@ def register(mcp: FastMCP):
             event_sync_config: Preview an inline config before saving —
                 {"master_group_id": int, "secondary_group_ids": [int, ...],
                  optional "patterns"/"group_patterns"/"time_window_minutes"/
-                 "attach_threshold"}.
+                 "attach_threshold"/"max_attach_per_run"/"auto_run"/
+                 "dummy_epg_profile_id"/"include_master_group_streams"/
+                 "assume_current_date"/"parse_master_from_stream"}.
+                include_master_group_streams (bool, default false, bead
+                6xxmp): also match the MASTER group's OWN streams to the
+                master channels — the path for two providers sharing one
+                same-named channel group (Dispatcharr merges same-named
+                groups into one id). Streams already attached are skipped, so
+                only the unsynced provider's streams attach.
+                assume_current_date (bool, default false): place a listing
+                that carries a time but NO date onto the CURRENT date so
+                dateless "today's schedule" feeds become matchable — relaxes
+                the never-guess-the-date rail (cross-day match risk).
+                parse_master_from_stream (bool, default false): read each
+                master channel's event identity (title+time) from its first
+                attached stream's name instead of the channel name, so master
+                channels can be named freely.
+                The built-in parse patterns also accept "|" and "("
+                delimiters, weekday prefixes, trailing suffixes after the
+                time, and numeric month-first dates ("(7.12 9:15 AM ET)"); a
+                Dispatcharr Channel Group Override on the master group is
+                followed automatically (master channels are read from the
+                override's target group). None of those need config keys.
 
         Args:
             rule_id: Saved channel-pipeline rule id (event_sync kind).


### PR DESCRIPTION
## Summary

Broadens Event Sync matching and fixes several live-provider gaps operators reported after the recent update. Eight related changes, all in the Event Sync surface; the four new `event_sync_config` flags are **off by default** and compose with each other.

### Parse coverage
- **Trailing suffixes / `|` delimiters / weekday prefixes** — a provider/slot label after the time (`… @ Jul 11 9:30 AM :Flo Racing 03`) or a pipe-delimited/weekday-prefixed listing (`… | Sun 12 Jul 02:00 EDT (US) | US: ESPN+ PPV 40`) no longer causes "Incomplete date/time". (bead `9c9j7`)
- **Numeric parenthesized dates** — `PPV EVENT 01: Title (7.12 9:15 AM ET)` now parses (US month-first). (bead `1xszv`)
- Shipped-pattern parity gate kept green; **0 regressions across the 60-name matcher corpus**.

### Fixes & options
- **Channel Group Override** (bead `j7i0z`) — the master-channel fetch (preview + run) and pre-flight now **follow a Dispatcharr Channel Group Override**, so pointing the master at the auto-synced source group works even though its channels live in the override target group. Verified against live instance data (group 95 → target 420).
- **`include_master_group_streams`** (bead `6xxmp`) — opt-in: match a same-named cross-provider group's own unattached streams to the master channels; the resolver drops already-attached streams so preview and run stay in lockstep.
- **`assume_current_date`** — opt-in: place dateless "today's schedule" listings (a time but no date, e.g. `Boxing 05 : FURY vs HALL 6PM`) on the current date. Deliberately relaxes the never-guess-the-date rail; **off by default**. (bead `553x2`)
- **`parse_master_from_stream`** — opt-in: read each master channel's event identity from its first attached stream's name instead of the channel name, so master channels can be named freely.
- **Stale FFmpeg e2e tests** removed (hit the removed `/api/ffmpeg` router). (bead `72z02`)
- **MCP** `preview_event_sync` docstring updated for the new flags (config is forwarded verbatim, so no functional MCP change was needed).

## Testing
- Full backend suite green (0 failures); new unit tests for every flag (matcher, resolver, preflight, executor run-path, schema), frontend editor tests, and MCP pass-through test.
- `docs/event_sync.md` updated (parse cookbook, override, dateless, master-naming, and the four flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
