### PR TITLE
v0.17.6-0077: Event Sync same-named-group usability + more dateless parse shapes (3ux85, uwm8d)

### DIFF
--- a/backend/channel_pipeline_schema.py
+++ b/backend/channel_pipeline_schema.py
@@ -955,17 +955,33 @@ def validate_event_sync_config(config: Any) -> list[str]:
             "(auto_channel_sync ON)",
         ))
 
+    # bead 3ux85: an empty secondary list is allowed ONLY when the master
+    # group is itself the stream source (include_master_group_streams) — the
+    # pure same-named cross-provider case, where Dispatcharr collapses both
+    # providers into ONE channel group (ChannelGroup.name is unique) so there
+    # is no separate secondary group to pick. The rule stays SCOPED (to the
+    # master group), so the anti-unscoped-matching rail is intact.
+    include_master_streams = config.get("include_master_group_streams") is True
     secondary_group_ids = config.get("secondary_group_ids")
+    if secondary_group_ids is None and include_master_streams:
+        secondary_group_ids = config["secondary_group_ids"] = []
     if (not isinstance(secondary_group_ids, list)
-            or not secondary_group_ids
             or not all(_is_group_id(g) for g in secondary_group_ids)):
         errors.append(_event_sync_error(
             "secondary_group_ids", secondary_group_ids,
-            "a non-empty list of positive integer group IDs — the "
-            "secondary event groups (auto_channel_sync OFF) whose streams "
-            "attach to master channels; an unscoped event rule is refused",
+            "a list of positive integer group IDs — the secondary event "
+            "groups (auto_channel_sync OFF) whose streams attach to master "
+            "channels",
         ))
         secondary_group_ids = []
