### PR TITLE
v0.17.6-0078: Event Sync provider-scoped groups P1 — nested config schema + auto-upgrade (Option A)

### DIFF
--- a/backend/channel_pipeline_schema.py
+++ b/backend/channel_pipeline_schema.py
@@ -777,6 +777,11 @@ class TemplateVariables:
 # rejected — a typo'd optional key ("attach_treshold") would otherwise
 # silently fall back to its default, which for a threshold is a safety knob.
 _EVENT_SYNC_ALLOWED_KEYS = frozenset({
+    # Provider-scoped canonical shape (bead 3p2af).
+    "master",
+    "secondary",
+    # Legacy flat shape — still accepted as input and kept in sync as derived
+    # keys so existing readers work (validate upgrades legacy -> nested).
     "master_group_id",
     "secondary_group_ids",
     "patterns",
@@ -892,6 +897,30 @@ def _is_group_id(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and value >= 1
 
 
+def _is_provider_id(value: Any) -> bool:
+    """m3u_account_id: a positive int, or None (= whole group / any provider)."""
+    return value is None or _is_group_id(value)
+
+
+def _normalize_scope(raw: Any) -> dict | None:
+    """Normalize one provider-scoped group to ``{group_id, m3u_account_id}``.
+
+    Accepts the nested form (``{"group_id": int, "m3u_account_id": int|null}``)
+    or a bare integer group id (legacy shape — upgraded here on read, so no
+    data migration is needed). Returns ``None`` when the shape is invalid.
+    ``m3u_account_id`` of ``None`` means "the whole group / any provider" —
+    the pre-provider-scope behavior.
+    """
+    if _is_group_id(raw):
+        return {"group_id": raw, "m3u_account_id": None}
+    if isinstance(raw, dict):
+        gid = raw.get("group_id")
+        pid = raw.get("m3u_account_id")
+        if _is_group_id(gid) and _is_provider_id(pid):
+            return {"group_id": gid, "m3u_account_id": pid}
+    return None
+
+
 def validate_event_sync_config(config: Any) -> list[str]:
     """Validate (and default-fill) an event_sync rule config at save time.
 
@@ -945,50 +974,97 @@ def validate_event_sync_config(config: Any) -> list[str]:
             f"only the keys {sorted(_EVENT_SYNC_ALLOWED_KEYS)}",
         ))
 
-    # --- Mandatory scoping (the anti-1,341 rail) -------------------------
-    master_group_id = config.get("master_group_id")
-    if not _is_group_id(master_group_id):
+    # --- Mandatory scoping (provider-scoped, beads 3p2af/2c2vz) ----------
+    # Canonical shape is nested and provider-scoped:
+    #   master:    {group_id, m3u_account_id}
+    #   secondary: [{group_id, m3u_account_id}, ...]
+    # ``m3u_account_id`` is None for "the whole group / any provider" (the
+    # pre-provider-scope behavior). A legacy flat config
+    # ({master_group_id, secondary_group_ids}) is UPGRADED here on read (no
+    # data migration). The derived flat keys are kept in sync below so every
+    # existing reader of master_group_id / secondary_group_ids is untouched;
+    # only the provider-aware fetch/preflight read the nested provider ids.
+    include_master_streams = config.get("include_master_group_streams") is True
+
+    raw_master = config.get("master")
+    if raw_master is None and "master_group_id" in config:
+        raw_master = config.get("master_group_id")
+    master_scope = _normalize_scope(raw_master)
+    if master_scope is None:
         errors.append(_event_sync_error(
-            "master_group_id", master_group_id,
-            "a positive integer Dispatcharr group ID — the ONE master "
-            "event group whose channels Dispatcharr owns "
-            "(auto_channel_sync ON)",
+            "master_group_id", raw_master,
+            'the master event group as a positive integer group id, or '
+            '{"group_id": <positive int>, "m3u_account_id": <positive int or '
+            "null>} (null = whole group / any provider) — the ONE group whose "
+            "channels Dispatcharr owns (auto_channel_sync ON)",
         ))
 
+    raw_secondary = config.get("secondary")
+    if raw_secondary is None and "secondary_group_ids" in config:
+        raw_secondary = config.get("secondary_group_ids")
     # bead 3ux85: an empty secondary list is allowed ONLY when the master
-    # group is itself the stream source (include_master_group_streams) — the
-    # pure same-named cross-provider case, where Dispatcharr collapses both
-    # providers into ONE channel group (ChannelGroup.name is unique) so there
-    # is no separate secondary group to pick. The rule stays SCOPED (to the
-    # master group), so the anti-unscoped-matching rail is intact.
-    include_master_streams = config.get("include_master_group_streams") is True
-    secondary_group_ids = config.get("secondary_group_ids")
-    if secondary_group_ids is None and include_master_streams:
-        secondary_group_ids = config["secondary_group_ids"] = []
-    if (not isinstance(secondary_group_ids, list)
-            or not all(_is_group_id(g) for g in secondary_group_ids)):
+    # group is itself the stream source (include_master_group_streams).
+    if raw_secondary is None and include_master_streams:
+        raw_secondary = []
+    secondary_scopes: list[dict] = []
+    secondary_ok = True
+    if not isinstance(raw_secondary, list):
+        secondary_ok = False
         errors.append(_event_sync_error(
-            "secondary_group_ids", secondary_group_ids,
-            "a list of positive integer group IDs — the secondary event "
-            "groups (auto_channel_sync OFF) whose streams attach to master "
-            "channels",
+            "secondary_group_ids", raw_secondary,
+            'a list of secondary event groups — each a positive integer group '
+            'id or {"group_id": int, "m3u_account_id": int|null}',
         ))
+    else:
+        for item in raw_secondary:
+            sc = _normalize_scope(item)
+            if sc is None:
+                secondary_ok = False
+                errors.append(_event_sync_error(
+                    "secondary_group_ids", item,
+                    'each secondary as a positive integer group id or '
+                    '{"group_id": int, "m3u_account_id": int|null}',
+                ))
+            else:
+                secondary_scopes.append(sc)
+        if secondary_ok and not secondary_scopes and not include_master_streams:
+            errors.append(_event_sync_error(
+                "secondary_group_ids", raw_secondary,
+                "a non-empty list — an unscoped event rule is refused. (An "
+                "empty list is allowed only when include_master_group_streams "
+                "is true, so the master group is itself the stream source.)",
+            ))
+
+    # The master-not-in-secondary rail is now the (group, provider) PAIR: the
+    # SAME group with a DIFFERENT provider IS a valid secondary (that is the
+    # whole point of provider scoping), but an identical group+provider cannot
+    # be both master and secondary.
+    if master_scope is not None and secondary_ok:
+        m_pair = (master_scope["group_id"], master_scope["m3u_account_id"])
+        if any((sc["group_id"], sc["m3u_account_id"]) == m_pair
+               for sc in secondary_scopes):
+            errors.append(_event_sync_error(
+                "secondary_group_ids", secondary_scopes,
+                "a list whose (group, provider) does not duplicate "
+                "master_group_id's — an identical group+provider cannot be "
+                "both master and secondary. (The same group with a DIFFERENT "
+                "provider IS allowed.)",
+            ))
+
+    # Write canonical nested + derived flat. Downstream readers use the flat
+    # keys (unchanged); provider-aware code reads master/secondary.
+    if master_scope is not None:
+        config["master"] = master_scope
+        config["master_group_id"] = master_group_id = master_scope["group_id"]
+    else:
+        master_group_id = None
+    if secondary_ok:
+        config["secondary"] = secondary_scopes
+        config["secondary_group_ids"] = secondary_group_ids = [
+            sc["group_id"] for sc in secondary_scopes
+        ]
+    else:
         secondary_group_ids = []
-    elif not secondary_group_ids and not include_master_streams:
-        errors.append(_event_sync_error(
-            "secondary_group_ids", secondary_group_ids,
-            "a non-empty list of positive integer group IDs — an unscoped "
-            "event rule is refused. (An empty list is allowed only when "
-            "include_master_group_streams is true, so the master group is "
-            "itself the self-attach stream source.)",
-        ))
-    elif _is_group_id(master_group_id) and master_group_id in secondary_group_ids:
-        errors.append(_event_sync_error(
-            "secondary_group_ids", secondary_group_ids,
-            f"a list that does NOT contain master_group_id "
-            f"{master_group_id} — a group cannot be both the master "
-            f"(Dispatcharr-owned channels) and a secondary (stream source)",
-        ))
 
     # --- Parse patterns (shared and per-group) ---------------------------
     if "patterns" in config:

--- a/backend/main.py
+++ b/backend/main.py
@@ -140,7 +140,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0077",
+    version="0.17.6-0078",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -75,7 +75,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0077"
+APP_VERSION = "0.17.6-0078"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/tests/routers/test_event_sync_persistence_roundtrip.py
+++ b/backend/tests/routers/test_event_sync_persistence_roundtrip.py
@@ -50,6 +50,20 @@ def _event_sync_config(**overrides) -> dict:
         "parse_master_from_stream": False,
     }
     config.update(overrides)
+    # bead 3p2af: the validator normalizes to the nested provider-scoped
+    # canonical shape AND keeps the derived flat keys in sync, so a
+    # round-tripped stored config carries both. Derive the nested shape from
+    # the (possibly overridden) flat keys unless the caller overrode it
+    # directly — so existing flat-key overrides keep taking effect.
+    if "master" not in overrides:
+        config["master"] = {
+            "group_id": config["master_group_id"], "m3u_account_id": None,
+        }
+    if "secondary" not in overrides:
+        config["secondary"] = [
+            {"group_id": g, "m3u_account_id": None}
+            for g in config["secondary_group_ids"]
+        ]
     return config
 
 

--- a/backend/tests/unit/test_event_sync_config_schema.py
+++ b/backend/tests/unit/test_event_sync_config_schema.py
@@ -562,3 +562,76 @@ class TestTeachingErrorFormat:
         errors = validate_event_sync_config(config)
         assert len(errors) >= 6
         assert all("docs/event_sync.md" in e for e in errors)
+
+
+class TestProviderScopedSchema:
+    """Nested provider-scoped shape (bead 3p2af/2c2vz).
+
+    Canonical config is {master:{group_id,m3u_account_id}, secondary:[...]};
+    a legacy flat config auto-upgrades on read (no data migration); the flat
+    keys are kept in sync so existing readers are untouched.
+    """
+
+    def test_legacy_flat_config_upgrades_to_nested(self):
+        config = {"master_group_id": 10, "secondary_group_ids": [20, 30]}
+        assert validate_event_sync_config(config) == []
+        assert config["master"] == {"group_id": 10, "m3u_account_id": None}
+        assert config["secondary"] == [
+            {"group_id": 20, "m3u_account_id": None},
+            {"group_id": 30, "m3u_account_id": None},
+        ]
+        # derived flat keys stay in sync for existing readers
+        assert config["master_group_id"] == 10
+        assert config["secondary_group_ids"] == [20, 30]
+
+    def test_nested_config_derives_flat_keys(self):
+        config = {
+            "master": {"group_id": 10, "m3u_account_id": 3},
+            "secondary": [{"group_id": 10, "m3u_account_id": 7}],
+        }
+        assert validate_event_sync_config(config) == []
+        assert config["master_group_id"] == 10
+        assert config["secondary_group_ids"] == [10]
+        assert config["master"]["m3u_account_id"] == 3
+        assert config["secondary"][0]["m3u_account_id"] == 7
+
+    def test_same_group_different_provider_is_valid(self):
+        # The whole point: master group 10 / provider 3, secondary group 10 /
+        # provider 7 — same group, different provider — is allowed.
+        config = {
+            "master": {"group_id": 10, "m3u_account_id": 3},
+            "secondary": [{"group_id": 10, "m3u_account_id": 7}],
+        }
+        assert validate_event_sync_config(config) == []
+
+    def test_identical_group_provider_pair_rejected(self):
+        config = {
+            "master": {"group_id": 10, "m3u_account_id": 3},
+            "secondary": [{"group_id": 10, "m3u_account_id": 3}],
+        }
+        errors = validate_event_sync_config(config)
+        assert any("secondary_group_ids" in e for e in errors)
+
+    def test_same_group_null_provider_both_still_rejected(self):
+        # Legacy behavior preserved: group 10 (any provider) as both master and
+        # secondary is still forbidden (identical pair (10, None)).
+        config = {"master_group_id": 10, "secondary_group_ids": [10]}
+        errors = validate_event_sync_config(config)
+        assert any("secondary_group_ids" in e for e in errors)
+
+    @pytest.mark.parametrize("bad_pid", ["3", 0, -1, True, 1.5])
+    def test_bad_provider_id_rejected(self, bad_pid):
+        config = {
+            "master": {"group_id": 10, "m3u_account_id": bad_pid},
+            "secondary": [{"group_id": 20, "m3u_account_id": None}],
+        }
+        errors = validate_event_sync_config(config)
+        assert any("master_group_id" in e for e in errors)
+
+    def test_null_provider_means_whole_group(self):
+        config = {
+            "master": {"group_id": 10, "m3u_account_id": None},
+            "secondary": [{"group_id": 20, "m3u_account_id": None}],
+        }
+        assert validate_event_sync_config(config) == []
+        assert config["master_group_id"] == 10

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0077",
+  "version": "0.17.6-0078",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/types/eventSync.ts
+++ b/frontend/src/types/eventSync.ts
@@ -29,7 +29,22 @@ export interface EventSyncPattern {
  * event_sync rule; its conditions/actions are placeholders ignored by the
  * engine (docs/event_sync.md).
  */
+/** One provider-scoped group: a group id + optional M3U account (provider) id
+ *  (null/absent = the whole group / any provider). bead 3p2af. */
+export interface EventSyncGroupScope {
+  group_id: number;
+  m3u_account_id: number | null;
+}
+
 export interface EventSyncConfig {
+  /**
+   * bead 3p2af: canonical provider-scoped shape. The backend validator keeps
+   * these in sync with the flat `master_group_id` / `secondary_group_ids`
+   * (derived) so both are present on a stored config. The editor currently
+   * reads/writes the flat keys; the provider-scoped picker (P4) will use these.
+   */
+  master?: EventSyncGroupScope;
+  secondary?: EventSyncGroupScope[];
   master_group_id: number;
   secondary_group_ids: number[];
   /** Shared pattern variants; omit to use the matcher's built-in defaults. */


### PR DESCRIPTION
## Summary — Option A P1 (epic 3p2af)

Foundation for **provider-scoped Event Sync groups**. Since two providers' same-named group is **one** Dispatcharr channel group (`ChannelGroup.name` is unique), the M3U-account (provider) id is what lets Provider A's "MLB PPV" be the master and Provider B's "MLB PPV" be a secondary.

`event_sync_config` canonical shape is now nested & provider-scoped:
```
master:    { group_id, m3u_account_id }
secondary: [ { group_id, m3u_account_id }, ... ]
```
`m3u_account_id: null` = "whole group / any provider" (pre-scope behavior).

**Zero data migration, zero downstream churn** — `validate_event_sync_config` (the gate before every consume) accepts the nested shape *or* auto-upgrades a legacy flat config in memory on read, and derives the flat `master_group_id`/`secondary_group_ids` so all 92 existing readers are untouched. The `master ∉ secondary` rail is now the **(group, provider) pair** — same group + different provider is allowed.

### Decision to review
For P1 the stored config carries **both** nested (canonical) and derived flat keys — self-healing, lowest risk. **Pure nested-only storage** (strip derived keys on persist) is a deliberate **P3 cleanup**, not done here.

### Remaining phases (own beads)
P2 provider-scoped fetch (`m3u_account` filter) + per-(group,provider) preflight · P3 backup/restore + YAML round-trip + nested-only storage · P4 frontend provider-scoped picker · P5 docs + fold `include_master_group_streams`.

## Testing
Full backend suite green (downstream unaffected via derived flat keys); new tests: nested/legacy validation, auto-upgrade, same-group-different-provider allowed, identical-pair rejected, provider-id validation. Frontend tsc clean (type carries optional nested fields; editor still uses flat keys until P4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
