### PR TITLE
v0.17.6-0076: Event Sync review-queue + badge follow-ups (xeli0, 8rzkq, 8fq6x, odnnf)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -140,7 +140,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0075",
+    version="0.17.6-0076",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -36,6 +36,7 @@ from models import (
     ChannelPipelineRule,
     DummyEPGProfile,
     DummyEPGChannelAssignment,
+    EventSyncReview,
     FFmpegProfile,
     NormalizationRuleGroup,
     NormalizationRule,
@@ -74,7 +75,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0075"
+APP_VERSION = "0.17.6-0076"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable
@@ -2438,8 +2439,39 @@ def _restore_auto_creation_rules(items: list) -> dict:
 
     session = get_session()
     warnings: list[str] = []
+    # bead 8fq6x: the delete-all below CASCADEs to event_sync_reviews, dropping
+    # every review row — including ANSWERED accept/reject decisions. Preserve
+    # them across the delete+recreate and re-key onto the restored rule by
+    # NAME (fingerprints are content-based and survive; only the rule_id FK
+    # breaks). Captured BEFORE the delete because the CASCADE fires on delete.
+    _REVIEW_FIELDS = (
+        "provider_id", "stream_name_hash", "event_key", "status",
+        "created_at", "last_seen_at", "resolved_at", "resolution_source",
+        "actor_token_id", "evidence",
+    )
     try:
+        id_to_name = {
+            rid: name
+            for rid, name in session.query(
+                ChannelPipelineRule.id, ChannelPipelineRule.name
+            )
+        }
+        preserved_reviews: list[dict] = []
+        for rv in session.query(EventSyncReview).all():
+            rule_name = id_to_name.get(rv.rule_id)
+            if rule_name is None:
+                continue
+            preserved_reviews.append({
+                "rule_name": rule_name,
+                **{f: getattr(rv, f) for f in _REVIEW_FIELDS},
+            })
+
         session.query(ChannelPipelineRule).delete()
+        # Clear the review table explicitly rather than relying on the FK
+        # CASCADE — deterministic regardless of the connection's
+        # foreign_keys pragma, and the captured rows above are re-inserted
+        # with the restored rules' new ids below.
+        session.query(EventSyncReview).delete()
         for item in items:
             # ti939.1.3: the export (to_dict) carries event_sync_config as a
             # parsed dict — re-serialize for the Text column. Dropping it
@@ -2497,6 +2529,48 @@ def _restore_auto_creation_rules(items: list) -> dict:
                 ),
             )
             session.add(rule)
+        session.flush()  # assign ids to the recreated rules
+
+        # bead 8fq6x: re-attach the preserved review decisions to the restored
+        # rule by NAME. Rows whose rule is not in the restore set are dropped
+        # (warned). Dedup on (new_rule_id, fingerprint) so duplicate rule
+        # names can't collapse two rules' rows onto one id and violate the
+        # unique-fingerprint constraint.
+        name_to_new_id: dict[str, int] = {}
+        for rid, name in (
+            session.query(ChannelPipelineRule.id, ChannelPipelineRule.name)
+            .order_by(ChannelPipelineRule.id)
+        ):
+            name_to_new_id.setdefault(name, rid)  # lowest id wins
+        seen: set = set()
+        rekeyed = 0
+        orphaned = 0
+        for pr in preserved_reviews:
+            new_id = name_to_new_id.get(pr["rule_name"])
+            if new_id is None:
+                orphaned += 1
+                continue
+            key = (
+                new_id, pr["provider_id"], pr["stream_name_hash"],
+                pr["event_key"],
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            session.add(EventSyncReview(
+                rule_id=new_id, **{f: pr[f] for f in _REVIEW_FIELDS}
+            ))
+            rekeyed += 1
+        if orphaned:
+            warnings.append(
+                f"{orphaned} Event Sync review decision(s) dropped on restore: "
+                f"their rule is not in the restored set."
+            )
+        if rekeyed:
+            logger.info(
+                "[BACKUP] Re-keyed %s Event Sync review decision(s) onto "
+                "restored rules by name", rekeyed,
+            )
         session.commit()
         return {"warnings": warnings}
     except Exception:

--- a/backend/tests/routers/test_event_sync_persistence_roundtrip.py
+++ b/backend/tests/routers/test_event_sync_persistence_roundtrip.py
@@ -111,6 +111,66 @@ class TestDbasRestoreRoundTrip:
         )
         assert restored.get_event_sync_config() == _event_sync_config()
 
