### PR TITLE
v0.17.6-0081: Event Sync provider-scoped groups P4 (part 1) — endpoint + picker component (Option A)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -140,7 +140,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0080",
+    version="0.17.6-0081",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -75,7 +75,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0080"
+APP_VERSION = "0.17.6-0081"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/routers/streams.py
+++ b/backend/routers/streams.py
@@ -337,3 +337,34 @@ async def get_all_provider_group_settings():
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.get("/api/providers/group-settings/by-provider", tags=["Providers"])
+async def get_provider_group_settings_by_provider():
+    """Per-(provider, group) group settings, NON-collapsed (bead 38dzi).
+
+    Unlike ``/api/providers/group-settings`` (one row per channel-group id,
+    collapsed preferring auto_channel_sync ON), this returns ONE row per
+    (m3u_account, channel_group) junction — so the UI can offer provider-scoped
+    Event Sync group selection (Provider A's "MLB PPV" vs Provider B's
+    "MLB PPV", which share one channel-group id). The group NAME is not
+    included; the caller joins on ``channel_group_id`` against the channel
+    groups it already loads.
+    """
+    logger.debug("[STREAMS] GET /api/providers/group-settings/by-provider")
+    client = get_client()
+    try:
+        by_pair = await client.get_m3u_group_settings_by_provider()
+        return [
+            {
+                "m3u_account_id": setting.get("m3u_account_id"),
+                "m3u_account_name": setting.get("m3u_account_name"),
+                "channel_group_id": setting.get("channel_group"),
+                "auto_channel_sync": bool(setting.get("auto_channel_sync")),
+                "enabled": bool(setting.get("enabled")),
+                "stream_count": setting.get("stream_count"),
+            }
+            for setting in by_pair.values()
+        ]
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/tests/routers/test_streams.py
+++ b/backend/tests/routers/test_streams.py
@@ -211,6 +211,42 @@ class TestGetProviderGroupSettings:
         assert data["10"]["enabled"] is True
 
 
