### PR TITLE
Channel Pipeline: analyze unsaved rule body (advisory) + typed binding (m1s38.2)

### DIFF
--- a/backend/routers/channel_pipeline.py
+++ b/backend/routers/channel_pipeline.py
@@ -166,6 +166,29 @@ class BulkUpdateChannelPipelineRulesRequest(UpdateChannelPipelineRuleRequest):
         return data
 
 
+class AnalyzeRuleBodyRequest(CreateChannelPipelineRuleRequest):
+    """Analyze an UNSAVED rule body — advisory findings, no persistence
+    (enhancedchannelmanager-m1s38.2).
+
+    Reuses the create-rule field set so the rule builder can POST the same
+    shape it would save, but relaxes and bounds it for live authoring:
+
+    * ``name`` is optional — the analyzer runs while the rule is still being
+      drafted, before the operator has typed a name.
+    * ``conditions``/``actions`` are optional (an empty draft yields empty
+      findings) and CAPPED at 200 each. No saved-rule cap exists today; 200
+      is ~10x the largest rule seen in production and exists only to stop a
+      giant pasted body from self-inflicting a slow AST-walk regex lint. The
+      analyzer never executes user regex (regex_lint does a safe AST walk),
+      so this is a work bound, not a ReDoS control. Advisory endpoint: the
+      cap bounds the analyze request only — it never blocks a save.
+    """
+
+    name: str = ""
+    conditions: list = Field(default_factory=list, max_length=200)
+    actions: list = Field(default_factory=list, max_length=200)
+
+
 class RunPipelineRequest(BaseModel):
     """Request to run the auto-creation pipeline."""
     dry_run: bool = False
@@ -532,6 +555,118 @@ async def analyze_auto_creation_rules_from_bundle(
         sum(result["summary"].values()),
     )
     return result