+    elif not secondary_group_ids and not include_master_streams:
+        errors.append(_event_sync_error(
+            "secondary_group_ids", secondary_group_ids,
+            "a non-empty list of positive integer group IDs — an unscoped "
+            "event rule is refused. (An empty list is allowed only when "
+            "include_master_group_streams is true, so the master group is "
+            "itself the self-attach stream source.)",
+        ))
     elif _is_group_id(master_group_id) and master_group_id in secondary_group_ids:
         errors.append(_event_sync_error(
             "secondary_group_ids", secondary_group_ids,

--- a/backend/main.py
+++ b/backend/main.py
@@ -140,7 +140,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0076",
+    version="0.17.6-0077",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -75,7 +75,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0076"
+APP_VERSION = "0.17.6-0077"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/services/event_sync_matcher.py
+++ b/backend/services/event_sync_matcher.py
@@ -334,39 +334,44 @@ DEFAULT_EVENT_PATTERNS: tuple[dict, ...] = (
 
 _BARE_SLOT = r"(?:[^@:|(]{0,40}?(?<!\d)\d{1,2}\s*[:\-]\s*)?"
 
+# Optional "@"/"|" that some providers place between the title and a
+# dateless time ("Title @ 06:00 PM ET") — consumed so it never rides into
+# the parsed title.
+_DATELESS_TIME_LEAD = r"(?:[@|]\s*)?"
+
 _ASSUME_DATE_PATTERNS: tuple[dict, ...] = (
-    # Time-of-day at the END, am/pm form: "6PM" / "4:15pm" / "12am".
+    # Time-of-day at the END, am/pm form: "6PM" / "4:15pm" / "@ 06:00 PM ET".
     {
         "name": "dateless-title-time-ampm",
         "title_pattern": (
-            r"^" + _BARE_SLOT + r"\s*(?P<title>.+?)\s+"
-            r"\d{1,2}(?::\d{2})?\s*[AaPp]\.?[Mm]?\.?(?:\s*E[SD]?T)?\s*$"
+            r"^" + _BARE_SLOT + r"\s*(?P<title>.+?)\s+" + _DATELESS_TIME_LEAD
+            + r"\d{1,2}(?::\d{2})?\s*[AaPp]\.?[Mm]?\.?(?:\s*E[SD]?T)?\s*$"
         ),
         "time_pattern": (
             r"(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?"
             r"\s*(?P<ampm>[AaPp])\.?[Mm]?\.?(?:\s*E[SD]?T)?\s*$"
         ),
     },
-    # Time-of-day at the END, 24h form: "19:00" / "18:30 ET".
+    # Time-of-day at the END, 24h form: "19:00" / "18:30 ET" / "@ 18:30 ET".
     {
         "name": "dateless-title-time-24h",
         "title_pattern": (
-            r"^" + _BARE_SLOT + r"\s*(?P<title>.+?)\s+"
-            r"\d{1,2}:\d{2}(?:\s*E[SD]?T)?\s*$"
+            r"^" + _BARE_SLOT + r"\s*(?P<title>.+?)\s+" + _DATELESS_TIME_LEAD
+            + r"\d{1,2}:\d{2}(?:\s*E[SD]?T)?\s*$"
         ),
         "time_pattern": r"(?P<hour>\d{1,2}):(?P<minute>\d{2})(?:\s*E[SD]?T)?\s*$",
     },
-    # Time-of-day FIRST after a "-"/"|" separator: "LIVE EVENT 05 - 4:15pm
-    # <title>". am/pm required here (a leading 24h "HH:MM" is too easily a
-    # score/round number).
+    # Time-of-day FIRST after a ":"/"-"/"|" slot separator: "PPV 06: 4:15pm
+    # <title>", "LIVE EVENT 05 - 4:15pm <title>". am/pm REQUIRED here (a
+    # leading 24h "HH:MM" is too easily a score/round number/slot).
     {
         "name": "dateless-time-first",
         "title_pattern": (
-            r"^.*?[-|]\s*\d{1,2}(?::\d{2})?\s*[AaPp]\.?[Mm]?\.?\s+"
+            r"^.*?[:\-|]\s*\d{1,2}(?::\d{2})?\s*[AaPp]\.?[Mm]?\.?\s+"
             r"(?P<title>.+?)\s*$"
         ),
         "time_pattern": (
-            r"[-|]\s*(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?"
+            r"[:\-|]\s*(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?"
             r"\s*(?P<ampm>[AaPp])\.?[Mm]?\.?"
         ),
     },

--- a/backend/tests/services/test_event_sync_matcher.py
+++ b/backend/tests/services/test_event_sync_matcher.py
@@ -327,6 +327,29 @@ class TestParseEventName:
         )
         assert parsed.start is None
 
+    @pytest.mark.parametrize(
+        ("name", "expected_title", "hour", "minute"),
+        [
+            # bead uwm8d: time-FIRST after a colon slot (no dash).
+            ("PPV 06: 4:15pm Zenith Racing Series Road America",
+             "Zenith Racing Series Road America", 16, 15),
+            ("PPV 08: 6pm DIRTcar Summer Nationals Late Model Crystal",
+             "DIRTcar Summer Nationals Late Model Crystal", 18, 0),
+            # "@ <time>" dateless — the "@" is consumed, not left in the title.
+            ("PPV01: Crystal Motor Speedway @ 06:00 PM EDT",
+             "Crystal Motor Speedway", 18, 0),
+        ],
+    )
+    def test_dateless_colon_slot_and_at_time_formats(
+        self, name, expected_title, hour, minute
+    ):
+        parsed = parse_event_name(name, now=_NOW, assume_current_date=True)
+        assert parsed.title == expected_title
+        assert parsed.start is not None
+        assert (parsed.start.hour, parsed.start.minute) == (hour, minute)
+        # never-guess preserved without the flag
+        assert parse_event_name(name, now=_NOW).start is None
+
     def test_pipe_delimited_name_with_weekday_and_region_marker_parses(self):
         # bead 9c9j7: live pipe-delimited listing shape that produced
         # "Incomplete date/time" — "|" delimiter, a "Sun" weekday prefix, a

--- a/backend/tests/unit/test_event_sync_config_schema.py
+++ b/backend/tests/unit/test_event_sync_config_schema.py
@@ -376,6 +376,24 @@ class TestIncludeMasterGroupStreamsFlag:
         errors = validate_event_sync_config(config)
         assert any("secondary_group_ids" in e for e in errors)
 
+    def test_empty_secondary_allowed_with_flag(self):
+        # bead 3ux85: the pure same-named-group case — master group is the
+        # only stream source, so an empty secondary list is valid WITH the
+        # flag on (and both None and [] normalize to []).
+        for empty in ([], None):
+            config = _valid_config(include_master_group_streams=True)
+            if empty is None:
+                del config["secondary_group_ids"]
+            else:
+                config["secondary_group_ids"] = empty
+            assert validate_event_sync_config(config) == []
+            assert config["secondary_group_ids"] == []
+
+    def test_empty_secondary_rejected_without_flag(self):
+        config = _valid_config(secondary_group_ids=[])
+        errors = validate_event_sync_config(config)
+        assert any("secondary_group_ids" in e for e in errors)
+
 
 class TestAssumeCurrentDateFlag:
     """assume_current_date flag (bead assume-current-date — dateless opt-in).

--- a/docs/event_sync.md
+++ b/docs/event_sync.md
@@ -290,9 +290,12 @@ risk, set **`assume_current_date: true`** on the rule (in the editor:
 a listing that carries a time but no date is placed on the **current date**
 (in the rule's timezone) so it becomes matchable. Both the master and
 secondary sides share the same "today", so their times compare on one day.
-The built-in dateless shapes cover `… TITLE 6PM` / `… TITLE 19:00` (time
-last) and `… - 4:15pm TITLE` (time first); a bare time must carry a colon or
-an am/pm marker so a lone number in a title is never mistaken for a time.
+The built-in dateless shapes cover `… TITLE 6PM` / `… TITLE 19:00` /
+`… TITLE @ 06:00 PM ET` (time last, an optional `@`/`|` before the time is
+stripped) and time-first after a `:`/`-`/`|` slot separator
+(`PPV 06: 4:15pm TITLE`, `LIVE EVENT 05 - 4:15pm TITLE`); a bare time must
+carry a colon or an am/pm marker so a lone number in a title is never
+mistaken for a time.
 
 **The risk:** a listing that is really for a *different* day (a replay at the
 same time-of-day tomorrow) can mis-match — the ±`time_window_minutes` window
@@ -334,7 +337,7 @@ the rule.
 | Field | Required | Meaning |
 |-|-|-|
 | `master_group_id` | yes | The ONE Dispatcharr group whose channels Dispatcharr owns (`auto_channel_sync` ON). Positive integer group ID. |
-| `secondary_group_ids` | yes, non-empty | The secondary event groups (`auto_channel_sync` OFF) whose streams get matched onto master channels. Must NOT contain `master_group_id`. |
+| `secondary_group_ids` | yes* | The secondary event groups (`auto_channel_sync` OFF) whose streams get matched onto master channels. Must NOT contain `master_group_id`. *May be **empty** when `include_master_group_streams` is true — then the master group is itself the stream source (bead 3ux85). |
 | `patterns` | no | Shared parse-pattern variants (title/time/date regexes with named capture groups, same shape as the built-in defaults in `backend/services/event_sync_matcher.py`). Omit to use the built-in defaults. API-authored arrays survive UI resaves: the rule editor round-trips the full array (an untouched save emits it verbatim; patterns beyond the one custom slot the UI can edit are preserved read-only, and built-ins are never silently re-added to an all-custom selection). |
 | `group_patterns` | no | Per-group pattern overrides, keyed by group ID (master or a secondary). A group with an override uses ONLY its own patterns for parsing; other groups keep the shared `patterns` selection. Multi-pattern lists round-trip through the UI the same way as `patterns` (the editor edits only the first pattern per group; the rest are preserved). |
 | `time_window_minutes` | no (default 30) | Parsed start times must be within ± this window to become candidate pairs. Capped at 1440 (24 hours). |
@@ -374,27 +377,33 @@ value you sent, what was expected, and a link back to this document.
 
 ### Two providers, one group name
 
-Dispatcharr channel groups are **global and unique by name**: if two M3U
-providers both carry a group called `Live Events`, their streams land in the
-*same* channel group — one group ID. That means you cannot pick provider A's
-`Live Events` as the master and provider B's `Live Events` as a secondary;
-the group picker shows one entry, and choosing it as master removes it from
-the secondary list (a group cannot be both — the mandatory-scoping rail).
+Dispatcharr channel-group names are **globally unique** — its `ChannelGroup`
+model declares `name = models.TextField(unique=True)`, and per-provider
+settings (`auto_channel_sync`, `enabled`) live in a `ChannelGroupM3UAccount`
+junction. So if two M3U providers both carry a group called `MLB PPV`, their
+streams land in the **same** channel group — one group ID with two junction
+rows (provider A: sync ON, provider B: sync OFF). There is no second group to
+pick: the picker shows one entry, and it correctly cannot be both master and
+secondary. **This is not an ECM limitation — Dispatcharr cannot represent two
+same-named groups.**
 
 `include_master_group_streams` is the sanctioned path for exactly this case:
 
-1. Leave the shared group as the **master** (`auto_channel_sync` ON) so
-   Dispatcharr owns one channel per event, built from provider A's streams.
+1. Pick the shared group as the **master** (`auto_channel_sync` ON via
+   provider A) so Dispatcharr owns one channel per event.
 2. Set `include_master_group_streams: true` (in the rule editor: **"Also
    attach the master group's own streams"** under Advanced).
+3. **Leave `secondary_group_ids` empty** — with the flag on, the master group
+   is itself the stream source, so no separate secondary is required (bead
+   3ux85). The editor's Save is enabled with no secondary once the flag is on.
 
 On each run the master group's own streams are matched to the master
-channels alongside the secondary groups. Streams **already attached** to a
-master channel — provider A's own — are skipped by the resolver, so only
-provider B's still-unattached streams attach. Preview and run stay in
-lockstep (the preview's *would attach* count already excludes the
-already-attached streams), and the master group is **never** added to
-`secondary_group_ids` — that rail is untouched.
+channels. Streams **already attached** to a master channel — provider A's own
+— are skipped by the resolver, so only provider B's still-unattached streams
+attach. Preview and run stay in lockstep (the preview's *would attach* count
+already excludes the already-attached streams). The master group is **never**
+added to `secondary_group_ids` — the empty list plus the flag is the scoped
+path, so the anti-unscoped-matching rail is untouched.
 
 If you would rather keep the two providers fully separate, the alternative
 is to **rename one provider's group** in Dispatcharr (a group override) so

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0076",
+  "version": "0.17.6-0077",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
@@ -194,6 +194,47 @@ describe('EventSyncRuleEditor', () => {
   });
 
   describe('master-group self-attach (bead 6xxmp)', () => {
+    it('saves with an EMPTY secondary list when the flag is on (bead 3ux85)', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onSave = vi.fn();
+      const rule = {
+        ...EXISTING_RULE,
+        event_sync_config: {
+          ...EXISTING_RULE.event_sync_config!,
+          secondary_group_ids: [],
+          include_master_group_streams: true,
+        },
+      };
+      render(<EventSyncRuleEditor rule={rule} onSave={onSave} onCancel={vi.fn()} />);
+
+      // No secondary selected + flag on => save is allowed.
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+      const cfg = onSave.mock.calls[0][0].event_sync_config;
+      expect(cfg.secondary_group_ids).toEqual([]);
+      expect(cfg.include_master_group_streams).toBe(true);
+    });
+
+    it('blocks save with an empty secondary list when the flag is OFF', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onSave = vi.fn();
+      const rule = {
+        ...EXISTING_RULE,
+        event_sync_config: {
+          ...EXISTING_RULE.event_sync_config!,
+          secondary_group_ids: [],
+        },
+      };
+      render(<EventSyncRuleEditor rule={rule} onSave={onSave} onCancel={vi.fn()} />);
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
     it('defaults OFF and omits include_master_group_streams when never set', async () => {
       const user = userEvent.setup();
       seedGroups();

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
@@ -450,7 +450,13 @@ export function EventSyncRuleEditor({
 
   const validationError: string | null = (() => {
     if (masterGroupId == null) return 'Pick a master group first';
-    if (secondaryGroupIds.length === 0) return 'Pick at least one secondary group';
+    // bead 3ux85: no separate secondary is required when the master group is
+    // itself the stream source (include_master_group_streams) — the
+    // same-named cross-provider case.
+    if (secondaryGroupIds.length === 0 && !includeMasterGroupStreams) {
+      return 'Pick at least one secondary group (or enable '
+        + '"Also attach the master group’s own streams" under Advanced)';
+    }
     if (effectivePatterns.length === 0) {
       return 'Select at least one parse pattern (or add a custom one)';
     }
@@ -459,7 +465,12 @@ export function EventSyncRuleEditor({
 
   /** Build the event_sync_config from the current form state. */
   const buildConfig = (): EventSyncConfig | null => {
-    if (masterGroupId == null || secondaryGroupIds.length === 0) return null;
+    // bead 3ux85: a secondary group is required UNLESS the master group is
+    // itself the stream source (include_master_group_streams) — the pure
+    // same-named cross-provider case, where Dispatcharr collapses both
+    // providers into one channel group so there is no separate secondary.
+    if (masterGroupId == null) return null;
+    if (secondaryGroupIds.length === 0 && !includeMasterGroupStreams) return null;
 
     const built: EventSyncConfig = {
       master_group_id: masterGroupId,
@@ -1064,12 +1075,14 @@ export function EventSyncRuleEditor({
                 <span className="form-hint">
                   Off by default. Turn this on when a second provider&apos;s
                   streams live in the <em>same-named</em> channel group as the
-                  master (Dispatcharr merges same-named groups into one, so
-                  they cannot be picked as a separate secondary). When on, the
-                  master group&apos;s streams are matched to the master
-                  channels too; streams already attached (the auto-synced
-                  provider&apos;s own) are skipped, so only the unsynced
-                  provider&apos;s streams attach.
+                  master (Dispatcharr requires channel-group names to be
+                  unique, so both providers share <strong>one</strong> group —
+                  it cannot be picked twice). When on, the master group&apos;s
+                  streams are matched to the master channels too; streams
+                  already attached (the auto-synced provider&apos;s own) are
+                  skipped, so only the unsynced provider&apos;s streams attach.
+                  <strong> With this on you can leave the secondary list empty</strong>
+                  {' '}— the master group is the stream source.
                 </span>
               </div>
 


### PR DESCRIPTION
## Summary

Two operator-reported Event Sync gaps.

### `3ux85` — the real same-named cross-provider group fix
Verified against **Dispatcharr's source**: `ChannelGroup.name = models.TextField(unique=True)`, and per-provider `auto_channel_sync`/`enabled` live in the `ChannelGroupM3UAccount` junction. So two providers' "MLB PPV" is **one** channel group — there is no second group to pick, and that's a Dispatcharr constraint, not ECM's.

`include_master_group_streams` was the right mechanism, but the schema still required a **non-empty** `secondary_group_ids`, so the pure same-group case (attach only the *other* provider's streams, which live in the same group as master) couldn't be saved. Now: **with `include_master_group_streams: true`, `secondary_group_ids` may be empty** — the master group is itself the scoped stream source. Editor Save enables with no secondary once the flag is on; hint copy explains it. The rule stays scoped to the master group, so the anti-unscoped-matching rail is intact.

### `uwm8d` — more dateless parse shapes (opt-in via `assume_current_date`)
Live PPV feeds that failed even with the flag now parse:
- time-first after a `:`/`-`/`|` slot — `PPV 06: 4:15pm TITLE`, `PPV 08: 6pm TITLE`
- `@ <time>` / `| <time>` dateless — `Crystal Motor Speedway @ 06:00 PM ET` (leading `@`/`|` stripped from the title)

Still gated behind `assume_current_date`; never-guess preserved with the flag off (0 leaks in testing).

## Testing
Full backend suite green. New tests: schema (empty-secondary allowed with flag / rejected without), matcher (colon-slot + @-time dateless, flag-off = None), editor (empty-secondary save enabled with flag, blocked without). Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