+    def test_restore_preserves_answered_review_decisions_by_name(self, test_session):
+        """bead 8fq6x: an ANSWERED accept/reject decision survives a config
+        restore, re-keyed onto the recreated rule by NAME (the rule_id FK
+        breaks across delete+recreate; the fingerprint is content-based)."""
+        from routers.backup import _restore_auto_creation_rules
+        from models import EventSyncReview
+
+        rule = _create_rule(test_session, name="RoundTrip")
+        test_session.add(EventSyncReview(
+            rule_id=rule.id, provider_id=7, stream_name_hash="hash-abc",
+            event_key="evt-xyz", status="accepted",
+            created_at=1000, last_seen_at=1000, resolved_at=1200,
+            resolution_source="operator", evidence="{}",
+        ))
+        test_session.commit()
+        exported = rule.to_dict()
+
+        with patch("routers.backup.get_session", return_value=test_session):
+            result = _restore_auto_creation_rules([exported])
+
+        assert result["warnings"] == []
+        restored = test_session.query(ChannelPipelineRule).filter(
+            ChannelPipelineRule.name == "RoundTrip"
+        ).one()
+        rows = test_session.query(EventSyncReview).filter(
+            EventSyncReview.rule_id == restored.id
+        ).all()
+        assert len(rows) == 1, "answered review decision was not preserved"
+        assert rows[0].status == "accepted"
+        assert rows[0].event_key == "evt-xyz"
+        assert rows[0].provider_id == 7
+
+    def test_restore_drops_review_rows_for_a_rule_not_in_the_set(self, test_session):
+        """A review whose rule is absent from the restore set is dropped with
+        a warning (its rule no longer exists to re-key onto)."""
+        from routers.backup import _restore_auto_creation_rules
+        from models import EventSyncReview
+
+        keep = _create_rule(test_session, name="Keep")
+        gone = _create_rule(test_session, name="Gone")
+        for r in (keep, gone):
+            test_session.add(EventSyncReview(
+                rule_id=r.id, provider_id=1, stream_name_hash=f"h-{r.name}",
+                event_key="evt", status="rejected",
+                created_at=1, last_seen_at=1, evidence="{}",
+            ))
+        test_session.commit()
+
+        # Restore only "Keep".
+        with patch("routers.backup.get_session", return_value=test_session):
+            result = _restore_auto_creation_rules([keep.to_dict()])
+
+        assert any("dropped on restore" in w for w in result["warnings"])
+        restored = test_session.query(ChannelPipelineRule).filter(
+            ChannelPipelineRule.name == "Keep"
+        ).one()
+        all_rows = test_session.query(EventSyncReview).all()
+        assert len(all_rows) == 1
+        assert all_rows[0].rule_id == restored.id
+
     def test_restore_standard_rule_stays_standard(self, test_session):
         from routers.backup import _restore_auto_creation_rules
 

--- a/backend/tests/unit/test_event_sync_attach_execution.py
+++ b/backend/tests/unit/test_event_sync_attach_execution.py
@@ -794,6 +794,60 @@ class TestEnginePhaseAutoRun:
         assert results["event_sync"][0]["attached"] == 1
 
 