+
+
+@router.post("/rules/analyze-body")
+async def analyze_channel_pipeline_rule_body(request: AnalyzeRuleBodyRequest):
+    """Analyze an UNSAVED rule body; return advisory findings WITHOUT saving.
+
+    Enables live authoring feedback in the rule builder (the rail is
+    enhancedchannelmanager-m1s38.3). Same advisory-only contract and same
+    response shape as ``POST /rules/analyze``::
+
+        {
+          "rules": [{"rule_id", "rule_name", "findings": [...]}],
+          "summary": {"error": int, "warning": int, "info": int}
+        }
+
+    Advisory-only (bd-0gntx contract): findings are warnings/info, never a
+    gate — this endpoint never refuses a save. It reuses the same
+    ``analyze_rules`` engine as the saved-rule and from-bundle routes; the
+    only new behavior vs those routes is that the body is caller-supplied
+    (validated by ``AnalyzeRuleBodyRequest`` and length-capped) rather than
+    read from the DB or a debug bundle.
+
+    Auth: inherits the global ``/api/*`` gate (any authenticated user),
+    matching the sibling ``/rules/analyze`` surface — no per-route admin
+    dependency.
+    """
+    logger.debug("[AUTO-CREATE] POST /rules/analyze-body")
+    try:
+        from channel_pipeline_rule_analyzer import analyze_rules
+        from models import NormalizationRuleGroup
+
+        # The analyzer reads a dict shaped like a rule's to_dict(). Only the
+        # fields it consumes are forwarded; the rest of the create-shaped body
+        # (sort fields, orphan_action, etc.) is accepted for forward-compat but
+        # not needed by any current check.
+        rule_dict = {
+            "id": None,
+            "name": request.name,
+            "conditions": request.conditions,
+            "actions": request.actions,
+            "target_group_id": request.target_group_id,
+            "normalization_group_ids": request.normalization_group_ids,
+            "match_scope_target_group": request.match_scope_target_group,
+        }
+
+        # Richer findings (bd-m1s38.2): normalization-group enabled-state lets
+        # the disabled-normalization-group advisory fire; live channel-group
+        # counts let the merge-empty-target advisory fire. Both are best-effort
+        # — the analyzer no-ops when they're absent — so a lookup failure must
+        # NOT 500 an advisory endpoint; we log and degrade to fewer findings.
+        norm_groups = None
+        try:
+            session = get_session()
+            try:
+                norm_groups = [
+                    g.to_dict()
+                    for g in session.query(NormalizationRuleGroup).all()
+                ]
+            finally:
+                session.close()
+        except Exception as e:
+            logger.warning(
+                "[AUTO-CREATE] analyze-body: normalization groups unavailable, "
+                "skipping disabled-group advisory: %s", e,
+            )
+
+        # Only pay the Dispatcharr round-trip when the merge-empty-target check
+        # could actually fire (a merge_streams action AND an explicit target
+        # group). Keeps the common debounced authoring call from fetching all
+        # channel groups on every keystroke.
+        diagnostic = None
+        has_merge = any(
+            isinstance(a, dict) and a.get("type") == "merge_streams"
+            for a in request.actions
+        )
+        if has_merge and request.target_group_id is not None:
+            try:
+                client = get_client()
+                groups = await client.get_channel_groups() or []
+                diagnostic = {
+                    "groups": [
+                        {
+                            "id": g.get("id"),
+                            "name": g.get("name"),
+                            "channel_count": g.get("channel_count"),
+                        }
+                        for g in groups
+                        if isinstance(g, dict)
+                    ]
+                }
+            except Exception as e:
+                logger.warning(
+                    "[AUTO-CREATE] analyze-body: channel groups unavailable, "
+                    "skipping merge-empty-target advisory: %s", e,
+                )
+
+        result = analyze_rules(
+            [rule_dict],
+            channel_groups_diagnostic=diagnostic,
+            normalization_groups=norm_groups,
+        )
+        logger.info(
+            "[AUTO-CREATE] Analyzed unsaved rule body (%s conditions, "
+            "%s actions): %s findings",
+            len(request.conditions),
+            len(request.actions),
+            sum(result["summary"].values()),
+        )
+        return result
+    except Exception as e:
+        logger.exception("[AUTO-CREATE] Failed to analyze rule body: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("/rules/{rule_id}")

--- a/backend/tests/routers/test_channel_pipeline.py
+++ b/backend/tests/routers/test_channel_pipeline.py
@@ -2550,6 +2550,293 @@ rules:
         assert response.status_code == 400
 
 
+class TestAnalyzeRuleBody:
+    """POST /api/channel-pipeline/rules/analyze-body — analyze an UNSAVED
+    rule body (enhancedchannelmanager-m1s38.2).
+
+    These tests exercise routing, auth, deserialization/validation, the
+    input cap, and the diagnostic wiring — NOT the analyzer's own 100+
+    finding cases (those live in tests/unit/test_channel_pipeline_rule_analyzer.py).
+    They assert the endpoint forwards the right data to analyze_rules and
+    returns the shared response shape.
+    """
+
+    ANALYZE_BODY_PATH = "/api/channel-pipeline/rules/analyze-body"
+
+    @pytest.mark.asyncio
+    async def test_match_all_regex_flags_trivially_matches_all(self, async_client):
+        response = await async_client.post(
+            self.ANALYZE_BODY_PATH,
+            json={
+                "name": "Draft",
+                "conditions": [
+                    {"type": "stream_group_matches", "value": "UK|", "connector": "and"},
+                ],
+                "actions": [],
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        # Shared analyzer response shape.
+        assert set(body.keys()) == {"rules", "summary"}
+        assert set(body["summary"].keys()) == {"error", "warning", "info"}
+        codes = {f["code"] for r in body["rules"] for f in r["findings"]}
+        assert "REGEX_TRIVIALLY_MATCHES_ALL" in codes
+
+    @pytest.mark.asyncio
+    async def test_merge_scope_not_target_group_fires(self, async_client):
+        """create_channel + if_exists=merge with match_scope_target_group off
+        → MERGE_SCOPE_NOT_TARGET_GROUP (info)."""
+        response = await async_client.post(
+            self.ANALYZE_BODY_PATH,
+            json={
+                "conditions": [],
+                "actions": [{"type": "create_channel", "if_exists": "merge"}],
+                "match_scope_target_group": False,
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        findings = [f for r in body["rules"] for f in r["findings"]]
+        codes = {f["code"] for f in findings}
+        assert "MERGE_SCOPE_NOT_TARGET_GROUP" in codes
+        scope = next(f for f in findings if f["code"] == "MERGE_SCOPE_NOT_TARGET_GROUP")
+        assert scope["severity"] == "info"
+
+    @pytest.mark.asyncio
+    async def test_clean_rule_produces_no_findings(self, async_client):
+        response = await async_client.post(
+            self.ANALYZE_BODY_PATH,
+            json={
+                "name": "Movie Networks - UK add",
+                "conditions": [
+                    {"type": "normalized_name_in_group", "value": 1473, "connector": "and"},
+                    {"type": "stream_group_matches", "value": r"^UK\|", "connector": "and"},
+                ],
+                "actions": [{"type": "merge_streams", "target": "auto"}],
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["summary"] == {"error": 0, "warning": 0, "info": 0}
+        assert body["rules"][0]["findings"] == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_findings_in_one_body(self, async_client):
+        """The 2026-04-28 Sports rule shape surfaces several codes at once."""
+        response = await async_client.post(
+            self.ANALYZE_BODY_PATH,
+            json={
+                "conditions": [
+                    {"type": "normalized_name_in_group", "value": 1464, "connector": "and"},
+                    {"type": "stream_group_matches", "value": "UK|", "connector": "and"},
+                    {"type": "stream_group_matches", "value": "US|", "connector": "or"},
+                    {"type": "stream_group_contains", "value": "^4K", "connector": "or"},
+                ],
+                "actions": [{"type": "merge_streams", "target": "auto"}],
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        codes = {f["code"] for r in body["rules"] for f in r["findings"]}
+        assert "REGEX_TRIVIALLY_MATCHES_ALL" in codes
+        assert "OPERATOR_VALUE_LOOKS_LIKE_REGEX" in codes
+        assert len(codes) >= 2
+
+    @pytest.mark.asyncio
+    async def test_andor_drops_guard_fires(self, async_client):
+        """Guard condition in the first AND-group but not the OR-arms →
+        ANDOR_DROPS_GUARD."""
+        response = await async_client.post(
+            self.ANALYZE_BODY_PATH,
+            json={
+                "conditions": [
+                    {"type": "normalized_name_in_group", "value": 1464, "connector": "and"},
+                    {"type": "stream_group_is", "value": "Sports", "connector": "and"},
+                    {"type": "stream_group_is", "value": "News", "connector": "or"},
+                ],
+                "actions": [{"type": "merge_streams", "target": "auto"}],
+            },
+        )
+        assert response.status_code == 200
+        codes = {
+            f["code"]
+            for r in response.json()["rules"]
+            for f in r["findings"]
+        }
+        assert "ANDOR_DROPS_GUARD" in codes
+
+    @pytest.mark.asyncio
+    async def test_fifty_wellformed_conditions_are_clean(self, async_client):
+        """A large but benign body analyzes to empty findings (guardrail f)."""
+        conditions = [
+            {"type": "stream_name_contains", "value": f"Channel{i}", "connector": "and"}
+            for i in range(50)
+        ]
+        response = await async_client.post(
+            self.ANALYZE_BODY_PATH,
+            json={"conditions": conditions, "actions": []},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["rules"][0]["findings"] == []
+
+    @pytest.mark.asyncio
+    async def test_conditions_over_cap_rejected(self, async_client):
+        """>200 conditions is rejected by the Pydantic cap, not analyzed."""
+        conditions = [
+            {"type": "stream_name_contains", "value": "x", "connector": "and"}
+            for _ in range(201)
+        ]
+        response = await async_client.post(
+            self.ANALYZE_BODY_PATH,
+            json={"conditions": conditions, "actions": []},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_malformed_conditions_type_is_validation_error_not_500(
+        self, async_client,
+    ):
+        """conditions must be a list — a string body is a 4xx validation
+        error, never a 500."""
+        response = await async_client.post(
+            self.ANALYZE_BODY_PATH,
+            json={"conditions": "not a list", "actions": []},
+        )
+        assert response.status_code in (400, 422)
+
+    @pytest.mark.asyncio
+    async def test_null_conditions_is_validation_error(self, async_client):
+        response = await async_client.post(
+            self.ANALYZE_BODY_PATH,
+            json={"conditions": None, "actions": []},
+        )
+        assert response.status_code in (400, 422)
+
+    @pytest.mark.asyncio
+    async def test_empty_body_returns_clean_summary(self, async_client):
+        """No conditions/actions at all (fresh draft) → empty findings, 200."""
+        response = await async_client.post(self.ANALYZE_BODY_PATH, json={})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["summary"] == {"error": 0, "warning": 0, "info": 0}
+
+    @pytest.mark.asyncio
+    async def test_disabled_normalization_group_advisory_fires(
+        self, async_client, test_session,
+    ):
+        """A body referencing a DISABLED normalization group surfaces the
+        disabled-group advisory — proves normalization_groups is wired in
+        from the DB."""
+        group = _create_normalization_group(
+            test_session, name="Disabled Group", enabled=False,
+        )
+        response = await async_client.post(
+            self.ANALYZE_BODY_PATH,
+            json={
+                "conditions": [],
+                "actions": [{"type": "merge_streams", "target": "auto"}],
+                "normalization_group_ids": [group.id],
+            },
+        )
+        assert response.status_code == 200
+        codes = {
+            f["code"]
+            for r in response.json()["rules"]
+            for f in r["findings"]
+        }
+        assert "RULE_REFERENCES_DISABLED_NORMALIZATION_GROUP" in codes
+
+    @pytest.mark.asyncio
+    async def test_merge_empty_target_group_advisory_fires(self, async_client):
+        """merge_streams + explicit target_group_id pointing at an empty
+        group → MERGE_STREAMS_NO_TARGET_CHANNELS. Proves the live channel-
+        group diagnostic is built and forwarded to the analyzer."""
+        mock_client = MagicMock()
+        mock_client.get_channel_groups = AsyncMock(
+            return_value=[{"id": 99, "name": "Empty", "channel_count": 0}]
+        )
+        with patch(
+            "routers.channel_pipeline.get_client", return_value=mock_client
+        ):
+            response = await async_client.post(
+                self.ANALYZE_BODY_PATH,
+                json={
+                    "conditions": [],
+                    "actions": [{"type": "merge_streams", "target": "auto"}],
+                    "target_group_id": 99,
+                },
+            )
+        assert response.status_code == 200
+        mock_client.get_channel_groups.assert_awaited_once()
+        codes = {
+            f["code"]
+            for r in response.json()["rules"]
+            for f in r["findings"]
+        }
+        assert "MERGE_STREAMS_NO_TARGET_CHANNELS" in codes
+
+    @pytest.mark.asyncio
+    async def test_no_dispatcharr_call_without_merge_target(self, async_client):
+        """No merge_streams action ⇒ the endpoint must NOT fetch channel
+        groups (keeps the debounced authoring call cheap)."""
+        mock_client = MagicMock()
+        mock_client.get_channel_groups = AsyncMock(return_value=[])
+        with patch(
+            "routers.channel_pipeline.get_client", return_value=mock_client
+        ):
+            response = await async_client.post(
+                self.ANALYZE_BODY_PATH,
+                json={
+                    "conditions": [
+                        {"type": "stream_name_contains", "value": "ESPN"},
+                    ],
+                    "actions": [{"type": "create_channel", "name_template": "{stream_name}"}],
+                    "target_group_id": 99,
+                },
+            )
+        assert response.status_code == 200
+        mock_client.get_channel_groups.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_channel_groups_fetch_failure_degrades_not_500(
+        self, async_client,
+    ):
+        """If the Dispatcharr channel-groups fetch fails, the advisory
+        endpoint degrades to fewer findings — it must not 500."""
+        mock_client = MagicMock()
+        mock_client.get_channel_groups = AsyncMock(
+            side_effect=RuntimeError("dispatcharr down")
+        )
+        with patch(
+            "routers.channel_pipeline.get_client", return_value=mock_client
+        ):
+            response = await async_client.post(
+                self.ANALYZE_BODY_PATH,
+                json={
+                    "conditions": [],
+                    "actions": [{"type": "merge_streams", "target": "auto"}],
+                    "target_group_id": 99,
+                },
+            )
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_requires_auth_when_enabled(self, async_client):
+        """The route inherits the global /api/* auth gate — an unauthenticated
+        request with auth enabled is rejected (401). Proves it is NOT in
+        AUTH_EXEMPT_PATHS (guardrail c/f)."""
+        with patch("main.get_auth_settings") as auth_mock:
+            auth_mock.return_value.require_auth = True
+            auth_mock.return_value.setup_complete = True
+            response = await async_client.post(
+                self.ANALYZE_BODY_PATH,
+                json={"conditions": [], "actions": []},
+            )
+        assert response.status_code == 401
+
+
 # ---------------------------------------------------------------------------
 # Admin gating (bd-757hc) — destructive / mutating endpoints carry
 # RequireAdminIfEnabled, matching backup.py's create_backup / restore_backup.

--- a/frontend/src/services/channelPipelineApi.test.ts
+++ b/frontend/src/services/channelPipelineApi.test.ts
@@ -17,6 +17,8 @@ import {
   updateChannelPipelineRule,
   deleteChannelPipelineRule,
   toggleChannelPipelineRule,
+  // Rule analyzer
+  analyzeChannelPipelineRuleBody,
   // Validation & Schema
   validateChannelPipelineRule,
   getConditionSchema,
@@ -234,6 +236,70 @@ describe('Channel Pipeline API Service', () => {
 
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('analyzeChannelPipelineRuleBody', () => {
+    it('POSTs the rule body and returns typed findings', async () => {
+      let captured: unknown;
+      server.use(
+        http.post('/api/channel-pipeline/rules/analyze-body', async ({ request }) => {
+          captured = await request.json();
+          return HttpResponse.json({
+            rules: [
+              {
+                rule_id: null,
+                rule_name: 'Draft',
+                findings: [
+                  {
+                    code: 'REGEX_TRIVIALLY_MATCHES_ALL',
+                    severity: 'warning',
+                    field: 'conditions[0].value',
+                    message: 'matches everything',
+                    suggestion: '',
+                    detail: { reason: 'empty-alternation' },
+                  },
+                ],
+              },
+            ],
+            summary: { error: 0, warning: 1, info: 0 },
+          });
+        }),
+      );
+
+      const result = await analyzeChannelPipelineRuleBody({
+        name: 'Draft',
+        conditions: [{ type: 'stream_group_matches', value: 'UK|' }],
+        actions: [],
+      });
+
+      // Body is forwarded verbatim.
+      expect(captured).toEqual({
+        name: 'Draft',
+        conditions: [{ type: 'stream_group_matches', value: 'UK|' }],
+        actions: [],
+      });
+      // Response is the shared analyzer shape.
+      expect(result.summary).toEqual({ error: 0, warning: 1, info: 0 });
+      expect(result.rules[0].rule_id).toBeNull();
+      expect(result.rules[0].findings[0].code).toBe('REGEX_TRIVIALLY_MATCHES_ALL');
+      expect(result.rules[0].findings[0].severity).toBe('warning');
+    });
+
+    it('returns an empty summary for a clean draft', async () => {
+      server.use(
+        http.post('/api/channel-pipeline/rules/analyze-body', () => {
+          return HttpResponse.json({
+            rules: [{ rule_id: null, rule_name: '', findings: [] }],
+            summary: { error: 0, warning: 0, info: 0 },
+          });
+        }),
+      );
+
+      const result = await analyzeChannelPipelineRuleBody({ conditions: [], actions: [] });
+
+      expect(result.summary).toEqual({ error: 0, warning: 0, info: 0 });
+      expect(result.rules[0].findings).toHaveLength(0);
     });
   });
 

--- a/frontend/src/services/channelPipelineApi.ts
+++ b/frontend/src/services/channelPipelineApi.ts
@@ -9,6 +9,8 @@ import type {
   UpdateRuleData,
   BulkUpdateRulesPatch,
   BulkUpdateRulesResponse,
+  AnalyzeRuleBodyRequest,
+  RuleAnalyzerResponse,
   RulesListResponse,
   ExecutionsListResponse,
   ChannelPipelineExecution,
@@ -106,6 +108,28 @@ export async function bulkUpdateChannelPipelineRules(
   return fetchJson<BulkUpdateRulesResponse>(`${API_BASE}/channel-pipeline/rules/bulk-update`, {
     method: 'POST',
     body: JSON.stringify({ rule_ids: ruleIds, ...patch }),
+  });
+}
+
+// =============================================================================
+// Rule analyzer (advisory — never gates a save)
+// =============================================================================
+
+/**
+ * Analyze an UNSAVED rule body and return advisory findings without saving it.
+ *
+ * Backs live authoring feedback in the rule builder. The rule is NOT persisted;
+ * findings are warnings/info only and never block a save (bd-0gntx contract).
+ * Reuses the same analyzer as the saved-rule and from-bundle endpoints, so the
+ * response shape is identical. Debouncing is the caller's responsibility
+ * (bd-m1s38.3 owns the rail + debounce).
+ */
+export async function analyzeChannelPipelineRuleBody(
+  body: AnalyzeRuleBodyRequest
+): Promise<RuleAnalyzerResponse> {
+  return fetchJson<RuleAnalyzerResponse>(`${API_BASE}/channel-pipeline/rules/analyze-body`, {
+    method: 'POST',
+    body: JSON.stringify(body),
   });
 }
 

--- a/frontend/src/types/channelPipeline.ts
+++ b/frontend/src/types/channelPipeline.ts
@@ -338,6 +338,47 @@ export interface BulkUpdateRulesResponse {
 }
 
 // =============================================================================
+// Rule analyzer (bd-0gntx / bd-m1s38.2)
+// =============================================================================
+
+/** Severity of an analyzer finding. Always advisory — never gates a save. */
+export type RuleAnalyzerSeverity = 'error' | 'warning' | 'info';
+
+/**
+ * A single advisory finding from the rule analyzer (e.g.
+ * `REGEX_TRIVIALLY_MATCHES_ALL`, `MERGE_SCOPE_NOT_TARGET_GROUP`).
+ * Shared shape across the saved-rule, from-bundle, and analyze-body endpoints.
+ */
+export interface RuleAnalyzerFinding {
+  code: string;
+  severity: RuleAnalyzerSeverity;
+  field: string;
+  message: string;
+  suggestion: string;
+  detail: Record<string, unknown>;
+}
+
+/** Per-rule findings block; `rule_id` is null for an unsaved analyze-body call. */
+export interface RuleAnalyzerRuleResult {
+  rule_id: number | null;
+  rule_name: string;
+  findings: RuleAnalyzerFinding[];
+}
+
+/** Response shape shared by every rule-analyzer endpoint. */
+export interface RuleAnalyzerResponse {
+  rules: RuleAnalyzerRuleResult[];
+  summary: Record<RuleAnalyzerSeverity, number>;
+}
+
+/**
+ * Request body for POST /channel-pipeline/rules/analyze-body — an UNSAVED rule.
+ * Any subset of the create-rule fields; the backend caps conditions/actions at
+ * 200 each and treats an empty body as a clean draft.
+ */
+export type AnalyzeRuleBodyRequest = Partial<CreateRuleData>;
+
+// =============================================================================
 // Execution
 // =============================================================================
 


### PR DESCRIPTION
Bead **enhancedchannelmanager-m1s38.2**. Adds `POST /api/channel-pipeline/rules/analyze-body` so the standard rule builder can show live advisory analyzer feedback while authoring, before the rule is saved.

- Reuses the existing `analyze_rules` engine (no fork); response shape identical to `/rules/analyze` so consumers render findings uniformly.
- Typed Pydantic input (`AnalyzeRuleBodyRequest`, name optional, conditions/actions capped at 200) — this is the one analyze path that accepts a never-persisted body. Route stays under `/api/channel-pipeline/*` so it inherits the global auth gate (unauth → 401). Advisory only: never gates a save.
- Richer findings: passes normalization groups + a live channel-groups diagnostic (only when a merge_streams action has an explicit target), both best-effort.
- Frontend: `analyzeChannelPipelineRuleBody` binding + `RuleAnalyzer*` types (no UI — child m1s38.3 owns the rail).

Gates: backend pytest 15 new + 855 channel_pipeline subset green; tsc/eslint clean; 50 frontend binding tests. Deployed + live-smoked (unauth 401, match-all → REGEX_TRIVIALLY_MATCHES_ALL, clean → []).

🤖 Generated with [Claude Code](https://claude.com/claude-code)