### PR TITLE
v0.17.6-0082: Event Sync editor uses provider-scoped group picker (bead 38dzi)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -140,7 +140,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0081",
+    version="0.17.6-0082",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -75,7 +75,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0081"
+APP_VERSION = "0.17.6-0082"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0081",
+  "version": "0.17.6-0082",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../test/mocks/server';
 import { EventSyncRuleEditor } from './EventSyncRuleEditor';
 import type { ChannelPipelineRule } from '../../types/channelPipeline';
+import type { ProviderGroupScopeRow } from '../../services/api';
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => {
@@ -27,54 +28,48 @@ afterEach(() => {
 });
 afterAll(() => server.close());
 
-/** Stub GET /api/providers/group-settings with per-group auto-sync flags.
- * All groups are `enabled: true` — use `stubGroupSettingsFull` for tests
- * that need to control the `enabled` flag itself. */
-function stubGroupSettings(autoSyncByGroupId: Record<number, boolean>) {
+/** Stub GET /api/providers/group-settings/by-provider with (provider, group)
+ * junction rows (bead 38dzi). The picker groups rows by channel_group_id; a
+ * single row per group renders as a flat WHOLE-GROUP (m3u_account_id null)
+ * option with data-testid `psg-<role>-<groupId>-any`. */
+function stubJunctions(rows: ProviderGroupScopeRow[]) {
   server.use(
-    http.get('/api/providers/group-settings', () =>
-      HttpResponse.json(
-        Object.fromEntries(
-          Object.entries(autoSyncByGroupId).map(([groupId, autoSync]) => [
-            groupId,
-            {
-              channel_group: Number(groupId),
-              enabled: true,
-              auto_channel_sync: autoSync,
-              auto_sync_channel_start: null,
-              m3u_account_id: 1,
-              m3u_account_name: 'Provider A',
-            },
-          ])
-        )
-      )
+    http.get('/api/providers/group-settings/by-provider', () =>
+      HttpResponse.json(rows)
     )
   );
 }
 
-/** Stub GET /api/providers/group-settings with explicit `enabled` +
- * `auto_channel_sync` per group (bead x82s3 — enabled-groups filter). */
+/** Convenience: one single-provider junction per group ('Provider A', id 1,
+ * enabled) with the given auto-sync flag. Use `stubJunctionsFull` for tests
+ * that need to control the `enabled` flag itself (bead x82s3). */
+function stubGroupSettings(autoSyncByGroupId: Record<number, boolean>) {
+  stubJunctions(
+    Object.entries(autoSyncByGroupId).map(([groupId, autoSync]) => ({
+      m3u_account_id: 1,
+      m3u_account_name: 'Provider A',
+      channel_group_id: Number(groupId),
+      auto_channel_sync: autoSync,
+      enabled: true,
+      stream_count: 10,
+    }))
+  );
+}
+
+/** One single-provider junction per group with explicit `enabled` +
+ * `auto_channel_sync` (bead x82s3 — enabled-groups filter). */
 function stubGroupSettingsFull(
   settings: Record<number, { enabled: boolean; auto_channel_sync: boolean }>
 ) {
-  server.use(
-    http.get('/api/providers/group-settings', () =>
-      HttpResponse.json(
-        Object.fromEntries(
-          Object.entries(settings).map(([groupId, s]) => [
-            groupId,
-            {
-              channel_group: Number(groupId),
-              enabled: s.enabled,
-              auto_channel_sync: s.auto_channel_sync,
-              auto_sync_channel_start: null,
-              m3u_account_id: 1,
-              m3u_account_name: 'Provider A',
-            },
-          ])
-        )
-      )
-    )
+  stubJunctions(
+    Object.entries(settings).map(([groupId, s]) => ({
+      m3u_account_id: 1,
+      m3u_account_name: 'Provider A',
+      channel_group_id: Number(groupId),
+      auto_channel_sync: s.auto_channel_sync,
+      enabled: s.enabled,
+      stream_count: 10,
+    }))
   );
 }
 
@@ -213,7 +208,8 @@ describe('EventSyncRuleEditor', () => {
       await user.click(screen.getByRole('button', { name: 'Save' }));
       await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
       const cfg = onSave.mock.calls[0][0].event_sync_config;
-      expect(cfg.secondary_group_ids).toEqual([]);
+      expect(cfg.secondary).toEqual([]);
+      expect(cfg).not.toHaveProperty('secondary_group_ids');
       expect(cfg.include_master_group_streams).toBe(true);
     });
 
@@ -488,38 +484,45 @@ describe('EventSyncRuleEditor', () => {
     });
   });
 
-  describe('live auto-sync guidance (toggles ONLY via the confirmed fix)', () => {
-    it('warns with guidance + a Fix button when the master group has auto-sync OFF', async () => {
+  describe('inline auto-sync status (picker; toggles ONLY via the confirmed fix)', () => {
+    it('shows an inline mismatch + Fix when the master scope has auto-sync OFF', async () => {
       seedGroups();
       stubGroupSettings({ 1: false, 2: false });
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
 
-      const warning = await screen.findByTestId('master-autosync-warning');
-      expect(warning).toHaveTextContent(/auto-sync is/i);
-      expect(warning).toHaveTextContent(/never as a side effect/i);
-      expect(screen.getByTestId('master-autosync-fix')).toBeInTheDocument();
+      // The migrated master scope (whole group 1) renders checked with an OFF
+      // junction — a master needs it ON, so the picker shows the inline fix.
+      const fix = await screen.findByRole('button', {
+        name: /turn auto-sync ON for Provider A/i,
+      });
+      expect(fix).toBeInTheDocument();
+      expect(screen.getByText(/a master needs it ON/i)).toBeInTheDocument();
     });
 
-    it('shows an OK status when the master group has auto-sync ON', async () => {
+    it('shows an OK sync badge (no Fix) when the master scope has auto-sync ON', async () => {
       seedGroups();
       stubGroupSettings({ 1: true, 2: false });
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
 
+      const master = await screen.findByTestId('psg-master');
+      expect(await within(master).findByText(/Auto-sync ON ✓/)).toBeInTheDocument();
       expect(
-        await screen.findByText(/auto-sync is on — dispatcharr owns this group/i)
-      ).toBeInTheDocument();
-      expect(screen.queryByTestId('master-autosync-warning')).toBeNull();
+        within(master).queryByRole('button', { name: /turn auto-sync/i })
+      ).toBeNull();
     });
 
-    it('warns with guidance + a per-group Fix button when a secondary group has auto-sync ON', async () => {
+    it('shows an inline mismatch + Fix when a secondary scope has auto-sync ON', async () => {
       seedGroups();
       stubGroupSettings({ 1: true, 2: true });
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
 
-      const warning = await screen.findByTestId('secondary-autosync-warning');
-      expect(warning).toHaveTextContent('Secondary Events');
-      expect(warning).toHaveTextContent(/never as a side effect/i);
-      expect(screen.getByTestId('secondary-autosync-fix-2')).toBeInTheDocument();
+      const secondary = await screen.findByTestId('psg-secondary');
+      expect(
+        await within(secondary).findByRole('button', {
+          name: /turn auto-sync OFF for Provider A/i,
+        })
+      ).toBeInTheDocument();
+      expect(within(secondary).getByText(/a secondary needs it OFF/i)).toBeInTheDocument();
     });
   });
 
@@ -542,7 +545,7 @@ describe('EventSyncRuleEditor', () => {
       );
     }
 
-    it('the Fix button only OPENS the confirmation dialog — nothing is written yet', async () => {
+    it('the picker Fix affordance only OPENS the confirmation dialog — nothing is written yet', async () => {
       const user = userEvent.setup();
       const calls: unknown[] = [];
       seedGroups();
@@ -550,7 +553,9 @@ describe('EventSyncRuleEditor', () => {
       stubToggleEndpoint(calls);
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
 
-      await user.click(await screen.findByTestId('secondary-autosync-fix-2'));
+      await user.click(
+        await screen.findByRole('button', { name: /turn auto-sync OFF for Provider A/i })
+      );
 
       // Dialog states exactly what will change and why, including the
       // consequence and the snapshot-restore recovery note.
@@ -572,7 +577,9 @@ describe('EventSyncRuleEditor', () => {
       stubToggleEndpoint(calls);
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
 
-      await user.click(await screen.findByTestId('secondary-autosync-fix-2'));
+      await user.click(
+        await screen.findByRole('button', { name: /turn auto-sync OFF for Provider A/i })
+      );
       const dialog = screen.getByRole('alertdialog');
       await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
 
@@ -580,7 +587,7 @@ describe('EventSyncRuleEditor', () => {
       expect(calls).toHaveLength(0);
     });
 
-    it('Confirm sends confirm:true for the OFF direction and the warning clears after refetch', async () => {
+    it('Confirm sends confirm:true for the OFF direction and the inline fix clears after refetch', async () => {
       const user = userEvent.setup();
       const calls: unknown[] = [];
       seedGroups();
@@ -588,8 +595,10 @@ describe('EventSyncRuleEditor', () => {
       stubToggleEndpoint(calls);
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
 
-      await user.click(await screen.findByTestId('secondary-autosync-fix-2'));
-      // The refetch after the confirmed toggle sees the FIXED settings.
+      await user.click(
+        await screen.findByRole('button', { name: /turn auto-sync OFF for Provider A/i })
+      );
+      // The refetch after the confirmed toggle sees the FIXED junction.
       stubGroupSettings({ 1: true, 2: false });
       await user.click(screen.getByTestId('autosync-fix-confirm'));
 
@@ -599,9 +608,11 @@ describe('EventSyncRuleEditor', () => {
         auto_channel_sync: false,
         confirm: true,
       });
-      // Pre-flight warning clears — the editor refetched live settings.
+      // The inline mismatch fix clears — the editor refetched the junctions.
       await waitFor(() =>
-        expect(screen.queryByTestId('secondary-autosync-warning')).toBeNull()
+        expect(
+          screen.queryByRole('button', { name: /turn auto-sync OFF for Provider A/i })
+        ).toBeNull()
       );
       expect(screen.queryByRole('alertdialog')).toBeNull();
     });
@@ -614,7 +625,9 @@ describe('EventSyncRuleEditor', () => {
       stubToggleEndpoint(calls);
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
 
-      await user.click(await screen.findByTestId('master-autosync-fix'));
+      await user.click(
+        await screen.findByRole('button', { name: /turn auto-sync ON for Provider A/i })
+      );
       const dialog = screen.getByRole('alertdialog');
       expect(dialog).toHaveTextContent(/begin creating and managing channels/i);
       stubGroupSettings({ 1: true, 2: false });
@@ -627,11 +640,13 @@ describe('EventSyncRuleEditor', () => {
         confirm: true,
       });
       await waitFor(() =>
-        expect(screen.queryByTestId('master-autosync-warning')).toBeNull()
+        expect(
+          screen.queryByRole('button', { name: /turn auto-sync ON for Provider A/i })
+        ).toBeNull()
       );
     });
 
-    it('saving a rule NEVER calls the toggle endpoint, even with warnings showing', async () => {
+    it('saving a rule NEVER calls the toggle endpoint, even with a mismatch showing', async () => {
       const user = userEvent.setup();
       const calls: unknown[] = [];
       seedGroups();
@@ -640,7 +655,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      await screen.findByTestId('master-autosync-warning');
+      await screen.findByRole('button', { name: /turn auto-sync ON for Provider A/i });
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
       await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
@@ -663,9 +678,12 @@ describe('EventSyncRuleEditor', () => {
       expect(saved.name).toBe('PPV Events');
       expect(saved.conditions).toEqual([{ type: 'always' }]);
       expect(saved.actions).toEqual([{ type: 'skip' }]);
+      // bead 38dzi: the editor emits the nested provider-scoped shape; the
+      // legacy flat master_group_id/secondary_group_ids migrate to
+      // whole-group scopes (m3u_account_id null) and the flat keys are gone.
       expect(saved.event_sync_config).toEqual({
-        master_group_id: 1,
-        secondary_group_ids: [2],
+        master: { group_id: 1, m3u_account_id: null },
+        secondary: [{ group_id: 2, m3u_account_id: null }],
         time_window_minutes: 30,
         attach_threshold: 0.8,
         enabled: true,
@@ -757,8 +775,14 @@ describe('EventSyncRuleEditor', () => {
 
       await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
       const saved = onSave.mock.calls[0][0].event_sync_config;
-      // The whole config round-trips content-identically...
-      expect(saved).toEqual(API_CONFIG);
+      // The group scopes migrate to the nested provider-scoped shape (the
+      // flat keys are gone), but everything else round-trips content-identically...
+      expect(saved.master).toEqual({ group_id: 1, m3u_account_id: null });
+      expect(saved.secondary).toEqual([{ group_id: 2, m3u_account_id: null }]);
+      expect(saved).not.toHaveProperty('master_group_id');
+      expect(saved).not.toHaveProperty('secondary_group_ids');
+      expect(saved.time_window_minutes).toBe(45);
+      expect(saved.attach_threshold).toBe(0.9);
       // ...and the arrays the UI cannot express are passed through VERBATIM
       // (same objects — not a re-built lossy approximation).
       expect(saved.patterns).toBe(API_CONFIG.patterns);
@@ -974,7 +998,8 @@ describe('EventSyncRuleEditor', () => {
     stubGroupSettings({ 1: true, 2: false });
     render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
 
-    await screen.findByText(/auto-sync is on — dispatcharr owns this group/i);
+    const master = await screen.findByTestId('psg-master');
+    await within(master).findByText(/Auto-sync ON ✓/);
     expect(screen.queryByRole('button', { name: /apply|attach/i })).toBeNull();
   });
 
@@ -988,44 +1013,37 @@ describe('EventSyncRuleEditor', () => {
       });
     }
 
-    it('defaults to hiding disabled groups from both the master and secondary pickers', async () => {
-      const user = userEvent.setup();
+    it('defaults to hiding disabled junctions from both the master and secondary pickers', async () => {
       seedGroupsWithDisabled();
       stubThreeGroups();
       render(<EventSyncRuleEditor onSave={vi.fn()} onCancel={vi.fn()} />);
 
-      // Secondary list: disabled group absent, enabled groups present.
-      await screen.findByRole('checkbox', { name: /Secondary Events/i });
-      expect(screen.queryByRole('checkbox', { name: /Disabled Group/i })).toBeNull();
+      // Secondary picker: disabled group's junction absent, enabled present.
+      expect(await screen.findByTestId('psg-secondary-1-any')).toBeInTheDocument();
+      expect(screen.getByTestId('psg-secondary-2-any')).toBeInTheDocument();
+      expect(screen.queryByTestId('psg-secondary-3-any')).toBeNull();
 
       // Master picker: same filtering.
-      await user.click(screen.getByRole('button', { name: /select master group/i }));
-      const listbox = await screen.findByRole('listbox');
-      expect(within(listbox).getByText(/Master Events/)).toBeInTheDocument();
-      expect(within(listbox).getByText(/Secondary Events/)).toBeInTheDocument();
-      expect(within(listbox).queryByText(/Disabled Group/)).toBeNull();
+      expect(screen.getByTestId('psg-master-1-any')).toBeInTheDocument();
+      expect(screen.getByTestId('psg-master-2-any')).toBeInTheDocument();
+      expect(screen.queryByTestId('psg-master-3-any')).toBeNull();
     });
 
-    it('reveals disabled groups in both pickers when "Show all groups" is checked', async () => {
+    it('reveals disabled junctions in both pickers when "Show all groups" is checked', async () => {
       const user = userEvent.setup();
       seedGroupsWithDisabled();
       stubThreeGroups();
       render(<EventSyncRuleEditor onSave={vi.fn()} onCancel={vi.fn()} />);
 
-      await screen.findByRole('checkbox', { name: /Secondary Events/i });
-      expect(screen.queryByRole('checkbox', { name: /Disabled Group/i })).toBeNull();
+      await screen.findByTestId('psg-secondary-1-any');
+      expect(screen.queryByTestId('psg-secondary-3-any')).toBeNull();
 
       await user.click(
         screen.getByRole('checkbox', { name: /show all groups/i })
       );
 
-      expect(
-        await screen.findByRole('checkbox', { name: /Disabled Group/i })
-      ).toBeInTheDocument();
-
-      await user.click(screen.getByRole('button', { name: /select master group/i }));
-      const listbox = await screen.findByRole('listbox');
-      expect(within(listbox).getByText(/Disabled Group/)).toBeInTheDocument();
+      expect(await screen.findByTestId('psg-secondary-3-any')).toBeInTheDocument();
+      expect(screen.getByTestId('psg-master-3-any')).toBeInTheDocument();
     });
 
     it('keeps an already-selected but disabled master group visible, selected, and round-tripped on save', async () => {
@@ -1040,18 +1058,18 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      // The trigger still shows the selected (disabled) master group.
-      const trigger = await screen.findByRole('button', { name: /Master Events/i });
-      expect(trigger).toHaveTextContent('(disabled)');
-
-      await user.click(trigger);
-      const listbox = await screen.findByRole('listbox');
-      expect(within(listbox).getByText(/Master Events.*\(disabled\)/)).toBeInTheDocument();
-      await user.keyboard('{Escape}');
+      // The migrated whole-group master scope stays visible (round-trip guard)
+      // with a disabled hint, and checked.
+      const masterRow = await screen.findByTestId('psg-master-1-any');
+      expect(masterRow).toBeChecked();
+      expect(masterRow.closest('label')).toHaveTextContent('(disabled)');
 
       await user.click(screen.getByRole('button', { name: 'Save' }));
       await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
-      expect(onSave.mock.calls[0][0].event_sync_config.master_group_id).toBe(1);
+      expect(onSave.mock.calls[0][0].event_sync_config.master).toEqual({
+        group_id: 1,
+        m3u_account_id: null,
+      });
     });
 
     it('keeps an already-checked but disabled secondary group visible, checked, and round-tripped on save', async () => {
@@ -1068,19 +1086,24 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={rule} onSave={onSave} onCancel={vi.fn()} />);
 
-      const disabledCheckbox = await screen.findByRole('checkbox', { name: /Disabled Group/i });
-      expect(disabledCheckbox).toBeChecked();
-      expect(disabledCheckbox.closest('label')).toHaveTextContent('(disabled)');
+      const disabledRow = await screen.findByTestId('psg-secondary-3-any');
+      expect(disabledRow).toBeChecked();
+      expect(disabledRow.closest('label')).toHaveTextContent('(disabled)');
 
       await user.click(screen.getByRole('button', { name: 'Save' }));
       await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
-      expect(onSave.mock.calls[0][0].event_sync_config.secondary_group_ids).toEqual([2, 3]);
+      expect(onSave.mock.calls[0][0].event_sync_config.secondary).toEqual([
+        { group_id: 2, m3u_account_id: null },
+        { group_id: 3, m3u_account_id: null },
+      ]);
     });
 
-    it('treats a group absent from groupSettings as not-enabled but still round-trips it if already selected', async () => {
+    it('round-trips a selected group with no provider junction (shown as a chip, kept on save)', async () => {
       const user = userEvent.setup();
       seedGroupsWithDisabled();
-      // Group 3 has NO entry at all in group-settings.
+      // Group 3 has NO junction row at all, so it is not a selectable picker
+      // option — but the secondary selection chip still surfaces it and the
+      // scope survives on save (no data loss).
       stubGroupSettingsFull({
         1: { enabled: true, auto_channel_sync: true },
         2: { enabled: true, auto_channel_sync: false },
@@ -1095,28 +1118,31 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={rule} onSave={onSave} onCancel={vi.fn()} />);
 
-      const disabledCheckbox = await screen.findByRole('checkbox', { name: /Disabled Group/i });
-      expect(disabledCheckbox).toBeChecked();
+      const secondary = await screen.findByTestId('psg-secondary');
+      expect(within(secondary).getByText(/Group 3 · Any provider/)).toBeInTheDocument();
 
       await user.click(screen.getByRole('button', { name: 'Save' }));
       await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
-      expect(onSave.mock.calls[0][0].event_sync_config.secondary_group_ids).toEqual([2, 3]);
+      expect(onSave.mock.calls[0][0].event_sync_config.secondary).toEqual([
+        { group_id: 2, m3u_account_id: null },
+        { group_id: 3, m3u_account_id: null },
+      ]);
     });
 
-    it('composes the enabled filter with the existing name filter on the secondary list', async () => {
+    it('composes the enabled filter with the picker search on the secondary list', async () => {
       const user = userEvent.setup();
       seedGroupsWithDisabled();
       stubThreeGroups();
       render(<EventSyncRuleEditor onSave={vi.fn()} onCancel={vi.fn()} />);
 
       await user.click(screen.getByRole('checkbox', { name: /show all groups/i }));
-      await screen.findByRole('checkbox', { name: /Disabled Group/i });
+      await screen.findByTestId('psg-secondary-3-any');
 
       await user.type(screen.getByLabelText('Filter secondary groups'), 'Secondary');
 
-      expect(screen.getByRole('checkbox', { name: /Secondary Events/i })).toBeInTheDocument();
-      expect(screen.queryByRole('checkbox', { name: /Disabled Group/i })).toBeNull();
-      expect(screen.queryByRole('checkbox', { name: /Master Events/i })).toBeNull();
+      expect(screen.getByTestId('psg-secondary-2-any')).toBeInTheDocument();
+      expect(screen.queryByTestId('psg-secondary-3-any')).toBeNull();
+      expect(screen.queryByTestId('psg-secondary-1-any')).toBeNull();
     });
   });
 });

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
@@ -3,11 +3,15 @@
  *
  * Quick path: pick a master group, pick secondary groups, keep the shipped
  * default patterns, preview. Advanced knobs (time window, attach threshold,
- * dummy EPG profile, per-group pattern overrides) stay collapsed. Auto-sync
- * status is shown LIVE per group with guidance text when it's wrong, plus a
- * guided one-click fix (ti939.3.4): the Fix button opens a confirmation
- * dialog and ONLY its confirm button calls the admin-gated toggle endpoint
- * — never save, never preview, never a side effect.
+ * dummy EPG profile, per-group pattern overrides) stay collapsed. The master
+ * and secondary groups are chosen with the provider-scoped group picker (bead
+ * 38dzi): channel-group names are globally unique, so a group carried by two
+ * providers shares one channel_group_id but two per-provider junctions — the
+ * picker lets the operator scope the master/secondary to a specific provider
+ * (or the whole group). It renders LIVE per-scope auto-sync status inline and
+ * offers a guided one-click fix (ti939.3.4): the Fix affordance opens a
+ * confirmation dialog and ONLY its confirm button calls the admin-gated toggle
+ * endpoint — never save, never preview, never a side effect.
  *
  * There is NO apply/attach control anywhere: saving stores the config on the
  * rule; the only action against live data is the zero-write preview.
@@ -20,23 +24,33 @@
  * never dropped or reordered. Built-ins are recognized by VERBATIM equality
  * and are never silently re-added to an all-custom selection.
  *
- * Group pickers default to ENABLED groups only (bead x82s3): the master
- * select and secondary multi-select both hide groups whose provider setting
- * (`M3UGroupSetting.enabled`) is not `true` — a group with no settings entry
- * at all counts as not-enabled. A "Show all groups" toggle (default off)
- * reveals the full list. Round-trip guard: a group already referenced by the
- * rule being edited (masterGroupId, or a checked secondary id) always
- * renders — with a "(disabled)" hint — even when the enabled-only filter
- * would otherwise hide it, and `buildConfig` never drops it.
+ * Group pickers default to ENABLED junctions only (bead x82s3): both pickers
+ * hide (provider, group) junctions whose provider setting is not enabled — a
+ * group with no junction at all simply does not appear. A shared "Show all
+ * groups" toggle (default off) reveals the full list. Round-trip guard: a
+ * scope already referenced by the rule being edited (the master scope, or a
+ * checked secondary scope) always renders — with a "(disabled)" hint — even
+ * when the enabled-only filter would otherwise hide it, and `buildConfig`
+ * never drops it.
+ *
+ * Migration (bead 38dzi): a legacy rule whose config carries only the flat
+ * `master_group_id` / `secondary_group_ids` opens as WHOLE-GROUP scopes
+ * (`m3u_account_id: null`); saving emits the nested `master` / `secondary`
+ * and lets the backend derive the flat keys.
  */
 import { useEffect, useId, useMemo, useState } from 'react';
 import type { ChannelPipelineRule, CreateRuleData } from '../../types/channelPipeline';
-import type { EventSyncConfig, EventSyncPattern, EventSyncPreviewResponse } from '../../types/eventSync';
-import type { DummyEPGProfile, M3UGroupSetting } from '../../types';
+import type {
+  EventSyncConfig,
+  EventSyncGroupScope,
+  EventSyncPattern,
+  EventSyncPreviewResponse,
+} from '../../types/eventSync';
+import type { DummyEPGProfile } from '../../types';
 import {
   getChannelGroups,
   getDummyEPGProfiles,
-  getProviderGroupSettings,
+  getProviderGroupSettingsByProvider,
   toggleGroupAutoSync,
 } from '../../services/api';
 import { previewEventSync } from '../../services/channelPipelineApi';
@@ -46,6 +60,8 @@ import type { LabeledEventSyncPattern } from './EventSyncTestPatternsPanel';
 import { EventSyncPreviewPanel } from './EventSyncPreviewPanel';
 import { EventSyncAutoSyncFixDialog } from './EventSyncAutoSyncFixDialog';
 import type { AutoSyncFixTarget } from './EventSyncAutoSyncFixDialog';
+import { ProviderScopedGroupPicker } from './ProviderScopedGroupPicker';
+import { joinProviderRows, type GroupProviderRow } from './providerScopedGroups';
 import {
   SHIPPED_EVENT_SYNC_PATTERNS,
   DEFAULT_PATTERN_IDS,
@@ -184,18 +200,26 @@ export function EventSyncRuleEditor({
   const [description, setDescription] = useState(rule?.description || '');
   const [enabled, setEnabled] = useState(rule?.enabled ?? true);
 
-  // Scoping
-  const [masterGroupId, setMasterGroupId] = useState<number | null>(
-    config?.master_group_id ?? null
-  );
-  const [secondaryGroupIds, setSecondaryGroupIds] = useState<number[]>(
-    config?.secondary_group_ids ?? []
-  );
-  const [secondarySearch, setSecondarySearch] = useState('');
-  // bead x82s3: both group pickers default to enabled-only groups (hundreds
+  // Scoping (bead 38dzi): provider-scoped master + secondary. Initialize from
+  // the nested `master` / `secondary` when present; otherwise migrate the flat
+  // legacy keys to WHOLE-GROUP scopes (m3u_account_id null).
+  const [masterScope, setMasterScope] = useState<EventSyncGroupScope | null>(() => {
+    if (config?.master) return config.master;
+    if (config?.master_group_id != null) {
+      return { group_id: config.master_group_id, m3u_account_id: null };
+    }
+    return null;
+  });
+  const [secondaryScopes, setSecondaryScopes] = useState<EventSyncGroupScope[]>(() => {
+    if (config?.secondary) return config.secondary;
+    return (config?.secondary_group_ids ?? []).map(gid => ({
+      group_id: gid,
+      m3u_account_id: null,
+    }));
+  });
+  // bead x82s3: both group pickers default to enabled-only junctions (hundreds
   // of groups on a real instance is noisy); this reveals the full list for
-  // edge cases (temporarily-disabled group, a group with no provider
-  // settings at all). Default OFF.
+  // edge cases (temporarily-disabled group). Default OFF.
   const [showAllGroups, setShowAllGroups] = useState(false);
 
   // Patterns. `initial` keeps the untouched-open values so save can detect a
@@ -253,8 +277,9 @@ export function EventSyncRuleEditor({
 
   // Reference data
   const [channelGroups, setChannelGroups] = useState<{ id: number; name: string }[]>([]);
-  const [groupSettings, setGroupSettings] = useState<Record<number, M3UGroupSetting>>({});
-  const [settingsLoaded, setSettingsLoaded] = useState(false);
+  // bead 38dzi: (provider, group) junction rows joined to channel-group names,
+  // driving the provider-scoped pickers (and their inline auto-sync status).
+  const [junctions, setJunctions] = useState<GroupProviderRow[]>([]);
 
   // Guided setup (ti939.3.4): one-click confirmed auto_channel_sync fix.
   // The toggle API is ONLY called from the confirmation dialog's confirm
@@ -272,22 +297,24 @@ export function EventSyncRuleEditor({
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    getChannelGroups()
-      .then(groups => setChannelGroups(groups.map(g => ({ id: g.id, name: g.name }))))
-      .catch(() => {});
-    getProviderGroupSettings()
-      .then(settings => {
-        setGroupSettings(settings);
-        setSettingsLoaded(true);
-      })
-      .catch(() => {});
+    // The junction rows carry no group name; join them against the channel
+    // group list the editor already loads. Load both, then join.
+    Promise.all([
+      getChannelGroups().catch(() => []),
+      getProviderGroupSettingsByProvider().catch(() => []),
+    ]).then(([groups, rows]) => {
+      const simple = groups.map(g => ({ id: g.id, name: g.name }));
+      setChannelGroups(simple);
+      const byId = new Map(simple.map(g => [g.id, g.name]));
+      setJunctions(joinProviderRows(rows, gid => byId.get(gid)));
+    });
     getDummyEPGProfiles()
       .then(setDummyProfiles)
       .catch(() => {});
   }, []);
 
-  /** Guided fix (ti939.3.4): the CONFIRMED toggle, then refetch the live
-   * group settings so the pre-flight warnings clear. */
+  /** Guided fix (ti939.3.4): the CONFIRMED toggle, then refetch the junctions
+   * so the picker's inline auto-sync status updates. */
   const handleConfirmFix = async () => {
     if (!pendingFix) return;
     setFixBusy(true);
@@ -298,8 +325,9 @@ export function EventSyncRuleEditor({
         auto_channel_sync: pendingFix.enable,
         confirm: true,
       });
-      const settings = await getProviderGroupSettings();
-      setGroupSettings(settings);
+      const rows = await getProviderGroupSettingsByProvider();
+      const byId = new Map(channelGroups.map(g => [g.id, g.name]));
+      setJunctions(joinProviderRows(rows, gid => byId.get(gid)));
       setPendingFix(null);
     } catch (err) {
       setFixError(err instanceof Error ? err.message : 'Toggle failed');
@@ -308,84 +336,30 @@ export function EventSyncRuleEditor({
     }
   };
 
-  /** Fix-button target for a provider-backed group, or null when the group
-   * has no provider settings (nothing to toggle). */
-  const fixTargetFor = (groupId: number, enable: boolean): AutoSyncFixTarget | null => {
-    const setting = groupSettings[groupId];
-    if (!setting) return null;
-    return {
-      groupId,
-      groupName: groupName(groupId),
-      accountId: setting.m3u_account_id,
-      accountName: setting.m3u_account_name,
-      enable,
-    };
-  };
-
   const openFixDialog = (target: AutoSyncFixTarget) => {
     setFixError(null);
     setPendingFix(target);
+  };
+
+  /** Translate the picker's fix request (accountId + groupId) into the fix
+   * dialog target, looking up the provider name from the junction rows. */
+  const requestFix = (t: { accountId: number; groupId: number }, enable: boolean) => {
+    const row = junctions.find(
+      j => j.m3uAccountId === t.accountId && j.groupId === t.groupId
+    );
+    openFixDialog({
+      groupId: t.groupId,
+      groupName: groupName(t.groupId),
+      accountId: t.accountId,
+      accountName: row?.m3uAccountName ?? `Provider ${t.accountId}`,
+      enable,
+    });
   };
 
   const groupName = useMemo(() => {
     const byId = new Map(channelGroups.map(g => [g.id, g.name]));
     return (groupId: number) => byId.get(groupId) ?? `Group ${groupId}`;
   }, [channelGroups]);
-
-  /** Live auto-sync status: true/false when known, null when not provider-backed. */
-  const autoSyncStatus = (groupId: number): boolean | null => {
-    const setting = groupSettings[groupId];
-    return setting ? Boolean(setting.auto_channel_sync) : null;
-  };
-
-  /** bead x82s3: 'enabled' = the group's provider (M3U) setting is enabled.
-   * A group with no groupSettings entry at all is treated as NOT enabled
-   * (hidden by default unless already selected, or Show all groups is on). */
-  const isGroupEnabled = (groupId: number): boolean =>
-    groupSettings[groupId]?.enabled === true;
-
-  const masterStatus = masterGroupId != null ? autoSyncStatus(masterGroupId) : null;
-
-  const secondariesWithAutoSyncOn = secondaryGroupIds.filter(
-    groupId => autoSyncStatus(groupId) === true
-  );
-
-  /** Master group options: enabled groups by default, plus Show all groups
-   * escape hatch, plus (round-trip guard, bead z4y4a-style) the CURRENTLY
-   * selected master group even when it's disabled/hidden — an edited rule
-   * must never lose its saved master group just because it's filtered out
-   * of the list. Checks `groupSettings` directly (not via the `isGroupEnabled`
-   * / `autoSyncStatus` helpers) so the dependency array stays exhaustive
-   * without re-deriving on every render. */
-  const masterGroupOptions = useMemo(() => {
-    return channelGroups
-      .filter(g => showAllGroups || groupSettings[g.id]?.enabled === true || g.id === masterGroupId)
-      .slice()
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map(g => {
-        const setting = groupSettings[g.id];
-        const statusLabel =
-          setting === undefined
-            ? 'no provider settings'
-            : setting.auto_channel_sync
-              ? 'auto-sync ON'
-              : 'auto-sync OFF';
-        const disabledHint = setting?.enabled === true ? '' : ' (disabled)';
-        return { value: g.id.toString(), label: `${g.name} — ${statusLabel}${disabledHint}` };
-      });
-  }, [channelGroups, groupSettings, showAllGroups, masterGroupId]);
-
-  /** Secondary group options: enabled groups by default (composed with the
-   * name filter), plus Show all groups, plus the round-trip guard for any
-   * secondary group already checked on this rule. */
-  const filteredSecondaryOptions = useMemo(() => {
-    const query = secondarySearch.trim().toLowerCase();
-    return channelGroups
-      .filter(g => g.id !== masterGroupId)
-      .filter(g => showAllGroups || groupSettings[g.id]?.enabled === true || secondaryGroupIds.includes(g.id))
-      .filter(g => !query || g.name.toLowerCase().includes(query))
-      .sort((a, b) => a.name.localeCompare(b.name));
-  }, [channelGroups, masterGroupId, secondarySearch, showAllGroups, groupSettings, secondaryGroupIds]);
 
   /** The custom-shared draft as a pattern object, or null when empty. The
    * API-authored name of the first custom pattern is preserved (z4y4a);
@@ -442,18 +416,22 @@ export function EventSyncRuleEditor({
     return patterns;
   }, [selectedPatternIds, customShared, customSharedMeta]);
 
-  /** Groups in scope (master + secondaries) — for live samples + overrides. */
+  /** Groups in scope (master + secondaries) — for live samples + overrides.
+   * Deduped by group id: master and a secondary may share a group id under
+   * different providers. */
   const scopedGroups = useMemo(() => {
-    const ids = masterGroupId != null ? [masterGroupId, ...secondaryGroupIds] : [...secondaryGroupIds];
-    return ids.map(groupId => ({ id: groupId, name: groupName(groupId) }));
-  }, [masterGroupId, secondaryGroupIds, groupName]);
+    const ids = new Set<number>();
+    if (masterScope != null) ids.add(masterScope.group_id);
+    for (const s of secondaryScopes) ids.add(s.group_id);
+    return [...ids].map(groupId => ({ id: groupId, name: groupName(groupId) }));
+  }, [masterScope, secondaryScopes, groupName]);
 
   const validationError: string | null = (() => {
-    if (masterGroupId == null) return 'Pick a master group first';
+    if (masterScope == null) return 'Pick a master group first';
     // bead 3ux85: no separate secondary is required when the master group is
     // itself the stream source (include_master_group_streams) — the
     // same-named cross-provider case.
-    if (secondaryGroupIds.length === 0 && !includeMasterGroupStreams) {
+    if (secondaryScopes.length === 0 && !includeMasterGroupStreams) {
       return 'Pick at least one secondary group (or enable '
         + '"Also attach the master group’s own streams" under Advanced)';
     }
@@ -469,12 +447,14 @@ export function EventSyncRuleEditor({
     // itself the stream source (include_master_group_streams) — the pure
     // same-named cross-provider case, where Dispatcharr collapses both
     // providers into one channel group so there is no separate secondary.
-    if (masterGroupId == null) return null;
-    if (secondaryGroupIds.length === 0 && !includeMasterGroupStreams) return null;
+    if (masterScope == null) return null;
+    if (secondaryScopes.length === 0 && !includeMasterGroupStreams) return null;
 
     const built: EventSyncConfig = {
-      master_group_id: masterGroupId,
-      secondary_group_ids: [...secondaryGroupIds],
+      // bead 38dzi: emit the nested provider-scoped shape only; the backend
+      // validator derives the flat master_group_id / secondary_group_ids.
+      master: masterScope,
+      secondary: [...secondaryScopes],
       time_window_minutes: Math.min(
         MAX_TIME_WINDOW_MINUTES,
         Math.max(1, parseInt(timeWindowText, 10) || DEFAULT_TIME_WINDOW_MINUTES)
@@ -557,8 +537,8 @@ export function EventSyncRuleEditor({
     // an edited group keeps its saved name and its inexpressible extra
     // patterns (patterns[1..]) unchanged behind the edited first pattern.
     const scopedIds = new Set<number>([
-      ...(masterGroupId != null ? [masterGroupId] : []),
-      ...secondaryGroupIds,
+      ...(masterScope != null ? [masterScope.group_id] : []),
+      ...secondaryScopes.map(s => s.group_id),
     ]);
     const groupPatternsOut: Record<string, EventSyncPattern[]> = {};
     const savedGroupPatterns = config?.group_patterns ?? {};
@@ -651,12 +631,6 @@ export function EventSyncRuleEditor({
     }
   };
 
-  const toggleSecondary = (groupId: number) => {
-    setSecondaryGroupIds(ids =>
-      ids.includes(groupId) ? ids.filter(i => i !== groupId) : [...ids, groupId]
-    );
-  };
-
   const updateOverride = (groupId: number, field: keyof GroupPatternDraft, value: string) => {
     setGroupOverrides(overrides => ({
       ...overrides,
@@ -727,160 +701,53 @@ export function EventSyncRuleEditor({
             <span>Show all groups</span>
           </label>
           <span className="form-hint">
-            The master and secondary pickers below list only groups enabled
-            on their M3U/provider account by default. Turn this on to see
-            every group too — useful for a temporarily-disabled group, or one
-            with no provider settings at all.
+            The master and secondary pickers below list only groups whose
+            provider (M3U) junction is enabled by default. Turn this on to see
+            every provider junction too — useful for a temporarily-disabled
+            group.
           </span>
         </section>
 
-        {/* Master group */}
+        {/* Master group (bead 38dzi: provider-scoped picker) */}
         <section className="event-sync-section-block">
           <h3 className="event-sync-section-title">Master group</h3>
           <span className="form-hint">
             The ONE group whose channels Dispatcharr owns — auto-sync must be
-            ON for it. Secondary streams attach to these channels.
+            ON for it. Secondary streams attach to these channels. A group
+            carried by more than one provider expands so you can scope the
+            master to a specific provider.
           </span>
-          <CustomSelect
-            value={masterGroupId != null ? masterGroupId.toString() : ''}
-            onChange={value => {
-              const groupId = value ? parseInt(value, 10) : null;
-              setMasterGroupId(groupId);
-              if (groupId != null) {
-                setSecondaryGroupIds(ids => ids.filter(i => i !== groupId));
-              }
-            }}
-            options={masterGroupOptions}
-            placeholder="Select master group..."
-            searchable
-            searchPlaceholder="Search groups..."
+          <ProviderScopedGroupPicker
+            role="master"
+            rows={junctions}
+            value={masterScope}
+            onChange={s => setMasterScope(s as EventSyncGroupScope | null)}
+            showAll={showAllGroups}
+            excludeScope={null}
+            onRequestFix={t => requestFix(t, true)}
             disabled={isLoading}
           />
-          {masterGroupId != null && settingsLoaded && masterStatus !== true && (
-            <div className="warning-message" role="alert" data-testid="master-autosync-warning">
-              <span className="material-icons">warning</span>
-              <span>
-                {masterStatus === false ? (
-                  <>
-                    Auto-sync is <strong>OFF</strong> for this group, so
-                    Dispatcharr creates no master channels and the preview will
-                    match nothing. Enable <code>auto_channel_sync</code> for
-                    this group in M3U Manager → account → Groups, or use the
-                    Fix button — ECM changes this setting only through that
-                    explicitly confirmed fix, never as a side effect of saving
-                    or running.
-                    {(() => {
-                      const target = fixTargetFor(masterGroupId, true);
-                      return target ? (
-                        <button
-                          type="button"
-                          className="btn-secondary event-sync-fix-btn"
-                          data-testid="master-autosync-fix"
-                          onClick={() => openFixDialog(target)}
-                          disabled={isLoading}
-                        >
-                          Fix: turn auto-sync ON…
-                        </button>
-                      ) : null;
-                    })()}
-                  </>
-                ) : (
-                  <>
-                    This group has no provider group settings — it may not be
-                    provider-backed. Pick the provider event group Dispatcharr
-                    auto-syncs channels from.
-                  </>
-                )}
-              </span>
-            </div>
-          )}
-          {masterGroupId != null && masterStatus === true && (
-            <span className="event-sync-status-ok">
-              <span className="material-icons" aria-hidden="true">check_circle</span>
-              Auto-sync is ON — Dispatcharr owns this group&apos;s channels.
-            </span>
-          )}
         </section>
 
-        {/* Secondary groups */}
+        {/* Secondary groups (bead 38dzi: provider-scoped picker) */}
         <section className="event-sync-section-block">
           <h3 className="event-sync-section-title">Secondary groups</h3>
           <span className="form-hint">
             Pure stream sources from other providers — auto-sync should be OFF
             for each (otherwise Dispatcharr keeps creating duplicate channels
-            from them).
+            from them). The same group under a different provider than the
+            master IS selectable here.
           </span>
-          <input
-            type="text"
-            className="event-sync-secondary-search"
-            placeholder="Filter groups..."
-            value={secondarySearch}
-            onChange={e => setSecondarySearch(e.target.value)}
-            aria-label="Filter secondary groups"
+          <ProviderScopedGroupPicker
+            role="secondary"
+            rows={junctions}
+            value={secondaryScopes}
+            onChange={s => setSecondaryScopes(s as EventSyncGroupScope[])}
+            showAll={showAllGroups}
+            excludeScope={masterScope}
+            onRequestFix={t => requestFix(t, false)}
+            disabled={isLoading}
           />
-          <div className="event-sync-secondary-list checkbox-group" role="group" aria-label="Secondary groups">
-            {filteredSecondaryOptions.length === 0 ? (
-              <span className="form-hint">No groups match the filter</span>
-            ) : (
-              filteredSecondaryOptions.map(group => {
-                const status = autoSyncStatus(group.id);
-                const disabled = !isGroupEnabled(group.id);
-                return (
-                  <label key={group.id} className="checkbox-option">
-                    <input
-                      type="checkbox"
-                      checked={secondaryGroupIds.includes(group.id)}
-                      onChange={() => toggleSecondary(group.id)}
-                      disabled={isLoading}
-                    />
-                    <span>
-                      {group.name}
-                      {disabled && (
-                        <span className="event-sync-disabled-hint">(disabled)</span>
-                      )}
-                      {status === true && (
-                        <span className="event-sync-inline-warn">
-                          <span className="material-icons" aria-hidden="true">warning</span>
-                          auto-sync ON
-                        </span>
-                      )}
-                    </span>
-                  </label>
-                );
-              })
-            )}
-          </div>
-          {secondariesWithAutoSyncOn.length > 0 && (
-            <div className="warning-message" role="alert" data-testid="secondary-autosync-warning">
-              <span className="material-icons">warning</span>
-              <span>
-                Auto-sync is <strong>ON</strong> for{' '}
-                {secondariesWithAutoSyncOn.map(groupName).join(', ')} —
-                Dispatcharr will keep creating duplicate channels from{' '}
-                {secondariesWithAutoSyncOn.length === 1 ? 'this group' : 'these groups'}.
-                Disable <code>auto_channel_sync</code> for{' '}
-                {secondariesWithAutoSyncOn.length === 1 ? 'it' : 'them'} in M3U
-                Manager → account → Groups, or use the Fix buttons — ECM
-                changes this setting only through that explicitly confirmed
-                fix, never as a side effect of saving or running.
-                {secondariesWithAutoSyncOn.map(groupId => {
-                  const target = fixTargetFor(groupId, false);
-                  return target ? (
-                    <button
-                      key={groupId}
-                      type="button"
-                      className="btn-secondary event-sync-fix-btn"
-                      data-testid={`secondary-autosync-fix-${groupId}`}
-                      onClick={() => openFixDialog(target)}
-                      disabled={isLoading}
-                    >
-                      Fix: turn auto-sync OFF for {groupName(groupId)}…
-                    </button>
-                  ) : null;
-                })}
-              </span>
-            </div>
-          )}
         </section>
 
         {/* Parse patterns */}

--- a/frontend/src/components/channelPipeline/ProviderScopedGroupPicker.test.tsx
+++ b/frontend/src/components/channelPipeline/ProviderScopedGroupPicker.test.tsx
@@ -45,13 +45,25 @@ describe('joinProviderRows', () => {
 });
 
 describe('ProviderScopedGroupPicker', () => {
-  it('renders a single-provider group as a flat row (no expander)', () => {
+  it('renders a single-provider group as a flat WHOLE-GROUP row (no expander)', () => {
     render(
       <ProviderScopedGroupPicker role="secondary" rows={ROWS} value={[]}
         onChange={vi.fn()} showAll={false} />,
     );
-    // NBA is single-provider → a flat checkbox, not an expand button.
-    expect(screen.getByTestId('psg-secondary-20-7')).toBeInTheDocument();
+    // NBA is single-provider → a flat checkbox that selects the whole group
+    // (m3u_account_id null), per the PO decision.
+    expect(screen.getByTestId('psg-secondary-20-any')).toBeInTheDocument();
+  });
+
+  it('single-provider flat row emits a WHOLE-GROUP (null provider) scope', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ProviderScopedGroupPicker role="master" rows={ROWS} value={null}
+        onChange={onChange} showAll={false} />,
+    );
+    await user.click(screen.getByTestId('psg-master-20-any'));
+    expect(onChange).toHaveBeenCalledWith({ group_id: 20, m3u_account_id: null });
   });
 
   it('expands a multi-provider group into per-provider + whole-group rows', async () => {
@@ -84,13 +96,13 @@ describe('ProviderScopedGroupPicker', () => {
     const onChange = vi.fn();
     render(
       <ProviderScopedGroupPicker role="secondary" rows={ROWS}
-        value={[{ group_id: 20, m3u_account_id: 7 }]} onChange={onChange}
+        value={[{ group_id: 20, m3u_account_id: null }]} onChange={onChange}
         showAll={false} />,
     );
     await user.click(screen.getByRole('button', { name: /MLB PPV/i }));
     await user.click(screen.getByTestId('psg-secondary-10-7'));
     expect(onChange).toHaveBeenCalledWith([
-      { group_id: 20, m3u_account_id: 7 },
+      { group_id: 20, m3u_account_id: null },
       { group_id: 10, m3u_account_id: 7 },
     ]);
   });

--- a/frontend/src/components/channelPipeline/ProviderScopedGroupPicker.tsx
+++ b/frontend/src/components/channelPipeline/ProviderScopedGroupPicker.tsx
@@ -93,12 +93,17 @@ export function ProviderScopedGroupPicker({
     selectedKeys.has(scopeKey(s));
 
   // A scope is "kept visible" (round-trip guard) if it is selected or is the
-  // excluded master scope — never dropped by the enabled-only filter.
+  // excluded master scope — never dropped by the enabled-only filter. A
+  // WHOLE-GROUP reference ({group_id, null} — e.g. a migrated legacy flat
+  // scope, or a single-provider selection) keeps that group's provider rows
+  // visible too, so a disabled-but-selected group never silently disappears.
   const isReferenced = (groupId: number, providerId: number | null) => {
-    const k = scopeKey({ group_id: groupId, m3u_account_id: providerId });
-    return (
+    const refs = (k: string) =>
       selectedKeys.has(k) ||
-      (excludeScope != null && scopeKey(excludeScope) === k)
+      (excludeScope != null && scopeKey(excludeScope) === k);
+    return (
+      refs(scopeKey({ group_id: groupId, m3u_account_id: providerId })) ||
+      refs(scopeKey({ group_id: groupId, m3u_account_id: null }))
     );
   };
 
@@ -156,10 +161,16 @@ export function ProviderScopedGroupPicker({
     );
   };
 
-  const renderProviderRow = (p: GroupProviderRow, showGroupName: boolean) => {
+  // ``asWholeGroup`` (single-provider groups, PO decision): the emitted scope
+  // is the whole group (m3u_account_id null) — the common one-click case —
+  // even though we still show the provider name + its sync status. The Fix
+  // still targets that provider's junction.
+  const renderProviderRow = (
+    p: GroupProviderRow, showGroupName: boolean, asWholeGroup = false,
+  ) => {
     const scope: EventSyncGroupScope = {
       group_id: p.groupId,
-      m3u_account_id: p.m3uAccountId,
+      m3u_account_id: asWholeGroup ? null : p.m3uAccountId,
     };
     const excluded = isExcluded(scope);
     const checked = isSelectedScope(scope);
@@ -176,7 +187,11 @@ export function ProviderScopedGroupPicker({
             checked={checked}
             disabled={disabled || excluded}
             onChange={() => selectScope(scope)}
-            data-testid={`psg-${role}-${p.groupId}-${p.m3uAccountId}`}
+            data-testid={
+              asWholeGroup
+                ? `psg-${role}-${p.groupId}-any`
+                : `psg-${role}-${p.groupId}-${p.m3uAccountId}`
+            }
           />
           <span className="psg-label">{label}</span>
           {syncBadge(p.autoChannelSync, true)}
@@ -255,9 +270,10 @@ export function ProviderScopedGroupPicker({
           );
           if (visibleProviders.length === 0) return null;
 
-          // Single-provider group -> flat row (provider unambiguous).
+          // Single-provider group -> flat row selecting the WHOLE group
+          // (m3u_account_id null); the provider is unambiguous (PO decision).
           if (visibleProviders.length === 1 && node.providers.length === 1) {
-            return renderProviderRow(visibleProviders[0], true);
+            return renderProviderRow(visibleProviders[0], true, true);
           }
 
           // Multi-provider group -> expandable parent.

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -564,6 +564,13 @@ export const handlers = [
     return HttpResponse.json({})
   }),
 
+  http.get(`${API_BASE}/providers/group-settings/by-provider`, () => {
+    // Event Sync provider-scoped group picker fetches (provider, group)
+    // junction rows (bead 38dzi). Empty by default; tests stub rows via
+    // server.use().
+    return HttpResponse.json([])
+  }),
+
   http.get(`${API_BASE}/dummy-epg/profiles`, () => {
     // Event Sync editor's dummy EPG profile picker (ti939.3.3).
     // Empty by default; tests stub profiles via server.use().

--- a/frontend/src/types/eventSync.ts
+++ b/frontend/src/types/eventSync.ts
@@ -38,15 +38,18 @@ export interface EventSyncGroupScope {
 
 export interface EventSyncConfig {
   /**
-   * bead 3p2af: canonical provider-scoped shape. The backend validator keeps
-   * these in sync with the flat `master_group_id` / `secondary_group_ids`
-   * (derived) so both are present on a stored config. The editor currently
-   * reads/writes the flat keys; the provider-scoped picker (P4) will use these.
+   * bead 3p2af / 38dzi: canonical provider-scoped shape. The editor (P4)
+   * reads and writes these nested scopes; the backend validator derives the
+   * flat `master_group_id` / `secondary_group_ids` from them, so a stored
+   * config carries both. The flat keys are OPTIONAL on the client: the editor
+   * no longer emits them (the backend fills them), but they remain readable on
+   * a fetched config and are the migration fallback for a legacy rule authored
+   * before the nested shape existed.
    */
   master?: EventSyncGroupScope;
   secondary?: EventSyncGroupScope[];
-  master_group_id: number;
-  secondary_group_ids: number[];
+  master_group_id?: number;
+  secondary_group_ids?: number[];
   /** Shared pattern variants; omit to use the matcher's built-in defaults. */
   patterns?: EventSyncPattern[];
   /** Per-group overrides keyed by group ID (JSON object keys are strings). */


### PR DESCRIPTION
## Summary

Completes **Option A P4** (bead 38dzi, epic 3p2af): the Event Sync rule editor now chooses master and secondary groups with the **provider-scoped group picker** instead of the old flat group select + checkbox multi-select.

Channel-group names are globally unique in Dispatcharr, so a group carried by two M3U providers (e.g. both providers have "MLB PPV") shares **one** `channel_group_id` but keeps **per-provider** `auto_channel_sync`/`enabled` settings on the `ChannelGroupM3UAccount` junction. The picker lets the operator scope the master/secondary to a specific provider — or the whole group.

## What changed

- **`EventSyncRuleEditor.tsx`** — state moves from flat `masterGroupId`/`secondaryGroupIds` to `masterScope`/`secondaryScopes` (`EventSyncGroupScope`). Two `<ProviderScopedGroupPicker>` instances (master single-select, secondary multi-select) replace the old `CustomSelect` + checkbox list. Junctions load via `getProviderGroupSettingsByProvider()` joined to channel-group names. The picker renders live per-scope auto-sync status + the guided one-click Fix inline, so the separate status/guidance panel is removed (the guided-fix dialog itself is unchanged and reused).
- **Migration** — a legacy rule with only the flat `master_group_id`/`secondary_group_ids` opens as **whole-group** scopes (`m3u_account_id: null`); `buildConfig` emits the nested `master`/`secondary` only and the backend validator derives the flat keys.
- **`ProviderScopedGroupPicker.tsx`** — round-trip guard now also keeps a group visible when referenced by a whole-group scope, so a disabled single-provider group that a migrated rule selected never silently disappears.
- **`eventSync.ts`** — flat `master_group_id`/`secondary_group_ids` are now optional on the client (editor no longer emits them; still readable on fetched configs + used as the migration fallback).
- **Single-provider default** (PO decision): a group carried by one provider selects the **whole group** in one click, while still showing the provider name + its sync status.

## Verification

- `tsc --noEmit` clean, `eslint --max-warnings 0` clean
- **1721 frontend tests pass** (47 editor + 9 picker among them); production build green
- **Live smoke on `ecm-ecm-1`** (v0.17.6-0082): the `by-provider` endpoint returns 372 per-provider junction rows; both pickers render with correct **role-relative valence** (master "Auto-sync OFF ⚠", secondary "Auto-sync OFF ✓"), the "Any provider (whole group)" scope, and multi-provider expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)