+class TestUnattendedGatesEnqueueNothing:
+    """bead odnnf: a gated unattended run (tripped circuit breaker OR failed
+    pre-flight) must enqueue NOTHING to the review queue — pinned directly by
+    asserting enqueue_review_candidates is never called, not merely inferred
+    from the attach path being skipped. Uses an AMBIGUOUS stream so a run that
+    reached the enqueue step WOULD enqueue."""
+
+    def _ambiguous_setup(self):
+        channels = [
+            _master_channel(100, MASTER_MERCURY, streams=[9001]),
+            _master_channel(101, MASTER_IMSA, streams=[9002]),
+        ]
+        batch = [{"id": 7002, "name": STREAM_IMSA_AMBIG, "m3u_account": 1}]
+        return _engine_with_client(channels, batch)
+
+    def test_tripped_breaker_enqueues_nothing(self):
+        engine, executor, client = self._ambiguous_setup()
+        client.get_all_m3u_group_settings = AsyncMock(
+            return_value=GROUP_SETTINGS_OK
+        )
+        results = _results()
+        with patch("tasks.channel_pipeline._run_on_refresh_suppressed",
+                   return_value=(True, "circuit_breaker")), \
+             patch("services.event_sync_review_store."
+                   "enqueue_review_candidates") as enq:
+            _run(engine._run_event_sync_rules(
+                [_event_rule(config=_config(auto_run=True))],
+                executor, results, dry_run=False,
+                triggered_by="m3u_refresh", channels_touched_ids=set(),
+            ))
+        enq.assert_not_called()
+
+    def test_failed_preflight_enqueues_nothing(self):
+        engine, executor, client = self._ambiguous_setup()
+        client.get_all_m3u_group_settings = AsyncMock(
+            return_value=GROUP_SETTINGS_MASTER_OFF  # master auto-sync OFF
+        )
+        results = _results()
+        with _breaker_clear(), \
+             patch("services.event_sync_review_store."
+                   "enqueue_review_candidates") as enq:
+            _run(engine._run_event_sync_rules(
+                [_event_rule(config=_config(auto_run=True))],
+                executor, results, dry_run=False,
+                triggered_by="m3u_refresh", channels_touched_ids=set(),
+            ))
+        enq.assert_not_called()
+        # The pre-flight failure is surfaced, not silent.
+        assert any(
+            w["type"] == "event_sync_preflight_failed"
+            for w in results["event_sync_warnings"]
+        )
+
+
 class TestParseMasterFromStream:
     """bead parse-from-stream: master identity read from the attached stream,
     so a cleanly-named master channel still matches via its timed stream."""

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0075",
+  "version": "0.17.6-0076",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.test.tsx
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.test.tsx
@@ -89,6 +89,35 @@ describe('ChannelPipelineTab', () => {
       });
     });
 