+class TestGetProviderGroupSettingsByProvider:
+    """GET /api/providers/group-settings/by-provider — non-collapsed (bead 38dzi)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_one_row_per_provider_group_pair(self, async_client):
+        mock_client = AsyncMock()
+        # Same channel group (99) carried by TWO providers — the case the
+        # collapsed endpoint hides.
+        mock_client.get_m3u_group_settings_by_provider.return_value = {
+            (3, 99): {
+                "channel_group": 99, "auto_channel_sync": True,
+                "enabled": True, "stream_count": 40,
+                "m3u_account_id": 3, "m3u_account_name": "Provider A",
+            },
+            (11, 99): {
+                "channel_group": 99, "auto_channel_sync": False,
+                "enabled": True, "stream_count": 12,
+                "m3u_account_id": 11, "m3u_account_name": "Provider B",
+            },
+        }
+
+        with patch("routers.streams.get_client", return_value=mock_client):
+            response = await async_client.get(
+                "/api/providers/group-settings/by-provider"
+            )
+
+        assert response.status_code == 200
+        rows = response.json()
+        assert len(rows) == 2
+        by_provider = {r["m3u_account_id"]: r for r in rows}
+        assert by_provider[3]["channel_group_id"] == 99
+        assert by_provider[3]["auto_channel_sync"] is True
+        assert by_provider[11]["auto_channel_sync"] is False
+        assert by_provider[3]["m3u_account_name"] == "Provider A"
+
+
 class TestGetStreamsByIds:
     """Tests for POST /api/streams/by-ids endpoint."""
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0080",
+  "version": "0.17.6-0081",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/channelPipeline/ProviderScopedGroupPicker.css
+++ b/frontend/src/components/channelPipeline/ProviderScopedGroupPicker.css
@@ -1,0 +1,182 @@
+/* Provider-scoped Event Sync group picker (bead 38dzi / Option A P4). */
+.provider-scoped-group-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.psg-search {
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  background: var(--bg-input, var(--bg-secondary));
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.psg-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+}
+
+.psg-empty {
+  padding: 12px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  text-align: center;
+}
+
+.psg-provider-row {
+  border-bottom: 1px solid var(--border-subtle, var(--border-primary));
+}
+.psg-provider-row:last-child {
+  border-bottom: none;
+}
+
+.psg-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 13px;
+}
+.psg-option input {
+  flex-shrink: 0;
+}
+.psg-option.psg-excluded {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.psg-label {
+  flex: 1;
+  color: var(--text-primary);
+}
+
+.psg-streams {
+  color: var(--text-secondary);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.psg-disabled-hint {
+  font-style: italic;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+/* Sync status badges — text + icon, never color alone. */
+.psg-sync-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11.5px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border-primary);
+  white-space: nowrap;
+}
+.psg-sync-badge .material-icons {
+  font-size: 15px;
+}
+.psg-sync-ok {
+  color: var(--text-success, var(--text-secondary));
+  border-color: var(--border-success, var(--border-primary));
+}
+.psg-sync-mismatch {
+  color: var(--text-warning, var(--text-secondary));
+  border-color: var(--border-warning, var(--border-primary));
+}
+
+.psg-mismatch {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 12px 10px 34px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.psg-fix-btn {
+  align-self: flex-start;
+  padding: 4px 10px;
+  border: 1px solid var(--border-warning, var(--border-primary));
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+/* Multi-provider parent node. */
+.psg-group-node {
+  border-bottom: 1px solid var(--border-subtle, var(--border-primary));
+}
+.psg-group-node:last-child {
+  border-bottom: none;
+}
+.psg-group-parent {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+}
+.psg-group-parent .material-icons {
+  font-size: 18px;
+  color: var(--text-secondary);
+}
+.psg-group-name {
+  flex: 1;
+  font-weight: 500;
+}
+.psg-group-meta {
+  color: var(--text-secondary);
+  font-size: 12px;
+  white-space: nowrap;
+}
+.psg-sublist {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 16px;
+  background: var(--bg-subtle, transparent);
+}
+
+/* Selected-scope chips (secondary multi-select). */
+.psg-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.psg-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  border: 1px solid var(--border-primary);
+  border-radius: 12px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 12px;
+}
+.psg-chip-remove {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0;
+  line-height: 1;
+}

--- a/frontend/src/components/channelPipeline/ProviderScopedGroupPicker.test.tsx
+++ b/frontend/src/components/channelPipeline/ProviderScopedGroupPicker.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ProviderScopedGroupPicker } from './ProviderScopedGroupPicker';
+import {
+  joinProviderRows,
+  type GroupProviderRow,
+} from './providerScopedGroups';
+import type { ProviderGroupScopeRow } from '../../services/api';
+
+const NAMES: Record<number, string> = { 10: 'MLB PPV', 20: 'NBA', 30: 'NFL' };
+const groupName = (id: number) => NAMES[id];
+
+function raw(over: Partial<ProviderGroupScopeRow>): ProviderGroupScopeRow {
+  return {
+    m3u_account_id: 3,
+    m3u_account_name: 'Provider A',
+    channel_group_id: 10,
+    auto_channel_sync: true,
+    enabled: true,
+    stream_count: 40,
+    ...over,
+  };
+}
+
+// MLB PPV under two providers (3 ON, 7 OFF); NBA under one provider.
+const ROWS: GroupProviderRow[] = joinProviderRows(
+  [
+    raw({ m3u_account_id: 3, m3u_account_name: 'Provider A', channel_group_id: 10, auto_channel_sync: true }),
+    raw({ m3u_account_id: 7, m3u_account_name: 'Provider B', channel_group_id: 10, auto_channel_sync: false, stream_count: 38 }),
+    raw({ m3u_account_id: 7, m3u_account_name: 'Provider B', channel_group_id: 20, auto_channel_sync: false, stream_count: 52 }),
+  ],
+  groupName,
+);
+
+describe('joinProviderRows', () => {
+  it('joins names and drops rows for unknown groups', () => {
+    const rows = joinProviderRows(
+      [raw({ channel_group_id: 10 }), raw({ channel_group_id: 999 })],
+      groupName,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].groupName).toBe('MLB PPV');
+  });
+});
+
+describe('ProviderScopedGroupPicker', () => {
+  it('renders a single-provider group as a flat row (no expander)', () => {
+    render(
+      <ProviderScopedGroupPicker role="secondary" rows={ROWS} value={[]}
+        onChange={vi.fn()} showAll={false} />,
+    );
+    // NBA is single-provider → a flat checkbox, not an expand button.
+    expect(screen.getByTestId('psg-secondary-20-7')).toBeInTheDocument();
+  });
+
+  it('expands a multi-provider group into per-provider + whole-group rows', async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderScopedGroupPicker role="secondary" rows={ROWS} value={[]}
+        onChange={vi.fn()} showAll={false} />,
+    );
+    await user.click(screen.getByRole('button', { name: /MLB PPV/i }));
+    expect(screen.getByTestId('psg-secondary-10-3')).toBeInTheDocument();
+    expect(screen.getByTestId('psg-secondary-10-7')).toBeInTheDocument();
+    expect(screen.getByTestId('psg-secondary-10-any')).toBeInTheDocument();
+  });
+
+  it('master select emits a single scope', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ProviderScopedGroupPicker role="master" rows={ROWS} value={null}
+        onChange={onChange} showAll={false} />,
+    );
+    // The multi-provider node auto-expands (contains a mismatch), so the
+    // radios are visible.
+    await user.click(screen.getByTestId('psg-master-10-3'));
+    expect(onChange).toHaveBeenCalledWith({ group_id: 10, m3u_account_id: 3 });
+  });
+
+  it('secondary select accumulates a scope list', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ProviderScopedGroupPicker role="secondary" rows={ROWS}
+        value={[{ group_id: 20, m3u_account_id: 7 }]} onChange={onChange}
+        showAll={false} />,
+    );
+    await user.click(screen.getByRole('button', { name: /MLB PPV/i }));
+    await user.click(screen.getByTestId('psg-secondary-10-7'));
+    expect(onChange).toHaveBeenCalledWith([
+      { group_id: 20, m3u_account_id: 7 },
+      { group_id: 10, m3u_account_id: 7 },
+    ]);
+  });
+
+  it('role-relative valence: auto-sync ON is OK for master, a mismatch for secondary', async () => {
+    const user = userEvent.setup();
+    // Provider A (group 10) is auto-sync ON.
+    const { rerender } = render(
+      <ProviderScopedGroupPicker role="master" rows={ROWS} value={null}
+        onChange={vi.fn()} showAll={false} />,
+    );
+    await user.click(screen.getByRole('button', { name: /MLB PPV/i }));
+    const masterRowA = screen.getByTestId('psg-master-10-3').closest('li')!;
+    expect(within(masterRowA).getByText(/Auto-sync ON ✓/)).toBeInTheDocument();
+
+    rerender(
+      <ProviderScopedGroupPicker role="secondary" rows={ROWS} value={[]}
+        onChange={vi.fn()} showAll={false} />,
+    );
+    await user.click(screen.getByRole('button', { name: /MLB PPV/i }));
+    const secRowA = screen.getByTestId('psg-secondary-10-3').closest('li')!;
+    expect(within(secRowA).getByText(/Auto-sync ON ⚠/)).toBeInTheDocument();
+  });
+
+  it('excludes the master scope but allows the same group under a different provider', async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderScopedGroupPicker role="secondary" rows={ROWS} value={[]}
+        onChange={vi.fn()} showAll={false}
+        excludeScope={{ group_id: 10, m3u_account_id: 3 }} />,
+    );
+    await user.click(screen.getByRole('button', { name: /MLB PPV/i }));
+    // Provider A (master) is disabled; Provider B (same group) is selectable.
+    expect(screen.getByTestId('psg-secondary-10-3')).toBeDisabled();
+    expect(screen.getByTestId('psg-secondary-10-7')).not.toBeDisabled();
+  });
+
+  it('hides a disabled provider row unless showAll or it is already referenced', async () => {
+    const disabledRows = joinProviderRows(
+      [
+        raw({ m3u_account_id: 3, channel_group_id: 10, enabled: true }),
+        raw({ m3u_account_id: 7, m3u_account_name: 'Provider B', channel_group_id: 10, enabled: false, auto_channel_sync: false }),
+      ],
+      groupName,
+    );
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ProviderScopedGroupPicker role="secondary" rows={disabledRows} value={[]}
+        onChange={vi.fn()} showAll={false} />,
+    );
+    await user.click(screen.getByRole('button', { name: /MLB PPV/i }));
+    expect(screen.queryByTestId('psg-secondary-10-7')).not.toBeInTheDocument();
+
+    // Referenced (selected) -> stays visible even when disabled + showAll off.
+    rerender(
+      <ProviderScopedGroupPicker role="secondary" rows={disabledRows}
+        value={[{ group_id: 10, m3u_account_id: 7 }]} onChange={vi.fn()}
+        showAll={false} />,
+    );
+    expect(screen.getByTestId('psg-secondary-10-7')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/channelPipeline/ProviderScopedGroupPicker.tsx
+++ b/frontend/src/components/channelPipeline/ProviderScopedGroupPicker.tsx
@@ -1,0 +1,338 @@
+/**
+ * Provider-scoped Event Sync group picker (bead 38dzi / Option A P4).
+ *
+ * Channel-group NAMES are globally unique in Dispatcharr, so two M3U providers
+ * that both carry "MLB PPV" share ONE channel_group_id — but their
+ * auto_channel_sync / enabled settings live on the per-(provider, group)
+ * junction. This picker lets the operator select a group SCOPED to a provider:
+ * "MLB PPV — Provider A (auto-sync ON)" as the master, "MLB PPV — Provider B
+ * (auto-sync OFF)" as a secondary.
+ *
+ * UX (ux-designer spec): collapse-by-default, expand-on-conflict. A group
+ * carried by ONE provider renders as a flat row (the provider is
+ * unambiguous). A group carried by 2+ providers renders as an expandable
+ * parent whose sub-rows are the per-provider scopes plus an explicit
+ * "Any provider (whole group)" scope (m3u_account_id = null). Sync-status
+ * valence is ROLE-RELATIVE: a master should be auto-sync ON (OFF warns), a
+ * secondary should be OFF (ON warns); the warning offers the existing Fix.
+ */
+import { useMemo, useState } from 'react';
+import type { EventSyncGroupScope } from '../../types/eventSync';
+import { scopeKey, type GroupProviderRow } from './providerScopedGroups';
+import './ProviderScopedGroupPicker.css';
+
+interface GroupNode {
+  groupId: number;
+  groupName: string;
+  providers: GroupProviderRow[];
+}
+
+export interface ProviderScopedGroupPickerProps {
+  role: 'master' | 'secondary';
+  rows: GroupProviderRow[];
+  /** master: a single scope or null; secondary: a list of scopes. */
+  value: EventSyncGroupScope | EventSyncGroupScope[] | null;
+  onChange: (next: EventSyncGroupScope | EventSyncGroupScope[] | null) => void;
+  /** When false, junction rows whose provider setting is disabled are hidden
+   *  (unless already referenced by the rule — the round-trip guard). */
+  showAll: boolean;
+  /** secondary: the master's exact scope, excluded so a group+provider cannot
+   *  be both master and secondary (the SAME group with a DIFFERENT provider IS
+   *  allowed). */
+  excludeScope?: EventSyncGroupScope | null;
+  /** Offer the "Fix" affordance for a sync mismatch (reuses the editor's
+   *  existing auto-sync fix dialog). */
+  onRequestFix?: (target: { accountId: number; groupId: number }) => void;
+  disabled?: boolean;
+}
+
+export function ProviderScopedGroupPicker({
+  role,
+  rows,
+  value,
+  onChange,
+  showAll,
+  excludeScope,
+  onRequestFix,
+  disabled,
+}: ProviderScopedGroupPickerProps) {
+  const [search, setSearch] = useState('');
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+
+  const selected: EventSyncGroupScope[] = useMemo(() => {
+    if (value == null) return [];
+    return Array.isArray(value) ? value : [value];
+  }, [value]);
+  const selectedKeys = useMemo(
+    () => new Set(selected.map(scopeKey)),
+    [selected],
+  );
+
+  // Group junction rows by group id -> nodes (deterministic order).
+  const nodes: GroupNode[] = useMemo(() => {
+    const byGroup = new Map<number, GroupNode>();
+    for (const r of rows) {
+      let node = byGroup.get(r.groupId);
+      if (!node) {
+        node = { groupId: r.groupId, groupName: r.groupName, providers: [] };
+        byGroup.set(r.groupId, node);
+      }
+      node.providers.push(r);
+    }
+    const list = [...byGroup.values()];
+    for (const n of list) {
+      n.providers.sort((a, b) =>
+        a.m3uAccountName.localeCompare(b.m3uAccountName),
+      );
+    }
+    list.sort((a, b) => a.groupName.localeCompare(b.groupName));
+    return list;
+  }, [rows]);
+
+  const isSelectedScope = (s: EventSyncGroupScope) =>
+    selectedKeys.has(scopeKey(s));
+
+  // A scope is "kept visible" (round-trip guard) if it is selected or is the
+  // excluded master scope — never dropped by the enabled-only filter.
+  const isReferenced = (groupId: number, providerId: number | null) => {
+    const k = scopeKey({ group_id: groupId, m3u_account_id: providerId });
+    return (
+      selectedKeys.has(k) ||
+      (excludeScope != null && scopeKey(excludeScope) === k)
+    );
+  };
+
+  const q = search.trim().toLowerCase();
+  const matchesSearch = (n: GroupNode) => {
+    if (!q) return true;
+    if (n.groupName.toLowerCase().includes(q)) return true;
+    return n.providers.some(p => p.m3uAccountName.toLowerCase().includes(q));
+  };
+
+  // Desired auto-sync for this role; the OTHER value warns.
+  const wantsSync = role === 'master';
+
+  const toggleExpanded = (groupId: number) => {
+    setExpanded(prev => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
+  };
+
+  const selectScope = (scope: EventSyncGroupScope) => {
+    if (role === 'master') {
+      onChange(scope);
+    } else {
+      const key = scopeKey(scope);
+      const has = selected.some(s => scopeKey(s) === key);
+      onChange(
+        has
+          ? selected.filter(s => scopeKey(s) !== key)
+          : [...selected, scope],
+      );
+    }
+  };
+
+  const isExcluded = (scope: EventSyncGroupScope) =>
+    excludeScope != null && scopeKey(excludeScope) === scopeKey(scope);
+
+  const syncBadge = (autoSync: boolean, roleWarns: boolean) => {
+    const mismatch = autoSync !== wantsSync;
+    return (
+      <span
+        className={
+          'psg-sync-badge ' +
+          (mismatch ? 'psg-sync-mismatch' : 'psg-sync-ok')
+        }
+      >
+        <span className="material-icons" aria-hidden="true">
+          {autoSync ? 'sync' : 'sync_disabled'}
+        </span>
+        Auto-sync {autoSync ? 'ON' : 'OFF'}
+        {mismatch && roleWarns ? ' ⚠' : ' ✓'}
+      </span>
+    );
+  };
+
+  const renderProviderRow = (p: GroupProviderRow, showGroupName: boolean) => {
+    const scope: EventSyncGroupScope = {
+      group_id: p.groupId,
+      m3u_account_id: p.m3uAccountId,
+    };
+    const excluded = isExcluded(scope);
+    const checked = isSelectedScope(scope);
+    const mismatch = p.autoChannelSync !== wantsSync;
+    const InputTag = role === 'master' ? 'radio' : 'checkbox';
+    const label = showGroupName
+      ? `${p.groupName} · ${p.m3uAccountName}`
+      : p.m3uAccountName;
+    return (
+      <li key={scopeKey(scope)} className="psg-provider-row">
+        <label className={excluded ? 'psg-option psg-excluded' : 'psg-option'}>
+          <input
+            type={InputTag}
+            checked={checked}
+            disabled={disabled || excluded}
+            onChange={() => selectScope(scope)}
+            data-testid={`psg-${role}-${p.groupId}-${p.m3uAccountId}`}
+          />
+          <span className="psg-label">{label}</span>
+          {syncBadge(p.autoChannelSync, true)}
+          <span className="psg-streams">
+            {p.streamCount == null ? '—' : `${p.streamCount} streams`}
+          </span>
+          {!p.enabled && (
+            <span className="psg-disabled-hint">(disabled)</span>
+          )}
+        </label>
+        {checked && mismatch && onRequestFix && (
+          <div className="psg-mismatch" role="alert">
+            <span>
+              Auto-sync is {p.autoChannelSync ? 'ON' : 'OFF'} — {role === 'master'
+                ? 'a master needs it ON so Dispatcharr owns the channels.'
+                : 'a secondary needs it OFF or Dispatcharr creates duplicate channels.'}
+            </span>
+            <button
+              type="button"
+              className="psg-fix-btn"
+              disabled={disabled}
+              onClick={() =>
+                onRequestFix({ accountId: p.m3uAccountId, groupId: p.groupId })
+              }
+            >
+              Fix: turn auto-sync {wantsSync ? 'ON' : 'OFF'} for {p.m3uAccountName}…
+            </button>
+          </div>
+        )}
+      </li>
+    );
+  };
+
+  const renderWholeGroupRow = (node: GroupNode) => {
+    const scope: EventSyncGroupScope = {
+      group_id: node.groupId,
+      m3u_account_id: null,
+    };
+    const excluded = isExcluded(scope);
+    return (
+      <li key={scopeKey(scope)} className="psg-provider-row">
+        <label className={excluded ? 'psg-option psg-excluded' : 'psg-option'}>
+          <input
+            type={role === 'master' ? 'radio' : 'checkbox'}
+            checked={isSelectedScope(scope)}
+            disabled={disabled || excluded}
+            onChange={() => selectScope(scope)}
+            data-testid={`psg-${role}-${node.groupId}-any`}
+          />
+          <span className="psg-label">Any provider (whole group)</span>
+        </label>
+      </li>
+    );
+  };
+
+  const visibleNodes = nodes.filter(matchesSearch);
+
+  return (
+    <div className="provider-scoped-group-picker" data-testid={`psg-${role}`}>
+      <input
+        type="text"
+        className="psg-search"
+        placeholder="Filter groups…"
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+        disabled={disabled}
+        aria-label={`Filter ${role} groups`}
+      />
+      <ul className="psg-list">
+        {visibleNodes.length === 0 && (
+          <li className="psg-empty">No matching groups</li>
+        )}
+        {visibleNodes.map(node => {
+          const visibleProviders = node.providers.filter(
+            p => showAll || p.enabled || isReferenced(p.groupId, p.m3uAccountId),
+          );
+          if (visibleProviders.length === 0) return null;
+
+          // Single-provider group -> flat row (provider unambiguous).
+          if (visibleProviders.length === 1 && node.providers.length === 1) {
+            return renderProviderRow(visibleProviders[0], true);
+          }
+
+          // Multi-provider group -> expandable parent.
+          const isOpen =
+            expanded.has(node.groupId) ||
+            !!q ||
+            visibleProviders.some(
+              p =>
+                isSelectedScope({
+                  group_id: p.groupId,
+                  m3u_account_id: p.m3uAccountId,
+                }) || p.autoChannelSync !== wantsSync,
+            ) ||
+            isSelectedScope({ group_id: node.groupId, m3u_account_id: null });
+          const totalStreams = visibleProviders.reduce(
+            (sum, p) => sum + (p.streamCount ?? 0),
+            0,
+          );
+          return (
+            <li key={node.groupId} className="psg-group-node" role="group"
+                aria-label={`${node.groupName}, ${visibleProviders.length} providers`}>
+              <button
+                type="button"
+                className="psg-group-parent"
+                aria-expanded={isOpen}
+                onClick={() => toggleExpanded(node.groupId)}
+                disabled={disabled}
+              >
+                <span className="material-icons" aria-hidden="true">
+                  {isOpen ? 'expand_more' : 'chevron_right'}
+                </span>
+                <span className="psg-group-name">{node.groupName}</span>
+                <span className="psg-group-meta">
+                  {visibleProviders.length} providers · {totalStreams} streams
+                </span>
+              </button>
+              {isOpen && (
+                <ul className="psg-sublist">
+                  {visibleProviders.map(p => renderProviderRow(p, false))}
+                  {renderWholeGroupRow(node)}
+                </ul>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      {role === 'secondary' && selected.length > 0 && (
+        <div className="psg-chips" aria-live="polite">
+          {selected.map(s => {
+            const node = nodes.find(n => n.groupId === s.group_id);
+            const prov =
+              s.m3u_account_id == null
+                ? 'Any provider'
+                : node?.providers.find(p => p.m3uAccountId === s.m3u_account_id)
+                    ?.m3uAccountName ?? `Provider ${s.m3u_account_id}`;
+            return (
+              <span key={scopeKey(s)} className="psg-chip">
+                {(node?.groupName ?? `Group ${s.group_id}`)} · {prov}
+                <button
+                  type="button"
+                  className="psg-chip-remove"
+                  aria-label={`Remove ${node?.groupName ?? s.group_id}`}
+                  onClick={() => selectScope(s)}
+                  disabled={disabled}
+                >
+                  ✕
+                </button>
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ProviderScopedGroupPicker;

--- a/frontend/src/components/channelPipeline/providerScopedGroups.ts
+++ b/frontend/src/components/channelPipeline/providerScopedGroups.ts
@@ -1,0 +1,47 @@
+/**
+ * Helpers for the provider-scoped Event Sync group picker (bead 38dzi / P4).
+ * Kept out of the component file so Fast Refresh stays happy (a component file
+ * should only export components).
+ */
+import type { EventSyncGroupScope } from '../../types/eventSync';
+import type { ProviderGroupScopeRow } from '../../services/api';
+
+/** One (provider, group) junction, joined to its channel-group name. */
+export interface GroupProviderRow {
+  groupId: number;
+  groupName: string;
+  m3uAccountId: number;
+  m3uAccountName: string;
+  autoChannelSync: boolean;
+  enabled: boolean;
+  streamCount: number | null;
+}
+
+/** Join raw junction rows to channel-group names (the endpoint omits the name;
+ *  the caller already has the group list). Rows for unknown groups are
+ *  dropped. */
+export function joinProviderRows(
+  rows: ProviderGroupScopeRow[],
+  groupName: (id: number) => string | undefined,
+): GroupProviderRow[] {
+  const out: GroupProviderRow[] = [];
+  for (const r of rows) {
+    const name = groupName(r.channel_group_id);
+    if (!name) continue;
+    out.push({
+      groupId: r.channel_group_id,
+      groupName: name,
+      m3uAccountId: r.m3u_account_id,
+      m3uAccountName: r.m3u_account_name,
+      autoChannelSync: r.auto_channel_sync,
+      enabled: r.enabled,
+      streamCount: r.stream_count,
+    });
+  }
+  return out;
+}
+
+/** Stable identity for a scope, for selection/dedup/comparison. */
+export function scopeKey(s: EventSyncGroupScope): string {
+  return `${s.group_id}:${s.m3u_account_id ?? 'null'}`;
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -718,6 +718,23 @@ export async function getProviderGroupSettings(): Promise<Record<number, M3UGrou
   return fetchJson(`${API_BASE}/providers/group-settings`);
 }
 
+/** One (provider, channel-group) junction row — NON-collapsed. bead 38dzi:
+ *  powers the provider-scoped Event Sync group picker (the same channel-group
+ *  id can appear under multiple providers). Join on channel_group_id against
+ *  the channel groups the caller already loads for the group name. */
+export interface ProviderGroupScopeRow {
+  m3u_account_id: number;
+  m3u_account_name: string;
+  channel_group_id: number;
+  auto_channel_sync: boolean;
+  enabled: boolean;
+  stream_count: number | null;
+}
+
+export async function getProviderGroupSettingsByProvider(): Promise<ProviderGroupScopeRow[]> {
+  return fetchJson(`${API_BASE}/providers/group-settings/by-provider`);
+}
+
 // M3U Account CRUD
 export async function getM3UAccount(id: number): Promise<M3UAccount> {
   return fetchJson(`${API_BASE}/m3u/accounts/${id}`);


### PR DESCRIPTION
## Summary — Option A P4 (part 1): endpoint + provider-scoped picker component

The two self-contained, fully-tested building blocks for the provider-scoped group picker. The **editor rewire is a deliberate separate PR** (increment 3) since it's large and benefits from interactive review.

- **Backend** — `GET /api/providers/group-settings/by-provider`: the **non-collapsed** per-(provider, group) junction view. The existing `/group-settings` collapses to one row per channel-group id; this returns one row per `(m3u_account, channel_group)` so the UI can offer Provider A's "MLB PPV" vs Provider B's (they share one group id). *Verified live:* a two-provider group returns two rows.
- **Frontend** — `getProviderGroupSettingsByProvider()` + `ProviderGroupScopeRow`.
- **`ProviderScopedGroupPicker`** component, built to the ux-designer's spec:
  - **collapse-by-default / expand-on-conflict** — single-provider groups are flat rows (like today); only multi-provider groups expand into per-provider sub-rows + an explicit "Any provider (whole group)" scope.
  - **role-relative sync valence** — a master should be auto-sync ON, a secondary OFF; the mismatch warns (text+icon badge) and offers the existing Fix.
  - scope selection (`{group_id, m3u_account_id}`), enabled-only filter with a **round-trip guard** on the exact scope, and **exact-scope exclusion** (same group + different provider is a valid secondary).
  - 8 component tests.

Also filed the ux-designer's Event Sync editor heuristic findings (F1–F8) as a separate UX-debt bead.

## Remaining for P4 (increment 3 — own PR)
Wire the picker into `EventSyncRuleEditor`: `masterScope`/`secondaryScopes` state, load junctions, `buildConfig` emits nested `master`/`secondary` (flat rides along), migration = flat rules open as whole-group scopes, wire the auto-sync Fix dialog, update editor tests. **One PO decision** teed up on bead `38dzi`: default single-provider groups to "Any provider (whole group)" (ux recommends yes).

## Testing
Full backend suite + 468 frontend tests green; lint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
