### PR TITLE
v0.17.6-0079: Event Sync provider-scoped groups P2 — provider-scoped fetch + preflight (Option A)

### DIFF
--- a/backend/channel_pipeline_engine.py
+++ b/backend/channel_pipeline_engine.py
@@ -2693,7 +2693,18 @@ class ChannelPipelineEngine:
 
         secondary_streams: list = []
         truncated = False
-        for gid in config["secondary_group_ids"]:
+        # bead jiscc: iterate the provider-scoped secondary scopes. When a
+        # scope carries an m3u_account_id, the stream fetch is filtered to that
+        # provider (get_streams m3u_account=) — the same channel group can then
+        # supply DIFFERENT providers' streams to different rules. m3u_account_id
+        # None = the whole group (pre-provider-scope behavior).
+        secondary_scopes = config.get("secondary") or [
+            {"group_id": g, "m3u_account_id": None}
+            for g in config["secondary_group_ids"]
+        ]
+        for scope in secondary_scopes:
+            gid = scope["group_id"]
+            provider_filter = scope.get("m3u_account_id")
             gname = await self.client._channel_group_name_for_id(gid)
             if not gname:
                 logger.warning(
@@ -2708,6 +2719,7 @@ class ChannelPipelineEngine:
                 resp = await self.client.get_streams(
                     page=page, page_size=_EVENT_SYNC_FETCH_PAGE_SIZE,
                     channel_group_name=gname,
+                    m3u_account=provider_filter,
                 )
                 batch = (
                     resp.get("results", []) if isinstance(resp, dict)

--- a/backend/dispatcharr_client.py
+++ b/backend/dispatcharr_client.py
@@ -664,6 +664,29 @@ class DispatcharrClient:
         logger.info("[DISPATCHARR]   Unique channel group IDs extracted: %s", len(all_settings))
         return all_settings
 
+    async def get_m3u_group_settings_by_provider(self) -> dict:
+        """Per-(m3u_account_id, channel_group_id) group settings, NON-collapsed.
+
+        Complements :meth:`get_all_m3u_group_settings`, which collapses to one
+        entry per channel-group id (preferring auto_channel_sync ON). Provider-
+        scoped event_sync needs the SPECIFIC junction row for a (provider,
+        group) pair — e.g. on a group shared by two providers, provider A's row
+        may be auto_channel_sync ON while provider B's is OFF. Keyed by the
+        ``(m3u_account_id, channel_group_id)`` tuple.
+        """
+        accounts = await self.get_m3u_accounts()
+        by_pair: dict = {}
+        for account in accounts:
+            for setting in account.get("channel_groups", []):
+                channel_group_id = setting.get("channel_group")
+                if channel_group_id:
+                    by_pair[(account["id"], channel_group_id)] = {
+                        **setting,
+                        "m3u_account_id": account["id"],
+                        "m3u_account_name": account.get("name", ""),
+                    }
+        return by_pair
+
     async def get_m3u_account(self, account_id: int) -> dict:
         """Get a single M3U account by ID."""
         response = await self._request("GET", f"/api/m3u/accounts/{account_id}/")

--- a/backend/main.py
+++ b/backend/main.py
@@ -140,7 +140,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0078",
+    version="0.17.6-0079",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -75,7 +75,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0078"
+APP_VERSION = "0.17.6-0079"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/routers/channel_pipeline.py
+++ b/backend/routers/channel_pipeline.py
@@ -2550,7 +2550,16 @@ async def preview_event_sync(
     try:
         accounts = await client.get_m3u_accounts() or []
         account_names = {a.get("id"): a.get("name") for a in accounts}
-        for gid in secondary_group_ids:
+        # bead jiscc: provider-scoped secondary scopes (mirrors the engine
+        # fetch so preview and run stay in lockstep). m3u_account_id filters
+        # the fetch to one provider; None = the whole group.
+        secondary_scopes = config.get("secondary") or [
+            {"group_id": g, "m3u_account_id": None}
+            for g in secondary_group_ids
+        ]
+        for scope in secondary_scopes:
+            gid = scope["group_id"]
+            provider_filter = scope.get("m3u_account_id")
             gname = await client._channel_group_name_for_id(gid)
             group_names[gid] = gname
             if not gname:
@@ -2566,6 +2575,7 @@ async def preview_event_sync(
                 resp = await client.get_streams(
                     page=spage, page_size=_PREVIEW_FETCH_PAGE_SIZE,
                     channel_group_name=gname,
+                    m3u_account=provider_filter,
                 )
                 batch = resp.get("results", []) if isinstance(resp, dict) else (resp or [])
                 for s in batch:

--- a/backend/services/event_sync_preflight.py
+++ b/backend/services/event_sync_preflight.py
@@ -129,82 +129,115 @@ async def check_event_sync_group_settings(
         ``group_settings_found`` — scoping to a group no provider carries
         is a stale config worth surfacing, not a silent no-op.
     """
-    master_group_id = config.get("master_group_id")
-    secondary_group_ids = config.get("secondary_group_ids") or []
+    # bead jiscc: read the provider-scoped nested shape (P1 keeps it in sync
+    # with the flat keys; fall back to whole-group scopes for a bare config).
+    master_scope = config.get("master") or {
+        "group_id": config.get("master_group_id"), "m3u_account_id": None,
+    }
+    secondary_scopes = config.get("secondary") or [
+        {"group_id": g, "m3u_account_id": None}
+        for g in (config.get("secondary_group_ids") or [])
+    ]
 
     if all_settings is None:
         all_settings = await client.get_all_m3u_group_settings()
     target_to_source, _source_to_target = _build_override_maps(all_settings)
+
+    # The non-collapsed per-(provider, group) view is only needed when a scope
+    # is provider-specific — on a shared group the collapsed view (which
+    # prefers auto_channel_sync ON) would misreport the other provider's row.
+    needs_provider = (
+        master_scope.get("m3u_account_id") is not None
+        or any(s.get("m3u_account_id") is not None for s in secondary_scopes)
+    )
+    by_provider = (
+        await client.get_m3u_group_settings_by_provider()
+        if needs_provider else {}
+    )
+
+    def _scope_setting(scope: dict) -> dict | None:
+        """Effective junction setting for a scope, or None if not found.
+
+        Provider-scoped -> the specific (provider, group) row. Whole-group
+        (provider None) -> the collapsed setting, resolving a Channel Group
+        Override target through its source (bead override).
+        """
+        gid = scope.get("group_id")
+        pid = scope.get("m3u_account_id")
+        if pid is not None:
+            return by_provider.get((pid, gid))
+        setting = all_settings.get(gid)
+        if setting is None:
+            setting = target_to_source.get(gid)
+        return setting
+
+    def _scope_label(scope: dict) -> str:
+        pid = scope.get("m3u_account_id")
+        base = f"group {scope.get('group_id')}"
+        return f"{base} (provider {pid})" if pid is not None else base
+
     failures: list[dict] = []
 
-    master_settings = all_settings.get(master_group_id)
+    # --- Master ---------------------------------------------------------
+    master_settings = _scope_setting(master_scope)
     if master_settings is None:
-        # A Channel Group Override TARGET has no direct M3U setting of its
-        # own — auto-sync creates its channels from a SOURCE group. Read the
-        # effective auto-sync state through that source instead of failing
-        # "group not found" (bead override).
-        override_source = target_to_source.get(master_group_id)
-        if override_source is not None:
-            master_settings = override_source
-        else:
-            failures.append(_failure(
-                group_id=master_group_id,
-                role="master",
-                check=CHECK_GROUP_SETTINGS_FOUND,
-                expected="group present in an M3U account's group settings",
-                got="no settings for this group ID on any account",
-                message=(
-                    f"Master group {master_group_id} was not found in any "
-                    f"M3U account's group settings — the group may have been "
-                    f"removed or renamed by the provider."
-                ),
-            ))
-    if master_settings is not None and not master_settings.get(
-            "auto_channel_sync"):
         failures.append(_failure(
-            group_id=master_group_id,
+            group_id=master_scope.get("group_id"),
+            role="master",
+            check=CHECK_GROUP_SETTINGS_FOUND,
+            expected="group present in an M3U account's group settings",
+            got="no settings for this (group, provider) on any account",
+            message=(
+                f"Master {_scope_label(master_scope)} was not found in the "
+                f"M3U account's group settings — the group may have been "
+                f"removed or renamed, or that provider does not carry it."
+            ),
+        ))
+    elif not master_settings.get("auto_channel_sync"):
+        failures.append(_failure(
+            group_id=master_scope.get("group_id"),
             role="master",
             check=CHECK_MASTER_AUTO_SYNC_ON,
             expected="auto_channel_sync ON",
             got="auto_channel_sync OFF",
             message=(
-                f"Master group {master_group_id} has auto_channel_sync OFF "
-                f"in Dispatcharr — Dispatcharr creates no master channels, "
+                f"Master {_scope_label(master_scope)} has auto_channel_sync "
+                f"OFF in Dispatcharr — Dispatcharr creates no master channels, "
                 f"so event_sync has nothing to attach to. Enable "
-                f"auto_channel_sync for this group in Dispatcharr "
-                f"(ECM never toggles it for you)."
+                f"auto_channel_sync for it in Dispatcharr (ECM never toggles "
+                f"it for you)."
             ),
         ))
 
-    for group_id in secondary_group_ids:
-        settings = all_settings.get(group_id)
+    # --- Secondaries ----------------------------------------------------
+    for scope in secondary_scopes:
+        settings = _scope_setting(scope)
         if settings is None:
             failures.append(_failure(
-                group_id=group_id,
+                group_id=scope.get("group_id"),
                 role="secondary",
                 check=CHECK_GROUP_SETTINGS_FOUND,
                 expected="group present in an M3U account's group settings",
-                got="no settings for this group ID on any account",
+                got="no settings for this (group, provider) on any account",
                 message=(
-                    f"Secondary group {group_id} was not found in any M3U "
-                    f"account's group settings — the group may have been "
-                    f"removed or renamed by the provider."
+                    f"Secondary {_scope_label(scope)} was not found in the "
+                    f"M3U account's group settings — the group may have been "
+                    f"removed or renamed, or that provider does not carry it."
                 ),
             ))
         elif settings.get("auto_channel_sync"):
             failures.append(_failure(
-                group_id=group_id,
+                group_id=scope.get("group_id"),
                 role="secondary",
                 check=CHECK_SECONDARY_AUTO_SYNC_OFF,
                 expected="auto_channel_sync OFF",
                 got="auto_channel_sync ON",
                 message=(
-                    f"Secondary group {group_id} has auto_channel_sync ON "
-                    f"in Dispatcharr — Dispatcharr is creating its own "
-                    f"channels from this group, which duplicates the master "
-                    f"channels event_sync attaches to. Disable "
-                    f"auto_channel_sync for this group in Dispatcharr "
-                    f"(ECM never toggles it for you)."
+                    f"Secondary {_scope_label(scope)} has auto_channel_sync "
+                    f"ON in Dispatcharr — Dispatcharr is creating its own "
+                    f"channels from it, which duplicates the master channels "
+                    f"event_sync attaches to. Disable auto_channel_sync for it "
+                    f"in Dispatcharr (ECM never toggles it for you)."
                 ),
             ))
 
@@ -212,7 +245,8 @@ async def check_event_sync_group_settings(
         logger.warning(
             "[EVENT-SYNC] Pre-flight failed %s check(s) for master=%s "
             "secondaries=%s: %s",
-            len(failures), master_group_id, secondary_group_ids,
+            len(failures), _scope_label(master_scope),
+            [_scope_label(s) for s in secondary_scopes],
             [(f["group_id"], f["check"]) for f in failures],
         )
     return {"ok": not failures, "failures": failures}

--- a/backend/tests/unit/test_event_sync_attach_execution.py
+++ b/backend/tests/unit/test_event_sync_attach_execution.py
@@ -848,6 +848,30 @@ class TestUnattendedGatesEnqueueNothing:
         )
 
 
+class TestProviderScopedFetch:
+    """bead jiscc: a provider-scoped secondary fetches only that provider's
+    streams (get_streams m3u_account=), so a shared group can supply different
+    providers' streams to different rules."""
+
+    def test_provider_scope_passes_m3u_account_filter(self):
+        engine, _executor, client = _engine_with_client([], [])
+        config = {
+            "master_group_id": 10, "secondary_group_ids": [20],
+            "secondary": [{"group_id": 20, "m3u_account_id": 7}],
+        }
+        _run(engine._fetch_event_sync_secondary_streams(config, {1: "ProvB"}))
+        assert client.get_streams.call_args_list, "get_streams not called"
+        assert client.get_streams.call_args_list[0].kwargs.get(
+            "m3u_account") == 7
+
+    def test_whole_group_scope_passes_none_filter(self):
+        engine, _executor, client = _engine_with_client([], [])
+        config = {"master_group_id": 10, "secondary_group_ids": [20]}
+        _run(engine._fetch_event_sync_secondary_streams(config, {1: "ProvB"}))
+        assert client.get_streams.call_args_list[0].kwargs.get(
+            "m3u_account") is None
+
+
 class TestParseMasterFromStream:
     """bead parse-from-stream: master identity read from the attached stream,
     so a cleanly-named master channel still matches via its timed stream."""

--- a/backend/tests/unit/test_event_sync_preflight.py
+++ b/backend/tests/unit/test_event_sync_preflight.py
@@ -228,3 +228,81 @@ class TestChannelGroupOverride:
             all_settings=settings,
         )
         client.get_all_m3u_group_settings.assert_not_awaited()
+
+
+class _ProviderScopedClient:
+    """Client double exposing BOTH the collapsed and the per-(provider, group)
+    read methods — for provider-scoped pre-flight (bead jiscc)."""
+
+    def __init__(self, collapsed: dict, by_provider: dict):
+        self.get_all_m3u_group_settings = AsyncMock(return_value=collapsed)
+        self.get_m3u_group_settings_by_provider = AsyncMock(
+            return_value=by_provider
+        )
+
+
+class TestProviderScopedPreflight:
+    """bead jiscc: on a SHARED group, the pre-flight must check the SPECIFIC
+    provider's junction row, not the collapsed (auto-sync-ON-preferring) view.
+    """
+
+    def _shared_group_config(self):
+        # Master = group 10 / provider 3; secondary = group 10 / provider 7.
+        return {
+            "master": {"group_id": 10, "m3u_account_id": 3},
+            "secondary": [{"group_id": 10, "m3u_account_id": 7}],
+        }
+
+    async def test_shared_group_diff_providers_passes(self):
+        # Provider 3's group-10 row is ON (master), provider 7's is OFF
+        # (secondary) — valid, even though the COLLAPSED group 10 reads ON.
+        client = _ProviderScopedClient(
+            collapsed={10: _group(auto_sync=True)},
+            by_provider={
+                (3, 10): _group(auto_sync=True),
+                (7, 10): _group(auto_sync=False),
+            },
+        )
+        result = await check_event_sync_group_settings(
+            client, self._shared_group_config()
+        )
+        assert result == {"ok": True, "failures": []}
+
+    async def test_secondary_providers_row_auto_sync_on_fails(self):
+        client = _ProviderScopedClient(
+            collapsed={10: _group(auto_sync=True)},
+            by_provider={
+                (3, 10): _group(auto_sync=True),
+                (7, 10): _group(auto_sync=True),  # secondary provider ON -> bad
+            },
+        )
+        result = await check_event_sync_group_settings(
+            client, self._shared_group_config()
+        )
+        assert result["ok"] is False
+        assert any(f["check"] == CHECK_SECONDARY_AUTO_SYNC_OFF
+                   for f in result["failures"])
+
+    async def test_master_provider_not_carrying_group_fails(self):
+        client = _ProviderScopedClient(
+            collapsed={10: _group(auto_sync=True)},
+            by_provider={(7, 10): _group(auto_sync=False)},  # no (3,10) row
+        )
+        result = await check_event_sync_group_settings(
+            client, self._shared_group_config()
+        )
+        assert result["ok"] is False
+        assert any(f["check"] == CHECK_GROUP_SETTINGS_FOUND
+                   for f in result["failures"])
+
+    async def test_whole_group_scope_does_not_fetch_by_provider(self):
+        # A null-provider (whole-group) config must NOT call the per-provider
+        # read — the collapsed path is preserved for legacy configs.
+        client = _ProviderScopedClient(
+            collapsed={10: _group(True), 20: _group(False)},
+            by_provider={},
+        )
+        await check_event_sync_group_settings(
+            client, _config(master=10, secondaries=(20,))
+        )
+        client.get_m3u_group_settings_by_provider.assert_not_awaited()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0078",
+  "version": "0.17.6-0079",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary — Option A P2 (epic 3p2af)

Makes provider-scoped Event Sync groups actually **work** on the backend (builds on P1's nested schema).

- **Provider-scoped secondary fetch** (preview router + engine): iterates the nested `secondary` scopes and passes `get_streams(m3u_account=…)` when a scope carries an `m3u_account_id` — so one shared channel group can supply a *different* provider's streams to different rules. `null` provider = whole group (unchanged).
- **Provider-aware pre-flight** (required, not cosmetic): new client method `get_m3u_group_settings_by_provider()` returns the **non-collapsed** `{(m3u_account_id, group_id): setting}` view. When a scope is provider-scoped, the pre-flight checks that specific junction row — because on a **shared** group the collapsed view (which prefers `auto_channel_sync` ON) would spuriously fail the secondary check for the same group. Whole-group scopes keep the collapsed + Channel-Group-Override path and never trigger the extra per-provider fetch.

## Testing
Full backend suite green. New tests: provider-scoped pre-flight (shared group / different providers **passes**; secondary provider ON **fails**; master provider not carrying the group **fails**; whole-group scope does **not** fetch by provider), and provider-scoped fetch passes the `m3u_account` filter. Legacy flat configs use the whole-group fallback (unchanged).

## Remaining
P3 backup/restore + YAML round-trip (mostly already works via P1 auto-normalize — confirm with tests; + nested-only-storage cleanup) · **P4 frontend provider-scoped picker** (the user-facing piece — recommend a design pass / review) · P5 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