+    it('Event Sync badge tooltip reflects auto_run state (bead xeli0)', async () => {
+      mockDataStore.channelPipelineRules.push(
+        createMockChannelPipelineRule({
+          name: 'AutoRun ES',
+          event_sync_config: {
+            master_group_id: 1, secondary_group_ids: [2], auto_run: true,
+          },
+        }),
+        createMockChannelPipelineRule({
+          name: 'Manual ES',
+          event_sync_config: {
+            master_group_id: 1, secondary_group_ids: [2], auto_run: false,
+          },
+        })
+      );
+
+      renderWithProviders(<ChannelPipelineTab />);
+      await waitFor(() => expect(screen.getByText('AutoRun ES')).toBeInTheDocument());
+
+      const autoRow = screen.getByText('AutoRun ES').closest('tr');
+      const manualRow = screen.getByText('Manual ES').closest('tr');
+      expect(
+        within(autoRow!).getByText('Event Sync').getAttribute('title')
+      ).toContain('automatically after each M3U refresh');
+      expect(
+        within(manualRow!).getByText('Event Sync').getAttribute('title')
+      ).toContain('never on unattended refresh');
+    });
+
     it('shows rule enabled/disabled status', async () => {
       mockDataStore.channelPipelineRules.push(
         createMockChannelPipelineRule({ name: 'Enabled Rule', enabled: true }),

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
@@ -887,7 +887,11 @@ export function ChannelPipelineTab() {
                           {rule.event_sync_config && (
                             <span
                               className="badge badge-sm badge-info rule-kind-badge"
-                              title="Event Sync rule — attaches streams on MANUAL pipeline runs only (never on unattended refresh); attaches are journaled and reversible via rollback"
+                              title={
+                                rule.event_sync_config.auto_run
+                                  ? 'Event Sync rule — attaches streams on manual pipeline runs AND automatically after each M3U refresh (auto-run is ON); attaches are journaled and reversible via rollback'
+                                  : 'Event Sync rule — attaches streams on MANUAL pipeline runs only (never on unattended refresh); attaches are journaled and reversible via rollback'
+                              }
                             >
                               Event Sync
                             </span>

--- a/frontend/src/components/channelPipeline/EventSyncReviewQueue.css
+++ b/frontend/src/components/channelPipeline/EventSyncReviewQueue.css
@@ -51,6 +51,29 @@
   font-size: 13px;
 }
 
+/* Contested-pairing caution (bead 8rzkq): rejecting one side may auto-attach
+   the sibling — surface it inline on contested cards so the reject is not a
+   surprise. */
+.event-sync-review-contested-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0 0 10px;
+  padding: 8px 12px;
+  border: 1px solid var(--border-warning, var(--border-primary));
+  border-radius: 6px;
+  background: var(--bg-warning-subtle, var(--bg-secondary));
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  line-height: 1.4;
+}
+
+.event-sync-review-contested-note .material-icons {
+  font-size: 18px;
+  flex-shrink: 0;
+  color: var(--text-warning, var(--text-secondary));
+}
+
 .event-sync-review-list {
   list-style: none;
   margin: 0;

--- a/frontend/src/components/channelPipeline/EventSyncReviewQueue.test.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncReviewQueue.test.tsx
@@ -114,6 +114,27 @@ describe('EventSyncReviewQueue — evidence rendering', () => {
       await screen.findByText('No pairings awaiting review'),
     ).toBeInTheDocument();
   });
+
+  it('warns on contested rows that rejecting may auto-attach the sibling (bead 8rzkq)', async () => {
+    mockList([makeRecord()]); // default record is contested
+    render(<EventSyncReviewQueue />);
+    expect(
+      await screen.findByText(/rejecting this pairing may let the other/i),
+    ).toBeInTheDocument();
+  });
+
+  it('omits the contested warning on a non-contested (band) ambiguity', async () => {
+    const rec = makeRecord();
+    mockList([{
+      ...rec,
+      evidence: { ...rec.evidence, ambiguous_reason: 'top_candidate_ambiguous_band' },
+    }]);
+    render(<EventSyncReviewQueue />);
+    await screen.findByText('Fury vs. Usyk'); // wait for the card to render
+    expect(
+      screen.queryByText(/rejecting this pairing may let the other/i),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe('EventSyncReviewQueue — accept', () => {

--- a/frontend/src/components/channelPipeline/EventSyncReviewQueue.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncReviewQueue.tsx
@@ -292,6 +292,19 @@ export function EventSyncReviewQueue() {
                   )}
                 </div>
 
+                {ev.ambiguous_reason === 'contested_top_candidates' && (
+                  <p className="event-sync-review-contested-note" role="note">
+                    <span className="material-icons" aria-hidden="true">info</span>
+                    <span>
+                      Contested between two masters. Rejecting this pairing may
+                      let the other (sibling) master attach automatically on the
+                      next run if that pairing scores in the attach band —
+                      rejecting one side is how you steer the stream to the
+                      other.
+                    </span>
+                  </p>
+                )}
+
                 <div className="event-sync-review-actions">
                   <button
                     type="button"

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -158,6 +158,7 @@ export function createMockChannelPipelineRule(overrides: Partial<MockChannelPipe
     match_count: overrides.match_count ?? 0,
     created_at: overrides.created_at ?? new Date().toISOString(),
     updated_at: overrides.updated_at ?? new Date().toISOString(),
+    event_sync_config: overrides.event_sync_config ?? null,
   }
 }
 
@@ -327,6 +328,7 @@ interface MockChannelPipelineRule {
   match_count: number
   created_at: string
   updated_at: string
+  event_sync_config?: object | null
 }
 
 interface MockChannelPipelineExecution {


### PR DESCRIPTION
## Summary

Four small Event Sync follow-ups surfaced in the PR #622 / #626 reviews — a tooltip bug, a UX caution, a restore data-loss fix, and a test pin. All are narrow and independent.

- **`xeli0`** (bug) — the rules-list kind-badge tooltip hardcoded "never on unattended refresh", which is **false** for an `auto_run: true` rule (auto-run shipped in ti939.3.1). The tooltip is now conditional on `event_sync_config.auto_run`.
- **`8rzkq`** (UX copy) — contested review-queue cards now show an inline caution that **rejecting one pairing may auto-attach the sibling** (the survivor was always attach-band), so the reject isn't a surprise.
- **`8fq6x`** (data-loss fix) — a DBAS config restore deletes all pipeline rules, and the `event_sync_reviews` FK CASCADE dropped **every** review row, including *answered* accept/reject decisions. Restore now **captures the review rows before the delete and re-keys them onto the recreated rule by NAME** (fingerprints are content-based and survive; only the `rule_id` FK breaks). Rows whose rule isn't in the restore set are dropped with a warning. Deterministic regardless of the connection's `foreign_keys` pragma (explicit review-table clear).
- **`odnnf`** (test-only) — direct pin that a gated unattended run (tripped circuit breaker **or** failed pre-flight) enqueues **nothing** to the review queue (previously only inferred from the attach path being skipped).

## Testing
- Backend: restore re-key + orphan-drop, and enqueue-nothing under breaker/preflight — full suite green.
- Frontend: tooltip auto-run states, contested-note presence/absence — 58 component tests green; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
