### PR TITLE
Event Sync editor: two-pane redesign + 4-step wizard + shared modal primitives (m1s38.1)

### DIFF
--- a/backend/routers/channel_pipeline.py
+++ b/backend/routers/channel_pipeline.py
@@ -2737,6 +2737,13 @@ async def preview_event_sync(
             # a queue-driven attach prediction is visibly not a score-driven
             # one. None for every other disposition.
             "attach_source": r.attach_source,
+            # S5 (bead sf8dj): diagnostic provenance — the optional relaxations
+            # (assume_current_date / time_window_ignored / lowered_threshold /
+            # master_from_stream) that admitted this would-attach row. Empty
+            # for a plain in-window default-threshold match. Additive field.
+            "matched_via": [
+                {"key": key, "label": label} for key, label in r.matched_via
+            ],
             "would_attach_master": (
                 {
                     "channel_id": name_to_id.get(r.best.master_name),

--- a/backend/services/event_sync_resolver.py
+++ b/backend/services/event_sync_resolver.py
@@ -48,7 +48,7 @@ channel IDs against Dispatcharr on every run.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 
 import pytz
@@ -59,6 +59,8 @@ from services.event_sync_matcher import (
     DEFAULT_EVENT_TIMEZONE,
     DEFAULT_TIME_WINDOW_MINUTES,
     EVENT_ATTACH_FLOOR,
+    EVENT_NO_TEAMS_FLOOR,
+    TEAM_VERDICT_AGREE,
     MasterCandidate,
     StreamMatchResult,
     match_streams,
@@ -114,6 +116,18 @@ AMBIGUOUS_REASON_CONTESTED = "contested_top_candidates"
 # into the matcher's AMBIGUOUS band.
 AMBIGUOUS_REASON_BAND = "top_candidate_ambiguous_band"
 
+# S5 (bead sf8dj) — provenance: which optional relaxation admitted a
+# would-attach row. Each entry is a (machine_key, human_label) pair. The list
+# is a DIAGNOSTIC annotation only — computed from data already on the resolved
+# result (and, for assume_current_date, one cheap single-name re-parse). It
+# NEVER changes any score, band, or attach decision; the frozen matcher corpus
+# is untouched. A flag "contributed" when reverting just it to its default
+# would drop this row out of the attach band.
+MATCHED_VIA_ASSUME_CURRENT_DATE = ("assume_current_date", "assumed date")
+MATCHED_VIA_TIME_WINDOW_IGNORED = ("time_window_ignored", "time ignored")
+MATCHED_VIA_LOWERED_THRESHOLD = ("lowered_threshold", "low threshold")
+MATCHED_VIA_MASTER_FROM_STREAM = ("master_from_stream", "master-from-stream")
+
 # Runner-up-within-epsilon-of-winner ⇒ contested. Deliberately generous
 # (more contested = fewer attaches = the conservative direction): two
 # distinct real-world events that both survive the time-window block and
@@ -167,6 +181,12 @@ class ResolvedStream:
       ``MAX_REVIEW_CANDIDATES_PER_STREAM``. Empty otherwise.
     * ``rejected_suppressed`` — how many of this stream's candidates were
       removed because the operator previously REJECTED that pairing.
+    * ``matched_via`` — S5 (bead sf8dj) diagnostic provenance: for a
+      ``would_attach`` row, the (machine_key, human_label) pairs of the
+      optional relaxations that admitted it (assume_current_date,
+      time_window_ignored, lowered_threshold, master_from_stream). Empty for a
+      plain in-window default-threshold match and for every non-attach
+      disposition. Annotation only — never influences the match.
     """
 
     stream: SecondaryStream
@@ -177,6 +197,7 @@ class ResolvedStream:
     attach_source: str | None = None
     review_candidates: tuple[MasterCandidate, ...] = ()
     rejected_suppressed: int = 0
+    matched_via: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -415,6 +436,69 @@ def _resolve_stream(
     )
 
 
+def _matched_via(
+    resolved: ResolvedStream,
+    *,
+    patterns: list[dict] | None,
+    now: datetime,
+    assume_current_date: bool,
+    enforce_time_window: bool,
+    time_window_minutes: int,
+    parse_master_from_stream: bool,
+) -> tuple[tuple[str, str], ...]:
+    """S5 provenance for one resolved stream (bead sf8dj).
+
+    Diagnostic only — reads what the matcher already decided; it never
+    re-scores, re-bands, or otherwise alters the match. Each entry marks an
+    optional relaxation without which this ``would_attach`` row would drop out
+    of the attach band. Non-attach dispositions carry no provenance.
+    """
+    if resolved.disposition != DISPOSITION_WOULD_ATTACH or resolved.best is None:
+        return ()
+    best = resolved.best
+    via: list[tuple[str, str]] = []
+
+    # assume_current_date: the stream had a time but no date, so its start was
+    # placed on "today". Counterfactual — re-parse the single stream name with
+    # the flag OFF (one cheap parse, not a re-resolution): a parse-fail (no
+    # start) proves the flag is what made this stream a candidate at all.
+    if assume_current_date and resolved.result.parsed.start is not None:
+        without = parse_event_name(
+            resolved.stream.name, patterns, now=now, assume_current_date=False
+        )
+        if without.start is None:
+            via.append(MATCHED_VIA_ASSUME_CURRENT_DATE)
+
+    # time_window_ignored: the gate is off AND the winner's time delta exceeds
+    # the configured window — with the gate on, that candidate would have been
+    # eliminated before scoring.
+    if not enforce_time_window and best.time_delta_minutes > time_window_minutes:
+        via.append(MATCHED_VIA_TIME_WINDOW_IGNORED)
+
+    # lowered_threshold: the winner's score is below the DEFAULT effective floor
+    # it would face (0.80, or 0.90 without team agreement — is_event_attachable
+    # policy). It only reached the attach band because the operator lowered
+    # attach_threshold beneath that default; the score is >= the configured
+    # threshold by attach-band membership.
+    default_floor = (
+        EVENT_ATTACH_FLOOR
+        if best.team_verdict == TEAM_VERDICT_AGREE
+        else EVENT_NO_TEAMS_FLOOR
+    )
+    if best.score < default_floor:
+        via.append(MATCHED_VIA_LOWERED_THRESHOLD)
+
+    # master_from_stream: the master identity was read from the master's own
+    # stream name rather than the channel name. A clean counterfactual would
+    # need the original channel names, which this pure resolver no longer holds
+    # (the caller maps identity->id upstream) — so, per the accepted-heuristic
+    # allowance, the flag being on for a would-attach row marks it.
+    if parse_master_from_stream:
+        via.append(MATCHED_VIA_MASTER_FROM_STREAM)
+
+    return tuple(via)
+
+
 def resolve_event_sync(
     config: dict,
     master_names: list[str],
@@ -481,6 +565,11 @@ def resolve_event_sync(
     # bead assume-current-date: opt-in dateless matching (both master and
     # secondary sides share the same "today" so their times compare on one day).
     assume_current_date = bool(config.get("assume_current_date", False))
+    # S5 provenance inputs (bead sf8dj) — read straight from the config; used
+    # only to annotate would-attach rows, never to change the match.
+    enforce_time_window = config.get("enforce_time_window", True)
+    configured_window = config.get("time_window_minutes", DEFAULT_TIME_WINDOW_MINUTES)
+    parse_master_from_stream = bool(config.get("parse_master_from_stream", False))
 
     # Master-as-ceiling diagnostic: masters with no complete parsed identity
     # can never be candidates (match_streams filters them the same way —
@@ -526,7 +615,19 @@ def resolve_event_sync(
             assume_current_date=assume_current_date,
         )
         for stream, result in zip(streams, results):
-            resolved.append(_resolve_stream(stream, result, decisions))
+            rs = _resolve_stream(stream, result, decisions)
+            via = _matched_via(
+                rs,
+                patterns=patterns,
+                now=now,
+                assume_current_date=assume_current_date,
+                enforce_time_window=enforce_time_window,
+                time_window_minutes=configured_window,
+                parse_master_from_stream=parse_master_from_stream,
+            )
+            if via:
+                rs = replace(rs, matched_via=via)
+            resolved.append(rs)
 
     return EventSyncResolution(
         resolved=tuple(resolved),

--- a/backend/tests/services/test_event_sync_resolver.py
+++ b/backend/tests/services/test_event_sync_resolver.py
@@ -30,6 +30,8 @@ from services.event_sync_matcher import (
     BAND_ATTACH,
     BAND_REJECT,
     DEFAULT_EVENT_TIMEZONE,
+    TEAM_VERDICT_ABSENT,
+    TEAM_VERDICT_AGREE,
     MasterCandidate,
     ParsedEvent,
     REJECT_NO_PARSED_TIME,
@@ -43,8 +45,14 @@ from services.event_sync_resolver import (
     DISPOSITION_PARSE_FAILED,
     DISPOSITION_UNMATCHED,
     DISPOSITION_WOULD_ATTACH,
+    MATCHED_VIA_ASSUME_CURRENT_DATE,
+    MATCHED_VIA_LOWERED_THRESHOLD,
+    MATCHED_VIA_MASTER_FROM_STREAM,
+    MATCHED_VIA_TIME_WINDOW_IGNORED,
+    ResolvedStream,
     SecondaryStream,
     _classify,
+    _matched_via,
     effective_patterns,
     resolve_event_sync,
 )
@@ -568,3 +576,128 @@ class TestEnforceTimeWindowToggle:
         (resolved,) = resolution.resolved
         assert resolved.disposition != DISPOSITION_WOULD_ATTACH
         assert resolved.best is None
+
+
+class TestMatchedViaProvenance:
+    """S5 (bead sf8dj): the diagnostic ``matched_via`` provenance list.
+
+    Annotation only — these tests assert WHICH optional relaxation admitted a
+    would-attach row; the frozen matcher corpus and every band/score decision
+    are covered elsewhere and unchanged.
+    """
+
+    def _keys(self, resolved: ResolvedStream) -> list[str]:
+        return [key for key, _label in resolved.matched_via]
+
+    def test_plain_in_window_default_match_has_empty_provenance(self):
+        stream = SecondaryStream(
+            name="WNBA TV 01: Mercury vs. Aces @ 11 Jul 06:00 PM ET",
+            group_id=20, stream_id=201,
+        )
+        (resolved,) = resolve_event_sync(_config(), MASTERS, [stream], now=NOW).resolved
+        assert resolved.disposition == DISPOSITION_WOULD_ATTACH
+        assert resolved.matched_via == ()
+
+    def test_assume_current_date_marks_the_row(self):
+        # Time but no date -> a candidate only because the date was assumed.
+        stream = SecondaryStream(
+            name="Fubo 01: Mercury vs. Aces @ 06:00 PM ET",
+            group_id=20, stream_id=201,
+        )
+        config = _config(assume_current_date=True)
+        (resolved,) = resolve_event_sync(config, MASTERS, [stream], now=NOW).resolved
+        assert resolved.disposition == DISPOSITION_WOULD_ATTACH
+        assert self._keys(resolved) == [MATCHED_VIA_ASSUME_CURRENT_DATE[0]]
+
+    def test_time_window_ignored_marks_the_row(self):
+        # 180 min from the master; a candidate only because the gate is off.
+        stream = SecondaryStream(
+            name="WNBA TV 01: Mercury vs. Aces @ 11 Jul 09:00 PM ET",
+            group_id=20, stream_id=201,
+        )
+        config = _config(enforce_time_window=False)
+        (resolved,) = resolve_event_sync(config, MASTERS, [stream], now=NOW).resolved
+        assert resolved.disposition == DISPOSITION_WOULD_ATTACH
+        assert self._keys(resolved) == [MATCHED_VIA_TIME_WINDOW_IGNORED[0]]
+
+    def test_master_from_stream_marks_the_row(self):
+        # parse_master_from_stream on -> the master identity came from a stream.
+        stream = SecondaryStream(
+            name="WNBA TV 01: Mercury vs. Aces @ 11 Jul 06:00 PM ET",
+            group_id=20, stream_id=201,
+        )
+        config = _config(parse_master_from_stream=True)
+        (resolved,) = resolve_event_sync(config, MASTERS, [stream], now=NOW).resolved
+        assert resolved.disposition == DISPOSITION_WOULD_ATTACH
+        assert self._keys(resolved) == [MATCHED_VIA_MASTER_FROM_STREAM[0]]
+
+    # --- lowered_threshold: score below the DEFAULT effective floor. Scores
+    # are exercised directly on _matched_via (constructed candidates) so the
+    # provenance rule is pinned independently of the frozen fuzzy corpus. ---
+
+    def _resolved(self, *, score, team_verdict, time_delta=0.0) -> ResolvedStream:
+        parsed = ParsedEvent(
+            raw_name="stream", title="T", start=NOW, teams=None,
+            matched_pattern="p",
+        )
+        master = MasterCandidate(
+            master_name="Master", parsed=parsed, score=score, band=BAND_ATTACH,
+            team_verdict=team_verdict, time_delta_minutes=time_delta,
+            reject_reasons=(),
+        )
+        result = StreamMatchResult(
+            stream_name="stream", parsed=parsed, candidates=(master,),
+        )
+        return ResolvedStream(
+            stream=SecondaryStream(name="stream", group_id=20),
+            result=result, disposition=DISPOSITION_WOULD_ATTACH, best=master,
+        )
+
+    def _via(self, resolved, **overrides):
+        kwargs = dict(
+            patterns=None, now=NOW, assume_current_date=False,
+            enforce_time_window=True, time_window_minutes=30,
+            parse_master_from_stream=False,
+        )
+        kwargs.update(overrides)
+        return [key for key, _ in _matched_via(resolved, **kwargs)]
+
+    def test_lowered_threshold_when_score_below_teamless_default_floor(self):
+        # Teamless default floor is 0.90; a 0.85 attach only cleared a lowered
+        # attach_threshold.
+        resolved = self._resolved(score=0.85, team_verdict=TEAM_VERDICT_ABSENT)
+        assert self._via(resolved) == [MATCHED_VIA_LOWERED_THRESHOLD[0]]
+
+    def test_lowered_threshold_when_score_below_team_agree_default_floor(self):
+        # Team-agree default floor is 0.80; a 0.75 attach only cleared a
+        # lowered threshold.
+        resolved = self._resolved(score=0.75, team_verdict=TEAM_VERDICT_AGREE)
+        assert self._via(resolved) == [MATCHED_VIA_LOWERED_THRESHOLD[0]]
+
+    def test_no_lowered_flag_at_or_above_default_floor(self):
+        # A 0.95 teamless attach clears the 0.90 default floor on its own.
+        resolved = self._resolved(score=0.95, team_verdict=TEAM_VERDICT_ABSENT)
+        assert self._via(resolved) == []
+        # A 0.85 team-agree attach clears the 0.80 default floor on its own.
+        resolved = self._resolved(score=0.85, team_verdict=TEAM_VERDICT_AGREE)
+        assert self._via(resolved) == []
+
+    def test_non_attach_disposition_never_annotated(self):
+        resolved = self._resolved(score=0.75, team_verdict=TEAM_VERDICT_AGREE)
+        # Same data but a non-attach disposition -> no provenance at all.
+        ambiguous = ResolvedStream(
+            stream=resolved.stream, result=resolved.result,
+            disposition=DISPOSITION_AMBIGUOUS, best=None,
+        )
+        assert self._via(ambiguous) == []
+
+    def test_multiple_relaxations_accumulate(self):
+        # Gate off + teamless below floor -> both flags, keys stable/ordered.
+        resolved = self._resolved(
+            score=0.85, team_verdict=TEAM_VERDICT_ABSENT, time_delta=120.0,
+        )
+        keys = self._via(resolved, enforce_time_window=False)
+        assert keys == [
+            MATCHED_VIA_TIME_WINDOW_IGNORED[0],
+            MATCHED_VIA_LOWERED_THRESHOLD[0],
+        ]

--- a/frontend/src/components/ModalBase.css
+++ b/frontend/src/components/ModalBase.css
@@ -1696,3 +1696,210 @@
 .modal-preview-no-match .material-icons {
   font-size: 18px;
 }
+
+
+/* =============================================================================
+   TWO-PANE MODAL LAYOUT SYSTEM  (bead m1s38.1)
+   -----------------------------------------------------------------------------
+   Generic, reusable layout primitives for dense configuration modals: a main
+   configuration column beside a persistent sticky rail, an optional full-width
+   step-wizard strip, an intent card, collapsible purpose subgroups, and nested
+   "why / when to use" disclosures. These are deliberately editor-AGNOSTIC — the
+   Event Sync editor is the first consumer; the standard rule builder (bead
+   m1s38.3) is the second. Keep the names generic and do NOT fold any
+   editor-specific styling in here. Single-column collapse at 820px drops the
+   rail below the main column.
+
+     .modal-twopane        grid wrapper: main column + rail
+     .modal-main           the scrolling configuration column
+     .modal-rail           sticky companion rail (intent / impacts / preview)
+     .modal-stepper        full-width step-pill strip (drives the main column)
+     .modal-stepper-item   one step pill; aria-current="step" marks the active
+     .modal-stepper-num    the circular step number inside a pill
+     .modal-intent         plain-language intent card at the top of the rail
+     .modal-subgroup       labeled collapsible cluster with an "N changed" badge
+     .modal-why            nested rationale disclosure inside a subgroup control
+   ============================================================================= */
+
+.modal-twopane {
+  display: grid;
+  grid-template-columns: minmax(0, 62fr) minmax(0, 38fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.modal-main {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 0;
+}
+
+.modal-rail {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+
+/* Full-width step strip. Pills drive the main column only; the rail is
+   persistent across steps. */
+.modal-stepper {
+  display: flex;
+  gap: 6px;
+  width: 100%;
+  margin-bottom: 4px;
+}
+
+.modal-stepper-item {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md, 6px);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.modal-stepper-item:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.modal-stepper-item[aria-current='step'] {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-color: var(--accent-primary, #6366f1);
+}
+
+.modal-stepper-item:focus-visible {
+  outline: 2px solid var(--button-primary-bg, #6366f1);
+  outline-offset: 2px;
+}
+
+.modal-stepper-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.modal-stepper-item[aria-current='step'] .modal-stepper-num {
+  background: var(--button-primary-bg, #6366f1);
+  color: var(--button-primary-text, #fff);
+}
+
+/* Intent card — plain-language "what this will do" summary. */
+.modal-intent {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-lg, 8px);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.modal-intent-title {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.modal-intent-text {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
+.modal-intent-text strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.modal-intent-placeholder {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* Purpose subgroup — a labeled collapsible cluster. Self-contained so any modal
+   can use it without an editor-specific base class. */
+.modal-subgroup {
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md, 4px);
+}
+
+.modal-subgroup > summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 8px 12px;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.modal-subgroup > summary:focus-visible {
+  outline: 2px solid var(--button-primary-bg, #6366f1);
+  outline-offset: -2px;
+}
+
+.modal-subgroup-badge {
+  margin-left: auto;
+}
+
+/* Nested "why / when to use" disclosure inside a subgroup control. */
+.modal-why {
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md, 4px);
+  margin-top: 2px;
+}
+
+.modal-why > summary {
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  padding: 4px 8px;
+}
+
+.modal-why > summary:focus-visible {
+  outline: 2px solid var(--button-primary-bg, #6366f1);
+  outline-offset: -2px;
+}
+
+/* Single-column collapse: the rail drops below the main column. */
+@media (max-width: 820px) {
+  .modal-twopane {
+    grid-template-columns: 1fr;
+  }
+
+  .modal-rail {
+    position: static;
+  }
+
+  .modal-stepper {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.css
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.css
@@ -378,6 +378,14 @@
   max-width: 800px;
 }
 
+/* Event Sync wizard (the wide modal-xxl branch): pin a constant height so the
+   modal does not resize/re-center when a shorter step (Behavior, Review) is
+   shown. Without this the container sizes to the active step's content and
+   jumps between steps. Bounded by the modal-container max-height (90vh). */
+.rule-builder-modal.modal-xxl {
+  height: 90vh;
+}
+
 .rule-builder-modal .rule-builder {
   flex: 1;
   overflow: hidden;

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
@@ -258,6 +258,14 @@ export function ChannelPipelineTab() {
     setCreateRuleKind(null);
   }, []);
 
+  // S4a: the Event Sync editor owns the dirty-state discard guard and registers
+  // its guarded-close here, so Escape (overlay onClose) and the header × route
+  // through the same confirm instead of dropping a half-configured rule.
+  const eventSyncCloseRef = useRef<(() => void) | null>(null);
+  const registerEventSyncClose = useCallback((fn: (() => void) | null) => {
+    eventSyncCloseRef.current = fn;
+  }, []);
+
   const handleDeleteClick = useCallback((rule: ChannelPipelineRule) => {
     setShowDeleteConfirm(rule);
   }, []);
@@ -1109,8 +1117,17 @@ export function ChannelPipelineTab() {
         const title = showKindChooser
           ? 'Create Rule'
           : `${editingRule ? 'Edit' : 'Create'}${isEventSync ? ' Event Sync' : ''} Rule`;
+        // S4a: for the Event Sync editor, dismissors route through its
+        // registered dirty guard; everything else closes directly.
+        const requestClose = () => {
+          if (isEventSync && !showKindChooser && eventSyncCloseRef.current) {
+            eventSyncCloseRef.current();
+          } else {
+            handleCancelRuleBuilder();
+          }
+        };
         return (
-          <ModalOverlay onClose={handleCancelRuleBuilder} role="dialog" aria-modal="true" aria-labelledby="rule-builder-title">
+          <ModalOverlay onClose={requestClose} role="dialog" aria-modal="true" aria-labelledby="rule-builder-title">
             {/* Event Sync carries the app's densest form — give it modal-xxl
                 (1000px). The kind chooser and the standard rule builder keep
                 modal-lg. */}
@@ -1119,7 +1136,7 @@ export function ChannelPipelineTab() {
                 <h2 id="rule-builder-title">{title}</h2>
                 <button
                   className="modal-close-btn"
-                  onClick={handleCancelRuleBuilder}
+                  onClick={requestClose}
                   aria-label="Close"
                 >
                   <span className="material-icons">close</span>
@@ -1159,6 +1176,7 @@ export function ChannelPipelineTab() {
                   rule={editingRule || undefined}
                   onSave={handleSaveRule}
                   onCancel={handleCancelRuleBuilder}
+                  onRegisterClose={registerEventSyncClose}
                 />
               ) : (
                 <RuleBuilder

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
@@ -1111,7 +1111,10 @@ export function ChannelPipelineTab() {
           : `${editingRule ? 'Edit' : 'Create'}${isEventSync ? ' Event Sync' : ''} Rule`;
         return (
           <ModalOverlay onClose={handleCancelRuleBuilder} role="dialog" aria-modal="true" aria-labelledby="rule-builder-title">
-            <div className="modal-container modal-lg rule-builder-modal">
+            {/* Event Sync carries the app's densest form — give it modal-xxl
+                (1000px). The kind chooser and the standard rule builder keep
+                modal-lg. */}
+            <div className={`modal-container ${isEventSync && !showKindChooser ? 'modal-xxl' : 'modal-lg'} rule-builder-modal`}>
               <div className="modal-header">
                 <h2 id="rule-builder-title">{title}</h2>
                 <button

--- a/frontend/src/components/channelPipeline/EventSyncPreviewPanel.css
+++ b/frontend/src/components/channelPipeline/EventSyncPreviewPanel.css
@@ -2,7 +2,8 @@
  * EventSyncPreviewPanel styles
  *
  * Uses common.css for: .btn-primary, .btn-secondary, .form-hint,
- * .warning-message, .error-banner, .spinning
+ * .warning-message, .error-banner, .spinning, .badge, .badge-sm,
+ * .badge-warning (S5 provenance chips)
  */
 
 .event-sync-preview {
@@ -107,6 +108,12 @@
 
 .event-sync-flag .material-icons {
   font-size: 14px;
+}
+
+/* S5 (bead sf8dj): provenance chip — a would-attach row admitted only by an
+   optional relaxation. `title` carries the caution; the help cursor hints it. */
+.event-sync-matched-via {
+  cursor: help;
 }
 
 .event-sync-card-sides {

--- a/frontend/src/components/channelPipeline/EventSyncPreviewPanel.css
+++ b/frontend/src/components/channelPipeline/EventSyncPreviewPanel.css
@@ -25,6 +25,25 @@
   gap: 16px;
 }
 
+/* Stale marking (bead m1s38.1): the config changed since this preview ran —
+   dim the results but keep them readable, and flag the re-run notice. */
+.event-sync-preview-results--stale {
+  opacity: 0.5;
+}
+
+.event-sync-preview-stale {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--warning, #f59e0b);
+}
+
+.event-sync-preview-stale .material-icons {
+  font-size: 16px;
+}
+
 .event-sync-preflight {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/channelPipeline/EventSyncPreviewPanel.test.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncPreviewPanel.test.tsx
@@ -286,4 +286,46 @@ describe('EventSyncPreviewPanel', () => {
     expect(screen.getByText('Accepted (auto-attaches)')).toBeInTheDocument();
     expect(screen.getByText('Pending review')).toBeInTheDocument();
   });
+
+  describe('S5 provenance chips (bead sf8dj)', () => {
+    it('renders a chip per matched_via entry with a caution title', () => {
+      const preview = buildPreview();
+      preview.streams[0].matched_via = [
+        { key: 'time_window_ignored', label: 'time ignored' },
+        { key: 'assume_current_date', label: 'assumed date' },
+      ];
+      render(
+        <EventSyncPreviewPanel
+          preview={preview}
+          loading={false}
+          error={null}
+          onRunPreview={vi.fn()}
+        />
+      );
+
+      const timeChip = screen.getByText('time ignored');
+      expect(timeChip).toHaveClass('badge', 'badge-sm');
+      expect(timeChip).toHaveAttribute('title', expect.stringMatching(/window gate is off/i));
+      expect(screen.getByText('assumed date')).toHaveAttribute(
+        'title',
+        expect.stringMatching(/assumed to be today/i)
+      );
+    });
+
+    it('renders no provenance chip on a plain default-threshold match', () => {
+      render(
+        <EventSyncPreviewPanel
+          preview={buildPreview()}
+          loading={false}
+          error={null}
+          onRunPreview={vi.fn()}
+        />
+      );
+
+      expect(screen.queryByText('time ignored')).toBeNull();
+      expect(screen.queryByText('assumed date')).toBeNull();
+      expect(screen.queryByText('low threshold')).toBeNull();
+      expect(screen.queryByText('master-from-stream')).toBeNull();
+    });
+  });
 });

--- a/frontend/src/components/channelPipeline/EventSyncPreviewPanel.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncPreviewPanel.tsx
@@ -52,6 +52,19 @@ export interface EventSyncPreviewPanelProps {
   onRunPreview: () => void;
   /** Non-null blocks the preview button and explains why. */
   disabledReason?: string | null;
+  /**
+   * Compact mode (bead m1s38.1): render only the run affordance, pre-flight
+   * warnings, and the one-line summary — the detailed match cards, unmatched
+   * table, and parse-failure lists are omitted so the panel fits the rail on
+   * the configuration steps. The Review step passes false to show everything.
+   */
+  compact?: boolean;
+  /**
+   * Stale marking (bead m1s38.1): the results reflect a config that has since
+   * changed. Dim them and show a "Settings changed — re-run" notice; the
+   * results are NOT cleared (the operator can still read the last run).
+   */
+  stale?: boolean;
 }
 
 function formatStart(iso: string | null): string {
@@ -236,6 +249,8 @@ export function EventSyncPreviewPanel({
   error,
   onRunPreview,
   disabledReason = null,
+  compact = false,
+  stale = false,
 }: EventSyncPreviewPanelProps) {
   const [visibleCards, setVisibleCards] = useState(CARDS_PER_PAGE);
 
@@ -244,7 +259,7 @@ export function EventSyncPreviewPanel({
       <div className="event-sync-preview-actions">
         <button
           type="button"
-          className="btn-primary"
+          className="btn-primary event-sync-preview-run"
           onClick={() => {
             setVisibleCards(CARDS_PER_PAGE);
             onRunPreview();
@@ -257,6 +272,16 @@ export function EventSyncPreviewPanel({
           </span>
           {loading ? 'Previewing...' : 'Preview matches'}
         </button>
+        {stale && preview && (
+          <span
+            className="event-sync-preview-stale"
+            role="status"
+            data-testid="event-sync-preview-stale"
+          >
+            <span className="material-icons" aria-hidden="true">warning</span>
+            Settings changed — re-run
+          </span>
+        )}
         <span className="form-hint">
           Read-only dry run against live Dispatcharr data — nothing is written
           and no group settings are touched. A manual pipeline Run attaches
@@ -277,7 +302,11 @@ export function EventSyncPreviewPanel({
       )}
 
       {preview && (
-        <div className="event-sync-preview-results">
+        <div
+          className={`event-sync-preview-results${
+            stale ? ' event-sync-preview-results--stale' : ''
+          }`}
+        >
           {/* Pre-flight failures never block the preview — surface them loudly */}
           {!preview.preflight.ok && (
             <div className="event-sync-preflight" data-testid="event-sync-preflight">
@@ -311,6 +340,9 @@ export function EventSyncPreviewPanel({
             )}
           </p>
 
+          {/* Compact mode (rail on steps 1-3) stops at the summary; the Review
+              step renders the full detail below. */}
+          {!compact && (<>
           {preview.streams.length === 0 ? (
             <p className="form-hint">No secondary streams were found in the configured groups.</p>
           ) : (
@@ -420,6 +452,7 @@ export function EventSyncPreviewPanel({
               </ul>
             </details>
           )}
+          </>)}
         </div>
       )}
     </div>

--- a/frontend/src/components/channelPipeline/EventSyncPreviewPanel.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncPreviewPanel.tsx
@@ -29,6 +29,22 @@ import './EventSyncPreviewPanel.css';
 /** Cards rendered before the "Show more" affordance kicks in. */
 const CARDS_PER_PAGE = 50;
 
+/**
+ * S5 (bead sf8dj): the caution behind each provenance chip — why this
+ * would-attach row deserves a second look. Keyed on the machine `key`;
+ * an unknown key falls back to the chip label alone.
+ */
+const MATCHED_VIA_TITLES: Record<string, string> = {
+  assume_current_date:
+    'Matched only because the missing date was assumed to be today — confirm the event really is today.',
+  time_window_ignored:
+    'Matched outside the time window because the window gate is off — confirm both start times refer to the same event.',
+  lowered_threshold:
+    'Matched on a score below the default floor because the attach threshold was lowered — double-check this is the right master.',
+  master_from_stream:
+    'The master identity was read from its attached stream name (parse-from-stream), not the channel name.',
+};
+
 export interface EventSyncPreviewPanelProps {
   preview: EventSyncPreviewResponse | null;
   loading: boolean;
@@ -104,6 +120,17 @@ function MatchCard({ stream }: { stream: EventSyncStreamRow }) {
           <span key={flag} className="event-sync-flag">
             <span className="material-icons" aria-hidden="true">flag</span>
             {flag}
+          </span>
+        ))}
+        {/* S5 (bead sf8dj): provenance chips — this row would attach only
+            because an optional relaxation was enabled. */}
+        {(stream.matched_via ?? []).map(via => (
+          <span
+            key={via.key}
+            className="badge badge-sm badge-warning event-sync-matched-via"
+            title={MATCHED_VIA_TITLES[via.key] ?? via.label}
+          >
+            {via.label}
           </span>
         ))}
       </div>

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.css
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.css
@@ -2,26 +2,235 @@
  * EventSyncRuleEditor styles
  *
  * Uses common.css for: .btn-primary, .btn-secondary, .form-group, .form-hint,
- * .checkbox-group, .checkbox-option, .warning-message, .spinning
- * Uses ModalBase.css (via parent modal) for: .modal-container, .modal-header
+ * .checkbox-group, .checkbox-option, .warning-message, .spinning,
+ * .badge, .badge-sm, .badge-info
+ * Uses ModalBase.css (via parent modal) for: .modal-container, .modal-header,
+ * .modal-xxl
+ *
+ * Component-local layout classes (S3 two-pane redesign): .event-sync-editor-grid,
+ * .event-sync-main, .event-sync-rail, .event-sync-intent, .event-sync-subgroup,
+ * .event-sync-scrollspy, .event-sync-phase.
  */
 
+/* The parent modal-container owns the height (max-height 90vh); the editor
+   fills the space between the sticky header and footer and lets its content
+   region own the scroll — no inner max-height (that double-constrained the
+   height and clipped the top/bottom). */
 .event-sync-editor {
   display: flex;
   flex-direction: column;
-  max-height: 80vh;
+  flex: 1;
+  min-height: 0;
 }
 
 .event-sync-editor-content {
   overflow-y: auto;
   padding: 16px 20px;
+  flex: 1;
+  min-height: 0;
+}
+
+/* S3: two-pane grid — main configuration column + sticky validation rail. */
+.event-sync-editor-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 62fr) minmax(0, 38fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.event-sync-main {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  min-width: 0;
+}
+
+/* S3: sticky validation rail. Sticks to the top of the scroll container so the
+   rule intent + Preview stay visible while the operator scrolls the form. */
+.event-sync-rail {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+
+.event-sync-intent {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-lg, 8px);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.event-sync-intent-title {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.event-sync-intent-text {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
+.event-sync-intent-text strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.event-sync-intent-placeholder {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.event-sync-rail-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* S3: sticky in-modal scroll-spy nav strip over the 3-phase spine. */
+.event-sync-scrollspy {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  gap: 4px;
+  padding: 6px;
+  margin: -6px 0 0;
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.event-sync-scrollspy-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md, 4px);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.event-sync-scrollspy-item:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.event-sync-scrollspy-item.active {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-color: var(--border-primary);
+}
+
+.event-sync-scrollspy-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.event-sync-scrollspy-item.active .event-sync-scrollspy-num {
+  background: var(--button-primary-bg);
+  color: var(--button-primary-text, #fff);
+}
+
+/* Phase spine: strong section headings for Scope / Matching / Behavior. */
+.event-sync-phase {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  scroll-margin-top: 52px;
+}
+
+.event-sync-phase-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-primary);
+  padding-bottom: 6px;
+  border-bottom: 2px solid var(--border-primary);
+}
+
+.event-sync-phase-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+/* S2: labeled Advanced subgroups with an "N changed" badge on the summary. */
+.event-sync-subgroup > summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.event-sync-subgroup-badge {
+  margin-left: auto;
+}
+
+/* S2: nested "Why / when to use" disclosure inside a flag's form-group. */
+.event-sync-why {
+  margin-top: 2px;
+}
+
+.event-sync-why > summary {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  padding: 4px 8px;
 }
 
 .event-sync-quick-path {
   margin: 0;
+}
+
+/* Responsive: below ~820px collapse to one column — the rail drops beneath
+   the form (its pre-redesign position) and the scroll-spy degrades to a plain
+   sticky mini-header. */
+@media (max-width: 820px) {
+  .event-sync-editor-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .event-sync-rail {
+    position: static;
+  }
+
+  .event-sync-scrollspy {
+    flex-wrap: wrap;
+  }
 }
 
 .event-sync-section-block {

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.css
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.css
@@ -216,6 +216,29 @@
   margin: 0;
 }
 
+/* S4b: inline "use the master group's own streams" anchor in the Secondary
+   section — a link-styled button (no new primitive). */
+.event-sync-inline-link {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 12px;
+  color: var(--accent-primary);
+  cursor: pointer;
+  text-align: left;
+}
+
+.event-sync-inline-link:hover {
+  text-decoration: underline;
+}
+
+.event-sync-inline-link:focus-visible {
+  outline: 2px solid var(--button-primary-bg);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 /* Responsive: below ~820px collapse to one column — the rail drops beneath
    the form (its pre-redesign position) and the scroll-spy degrades to a plain
    sticky mini-header. */

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.css
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.css
@@ -283,7 +283,20 @@
   gap: 10px;
 }
 
+/* Keep the checkbox inline with the pattern title rather than wrapped onto its
+   own line above it. The base .checkbox-option is `flex-wrap: wrap` +
+   `align-items: center`, and the text column has no width bound, so the long
+   description pushes the column below the box. Top-align the box to the first
+   line, forbid wrapping, and let the text column take the remaining width and
+   wrap its own text (min-width: 0 lets it shrink below content size). */
+.event-sync-pattern-option {
+  align-items: flex-start;
+  flex-wrap: nowrap;
+}
+
 .event-sync-pattern-option > span {
+  flex: 1;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 2px;

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.css
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.css
@@ -3,13 +3,18 @@
  *
  * Uses common.css for: .btn-primary, .btn-secondary, .form-group, .form-hint,
  * .checkbox-group, .checkbox-option, .warning-message, .spinning,
- * .badge, .badge-sm, .badge-info
- * Uses ModalBase.css (via parent modal) for: .modal-container, .modal-header,
- * .modal-xxl
+ * .badge, .badge-sm, .badge-info, .badge-warning
  *
- * Component-local layout classes (S3 two-pane redesign): .event-sync-editor-grid,
- * .event-sync-main, .event-sync-rail, .event-sync-intent, .event-sync-subgroup,
- * .event-sync-scrollspy, .event-sync-phase.
+ * Uses the SHARED two-pane modal layout system in ModalBase.css (bead
+ * m1s38.1) for the wizard layout: .modal-twopane / .modal-main / .modal-rail,
+ * the .modal-stepper step pills, the .modal-intent card, and the
+ * .modal-subgroup / .modal-why collapsibles. Those replaced the former
+ * event-sync-* layout variants (grid / main / rail / intent / scrollspy /
+ * subgroup / why) — do NOT reintroduce editor-specific copies of them here.
+ *
+ * The classes below are the parts that stay component-local: the editor shell
+ * (content region + footer), the per-step phase headings, the wizard impact
+ * block, the Review summary, and Event-Sync-specific form widgets.
  */
 
 /* The parent modal-container owns the height (max-height 90vh); the editor
@@ -30,44 +35,20 @@
   min-height: 0;
 }
 
-/* S3: two-pane grid — main configuration column + sticky validation rail. */
-.event-sync-editor-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 62fr) minmax(0, 38fr);
-  gap: 20px;
-  align-items: start;
-}
-
-.event-sync-main {
+.event-sync-rail-preview {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  min-width: 0;
+  gap: 8px;
 }
 
-/* S3: sticky validation rail. Sticks to the top of the scroll container so the
-   rule intent + Preview stay visible while the operator scrolls the form. */
-.event-sync-rail {
-  position: sticky;
-  top: 0;
-  align-self: start;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  min-width: 0;
-}
-
-.event-sync-intent {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-lg, 8px);
-  padding: 12px 14px;
+/* Step-reactive impact block in the rail (bead m1s38.1). */
+.event-sync-impact {
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.event-sync-intent-title {
+.event-sync-impact-title {
   margin: 0;
   font-size: 12px;
   font-weight: 600;
@@ -76,92 +57,37 @@
   color: var(--text-secondary);
 }
 
-.event-sync-intent-text {
+.event-sync-impact-line {
   margin: 0;
   font-size: 13px;
   line-height: 1.5;
   color: var(--text-primary);
-}
-
-.event-sync-intent-text strong {
-  color: var(--text-primary);
-  font-weight: 600;
-}
-
-.event-sync-intent-placeholder {
-  color: var(--text-muted);
-  font-style: italic;
-}
-
-.event-sync-rail-preview {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-/* S3: sticky in-modal scroll-spy nav strip over the 3-phase spine. */
-.event-sync-scrollspy {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  display: flex;
-  gap: 4px;
-  padding: 6px;
-  margin: -6px 0 0;
-  background: var(--bg-primary);
-  border-bottom: 1px solid var(--border-primary);
-}
-
-.event-sync-scrollspy-item {
-  display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 12px;
-  border: 1px solid transparent;
-  border-radius: var(--radius-md, 4px);
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.15s, color 0.15s;
+  flex-wrap: wrap;
 }
 
-.event-sync-scrollspy-item:hover {
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
+.event-sync-impact-chips {
+  margin: 0;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 
-.event-sync-scrollspy-item.active {
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
-  border-color: var(--border-primary);
-}
-
-.event-sync-scrollspy-num {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.event-sync-scrollspy-item.active .event-sync-scrollspy-num {
-  background: var(--button-primary-bg);
-  color: var(--button-primary-text, #fff);
-}
-
-/* Phase spine: strong section headings for Scope / Matching / Behavior. */
+/* Phase spine: strong step-section headings for Scope / Matching / Behavior /
+   Review. Each step section is toggled with the `hidden` attribute. */
 .event-sync-phase {
   display: flex;
   flex-direction: column;
   gap: 16px;
-  scroll-margin-top: 52px;
+}
+
+/* An explicit `display` above overrides the UA `[hidden] { display: none }`
+   rule, so the hidden (non-active) step sections would otherwise all render.
+   Re-assert the hide so the wizard actually swaps the left column per step. */
+.event-sync-phase[hidden] {
+  display: none;
 }
 
 .event-sync-phase-title {
@@ -174,6 +100,11 @@
   color: var(--text-primary);
   padding-bottom: 6px;
   border-bottom: 2px solid var(--border-primary);
+}
+
+.event-sync-phase-title:focus-visible {
+  outline: 2px solid var(--button-primary-bg);
+  outline-offset: 2px;
 }
 
 .event-sync-phase-num {
@@ -189,27 +120,62 @@
   font-weight: 700;
 }
 
-/* S2: labeled Advanced subgroups with an "N changed" badge on the summary. */
-.event-sync-subgroup > summary {
+/* Review-step summary (bead m1s38.1) with per-row jump-back links. */
+.event-sync-review {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 0;
+}
+
+.event-sync-review-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.event-sync-review-row dt {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+  font-weight: 600;
+  color: var(--text-primary);
 }
 
-.event-sync-subgroup-badge {
-  margin-left: auto;
-}
-
-/* S2: nested "Why / when to use" disclosure inside a flag's form-group. */
-.event-sync-why {
-  margin-top: 2px;
-}
-
-.event-sync-why > summary {
-  font-size: 12px;
-  font-weight: 500;
+.event-sync-review-row dd {
+  margin: 0;
+  font-size: 13px;
   color: var(--text-secondary);
-  padding: 4px 8px;
+  line-height: 1.5;
+}
+
+.event-sync-review-warn {
+  color: var(--warning, #f59e0b);
+  font-weight: 600;
+}
+
+.event-sync-review-jump {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  background: none;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md, 4px);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.event-sync-review-jump:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.event-sync-review-jump .material-icons {
+  font-size: 16px;
 }
 
 .event-sync-quick-path {
@@ -237,23 +203,6 @@
   outline: 2px solid var(--button-primary-bg);
   outline-offset: 2px;
   border-radius: 2px;
-}
-
-/* Responsive: below ~820px collapse to one column — the rail drops beneath
-   the form (its pre-redesign position) and the scroll-spy degrades to a plain
-   sticky mini-header. */
-@media (max-width: 820px) {
-  .event-sync-editor-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .event-sync-rail {
-    position: static;
-  }
-
-  .event-sync-scrollspy {
-    flex-wrap: wrap;
-  }
 }
 
 .event-sync-section-block {
@@ -386,15 +335,22 @@
 
 .event-sync-editor-footer {
   display: flex;
-  justify-content: flex-end;
   align-items: center;
   gap: 8px;
   padding: 12px 20px;
   border-top: 1px solid var(--border-primary);
 }
 
+/* The Back / Save / Next cluster sits at the far right; Cancel stays far
+   left. */
+.event-sync-footer-nav {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .event-sync-save-error {
-  margin-right: auto;
   color: var(--text-primary);
   font-size: 13px;
   display: inline-flex;

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
@@ -20,6 +20,7 @@ import {
 import { EventSyncRuleEditor } from './EventSyncRuleEditor';
 import type { ChannelPipelineRule } from '../../types/channelPipeline';
 import type { ProviderGroupScopeRow } from '../../services/api';
+import type { EventSyncPreviewResponse } from '../../types/eventSync';
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => {
@@ -71,6 +72,16 @@ function stubGroupSettingsFull(
       stream_count: 10,
     }))
   );
+}
+
+/** Click a wizard step pill (bead m1s38.1). Controls that live on a step
+ * other than the current one are `hidden`, so role/visibility queries only
+ * reach them after navigating to that step. */
+async function goToStep(
+  user: ReturnType<typeof userEvent.setup>,
+  n: 1 | 2 | 3 | 4
+) {
+  await user.click(screen.getByTestId(`event-sync-step-${n}`));
 }
 
 function seedGroups() {
@@ -738,6 +749,8 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
+      // Parse patterns live on the Matching step.
+      await goToStep(user, 2);
       // Deselect one of the built-ins; the remaining built-ins are emitted.
       await user.click(screen.getByRole('checkbox', { name: /month-first date \(built-in\)/i }));
       await user.click(screen.getByRole('button', { name: 'Save' }));
@@ -839,6 +852,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={apiRule} onSave={onSave} onCancel={vi.fn()} />);
 
+      await goToStep(user, 2);
       // The built-in checkboxes reflect the saved selection: none selected.
       expect(screen.getByRole('checkbox', { name: /day-first date \(built-in\)/i }))
         .not.toBeChecked();
@@ -1004,6 +1018,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
+      await goToStep(user, 3);
       await user.click(screen.getByText('Guide data'));
       // Open the profile picker (shows the None placeholder) and pick one.
       await user.click(
@@ -1281,6 +1296,8 @@ describe('EventSyncRuleEditor', () => {
       const details = await screen.findByTestId('event-sync-test-patterns-details');
       expect(details).not.toHaveAttribute('open');
 
+      // The Test Patterns panel lives on the Matching step.
+      await goToStep(user, 2);
       await user.type(screen.getByLabelText('Sample stream names'), 'Totally Unparseable Name');
       await user.click(screen.getByRole('button', { name: /test patterns/i }));
 
@@ -1385,6 +1402,247 @@ describe('EventSyncRuleEditor', () => {
 
       await waitFor(() => expect(checkbox).toHaveFocus());
       expect(checkbox.closest('details')).toHaveAttribute('open');
+    });
+  });
+
+  describe('4-step wizard (bead m1s38.1)', () => {
+    const PREVIEW_FIXTURE: EventSyncPreviewResponse = {
+      preflight: { ok: true, failures: [] },
+      summary: {
+        secondary_streams: 5,
+        would_attach: 3,
+        ambiguous_skipped: 1,
+        unmatched: 1,
+        parse_failed: 0,
+        master_channels: 4,
+        master_channels_unparsed: 0,
+        would_attach_via_review: 0,
+        candidates_pending_review: 0,
+      },
+      streams: [
+        {
+          stream_id: 1,
+          stream_name: 'X vs Y @ 11 Jul 06:00 PM ET',
+          group_id: 2,
+          provider: 'Provider B',
+          parsed_title: 'X vs Y',
+          parsed_start: '2026-07-11T18:00:00-04:00',
+          matched_pattern: 'slot-title-day-first-date',
+          disposition: 'would_attach',
+          unmatchable_reason: null,
+          attach_source: 'threshold',
+          would_attach_master: { channel_id: 7, name: 'Master X vs Y' },
+          candidates: [],
+        },
+      ],
+      unmatched_streams: [],
+      parse_failures: [],
+      unparsed_master_channels: [],
+      truncated: false,
+    };
+
+    function stubPreview() {
+      server.use(
+        http.post('/api/channel-pipeline/event-sync-preview', () =>
+          HttpResponse.json(PREVIEW_FIXTURE)
+        )
+      );
+    }
+
+    it('step pills switch the visible left-column section and mark the active pill', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
+      await screen.findByTestId('psg-master');
+
+      // Step 1 active: Scope visible, Matching hidden.
+      expect(screen.getByTestId('event-sync-step-1')).toHaveAttribute('aria-current', 'step');
+      expect(screen.getByText('Scope', { selector: 'h2' })).toBeVisible();
+      expect(screen.getByText('Matching', { selector: 'h2' })).not.toBeVisible();
+
+      await goToStep(user, 2);
+
+      expect(screen.getByTestId('event-sync-step-2')).toHaveAttribute('aria-current', 'step');
+      expect(screen.getByTestId('event-sync-step-1')).not.toHaveAttribute('aria-current');
+      expect(screen.getByText('Matching', { selector: 'h2' })).toBeVisible();
+      expect(screen.getByText('Scope', { selector: 'h2' })).not.toBeVisible();
+    });
+
+    it('reactively updates the rail impact block per step', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
+      await screen.findByTestId('psg-master');
+
+      const impact = screen.getByTestId('event-sync-impact');
+      expect(within(impact).getByText('Scope impact')).toBeInTheDocument();
+
+      await goToStep(user, 2);
+      expect(within(impact).getByText('Matching impact')).toBeInTheDocument();
+
+      await goToStep(user, 3);
+      expect(within(impact).getByText('Behavior impact')).toBeInTheDocument();
+    });
+
+    it('renders ONE preview: compact on config steps, expanded on Review, stale on config change', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      stubPreview();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
+      await screen.findByTestId('psg-master');
+
+      // Run the single preview from the rail while on a config step (compact):
+      // the one-line summary shows, the detailed match-result list does not.
+      await user.click(screen.getByRole('button', { name: /preview matches/i }));
+      await screen.findByTestId('event-sync-summary');
+      expect(screen.queryByRole('list', { name: /match results/i })).toBeNull();
+
+      // The Review step expands the SAME preview instance → detail appears.
+      await goToStep(user, 4);
+      expect(screen.getByRole('list', { name: /match results/i })).toBeInTheDocument();
+      expect(screen.queryByTestId('event-sync-preview-stale')).toBeNull();
+
+      // Changing a config field marks the results stale (not cleared).
+      await goToStep(user, 2);
+      await user.click(screen.getByTestId('event-sync-ignore-time-window'));
+      expect(screen.getByTestId('event-sync-preview-stale')).toBeInTheDocument();
+      expect(screen.getByTestId('event-sync-summary')).toBeInTheDocument();
+    });
+
+    it('Back and Next never trigger the discard confirm when dirty; Cancel does', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
+      await screen.findByTestId('psg-master');
+
+      // Make the form dirty.
+      await user.type(screen.getByLabelText(/rule name/i), '!');
+
+      // Next advances without a discard prompt.
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+      expect(screen.queryByTestId('event-sync-discard-dialog')).toBeNull();
+      expect(screen.getByTestId('event-sync-step-2')).toHaveAttribute('aria-current', 'step');
+
+      // Back returns to the previous step (N-1), not nav history, no prompt.
+      await user.click(screen.getByRole('button', { name: 'Back' }));
+      expect(screen.queryByTestId('event-sync-discard-dialog')).toBeNull();
+      expect(screen.getByTestId('event-sync-step-1')).toHaveAttribute('aria-current', 'step');
+
+      // Cancel (dirty) still routes through the discard guard.
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(screen.getByTestId('event-sync-discard-dialog')).toBeInTheDocument();
+    });
+
+    it('Save-from-Review routes to the offending field step and focuses it (name)', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      render(
+        <EventSyncRuleEditor
+          rule={{ ...EXISTING_RULE, name: '' }}
+          onSave={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+      await screen.findByTestId('psg-master');
+
+      await goToStep(user, 4);
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('event-sync-step-1')).toHaveAttribute('aria-current', 'step')
+      );
+      expect(screen.getByLabelText(/rule name/i)).toHaveFocus();
+      expect(screen.getByRole('alert')).toHaveTextContent('Name is required');
+    });
+
+    it('Save-from-Review routes to the Matching step when the pattern selection is empty', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
+      await screen.findByTestId('psg-master');
+
+      // Deselect every built-in pattern on the Matching step (no custom either).
+      await goToStep(user, 2);
+      for (const box of screen.getAllByRole('checkbox').filter(cb => (cb as HTMLInputElement).checked)) {
+        await user.click(box);
+      }
+
+      await goToStep(user, 4);
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('event-sync-step-2')).toHaveAttribute('aria-current', 'step')
+      );
+      expect(screen.getByText('Matching', { selector: 'h2' })).toHaveFocus();
+      expect(screen.getByRole('alert')).toHaveTextContent(/parse pattern/i);
+    });
+
+    it('a NEW rule exposes Save only on the Review step (Next on config steps)', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      render(<EventSyncRuleEditor onSave={vi.fn()} onCancel={vi.fn()} />);
+      await screen.findByTestId('psg-master');
+
+      expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+      expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+
+      await goToStep(user, 4);
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Next' })).toBeNull();
+    });
+
+    it('editing an existing rule exposes Save on every step', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
+      await screen.findByTestId('psg-master');
+
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+      await goToStep(user, 2);
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+      await goToStep(user, 4);
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    });
+
+    it('consumes the shared .modal-* two-pane layout classes and drops the old event-sync layout variants', async () => {
+      const { container } = render(
+        <EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />
+      );
+      await screen.findByTestId('psg-master');
+
+      for (const cls of [
+        '.modal-twopane',
+        '.modal-main',
+        '.modal-rail',
+        '.modal-stepper',
+        '.modal-stepper-item',
+        '.modal-intent',
+        '.modal-subgroup',
+        '.modal-why',
+      ]) {
+        expect(container.querySelector(cls)).not.toBeNull();
+      }
+
+      // The migrated-away layout variants must not survive (grep guard).
+      for (const retired of [
+        '.event-sync-editor-grid',
+        '.event-sync-main',
+        '.event-sync-rail',
+        '.event-sync-scrollspy',
+        '.event-sync-scrollspy-item',
+        '.event-sync-intent',
+        '.event-sync-subgroup',
+      ]) {
+        expect(container.querySelector(retired)).toBeNull();
+      }
     });
   });
 });

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
@@ -109,7 +109,7 @@ describe('EventSyncRuleEditor', () => {
       stubGroupSettings({ 1: true, 2: false });
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Score threshold'));
       const input = screen.getByLabelText(/attach threshold/i);
       await user.clear(input);
       await user.type(input, '0.5');
@@ -125,7 +125,7 @@ describe('EventSyncRuleEditor', () => {
       stubGroupSettings({ 1: true, 2: false });
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Score threshold'));
       const input = screen.getByLabelText(/attach threshold/i);
       await user.clear(input);
       await user.type(input, '1.5');
@@ -141,7 +141,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Score threshold'));
       const input = screen.getByLabelText(/attach threshold/i);
       await user.clear(input);
       // A sub-default value is honored (only out-of-[0,1] values are clamped).
@@ -161,7 +161,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Time tuning'));
       const windowInput = screen.getByLabelText(/time window \(minutes\)/i);
       expect(windowInput).not.toBeDisabled();
 
@@ -277,7 +277,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Scope extension'));
       expect(
         screen.getByTestId('event-sync-include-master-group-streams')
       ).not.toBeChecked();
@@ -296,7 +296,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Scope extension'));
       await user.click(
         screen.getByTestId('event-sync-include-master-group-streams')
       );
@@ -322,7 +322,7 @@ describe('EventSyncRuleEditor', () => {
       };
       render(<EventSyncRuleEditor rule={rule} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Scope extension'));
       expect(
         screen.getByTestId('event-sync-include-master-group-streams')
       ).toBeChecked();
@@ -343,7 +343,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Scope extension'));
       expect(
         screen.getByTestId('event-sync-parse-master-from-stream')
       ).not.toBeChecked();
@@ -362,7 +362,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Scope extension'));
       await user.click(
         screen.getByTestId('event-sync-parse-master-from-stream')
       );
@@ -383,7 +383,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Date handling'));
       expect(
         screen.getByTestId('event-sync-assume-current-date')
       ).not.toBeChecked();
@@ -402,7 +402,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Date handling'));
       await user.click(screen.getByTestId('event-sync-assume-current-date'));
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -421,7 +421,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Automation'));
       expect(screen.getByTestId('event-sync-auto-run')).not.toBeChecked();
 
       await user.click(screen.getByRole('button', { name: 'Save' }));
@@ -436,7 +436,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Automation'));
       await user.click(screen.getByTestId('event-sync-auto-run'));
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -458,7 +458,7 @@ describe('EventSyncRuleEditor', () => {
       };
       render(<EventSyncRuleEditor rule={rule} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Automation'));
       expect(screen.getByTestId('event-sync-auto-run')).toBeChecked();
 
       await user.click(screen.getByRole('button', { name: 'Save' }));
@@ -499,7 +499,7 @@ describe('EventSyncRuleEditor', () => {
       };
       render(<EventSyncRuleEditor rule={rule} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Automation'));
       await user.click(screen.getByTestId('event-sync-auto-run'));
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -513,7 +513,7 @@ describe('EventSyncRuleEditor', () => {
       stubGroupSettings({ 1: true, 2: false });
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Automation'));
       expect(
         screen.getByText(/enable it only after you trust/i)
       ).toBeInTheDocument();
@@ -894,7 +894,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={apiRule} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Per-group pattern overrides'));
       // Open the secondary group's override editor and change its title.
       await user.click(screen.getByText(/Secondary Events/, { selector: 'summary' }));
       const overrideTitle = screen.getAllByLabelText('Title pattern')
@@ -923,7 +923,7 @@ describe('EventSyncRuleEditor', () => {
       const sharedIndicator = screen.getByTestId('custom-shared-extras');
       expect(sharedIndicator).toHaveTextContent(/preserved as saved/i);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Per-group pattern overrides'));
       await user.click(screen.getByText(/Secondary Events/, { selector: 'summary' }));
       const groupIndicator = screen.getByTestId('group-override-extras-2');
       expect(groupIndicator).toHaveTextContent(/preserved as saved/i);
@@ -1004,7 +1004,7 @@ describe('EventSyncRuleEditor', () => {
       const onSave = vi.fn();
       render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
 
-      await user.click(screen.getByText('Advanced'));
+      await user.click(screen.getByText('Guide data'));
       // Open the profile picker (shows the None placeholder) and pick one.
       await user.click(
         screen.getByRole('button', { name: /none — no automatic guide data/i })
@@ -1182,6 +1182,109 @@ describe('EventSyncRuleEditor', () => {
       expect(screen.getByTestId('psg-secondary-2-any')).toBeInTheDocument();
       expect(screen.queryByTestId('psg-secondary-3-any')).toBeNull();
       expect(screen.queryByTestId('psg-secondary-1-any')).toBeNull();
+    });
+  });
+
+  describe('UX redesign (bead dvzrf): 3-phase spine, intent, subgroups', () => {
+    it('renders the three phase headings and the Advanced subgroups by purpose', async () => {
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
+
+      // Phase spine headings.
+      expect(await screen.findByText('Scope', { selector: 'h2' })).toBeInTheDocument();
+      expect(screen.getByText('Matching', { selector: 'h2' })).toBeInTheDocument();
+      expect(screen.getByText('Behavior', { selector: 'h2' })).toBeInTheDocument();
+
+      // The flat Advanced wall is gone; the flags are grouped into labeled
+      // subgroups by purpose.
+      expect(screen.queryByText('Advanced', { selector: 'summary' })).toBeNull();
+      for (const label of [
+        'Time tuning',
+        'Score threshold',
+        'Date handling',
+        'Per-group pattern overrides',
+        'Automation',
+        'Scope extension',
+        'Guide data',
+      ]) {
+        expect(screen.getByText(label, { selector: 'summary' })).toBeInTheDocument();
+      }
+    });
+
+    it('shows a plain-language rule-intent sentence derived from the current config', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
+
+      const intent = await screen.findByTestId('event-sync-intent');
+      // Default (enforced time window, manual runs, default threshold).
+      expect(intent).toHaveTextContent(/Attach streams from 1 secondary group to master Master Events/i);
+      expect(intent).toHaveTextContent(/title \+ start time within ±30 min/i);
+      expect(intent).toHaveTextContent(/Runs only when you run it manually\./i);
+
+      // Turning on Ignore-time-window flips the matching clause to the risky
+      // (bold) phrasing, and auto-run flips the run clause.
+      await user.click(screen.getByText('Time tuning'));
+      await user.click(screen.getByTestId('event-sync-ignore-time-window'));
+      expect(intent).toHaveTextContent(/title only \(time ignored\)/i);
+
+      await user.click(screen.getByText('Automation'));
+      await user.click(screen.getByTestId('event-sync-auto-run'));
+      expect(intent).toHaveTextContent(/Runs automatically after each M3U refresh\./i);
+    });
+
+    it('badges a subgroup with the count of non-default flags it holds', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
+
+      // Automation starts at its default — no badge.
+      const automation = screen.getByText('Automation', { selector: 'summary' });
+      expect(within(automation).queryByText(/changed/i)).toBeNull();
+
+      await user.click(automation);
+      await user.click(screen.getByTestId('event-sync-auto-run'));
+      expect(within(automation).getByText('1 changed')).toBeInTheDocument();
+    });
+  });
+
+  describe('Test Patterns collapse (bead dvzrf / F4)', () => {
+    /** The batch preview endpoint the Test Patterns panel calls; return one
+     * non-matching row so the run registers a parse failure. */
+    function stubBatchParseFailure() {
+      server.use(
+        http.post('/api/dummy-epg/preview/batch', () =>
+          HttpResponse.json([{ matched: false, groups: {}, event_sync_start_valid: false }])
+        )
+      );
+    }
+
+    it('is collapsed by default so it does not compete with the Preview rail', async () => {
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
+
+      const details = await screen.findByTestId('event-sync-test-patterns-details');
+      expect(details).not.toHaveAttribute('open');
+    });
+
+    it('auto-expands when a test run turns up parse failures', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      stubBatchParseFailure();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
+
+      const details = await screen.findByTestId('event-sync-test-patterns-details');
+      expect(details).not.toHaveAttribute('open');
+
+      await user.type(screen.getByLabelText('Sample stream names'), 'Totally Unparseable Name');
+      await user.click(screen.getByRole('button', { name: /test patterns/i }));
+
+      await waitFor(() => expect(details).toHaveAttribute('open'));
     });
   });
 });

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
@@ -8,7 +8,7 @@
  * apply/attach control.
  */
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import {
@@ -1285,6 +1285,106 @@ describe('EventSyncRuleEditor', () => {
       await user.click(screen.getByRole('button', { name: /test patterns/i }));
 
       await waitFor(() => expect(details).toHaveAttribute('open'));
+    });
+  });
+
+  describe('dirty-state discard guard (bead dvzrf / S4a)', () => {
+    it('closes immediately via Cancel when nothing changed (no confirm)', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onCancel = vi.fn();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={onCancel} />);
+      await screen.findByTestId('psg-master');
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId('event-sync-discard-dialog')).toBeNull();
+    });
+
+    it('confirms before discarding via Cancel when the form is dirty', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onCancel = vi.fn();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={onCancel} />);
+      await screen.findByTestId('psg-master');
+
+      // Any divergence from the loaded rule marks it dirty.
+      await user.type(screen.getByLabelText(/rule name/i), '!');
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(screen.getByTestId('event-sync-discard-dialog')).toBeInTheDocument();
+      expect(onCancel).not.toHaveBeenCalled();
+
+      // "Keep editing" dismisses the prompt without discarding.
+      await user.click(screen.getByTestId('event-sync-discard-keep'));
+      expect(screen.queryByTestId('event-sync-discard-dialog')).toBeNull();
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    it('discards only after the confirm button is pressed', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onCancel = vi.fn();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={onCancel} />);
+      await screen.findByTestId('psg-master');
+
+      await user.type(screen.getByLabelText(/rule name/i), '!');
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+      await user.click(screen.getByTestId('event-sync-discard-confirm'));
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes the parent Escape/× dismissors through the same guard (onRegisterClose)', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onCancel = vi.fn();
+      let registeredClose: (() => void) | undefined;
+      render(
+        <EventSyncRuleEditor
+          rule={EXISTING_RULE}
+          onSave={vi.fn()}
+          onCancel={onCancel}
+          onRegisterClose={fn => {
+            if (fn) registeredClose = fn;
+          }}
+        />
+      );
+      await screen.findByTestId('psg-master');
+      expect(typeof registeredClose).toBe('function');
+
+      // Clean → the registered close (what Escape/× invoke) closes at once.
+      await act(async () => registeredClose!());
+      expect(onCancel).toHaveBeenCalledTimes(1);
+
+      // Dirty → the registered close shows the confirm instead of discarding.
+      await user.type(screen.getByLabelText(/rule name/i), '!');
+      await act(async () => registeredClose!());
+      expect(screen.getByTestId('event-sync-discard-dialog')).toBeInTheDocument();
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('secondary-empty inline anchor (bead dvzrf / S4b)', () => {
+    it('expands the Scope-extension subgroup and focuses the master-self-attach checkbox', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={vi.fn()} onCancel={vi.fn()} />);
+      await screen.findByTestId('psg-secondary');
+
+      const checkbox = screen.getByTestId('event-sync-include-master-group-streams');
+      expect(checkbox).not.toHaveFocus();
+
+      await user.click(screen.getByTestId('event-sync-use-master-streams'));
+
+      await waitFor(() => expect(checkbox).toHaveFocus());
+      expect(checkbox.closest('details')).toHaveAttribute('open');
     });
   });
 });

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
@@ -38,7 +38,8 @@
  * (`m3u_account_id: null`); saving emits the nested `master` / `secondary`
  * and lets the backend derive the flat keys.
  */
-import { useEffect, useId, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import type { ReactNode, RefObject } from 'react';
 import type { ChannelPipelineRule, CreateRuleData } from '../../types/channelPipeline';
 import type {
   EventSyncConfig,
@@ -301,6 +302,22 @@ export function EventSyncRuleEditor({
 
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+
+  // S1 (F4): Test Patterns is collapsed by default so it does not compete with
+  // the always-visible Preview rail; a test run that produces parse failures
+  // auto-expands it so the failing rows are never hidden below the fold.
+  const [testPatternsOpen, setTestPatternsOpen] = useState(false);
+
+  // S3: in-modal scroll-spy over the 3-phase spine. `activeSection` drives the
+  // sticky nav highlight; the section elements are observed inside the scroll
+  // container.
+  const contentRef = useRef<HTMLDivElement>(null);
+  const scopeRef = useRef<HTMLElement>(null);
+  const matchingRef = useRef<HTMLElement>(null);
+  const behaviorRef = useRef<HTMLElement>(null);
+  const [activeSection, setActiveSection] = useState<'scope' | 'matching' | 'behavior'>(
+    'scope'
+  );
 
   useEffect(() => {
     // The junction rows carry no group name; join them against the channel
@@ -651,518 +668,848 @@ export function EventSyncRuleEditor({
     }));
   };
 
+  // S3: scroll-spy. Highlight the phase whose heading is nearest the top of
+  // the scroll container. Guarded so it is a no-op where IntersectionObserver
+  // is unavailable (jsdom mocks it as a stub, so this stays inert in tests).
+  useEffect(() => {
+    if (typeof IntersectionObserver === 'undefined') return;
+    const root = contentRef.current;
+    const sections: { id: 'scope' | 'matching' | 'behavior'; el: HTMLElement | null }[] = [
+      { id: 'scope', el: scopeRef.current },
+      { id: 'matching', el: matchingRef.current },
+      { id: 'behavior', el: behaviorRef.current },
+    ];
+    const visible = new Map<Element, number>();
+    const observer = new IntersectionObserver(
+      entries => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) visible.set(entry.target, entry.intersectionRatio);
+          else visible.delete(entry.target);
+        }
+        let best: { id: 'scope' | 'matching' | 'behavior'; ratio: number } | null = null;
+        for (const { id, el } of sections) {
+          if (!el || !visible.has(el)) continue;
+          const ratio = visible.get(el) ?? 0;
+          if (!best || ratio > best.ratio) best = { id, ratio };
+        }
+        if (best) setActiveSection(best.id);
+      },
+      { root, rootMargin: '0px 0px -55% 0px', threshold: [0, 0.25, 0.5, 1] }
+    );
+    for (const { el } of sections) if (el) observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const scrollToSection = (ref: RefObject<HTMLElement | null>) => {
+    ref.current?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
+  };
+
+  // S3: plain-language rule-intent sentence. Bold clauses are the non-default
+  // or risk-carrying choices (time ignored, auto-run, assume-current-date) so
+  // the operator can see at a glance what the rule will actually do.
+  const currentThreshold = (() => {
+    const parsed = parseFloat(thresholdText);
+    return Number.isFinite(parsed) ? clampAttachThreshold(parsed) : EVENT_ATTACH_FLOOR;
+  })();
+  const currentTimeWindow = (() => {
+    const parsed = parseInt(timeWindowText, 10);
+    return Number.isFinite(parsed) ? parsed : DEFAULT_TIME_WINDOW_MINUTES;
+  })();
+
+  const intent: ReactNode = useMemo(() => {
+    if (masterScope == null) {
+      return (
+        <span className="event-sync-intent-placeholder">
+          Pick a master group to see what this rule will do.
+        </span>
+      );
+    }
+    const masterName = groupName(masterScope.group_id);
+    const secCount = secondaryScopes.length;
+    const source =
+      secCount === 0 && includeMasterGroupStreams ? (
+        <>the master group&apos;s own streams</>
+      ) : (
+        <>
+          streams from {secCount} secondary group{secCount === 1 ? '' : 's'}
+        </>
+      );
+    const matchClause = !enforceTimeWindow ? (
+      <strong>title only (time ignored)</strong>
+    ) : (
+      <>
+        title + start time within ±{currentTimeWindow} min
+      </>
+    );
+    const thresholdIsDefault = Math.abs(currentThreshold - EVENT_ATTACH_FLOOR) < 1e-9;
+    const scoreClause = thresholdIsDefault ? (
+      <>score ≥ {currentThreshold.toFixed(2)}</>
+    ) : (
+      <strong>score ≥ {currentThreshold.toFixed(2)}</strong>
+    );
+    return (
+      <>
+        Attach {source} to master <strong>{masterName}</strong>, matching on{' '}
+        {matchClause}, auto-attaching at {scoreClause}.{' '}
+        {autoRun ? (
+          <strong>Runs automatically after each M3U refresh.</strong>
+        ) : (
+          <>Runs only when you run it manually.</>
+        )}
+        {includeMasterGroupStreams && secCount > 0 && (
+          <> Also matches the master group&apos;s own streams.</>
+        )}
+        {assumeCurrentDate && (
+          <> <strong>Assumes today&apos;s date for dateless listings.</strong></>
+        )}
+        {dummyEpgProfileId != null && <> Assigns dummy EPG guide data on every run.</>}
+      </>
+    );
+  }, [
+    masterScope,
+    secondaryScopes,
+    includeMasterGroupStreams,
+    enforceTimeWindow,
+    currentTimeWindow,
+    currentThreshold,
+    autoRun,
+    assumeCurrentDate,
+    dummyEpgProfileId,
+    groupName,
+  ]);
+
+  // S2: per-subgroup "N changed" counts — non-default flag values inside a
+  // collapsed subgroup surface as a badge on its summary.
+  const timeTuningChanged =
+    (!enforceTimeWindow ? 1 : 0) +
+    (enforceTimeWindow && currentTimeWindow !== DEFAULT_TIME_WINDOW_MINUTES ? 1 : 0);
+  const scoreChanged = Math.abs(currentThreshold - EVENT_ATTACH_FLOOR) < 1e-9 ? 0 : 1;
+  const dateHandlingChanged = assumeCurrentDate ? 1 : 0;
+  const overridesChanged = scopedGroups.filter(
+    g => (groupOverrides[g.id]?.title_pattern ?? '').trim().length > 0
+  ).length;
+  const automationChanged = autoRun ? 1 : 0;
+  const scopeExtChanged =
+    (includeMasterGroupStreams ? 1 : 0) + (parseMasterFromStream ? 1 : 0);
+  const guideChanged = dummyEpgProfileId != null ? 1 : 0;
+
+  /** Collapsed-subgroup "N changed" badge (S2). */
+  const changedBadge = (count: number) =>
+    count > 0 ? (
+      <span className="badge badge-sm badge-info event-sync-subgroup-badge">
+        {count} changed
+      </span>
+    ) : null;
+
   return (
     <div className="event-sync-editor" data-testid="event-sync-editor">
-      <div className="event-sync-editor-content">
-        <p className="form-hint event-sync-quick-path">
-          Quick path: pick the master group, pick the secondary groups, keep
-          the default patterns, then Preview. Preview never writes; a manual
-          pipeline Run attaches matched streams to master channels — capped
-          per run, journaled, and reversible via execution rollback. Event
-          Sync runs unattended only if you explicitly enable auto-run under
-          Advanced (off by default).
-        </p>
+      <div className="event-sync-editor-content" ref={contentRef}>
+        <div className="event-sync-editor-grid">
+          <div className="event-sync-main">
+            {/* S3: sticky scroll-spy over the 3-phase spine. Degrades to a
+                plain sticky mini-header on narrow viewports (see CSS). */}
+            <nav className="event-sync-scrollspy" aria-label="Editor sections">
+              <button
+                type="button"
+                className={`event-sync-scrollspy-item${activeSection === 'scope' ? ' active' : ''}`}
+                aria-current={activeSection === 'scope' ? 'true' : undefined}
+                onClick={() => scrollToSection(scopeRef)}
+              >
+                <span className="event-sync-scrollspy-num">1</span> Scope
+              </button>
+              <button
+                type="button"
+                className={`event-sync-scrollspy-item${activeSection === 'matching' ? ' active' : ''}`}
+                aria-current={activeSection === 'matching' ? 'true' : undefined}
+                onClick={() => scrollToSection(matchingRef)}
+              >
+                <span className="event-sync-scrollspy-num">2</span> Matching
+              </button>
+              <button
+                type="button"
+                className={`event-sync-scrollspy-item${activeSection === 'behavior' ? ' active' : ''}`}
+                aria-current={activeSection === 'behavior' ? 'true' : undefined}
+                onClick={() => scrollToSection(behaviorRef)}
+              >
+                <span className="event-sync-scrollspy-num">3</span> Behavior
+              </button>
+            </nav>
 
-        {/* Basic Info */}
-        <section className="event-sync-section-block">
-          <h3 className="event-sync-section-title">Basic Information</h3>
-          <div className="form-group">
-            <label htmlFor={`${id}-name`}>Rule Name *</label>
-            <input
-              id={`${id}-name`}
-              type="text"
-              value={name}
-              onChange={e => setName(e.target.value)}
-              placeholder="Enter rule name"
-              disabled={isLoading}
-              aria-required="true"
-            />
-          </div>
-          <div className="form-group">
-            <label htmlFor={`${id}-description`}>Description</label>
-            <textarea
-              id={`${id}-description`}
-              value={description}
-              onChange={e => setDescription(e.target.value)}
-              placeholder="Optional description"
-              rows={2}
-              disabled={isLoading}
-            />
-          </div>
-          <label className="checkbox-option">
-            <input
-              type="checkbox"
-              checked={enabled}
-              onChange={e => setEnabled(e.target.checked)}
-              disabled={isLoading}
-            />
-            <span>Enabled</span>
-          </label>
-        </section>
+            <p className="form-hint event-sync-quick-path">
+              Quick path: pick the master group, pick the secondary groups, keep
+              the default patterns, then Preview. Preview never writes; a manual
+              pipeline Run attaches matched streams to master channels — capped
+              per run, journaled, and reversible via execution rollback. Event
+              Sync runs unattended only if you explicitly enable auto-run under
+              Behavior (off by default).
+            </p>
 
-        {/* Group visibility (bead x82s3): shared toggle for both the master
-            and secondary group pickers below. */}
-        <section className="event-sync-section-block">
-          <label className="checkbox-option">
-            <input
-              type="checkbox"
-              checked={showAllGroups}
-              onChange={e => setShowAllGroups(e.target.checked)}
-              disabled={isLoading}
-              data-testid="event-sync-show-all-groups"
-            />
-            <span>Show all groups</span>
-          </label>
-          <span className="form-hint">
-            The master and secondary pickers below list only groups whose
-            provider (M3U) junction is enabled by default. Turn this on to see
-            every provider junction too — useful for a temporarily-disabled
-            group.
-          </span>
-        </section>
+            {/* ── Phase 1: Scope ─────────────────────────────────────────── */}
+            <section
+              className="event-sync-phase"
+              ref={scopeRef}
+              id={`${id}-scope`}
+              aria-labelledby={`${id}-scope-title`}
+            >
+              <h2 className="event-sync-phase-title" id={`${id}-scope-title`}>
+                <span className="event-sync-phase-num">1</span> Scope
+              </h2>
 
-        {/* Master group (bead 38dzi: provider-scoped picker) */}
-        <section className="event-sync-section-block">
-          <h3 className="event-sync-section-title">Master group</h3>
-          <span className="form-hint">
-            The ONE group whose channels Dispatcharr owns — auto-sync must be
-            ON for it. Secondary streams attach to these channels. A group
-            carried by more than one provider expands so you can scope the
-            master to a specific provider.
-          </span>
-          <ProviderScopedGroupPicker
-            role="master"
-            rows={junctions}
-            value={masterScope}
-            onChange={s => setMasterScope(s as EventSyncGroupScope | null)}
-            showAll={showAllGroups}
-            excludeScope={null}
-            onRequestFix={t => requestFix(t, true)}
-            disabled={isLoading}
-          />
-        </section>
+              {/* Basic Info */}
+              <div className="event-sync-section-block">
+                <h3 className="event-sync-section-title">Basic Information</h3>
+                <div className="form-group">
+                  <label htmlFor={`${id}-name`}>Rule Name *</label>
+                  <input
+                    id={`${id}-name`}
+                    type="text"
+                    value={name}
+                    onChange={e => setName(e.target.value)}
+                    placeholder="Enter rule name"
+                    disabled={isLoading}
+                    aria-required="true"
+                  />
+                </div>
+                <div className="form-group">
+                  <label htmlFor={`${id}-description`}>Description</label>
+                  <textarea
+                    id={`${id}-description`}
+                    value={description}
+                    onChange={e => setDescription(e.target.value)}
+                    placeholder="Optional description"
+                    rows={2}
+                    disabled={isLoading}
+                  />
+                </div>
+                <label className="checkbox-option">
+                  <input
+                    type="checkbox"
+                    checked={enabled}
+                    onChange={e => setEnabled(e.target.checked)}
+                    disabled={isLoading}
+                  />
+                  <span>Enabled</span>
+                </label>
+              </div>
 
-        {/* Secondary groups (bead 38dzi: provider-scoped picker) */}
-        <section className="event-sync-section-block">
-          <h3 className="event-sync-section-title">Secondary groups</h3>
-          <span className="form-hint">
-            Pure stream sources from other providers — auto-sync should be OFF
-            for each (otherwise Dispatcharr keeps creating duplicate channels
-            from them). The same group under a different provider than the
-            master IS selectable here.
-          </span>
-          <ProviderScopedGroupPicker
-            role="secondary"
-            rows={junctions}
-            value={secondaryScopes}
-            onChange={s => setSecondaryScopes(s as EventSyncGroupScope[])}
-            showAll={showAllGroups}
-            excludeScope={masterScope}
-            onRequestFix={t => requestFix(t, false)}
-            disabled={isLoading}
-          />
-        </section>
-
-        {/* Parse patterns */}
-        <section className="event-sync-section-block">
-          <h3 className="event-sync-section-title">Parse patterns</h3>
-          <span className="form-hint">
-            Shipped patterns cover the common shapes — most rules never need a
-            custom regex. Patterns are tried in order; the first one that
-            extracts a complete title + date + time wins.
-          </span>
-          <div className="checkbox-group event-sync-pattern-list">
-            {SHIPPED_EVENT_SYNC_PATTERNS.map(shipped => (
-              <label key={shipped.id} className="checkbox-option event-sync-pattern-option">
-                <input
-                  type="checkbox"
-                  checked={selectedPatternIds.includes(shipped.id)}
-                  onChange={() =>
-                    setSelectedPatternIds(ids =>
-                      ids.includes(shipped.id)
-                        ? ids.filter(i => i !== shipped.id)
-                        : [...ids, shipped.id]
-                    )
-                  }
-                  disabled={isLoading}
-                />
-                <span>
-                  <span className="event-sync-pattern-label">{shipped.label}</span>
-                  <span className="event-sync-pattern-desc">{shipped.description}</span>
-                  <span className="event-sync-pattern-example">e.g. {shipped.example}</span>
+              {/* Group visibility (bead x82s3): shared toggle for both the
+                  master and secondary group pickers below. */}
+              <div className="event-sync-section-block">
+                <label className="checkbox-option">
+                  <input
+                    type="checkbox"
+                    checked={showAllGroups}
+                    onChange={e => setShowAllGroups(e.target.checked)}
+                    disabled={isLoading}
+                    data-testid="event-sync-show-all-groups"
+                  />
+                  <span>Show all groups</span>
+                </label>
+                <span className="form-hint">
+                  The master and secondary pickers below list only groups whose
+                  provider (M3U) junction is enabled by default. Turn this on to
+                  see every provider junction too — useful for a
+                  temporarily-disabled group.
                 </span>
-              </label>
-            ))}
-          </div>
+              </div>
 
-          <details className="event-sync-details">
-            <summary>Custom shared pattern (regex fallback)</summary>
-            <div className="event-sync-details-body">
-              <span className="form-hint">
-                Python-style named groups: <code>(?P&lt;title&gt;...)</code>,{' '}
-                <code>(?P&lt;hour&gt;...)</code>/<code>(?P&lt;minute&gt;...)</code>/
-                <code>(?P&lt;ampm&gt;...)</code>,{' '}
-                <code>(?P&lt;day&gt;...)</code>/<code>(?P&lt;month&gt;...)</code>/
-                <code>(?P&lt;year&gt;...)</code>. Verify with the Test Patterns
-                panel below.
-              </span>
-              <div className="form-group">
-                <label htmlFor={`${id}-custom-title`}>Title pattern</label>
-                <input
-                  id={`${id}-custom-title`}
-                  type="text"
-                  value={customShared.title_pattern}
-                  onChange={e => setCustomShared(c => ({ ...c, title_pattern: e.target.value }))}
-                  placeholder="^(?P<title>.+?)\s*@"
+              {/* Master group (bead 38dzi: provider-scoped picker) */}
+              <div className="event-sync-section-block">
+                <h3 className="event-sync-section-title">Master group</h3>
+                <span className="form-hint">
+                  The ONE group whose channels Dispatcharr owns — auto-sync must
+                  be ON for it. Secondary streams attach to these channels. A
+                  group carried by more than one provider expands so you can
+                  scope the master to a specific provider.
+                </span>
+                <ProviderScopedGroupPicker
+                  role="master"
+                  rows={junctions}
+                  value={masterScope}
+                  onChange={s => setMasterScope(s as EventSyncGroupScope | null)}
+                  showAll={showAllGroups}
+                  excludeScope={null}
+                  onRequestFix={t => requestFix(t, true)}
                   disabled={isLoading}
                 />
               </div>
-              <div className="form-group">
-                <label htmlFor={`${id}-custom-time`}>Time pattern</label>
-                <input
-                  id={`${id}-custom-time`}
-                  type="text"
-                  value={customShared.time_pattern}
-                  onChange={e => setCustomShared(c => ({ ...c, time_pattern: e.target.value }))}
-                  placeholder="(?P<hour>\d{1,2}):(?P<minute>\d{2})"
+
+              {/* Secondary groups (bead 38dzi: provider-scoped picker) */}
+              <div className="event-sync-section-block">
+                <h3 className="event-sync-section-title">Secondary groups</h3>
+                <span className="form-hint">
+                  Pure stream sources from other providers — auto-sync should be
+                  OFF for each (otherwise Dispatcharr keeps creating duplicate
+                  channels from them). The same group under a different provider
+                  than the master IS selectable here.
+                </span>
+                <ProviderScopedGroupPicker
+                  role="secondary"
+                  rows={junctions}
+                  value={secondaryScopes}
+                  onChange={s => setSecondaryScopes(s as EventSyncGroupScope[])}
+                  showAll={showAllGroups}
+                  excludeScope={masterScope}
+                  onRequestFix={t => requestFix(t, false)}
                   disabled={isLoading}
                 />
               </div>
-              <div className="form-group">
-                <label htmlFor={`${id}-custom-date`}>Date pattern</label>
-                <input
-                  id={`${id}-custom-date`}
-                  type="text"
-                  value={customShared.date_pattern}
-                  onChange={e => setCustomShared(c => ({ ...c, date_pattern: e.target.value }))}
-                  placeholder="(?P<day>\d{1,2})\s+(?P<month>[A-Za-z]{3,9})"
-                  disabled={isLoading}
-                />
+            </section>
+
+            {/* ── Phase 2: Matching ──────────────────────────────────────── */}
+            <section
+              className="event-sync-phase"
+              ref={matchingRef}
+              id={`${id}-matching`}
+              aria-labelledby={`${id}-matching-title`}
+            >
+              <h2 className="event-sync-phase-title" id={`${id}-matching-title`}>
+                <span className="event-sync-phase-num">2</span> Matching
+              </h2>
+
+              {/* Parse patterns */}
+              <div className="event-sync-section-block">
+                <h3 className="event-sync-section-title">Parse patterns</h3>
+                <span className="form-hint">
+                  Shipped patterns cover the common shapes — most rules never
+                  need a custom regex. Patterns are tried in order; the first
+                  one that extracts a complete title + date + time wins.
+                </span>
+                <div className="checkbox-group event-sync-pattern-list">
+                  {SHIPPED_EVENT_SYNC_PATTERNS.map(shipped => (
+                    <label key={shipped.id} className="checkbox-option event-sync-pattern-option">
+                      <input
+                        type="checkbox"
+                        checked={selectedPatternIds.includes(shipped.id)}
+                        onChange={() =>
+                          setSelectedPatternIds(ids =>
+                            ids.includes(shipped.id)
+                              ? ids.filter(i => i !== shipped.id)
+                              : [...ids, shipped.id]
+                          )
+                        }
+                        disabled={isLoading}
+                      />
+                      <span>
+                        <span className="event-sync-pattern-label">{shipped.label}</span>
+                        <span className="event-sync-pattern-desc">{shipped.description}</span>
+                        <span className="event-sync-pattern-example">e.g. {shipped.example}</span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+
+                <details className="event-sync-details">
+                  <summary>Custom shared pattern (regex fallback)</summary>
+                  <div className="event-sync-details-body">
+                    <span className="form-hint">
+                      Python-style named groups: <code>(?P&lt;title&gt;...)</code>,{' '}
+                      <code>(?P&lt;hour&gt;...)</code>/<code>(?P&lt;minute&gt;...)</code>/
+                      <code>(?P&lt;ampm&gt;...)</code>,{' '}
+                      <code>(?P&lt;day&gt;...)</code>/<code>(?P&lt;month&gt;...)</code>/
+                      <code>(?P&lt;year&gt;...)</code>. Verify with the Test
+                      Patterns panel below.
+                    </span>
+                    <div className="form-group">
+                      <label htmlFor={`${id}-custom-title`}>Title pattern</label>
+                      <input
+                        id={`${id}-custom-title`}
+                        type="text"
+                        value={customShared.title_pattern}
+                        onChange={e => setCustomShared(c => ({ ...c, title_pattern: e.target.value }))}
+                        placeholder="^(?P<title>.+?)\s*@"
+                        disabled={isLoading}
+                      />
+                    </div>
+                    <div className="form-group">
+                      <label htmlFor={`${id}-custom-time`}>Time pattern</label>
+                      <input
+                        id={`${id}-custom-time`}
+                        type="text"
+                        value={customShared.time_pattern}
+                        onChange={e => setCustomShared(c => ({ ...c, time_pattern: e.target.value }))}
+                        placeholder="(?P<hour>\d{1,2}):(?P<minute>\d{2})"
+                        disabled={isLoading}
+                      />
+                    </div>
+                    <div className="form-group">
+                      <label htmlFor={`${id}-custom-date`}>Date pattern</label>
+                      <input
+                        id={`${id}-custom-date`}
+                        type="text"
+                        value={customShared.date_pattern}
+                        onChange={e => setCustomShared(c => ({ ...c, date_pattern: e.target.value }))}
+                        placeholder="(?P<day>\d{1,2})\s+(?P<month>[A-Za-z]{3,9})"
+                        disabled={isLoading}
+                      />
+                    </div>
+                    {customSharedMeta.extras.length > 0 && (
+                      <span
+                        className="form-hint"
+                        data-testid="custom-shared-extras"
+                      >
+                        {customSharedMeta.extras.length} additional API-authored
+                        shared pattern{customSharedMeta.extras.length === 1 ? '' : 's'}{' '}
+                        ({customSharedMeta.extras
+                          .map((p, i) => p.name || `#${i + 2}`)
+                          .join(', ')}) {customSharedMeta.extras.length === 1 ? 'is' : 'are'}{' '}
+                        preserved as saved — this editor can edit only the first
+                        custom pattern; the rest are applied after it and never
+                        dropped on save.
+                      </span>
+                    )}
+                  </div>
+                </details>
               </div>
-              {customSharedMeta.extras.length > 0 && (
-                <span
-                  className="form-hint"
-                  data-testid="custom-shared-extras"
+
+              {/* Test Patterns — collapsed by default (S1/F4); auto-expands
+                  when a test run turns up parse failures. */}
+              <div className="event-sync-section-block">
+                <details
+                  className="event-sync-details"
+                  data-testid="event-sync-test-patterns-details"
+                  open={testPatternsOpen}
+                  onToggle={e => setTestPatternsOpen(e.currentTarget.open)}
                 >
-                  {customSharedMeta.extras.length} additional API-authored
-                  shared pattern{customSharedMeta.extras.length === 1 ? '' : 's'}{' '}
-                  ({customSharedMeta.extras
-                    .map((p, i) => p.name || `#${i + 2}`)
-                    .join(', ')}) {customSharedMeta.extras.length === 1 ? 'is' : 'are'}{' '}
-                  preserved as saved — this editor can edit only the first
-                  custom pattern; the rest are applied after it and never
-                  dropped on save.
-                </span>
-              )}
-            </div>
-          </details>
-        </section>
+                  <summary>Test patterns against sample names</summary>
+                  <div className="event-sync-details-body">
+                    <EventSyncTestPatternsPanel
+                      patterns={effectivePatterns}
+                      groupOptions={scopedGroups}
+                      onParseFailuresChange={has => {
+                        if (has) setTestPatternsOpen(true);
+                      }}
+                    />
+                  </div>
+                </details>
+              </div>
 
-        {/* Test Patterns */}
-        <section className="event-sync-section-block">
-          <details className="event-sync-details" open>
-            <summary>Test patterns against sample names</summary>
-            <div className="event-sync-details-body">
-              <EventSyncTestPatternsPanel
-                patterns={effectivePatterns}
-                groupOptions={scopedGroups}
+              {/* Matching-tuning subgroups (S2). */}
+              <details className="event-sync-details event-sync-subgroup">
+                <summary>
+                  Time tuning {changedBadge(timeTuningChanged)}
+                </summary>
+                <div className="event-sync-details-body">
+                  <div className="form-group">
+                    <label htmlFor={`${id}-time-window`}>Time window (minutes)</label>
+                    <input
+                      id={`${id}-time-window`}
+                      type="number"
+                      min={1}
+                      max={MAX_TIME_WINDOW_MINUTES}
+                      value={timeWindowText}
+                      onChange={e => setTimeWindowText(e.target.value)}
+                      disabled={isLoading || !enforceTimeWindow}
+                    />
+                    <span className="form-hint">
+                      Parsed start times must be within ± this window to become
+                      candidate pairs (default {DEFAULT_TIME_WINDOW_MINUTES}, max{' '}
+                      {MAX_TIME_WINDOW_MINUTES}).
+                    </span>
+                  </div>
+
+                  <div className="form-group">
+                    <label className="checkbox-option">
+                      <input
+                        type="checkbox"
+                        checked={!enforceTimeWindow}
+                        onChange={e => setEnforceTimeWindow(!e.target.checked)}
+                        disabled={isLoading}
+                        data-testid="event-sync-ignore-time-window"
+                      />
+                      <span>Ignore time window (match on title only)</span>
+                    </label>
+                    <span className="form-hint">
+                      When on, the time window is ignored and every parsed
+                      master event is a candidate, ranked by title/team score
+                      alone.
+                    </span>
+                    <details className="event-sync-details event-sync-why">
+                      <summary>Why / when to use</summary>
+                      <div className="event-sync-details-body">
+                        <span className="form-hint">
+                          Off by default. This rescues events whose providers
+                          publish different start times for the same fixture.
+                          Safe when the master group is a single
+                          provider&apos;s same-day event list. Leave it OFF for
+                          recurring or serial titles (a daily show, weekly
+                          numbered cards): without the time gate a stream can
+                          match the wrong day&apos;s channel. The 0.90 no-teams
+                          score floor and the team/numeric-identity rails still
+                          apply, so borderline pairs land in the review queue
+                          rather than auto-attaching.
+                        </span>
+                      </div>
+                    </details>
+                  </div>
+                </div>
+              </details>
+
+              <details className="event-sync-details event-sync-subgroup">
+                <summary>
+                  Score threshold {changedBadge(scoreChanged)}
+                </summary>
+                <div className="event-sync-details-body">
+                  <div className="form-group">
+                    <label htmlFor={`${id}-threshold`}>Attach threshold</label>
+                    <input
+                      id={`${id}-threshold`}
+                      type="number"
+                      min={0}
+                      max={1}
+                      step={0.01}
+                      value={thresholdText}
+                      onChange={e => setThresholdText(e.target.value)}
+                      onBlur={() =>
+                        setThresholdText(clampAttachThreshold(parseFloat(thresholdText)).toFixed(2))
+                      }
+                      disabled={isLoading}
+                    />
+                    <span className="form-hint">
+                      Auto-attach score floor on the parsed-title score. Default{' '}
+                      {EVENT_ATTACH_FLOOR.toFixed(2)} (precision over recall).
+                    </span>
+                    <details className="event-sync-details event-sync-why">
+                      <summary>Why / when to use</summary>
+                      <div className="event-sync-details-body">
+                        <span className="form-hint">
+                          You can raise it for stricter matching, or lower it
+                          when a provider&apos;s titles carry slot/venue noise
+                          that caps the score — but a lower floor auto-attaches
+                          weaker matches, so review the preview first.
+                          Team-conflict and different-event-number pairs are
+                          still hard-rejected at any threshold.
+                        </span>
+                      </div>
+                    </details>
+                  </div>
+                </div>
+              </details>
+
+              <details className="event-sync-details event-sync-subgroup">
+                <summary>
+                  Date handling {changedBadge(dateHandlingChanged)}
+                </summary>
+                <div className="event-sync-details-body">
+                  <div className="form-group">
+                    <label className="checkbox-option">
+                      <input
+                        type="checkbox"
+                        checked={assumeCurrentDate}
+                        onChange={e => setAssumeCurrentDate(e.target.checked)}
+                        disabled={isLoading}
+                        data-testid="event-sync-assume-current-date"
+                      />
+                      <span>Assume today&apos;s date for dateless listings</span>
+                    </label>
+                    <span className="form-hint">
+                      Places time-only listings (no date) on the current date so
+                      they match same-day events.
+                    </span>
+                    <details className="event-sync-details event-sync-why">
+                      <summary>Why / when to use</summary>
+                      <div className="event-sync-details-body">
+                        <span className="form-hint">
+                          Off by default. Some providers list a live schedule
+                          with a time but <em>no date</em> (e.g. &quot;FURY vs
+                          HALL 6PM&quot;). Normally those can&apos;t be matched
+                          (the time could be any day). Turn this on to place
+                          such listings on the <strong>current date</strong> so
+                          they match same-day events. Risk: a listing that is
+                          really for another day (e.g. a replay at the same time
+                          tomorrow) can mis-match — the ±time window still
+                          applies, but same-time-of-day collisions can slip
+                          through. Leave off unless the group only ever lists
+                          today.
+                        </span>
+                      </div>
+                    </details>
+                  </div>
+                </div>
+              </details>
+
+              <details className="event-sync-details event-sync-subgroup">
+                <summary>
+                  Per-group pattern overrides {changedBadge(overridesChanged)}
+                </summary>
+                <div className="event-sync-details-body">
+                  <span className="form-hint">
+                    A group with an override uses ONLY its own patterns; other
+                    groups keep the shared selection above.
+                  </span>
+                  {scopedGroups.length === 0 ? (
+                    <span className="form-hint">Pick groups first.</span>
+                  ) : (
+                    scopedGroups.map(group => {
+                      const draft = groupOverrides[group.id] ?? EMPTY_GROUP_PATTERN;
+                      const savedExtras = (
+                        config?.group_patterns?.[String(group.id)] ?? []
+                      ).slice(1);
+                      return (
+                        <details key={group.id} className="event-sync-details event-sync-override">
+                          <summary>
+                            {group.name}
+                            {draft.title_pattern.trim() ? ' — override set' : ''}
+                          </summary>
+                          <div className="event-sync-details-body">
+                            <div className="form-group">
+                              <label htmlFor={`${id}-ov-${group.id}-title`}>Title pattern</label>
+                              <input
+                                id={`${id}-ov-${group.id}-title`}
+                                type="text"
+                                value={draft.title_pattern}
+                                onChange={e => updateOverride(group.id, 'title_pattern', e.target.value)}
+                                placeholder="Leave empty for no override"
+                                disabled={isLoading}
+                              />
+                            </div>
+                            <div className="form-group">
+                              <label htmlFor={`${id}-ov-${group.id}-time`}>Time pattern</label>
+                              <input
+                                id={`${id}-ov-${group.id}-time`}
+                                type="text"
+                                value={draft.time_pattern}
+                                onChange={e => updateOverride(group.id, 'time_pattern', e.target.value)}
+                                disabled={isLoading}
+                              />
+                            </div>
+                            <div className="form-group">
+                              <label htmlFor={`${id}-ov-${group.id}-date`}>Date pattern</label>
+                              <input
+                                id={`${id}-ov-${group.id}-date`}
+                                type="text"
+                                value={draft.date_pattern}
+                                onChange={e => updateOverride(group.id, 'date_pattern', e.target.value)}
+                                disabled={isLoading}
+                              />
+                            </div>
+                            {savedExtras.length > 0 && (
+                              <span
+                                className="form-hint"
+                                data-testid={`group-override-extras-${group.id}`}
+                              >
+                                {savedExtras.length} additional API-authored
+                                pattern{savedExtras.length === 1 ? '' : 's'} for
+                                this group (
+                                {savedExtras
+                                  .map((p, i) => p.name || `#${i + 2}`)
+                                  .join(', ')}
+                                ) {savedExtras.length === 1 ? 'is' : 'are'}{' '}
+                                preserved as saved — this editor edits only the
+                                group&apos;s first pattern; the rest are applied
+                                after it and never dropped on save.
+                              </span>
+                            )}
+                          </div>
+                        </details>
+                      );
+                    })
+                  )}
+                </div>
+              </details>
+            </section>
+
+            {/* ── Phase 3: Behavior ──────────────────────────────────────── */}
+            <section
+              className="event-sync-phase"
+              ref={behaviorRef}
+              id={`${id}-behavior`}
+              aria-labelledby={`${id}-behavior-title`}
+            >
+              <h2 className="event-sync-phase-title" id={`${id}-behavior-title`}>
+                <span className="event-sync-phase-num">3</span> Behavior
+              </h2>
+
+              {/* Automation subgroup (S2). */}
+              <details className="event-sync-details event-sync-subgroup">
+                <summary>
+                  Automation {changedBadge(automationChanged)}
+                </summary>
+                <div className="event-sync-details-body">
+                  <div className="form-group">
+                    <label className="checkbox-option">
+                      <input
+                        type="checkbox"
+                        checked={autoRun}
+                        onChange={e => setAutoRun(e.target.checked)}
+                        disabled={isLoading}
+                        data-testid="event-sync-auto-run"
+                      />
+                      <span>Run automatically after each M3U refresh (auto-run)</span>
+                    </label>
+                    <span className="form-hint">
+                      When on, the rule runs unattended after every M3U refresh —
+                      same journaling, attach cap, and summary as a manual run.
+                    </span>
+                    <details className="event-sync-details event-sync-why">
+                      <summary>Why / when to use</summary>
+                      <div className="event-sync-details-body">
+                        <span className="form-hint">
+                          Off by default — enable it only after you trust this
+                          rule&apos;s manual runs. When on, the rule runs
+                          unattended after every M3U refresh with the same
+                          journaling, per-run attach cap, and run summary line as
+                          a manual run. Attach-cap overages and failed pre-flight
+                          checks (e.g. master auto-sync turned OFF) raise warning
+                          notifications. A tripped auto-creation circuit breaker
+                          pauses auto-runs until you reset it; manual runs stay
+                          available. A run landing right after a refresh can
+                          precede Dispatcharr creating a brand-new event&apos;s
+                          master channel — that stream attaches on the next run.
+                        </span>
+                      </div>
+                    </details>
+                  </div>
+                </div>
+              </details>
+
+              {/* Scope-extension subgroup (S2). */}
+              <details className="event-sync-details event-sync-subgroup">
+                <summary>
+                  Scope extension {changedBadge(scopeExtChanged)}
+                </summary>
+                <div className="event-sync-details-body">
+                  <div className="form-group">
+                    <label className="checkbox-option">
+                      <input
+                        type="checkbox"
+                        checked={includeMasterGroupStreams}
+                        onChange={e => setIncludeMasterGroupStreams(e.target.checked)}
+                        disabled={isLoading}
+                        data-testid="event-sync-include-master-group-streams"
+                      />
+                      <span>Also attach the master group&apos;s own streams</span>
+                    </label>
+                    <span className="form-hint">
+                      Matches the master group&apos;s own streams too — lets you
+                      leave the secondary list empty in the same-named
+                      cross-provider case.
+                    </span>
+                    <details className="event-sync-details event-sync-why">
+                      <summary>Why / when to use</summary>
+                      <div className="event-sync-details-body">
+                        <span className="form-hint">
+                          Off by default. Turn this on when a second
+                          provider&apos;s streams live in the <em>same-named</em>{' '}
+                          channel group as the master (Dispatcharr requires
+                          channel-group names to be unique, so both providers
+                          share <strong>one</strong> group — it cannot be picked
+                          twice). When on, the master group&apos;s streams are
+                          matched to the master channels too; streams already
+                          attached (the auto-synced provider&apos;s own) are
+                          skipped, so only the unsynced provider&apos;s streams
+                          attach.{' '}
+                          <strong>With this on you can leave the secondary list empty</strong>
+                          {' '}— the master group is the stream source.
+                        </span>
+                      </div>
+                    </details>
+                  </div>
+
+                  <div className="form-group">
+                    <label className="checkbox-option">
+                      <input
+                        type="checkbox"
+                        checked={parseMasterFromStream}
+                        onChange={e => setParseMasterFromStream(e.target.checked)}
+                        disabled={isLoading}
+                        data-testid="event-sync-parse-master-from-stream"
+                      />
+                      <span>Read master event time from the attached stream</span>
+                    </label>
+                    <span className="form-hint">
+                      Reads the master event time from its first attached stream
+                      instead of the channel name.
+                    </span>
+                    <details className="event-sync-details event-sync-why">
+                      <summary>Why / when to use</summary>
+                      <div className="event-sync-details-body">
+                        <span className="form-hint">
+                          Off by default. Event Sync normally reads a master
+                          channel&apos;s date/time from its <em>name</em>. Turn
+                          this on to read it from the master channel&apos;s{' '}
+                          <strong>first attached stream</strong> instead — so you
+                          can name the master channels however you like while the
+                          event time still comes from the underlying auto-synced
+                          stream. (If a master channel has no attached stream, it
+                          is skipped.)
+                        </span>
+                      </div>
+                    </details>
+                  </div>
+                </div>
+              </details>
+
+              {/* Guide-data subgroup (S2). */}
+              <details className="event-sync-details event-sync-subgroup">
+                <summary>
+                  Guide data {changedBadge(guideChanged)}
+                </summary>
+                <div className="event-sync-details-body">
+                  <div className="form-group">
+                    <label>Dummy EPG profile (optional)</label>
+                    <CustomSelect
+                      value={dummyEpgProfileId != null ? dummyEpgProfileId.toString() : ''}
+                      onChange={value =>
+                        setDummyEpgProfileId(value ? parseInt(value, 10) : null)
+                      }
+                      options={[
+                        { value: '', label: 'None — no automatic guide data' },
+                        ...dummyProfiles.map(p => ({
+                          value: p.id.toString(),
+                          label: p.enabled ? p.name : `${p.name} (disabled)`,
+                        })),
+                      ]}
+                      placeholder="None — no automatic guide data"
+                      disabled={isLoading}
+                    />
+                    <span className="form-hint">
+                      Assigns this dummy EPG profile to the master group&apos;s
+                      event channels on every run, so new events get guide data
+                      automatically.
+                    </span>
+                    <details className="event-sync-details event-sync-why">
+                      <summary>Why / when to use</summary>
+                      <div className="event-sync-details-body">
+                        <span className="form-hint">
+                          Assigns this dummy EPG profile to the master
+                          group&apos;s event channels on every run (manual and
+                          auto-run), so new events get guide data automatically.
+                          Channels the profile&apos;s XMLTV does not cover yet
+                          are retried after an automatic regenerate + refresh in
+                          the same run. Existing guide data from other sources is
+                          never overwritten. Tip: the profile&apos;s title/time
+                          patterns can reuse this rule&apos;s parse patterns —
+                          the master provider&apos;s naming is the same in both
+                          places.
+                        </span>
+                      </div>
+                    </details>
+                  </div>
+                </div>
+              </details>
+            </section>
+          </div>
+
+          {/* Sticky validation rail (S3): plain-language intent + always-
+              visible Preview. Drops below the main column under ~820px. */}
+          <aside className="event-sync-rail" aria-label="Validation and preview">
+            <div className="event-sync-intent" data-testid="event-sync-intent">
+              <h3 className="event-sync-intent-title">What this rule will do</h3>
+              <p className="event-sync-intent-text">{intent}</p>
+            </div>
+            <div className="event-sync-rail-preview">
+              <h3 className="event-sync-section-title">Preview</h3>
+              <EventSyncPreviewPanel
+                preview={preview}
+                loading={previewLoading}
+                error={previewError}
+                onRunPreview={handleRunPreview}
+                disabledReason={validationError}
               />
             </div>
-          </details>
-        </section>
-
-        {/* Advanced */}
-        <section className="event-sync-section-block">
-          <details className="event-sync-details">
-            <summary>Advanced</summary>
-            <div className="event-sync-details-body">
-              <div className="form-group">
-                <label htmlFor={`${id}-time-window`}>Time window (minutes)</label>
-                <input
-                  id={`${id}-time-window`}
-                  type="number"
-                  min={1}
-                  max={MAX_TIME_WINDOW_MINUTES}
-                  value={timeWindowText}
-                  onChange={e => setTimeWindowText(e.target.value)}
-                  disabled={isLoading || !enforceTimeWindow}
-                />
-                <span className="form-hint">
-                  Parsed start times must be within ± this window to become
-                  candidate pairs (default {DEFAULT_TIME_WINDOW_MINUTES}, max{' '}
-                  {MAX_TIME_WINDOW_MINUTES}).
-                </span>
-              </div>
-
-              <div className="form-group">
-                <label className="checkbox-option">
-                  <input
-                    type="checkbox"
-                    checked={!enforceTimeWindow}
-                    onChange={e => setEnforceTimeWindow(!e.target.checked)}
-                    disabled={isLoading}
-                    data-testid="event-sync-ignore-time-window"
-                  />
-                  <span>Ignore time window (match on title only)</span>
-                </label>
-                <span className="form-hint">
-                  Off by default. When on, the time window above is ignored and
-                  every parsed master event is a candidate, ranked by
-                  title/team score alone — this rescues events whose providers
-                  publish different start times for the same fixture. Safe when
-                  the master group is a single provider&apos;s same-day event
-                  list. Leave it OFF for recurring or serial titles (a daily
-                  show, weekly numbered cards): without the time gate a stream
-                  can match the wrong day&apos;s channel. The 0.90 no-teams
-                  score floor and the team/numeric-identity rails still apply,
-                  so borderline pairs land in the review queue rather than
-                  auto-attaching.
-                </span>
-              </div>
-              <div className="form-group">
-                <label htmlFor={`${id}-threshold`}>Attach threshold</label>
-                <input
-                  id={`${id}-threshold`}
-                  type="number"
-                  min={0}
-                  max={1}
-                  step={0.01}
-                  value={thresholdText}
-                  onChange={e => setThresholdText(e.target.value)}
-                  onBlur={() =>
-                    setThresholdText(clampAttachThreshold(parseFloat(thresholdText)).toFixed(2))
-                  }
-                  disabled={isLoading}
-                />
-                <span className="form-hint">
-                  Auto-attach score floor on the parsed-title score. Default{' '}
-                  {EVENT_ATTACH_FLOOR.toFixed(2)} (precision over recall). You
-                  can raise it for stricter matching, or lower it when a
-                  provider&apos;s titles carry slot/venue noise that caps the
-                  score — but a lower floor auto-attaches weaker matches, so
-                  review the preview first. Team-conflict and
-                  different-event-number pairs are still hard-rejected at any
-                  threshold.
-                </span>
-              </div>
-
-              <div className="form-group">
-                <label className="checkbox-option">
-                  <input
-                    type="checkbox"
-                    checked={autoRun}
-                    onChange={e => setAutoRun(e.target.checked)}
-                    disabled={isLoading}
-                    data-testid="event-sync-auto-run"
-                  />
-                  <span>Run automatically after each M3U refresh (auto-run)</span>
-                </label>
-                <span className="form-hint">
-                  Off by default — enable it only after you trust this
-                  rule&apos;s manual runs. When on, the rule runs unattended
-                  after every M3U refresh with the same journaling, per-run
-                  attach cap, and run summary line as a manual run. Attach-cap
-                  overages and failed pre-flight checks (e.g. master
-                  auto-sync turned OFF) raise warning notifications. A
-                  tripped auto-creation circuit breaker pauses auto-runs
-                  until you reset it; manual runs stay available. A run
-                  landing right after a refresh can precede Dispatcharr
-                  creating a brand-new event&apos;s master channel — that
-                  stream attaches on the next run.
-                </span>
-              </div>
-
-              <div className="form-group">
-                <label className="checkbox-option">
-                  <input
-                    type="checkbox"
-                    checked={includeMasterGroupStreams}
-                    onChange={e => setIncludeMasterGroupStreams(e.target.checked)}
-                    disabled={isLoading}
-                    data-testid="event-sync-include-master-group-streams"
-                  />
-                  <span>Also attach the master group&apos;s own streams</span>
-                </label>
-                <span className="form-hint">
-                  Off by default. Turn this on when a second provider&apos;s
-                  streams live in the <em>same-named</em> channel group as the
-                  master (Dispatcharr requires channel-group names to be
-                  unique, so both providers share <strong>one</strong> group —
-                  it cannot be picked twice). When on, the master group&apos;s
-                  streams are matched to the master channels too; streams
-                  already attached (the auto-synced provider&apos;s own) are
-                  skipped, so only the unsynced provider&apos;s streams attach.
-                  <strong> With this on you can leave the secondary list empty</strong>
-                  {' '}— the master group is the stream source.
-                </span>
-              </div>
-
-              <div className="form-group">
-                <label className="checkbox-option">
-                  <input
-                    type="checkbox"
-                    checked={parseMasterFromStream}
-                    onChange={e => setParseMasterFromStream(e.target.checked)}
-                    disabled={isLoading}
-                    data-testid="event-sync-parse-master-from-stream"
-                  />
-                  <span>Read master event time from the attached stream</span>
-                </label>
-                <span className="form-hint">
-                  Off by default. Event Sync normally reads a master
-                  channel&apos;s date/time from its <em>name</em>. Turn this on
-                  to read it from the master channel&apos;s <strong>first
-                  attached stream</strong> instead — so you can name the master
-                  channels however you like while the event time still comes
-                  from the underlying auto-synced stream. (If a master channel
-                  has no attached stream, it is skipped.)
-                </span>
-              </div>
-
-              <div className="form-group">
-                <label className="checkbox-option">
-                  <input
-                    type="checkbox"
-                    checked={assumeCurrentDate}
-                    onChange={e => setAssumeCurrentDate(e.target.checked)}
-                    disabled={isLoading}
-                    data-testid="event-sync-assume-current-date"
-                  />
-                  <span>Assume today&apos;s date for dateless listings</span>
-                </label>
-                <span className="form-hint">
-                  Off by default. Some providers list a live schedule with a
-                  time but <em>no date</em> (e.g. &quot;FURY vs HALL 6PM&quot;).
-                  Normally those can&apos;t be matched (the time could be any
-                  day). Turn this on to place such listings on the{' '}
-                  <strong>current date</strong> so they match same-day events.
-                  Risk: a listing that is really for another day (e.g. a replay
-                  at the same time tomorrow) can mis-match — the ±time window
-                  still applies, but same-time-of-day collisions can slip
-                  through. Leave off unless the group only ever lists today.
-                </span>
-              </div>
-
-              <div className="form-group">
-                <label>Dummy EPG profile (optional)</label>
-                <CustomSelect
-                  value={dummyEpgProfileId != null ? dummyEpgProfileId.toString() : ''}
-                  onChange={value =>
-                    setDummyEpgProfileId(value ? parseInt(value, 10) : null)
-                  }
-                  options={[
-                    { value: '', label: 'None — no automatic guide data' },
-                    ...dummyProfiles.map(p => ({
-                      value: p.id.toString(),
-                      label: p.enabled ? p.name : `${p.name} (disabled)`,
-                    })),
-                  ]}
-                  placeholder="None — no automatic guide data"
-                  disabled={isLoading}
-                />
-                <span className="form-hint">
-                  Assigns this dummy EPG profile to the master group&apos;s
-                  event channels on every run (manual and auto-run), so new
-                  events get guide data automatically. Channels the
-                  profile&apos;s XMLTV does not cover yet are retried after an
-                  automatic regenerate + refresh in the same run. Existing
-                  guide data from other sources is never overwritten. Tip: the
-                  profile&apos;s title/time patterns can reuse this rule&apos;s
-                  parse patterns — the master provider&apos;s naming is the
-                  same in both places.
-                </span>
-              </div>
-
-              <div className="form-group">
-                <label>Per-group pattern overrides</label>
-                <span className="form-hint">
-                  A group with an override uses ONLY its own patterns; other
-                  groups keep the shared selection above.
-                </span>
-                {scopedGroups.length === 0 ? (
-                  <span className="form-hint">Pick groups first.</span>
-                ) : (
-                  scopedGroups.map(group => {
-                    const draft = groupOverrides[group.id] ?? EMPTY_GROUP_PATTERN;
-                    const savedExtras = (
-                      config?.group_patterns?.[String(group.id)] ?? []
-                    ).slice(1);
-                    return (
-                      <details key={group.id} className="event-sync-details event-sync-override">
-                        <summary>
-                          {group.name}
-                          {draft.title_pattern.trim() ? ' — override set' : ''}
-                        </summary>
-                        <div className="event-sync-details-body">
-                          <div className="form-group">
-                            <label htmlFor={`${id}-ov-${group.id}-title`}>Title pattern</label>
-                            <input
-                              id={`${id}-ov-${group.id}-title`}
-                              type="text"
-                              value={draft.title_pattern}
-                              onChange={e => updateOverride(group.id, 'title_pattern', e.target.value)}
-                              placeholder="Leave empty for no override"
-                              disabled={isLoading}
-                            />
-                          </div>
-                          <div className="form-group">
-                            <label htmlFor={`${id}-ov-${group.id}-time`}>Time pattern</label>
-                            <input
-                              id={`${id}-ov-${group.id}-time`}
-                              type="text"
-                              value={draft.time_pattern}
-                              onChange={e => updateOverride(group.id, 'time_pattern', e.target.value)}
-                              disabled={isLoading}
-                            />
-                          </div>
-                          <div className="form-group">
-                            <label htmlFor={`${id}-ov-${group.id}-date`}>Date pattern</label>
-                            <input
-                              id={`${id}-ov-${group.id}-date`}
-                              type="text"
-                              value={draft.date_pattern}
-                              onChange={e => updateOverride(group.id, 'date_pattern', e.target.value)}
-                              disabled={isLoading}
-                            />
-                          </div>
-                          {savedExtras.length > 0 && (
-                            <span
-                              className="form-hint"
-                              data-testid={`group-override-extras-${group.id}`}
-                            >
-                              {savedExtras.length} additional API-authored
-                              pattern{savedExtras.length === 1 ? '' : 's'} for
-                              this group (
-                              {savedExtras
-                                .map((p, i) => p.name || `#${i + 2}`)
-                                .join(', ')}
-                              ) {savedExtras.length === 1 ? 'is' : 'are'}{' '}
-                              preserved as saved — this editor edits only the
-                              group&apos;s first pattern; the rest are applied
-                              after it and never dropped on save.
-                            </span>
-                          )}
-                        </div>
-                      </details>
-                    );
-                  })
-                )}
-              </div>
-            </div>
-          </details>
-        </section>
-
-        {/* Preview */}
-        <section className="event-sync-section-block">
-          <h3 className="event-sync-section-title">Preview</h3>
-          <EventSyncPreviewPanel
-            preview={preview}
-            loading={previewLoading}
-            error={previewError}
-            onRunPreview={handleRunPreview}
-            disabledReason={validationError}
-          />
-        </section>
+          </aside>
+        </div>
       </div>
 
       {/* Footer */}

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
@@ -38,7 +38,7 @@
  * (`m3u_account_id: null`); saving emits the nested `master` / `secondary`
  * and lets the backend derive the flat keys.
  */
-import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import type { ReactNode, RefObject } from 'react';
 import type { ChannelPipelineRule, CreateRuleData } from '../../types/channelPipeline';
 import type {
@@ -60,6 +60,8 @@ import { EventSyncTestPatternsPanel } from './EventSyncTestPatternsPanel';
 import type { LabeledEventSyncPattern } from './EventSyncTestPatternsPanel';
 import { EventSyncPreviewPanel } from './EventSyncPreviewPanel';
 import { EventSyncAutoSyncFixDialog } from './EventSyncAutoSyncFixDialog';
+import { ModalOverlay } from '../ModalOverlay';
+import '../ModalBase.css';
 import type { AutoSyncFixTarget } from './EventSyncAutoSyncFixDialog';
 import { ProviderScopedGroupPicker } from './ProviderScopedGroupPicker';
 import { joinProviderRows, type GroupProviderRow } from './providerScopedGroups';
@@ -80,6 +82,13 @@ export interface EventSyncRuleEditorProps {
   onSave: (data: CreateRuleData) => Promise<void> | void;
   onCancel: () => void;
   isLoading?: boolean;
+  /**
+   * S4a dirty-guard: the editor owns the discard confirm and registers its
+   * guarded-close here so parent-owned dismissors (the modal overlay's Escape
+   * handler and the header × button) route through the same guard instead of
+   * discarding a half-configured rule. Called with null on unmount.
+   */
+  onRegisterClose?: (attemptClose: (() => void) | null) => void;
 }
 
 interface GroupPatternDraft {
@@ -181,6 +190,62 @@ function sameDraft(a: GroupPatternDraft, b: GroupPatternDraft): boolean {
   );
 }
 
+/** Initial master scope from a config (bead 38dzi migration): nested `master`
+ * if present, else the flat legacy key as a whole-group scope. */
+function initialMasterScope(
+  config: EventSyncConfig | null | undefined
+): EventSyncGroupScope | null {
+  if (config?.master) return config.master;
+  if (config?.master_group_id != null) {
+    return { group_id: config.master_group_id, m3u_account_id: null };
+  }
+  return null;
+}
+
+/** Initial secondary scopes from a config (same migration). */
+function initialSecondaryScopes(
+  config: EventSyncConfig | null | undefined
+): EventSyncGroupScope[] {
+  if (config?.secondary) return config.secondary;
+  return (config?.secondary_group_ids ?? []).map(gid => ({
+    group_id: gid,
+    m3u_account_id: null,
+  }));
+}
+
+/** Order-insensitive equality of two group scopes. */
+function sameScope(
+  a: EventSyncGroupScope | null,
+  b: EventSyncGroupScope | null
+): boolean {
+  if (a == null || b == null) return a === b;
+  return a.group_id === b.group_id && (a.m3u_account_id ?? null) === (b.m3u_account_id ?? null);
+}
+
+/** Set-like equality of two scope lists (S4a dirty check — reordering in the
+ * picker is not an edit). */
+function sameScopes(a: EventSyncGroupScope[], b: EventSyncGroupScope[]): boolean {
+  if (a.length !== b.length) return false;
+  const key = (s: EventSyncGroupScope) => `${s.group_id}:${s.m3u_account_id ?? 'any'}`;
+  const bKeys = b.map(key).sort();
+  return a.map(key).sort().every((k, i) => k === bKeys[i]);
+}
+
+/** Canonical string for a group-overrides map, ignoring empty drafts (an
+ * override typed then cleared is not an edit). */
+function normalizeOverrides(o: Record<number, GroupPatternDraft>): string {
+  const entries = Object.entries(o)
+    .map(([k, d]) => [
+      k,
+      d.title_pattern.trim(),
+      d.time_pattern.trim(),
+      d.date_pattern.trim(),
+    ])
+    .filter(([, t, tm, dt]) => t || tm || dt)
+    .sort((x, y) => (x[0] < y[0] ? -1 : 1));
+  return JSON.stringify(entries);
+}
+
 /** Selection equality is set-like: toggling a box off and back on again is
  * not an edit. */
 function sameIds(a: string[], b: string[]): boolean {
@@ -192,6 +257,7 @@ export function EventSyncRuleEditor({
   onSave,
   onCancel,
   isLoading = false,
+  onRegisterClose,
 }: EventSyncRuleEditorProps) {
   const id = useId();
   const config = rule?.event_sync_config ?? null;
@@ -204,20 +270,12 @@ export function EventSyncRuleEditor({
   // Scoping (bead 38dzi): provider-scoped master + secondary. Initialize from
   // the nested `master` / `secondary` when present; otherwise migrate the flat
   // legacy keys to WHOLE-GROUP scopes (m3u_account_id null).
-  const [masterScope, setMasterScope] = useState<EventSyncGroupScope | null>(() => {
-    if (config?.master) return config.master;
-    if (config?.master_group_id != null) {
-      return { group_id: config.master_group_id, m3u_account_id: null };
-    }
-    return null;
-  });
-  const [secondaryScopes, setSecondaryScopes] = useState<EventSyncGroupScope[]>(() => {
-    if (config?.secondary) return config.secondary;
-    return (config?.secondary_group_ids ?? []).map(gid => ({
-      group_id: gid,
-      m3u_account_id: null,
-    }));
-  });
+  const [masterScope, setMasterScope] = useState<EventSyncGroupScope | null>(() =>
+    initialMasterScope(config)
+  );
+  const [secondaryScopes, setSecondaryScopes] = useState<EventSyncGroupScope[]>(() =>
+    initialSecondaryScopes(config)
+  );
   // bead x82s3: both group pickers default to enabled-only junctions (hundreds
   // of groups on a real instance is noisy); this reveals the full list for
   // edge cases (temporarily-disabled group). Default OFF.
@@ -318,6 +376,19 @@ export function EventSyncRuleEditor({
   const [activeSection, setActiveSection] = useState<'scope' | 'matching' | 'behavior'>(
     'scope'
   );
+
+  // S4a: dirty-state discard guard. The confirm is shown when a dismiss is
+  // attempted with unsaved changes; a pristine editor closes immediately.
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+
+  // S4b: the Secondary section's inline anchor expands the Behavior ->
+  // Scope-extension subgroup and focuses the master-self-attach checkbox
+  // (recognition over recall). The subgroup's open state is therefore
+  // controlled, and a pending-focus ref defers the focus until after it opens.
+  const [scopeExtOpen, setScopeExtOpen] = useState(false);
+  const scopeExtRef = useRef<HTMLDetailsElement>(null);
+  const includeMasterRef = useRef<HTMLInputElement>(null);
+  const pendingMasterFocus = useRef(false);
 
   useEffect(() => {
     // The junction rows carry no group name; join them against the channel
@@ -704,6 +775,68 @@ export function EventSyncRuleEditor({
     ref.current?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
   };
 
+  // S4a: does the form diverge from the rule as loaded? (showAllGroups is a
+  // view toggle, not config — deliberately excluded.)
+  const dirty = useMemo(() => {
+    return (
+      name !== (rule?.name || '') ||
+      description !== (rule?.description || '') ||
+      enabled !== (rule?.enabled ?? true) ||
+      !sameScope(masterScope, initialMasterScope(config)) ||
+      !sameScopes(secondaryScopes, initialSecondaryScopes(config)) ||
+      !sameIds(selectedPatternIds, initial.patternIds) ||
+      !sameDraft(customShared, customSharedMeta.draft) ||
+      normalizeOverrides(groupOverrides) !== normalizeOverrides(initial.groupOverrides) ||
+      timeWindowText !== String(config?.time_window_minutes ?? DEFAULT_TIME_WINDOW_MINUTES) ||
+      thresholdText !== (config?.attach_threshold ?? EVENT_ATTACH_FLOOR).toFixed(2) ||
+      enforceTimeWindow !== (config?.enforce_time_window ?? true) ||
+      autoRun !== (config?.auto_run ?? false) ||
+      includeMasterGroupStreams !== (config?.include_master_group_streams ?? false) ||
+      assumeCurrentDate !== (config?.assume_current_date ?? false) ||
+      parseMasterFromStream !== (config?.parse_master_from_stream ?? false) ||
+      dummyEpgProfileId !== (config?.dummy_epg_profile_id ?? null)
+    );
+  }, [
+    name, description, enabled, masterScope, secondaryScopes, selectedPatternIds,
+    customShared, groupOverrides, timeWindowText, thresholdText, enforceTimeWindow,
+    autoRun, includeMasterGroupStreams, assumeCurrentDate, parseMasterFromStream,
+    dummyEpgProfileId, config, rule, initial, customSharedMeta,
+  ]);
+  const dirtyRef = useRef(dirty);
+  dirtyRef.current = dirty;
+
+  // S4a: the guarded close. Confirm only when dirty; otherwise close at once so
+  // a modal opened by mistake is not held hostage by a prompt.
+  const attemptClose = useCallback(() => {
+    if (dirtyRef.current) setShowDiscardConfirm(true);
+    else onCancel();
+  }, [onCancel]);
+
+  // Register the guard so the parent's Escape/× dismissors route through it.
+  useEffect(() => {
+    onRegisterClose?.(attemptClose);
+    return () => onRegisterClose?.(null);
+  }, [onRegisterClose, attemptClose]);
+
+  // S4b: focus the master-self-attach checkbox once its subgroup has opened.
+  useEffect(() => {
+    if (scopeExtOpen && pendingMasterFocus.current) {
+      pendingMasterFocus.current = false;
+      scopeExtRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
+      includeMasterRef.current?.focus();
+    }
+  }, [scopeExtOpen]);
+
+  const handleUseMasterStreams = () => {
+    if (scopeExtOpen) {
+      scopeExtRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
+      includeMasterRef.current?.focus();
+    } else {
+      pendingMasterFocus.current = true;
+      setScopeExtOpen(true);
+    }
+  };
+
   // S3: plain-language rule-intent sentence. Bold clauses are the non-default
   // or risk-carrying choices (time ignored, auto-run, assume-current-date) so
   // the operator can see at a glance what the rule will actually do.
@@ -943,6 +1076,14 @@ export function EventSyncRuleEditor({
                   channels from them). The same group under a different provider
                   than the master IS selectable here.
                 </span>
+                <button
+                  type="button"
+                  className="event-sync-inline-link"
+                  onClick={handleUseMasterStreams}
+                  data-testid="event-sync-use-master-streams"
+                >
+                  No separate secondary? Use the master group&apos;s own streams →
+                </button>
                 <ProviderScopedGroupPicker
                   role="secondary"
                   rows={junctions}
@@ -1363,8 +1504,14 @@ export function EventSyncRuleEditor({
                 </div>
               </details>
 
-              {/* Scope-extension subgroup (S2). */}
-              <details className="event-sync-details event-sync-subgroup">
+              {/* Scope-extension subgroup (S2); controlled open for the S4b
+                  secondary anchor. */}
+              <details
+                className="event-sync-details event-sync-subgroup"
+                ref={scopeExtRef}
+                open={scopeExtOpen}
+                onToggle={e => setScopeExtOpen(e.currentTarget.open)}
+              >
                 <summary>
                   Scope extension {changedBadge(scopeExtChanged)}
                 </summary>
@@ -1373,6 +1520,7 @@ export function EventSyncRuleEditor({
                     <label className="checkbox-option">
                       <input
                         type="checkbox"
+                        ref={includeMasterRef}
                         checked={includeMasterGroupStreams}
                         onChange={e => setIncludeMasterGroupStreams(e.target.checked)}
                         disabled={isLoading}
@@ -1520,7 +1668,7 @@ export function EventSyncRuleEditor({
         <button
           type="button"
           className="btn-secondary"
-          onClick={onCancel}
+          onClick={attemptClose}
           disabled={saving}
         >
           Cancel
@@ -1545,6 +1693,44 @@ export function EventSyncRuleEditor({
           onCancel={() => setPendingFix(null)}
           onConfirm={handleConfirmFix}
         />
+      )}
+
+      {/* S4a: dirty-state discard confirm — reuses the modal-sm confirm pattern.
+          Rendered inside the editor (topmost overlay) so Escape dismisses this
+          prompt rather than the whole rule builder. */}
+      {showDiscardConfirm && (
+        <ModalOverlay
+          onClose={() => setShowDiscardConfirm(false)}
+          data-testid="event-sync-discard-dialog"
+        >
+          <div className="modal-container modal-sm" role="alertdialog" aria-modal="true">
+            <div className="modal-header">
+              <h3 className="modal-title">Discard this rule?</h3>
+            </div>
+            <div className="modal-body">
+              <p>Your patterns and scope selections will be lost.</p>
+            </div>
+            <div className="modal-footer">
+              <button
+                className="modal-btn-secondary"
+                onClick={() => setShowDiscardConfirm(false)}
+                data-testid="event-sync-discard-keep"
+              >
+                Keep editing
+              </button>
+              <button
+                className="modal-btn-danger"
+                onClick={() => {
+                  setShowDiscardConfirm(false);
+                  onCancel();
+                }}
+                data-testid="event-sync-discard-confirm"
+              >
+                Discard
+              </button>
+            </div>
+          </div>
+        </ModalOverlay>
       )}
     </div>
   );

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
@@ -39,7 +39,7 @@
  * and lets the backend derive the flat keys.
  */
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
-import type { ReactNode, RefObject } from 'react';
+import type { ReactNode } from 'react';
 import type { ChannelPipelineRule, CreateRuleData } from '../../types/channelPipeline';
 import type {
   EventSyncConfig,
@@ -74,7 +74,17 @@ import {
   clampAttachThreshold,
   selectionIsBuiltinDefaults,
 } from './eventSyncDefaults';
+import { stableStringify } from '../../utils/configDirty';
 import './EventSyncRuleEditor.css';
+
+/** The four wizard steps. */
+type WizardStep = 1 | 2 | 3 | 4;
+const WIZARD_STEPS: { n: WizardStep; label: string }[] = [
+  { n: 1, label: 'Scope' },
+  { n: 2, label: 'Matching' },
+  { n: 3, label: 'Behavior' },
+  { n: 4, label: 'Review' },
+];
 
 export interface EventSyncRuleEditorProps {
   /** Existing event_sync rule to edit; omit to create a new one. */
@@ -357,6 +367,13 @@ export function EventSyncRuleEditor({
   const [preview, setPreview] = useState<EventSyncPreviewResponse | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
+  // Stale-marking (bead m1s38.1): the built-config signature captured when the
+  // last preview ran. Results are marked stale (not cleared) when the current
+  // built config diverges from it, via the shared dirty-comparator.
+  const [previewSignature, setPreviewSignature] = useState<string | null>(null);
+  // Last Test-patterns run verdict, surfaced in the Matching impact block
+  // (null = not run yet). Fed by the panel's onParseFailuresChange callback.
+  const [lastTestFailures, setLastTestFailures] = useState<boolean | null>(null);
 
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -366,16 +383,22 @@ export function EventSyncRuleEditor({
   // auto-expands it so the failing rows are never hidden below the fold.
   const [testPatternsOpen, setTestPatternsOpen] = useState(false);
 
-  // S3: in-modal scroll-spy over the 3-phase spine. `activeSection` drives the
-  // sticky nav highlight; the section elements are observed inside the scroll
-  // container.
-  const contentRef = useRef<HTMLDivElement>(null);
-  const scopeRef = useRef<HTMLElement>(null);
-  const matchingRef = useRef<HTMLElement>(null);
-  const behaviorRef = useRef<HTMLElement>(null);
-  const [activeSection, setActiveSection] = useState<'scope' | 'matching' | 'behavior'>(
-    'scope'
-  );
+  // Wizard (bead m1s38.1): full-width step pills drive the LEFT column only.
+  // All four step sections stay MOUNTED and are toggled with `hidden`, so
+  // picker state, the Test Patterns panel, and every ref survive step changes.
+  // Editing an existing rule (rule prop present) exposes Save on every step;
+  // a brand-new rule can Save only from the Review step.
+  const isEditing = rule != null;
+  const [currentStep, setCurrentStep] = useState<WizardStep>(1);
+  // Step headings are focus targets (tabIndex=-1) so a screen reader announces
+  // the new step when nav happens. A field-focus request (Save-from-Review)
+  // overrides the heading focus for one transition.
+  const scopeHeadingRef = useRef<HTMLHeadingElement>(null);
+  const matchingHeadingRef = useRef<HTMLHeadingElement>(null);
+  const behaviorHeadingRef = useRef<HTMLHeadingElement>(null);
+  const reviewHeadingRef = useRef<HTMLHeadingElement>(null);
+  const pendingFieldFocus = useRef<string | null>(null);
+  const didInitStep = useRef(false);
 
   // S4a: dirty-state discard guard. The confirm is shown when a dismiss is
   // attempted with unsaved changes; a pristine editor closes immediately.
@@ -688,6 +711,8 @@ export function EventSyncRuleEditor({
   const handleRunPreview = async () => {
     const builtConfig = buildConfig();
     if (!builtConfig) return;
+    // Snapshot the config this run reflects; later edits mark the results stale.
+    setPreviewSignature(stableStringify(builtConfig));
     setPreviewLoading(true);
     setPreviewError(null);
     try {
@@ -704,11 +729,20 @@ export function EventSyncRuleEditor({
   const handleSave = async () => {
     if (!name.trim()) {
       setSaveError('Name is required');
-      document.getElementById(`${id}-name`)?.focus();
+      navigateToField(1, `${id}-name`);
       return;
     }
     if (validationError) {
       setSaveError(validationError);
+      // Save-from-Review (and edit-mode Save on any step): jump to the step
+      // that owns the offending field and focus its heading.
+      const targetsScope =
+        masterScope == null ||
+        (secondaryScopes.length === 0 && !includeMasterGroupStreams);
+      const [step, fieldId] = targetsScope
+        ? ([1, `${id}-scope-title`] as const)
+        : ([2, `${id}-matching-title`] as const);
+      navigateToField(step, fieldId);
       return;
     }
     const builtConfig = buildConfig();
@@ -739,40 +773,53 @@ export function EventSyncRuleEditor({
     }));
   };
 
-  // S3: scroll-spy. Highlight the phase whose heading is nearest the top of
-  // the scroll container. Guarded so it is a no-op where IntersectionObserver
-  // is unavailable (jsdom mocks it as a stub, so this stays inert in tests).
+  // Wizard nav + focus management (bead m1s38.1). On each step change focus the
+  // step heading so a screen reader announces it — unless a specific field
+  // focus was requested (Save-from-Review jumps to the offending field). The
+  // very first mount does not steal focus. The S4b master-self-attach anchor
+  // sets pendingMasterFocus, which suppresses the heading focus so the checkbox
+  // focus effect below wins.
   useEffect(() => {
-    if (typeof IntersectionObserver === 'undefined') return;
-    const root = contentRef.current;
-    const sections: { id: 'scope' | 'matching' | 'behavior'; el: HTMLElement | null }[] = [
-      { id: 'scope', el: scopeRef.current },
-      { id: 'matching', el: matchingRef.current },
-      { id: 'behavior', el: behaviorRef.current },
-    ];
-    const visible = new Map<Element, number>();
-    const observer = new IntersectionObserver(
-      entries => {
-        for (const entry of entries) {
-          if (entry.isIntersecting) visible.set(entry.target, entry.intersectionRatio);
-          else visible.delete(entry.target);
-        }
-        let best: { id: 'scope' | 'matching' | 'behavior'; ratio: number } | null = null;
-        for (const { id, el } of sections) {
-          if (!el || !visible.has(el)) continue;
-          const ratio = visible.get(el) ?? 0;
-          if (!best || ratio > best.ratio) best = { id, ratio };
-        }
-        if (best) setActiveSection(best.id);
-      },
-      { root, rootMargin: '0px 0px -55% 0px', threshold: [0, 0.25, 0.5, 1] }
-    );
-    for (const { el } of sections) if (el) observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
+    if (!didInitStep.current) {
+      didInitStep.current = true;
+      return;
+    }
+    const fieldId = pendingFieldFocus.current;
+    pendingFieldFocus.current = null;
+    if (fieldId) {
+      document.getElementById(fieldId)?.focus();
+      return;
+    }
+    // S4b anchor jumped us to Behavior to focus the master-self-attach box.
+    if (pendingMasterFocus.current) {
+      pendingMasterFocus.current = false;
+      scopeExtRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
+      includeMasterRef.current?.focus();
+      return;
+    }
+    const headingRef =
+      currentStep === 1
+        ? scopeHeadingRef
+        : currentStep === 2
+          ? matchingHeadingRef
+          : currentStep === 3
+            ? behaviorHeadingRef
+            : reviewHeadingRef;
+    headingRef.current?.focus();
+  }, [currentStep]);
 
-  const scrollToSection = (ref: RefObject<HTMLElement | null>) => {
-    ref.current?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
+  /** Plain step change (Back / Next / step pill / Review jump-back). Never
+   * routes through the dirty guard — only Cancel / Escape / × do. */
+  const goToStep = (step: WizardStep) => setCurrentStep(step);
+
+  /** Navigate to a step and focus a specific field once it is visible. */
+  const navigateToField = (step: WizardStep, fieldId: string) => {
+    if (step === currentStep) {
+      document.getElementById(fieldId)?.focus();
+    } else {
+      pendingFieldFocus.current = fieldId;
+      setCurrentStep(step);
+    }
   };
 
   // S4a: does the form diverge from the rule as loaded? (showAllGroups is a
@@ -828,13 +875,16 @@ export function EventSyncRuleEditor({
   }, [scopeExtOpen]);
 
   const handleUseMasterStreams = () => {
-    if (scopeExtOpen) {
+    // The master-self-attach checkbox lives in the Behavior step's Scope-
+    // extension subgroup — jump there, open the subgroup, and focus it.
+    if (currentStep === 3 && scopeExtOpen) {
       scopeExtRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
       includeMasterRef.current?.focus();
-    } else {
-      pendingMasterFocus.current = true;
-      setScopeExtOpen(true);
+      return;
     }
+    pendingMasterFocus.current = true;
+    setScopeExtOpen(true);
+    setCurrentStep(3);
   };
 
   // S3: plain-language rule-intent sentence. Bold clauses are the non-default
@@ -852,7 +902,7 @@ export function EventSyncRuleEditor({
   const intent: ReactNode = useMemo(() => {
     if (masterScope == null) {
       return (
-        <span className="event-sync-intent-placeholder">
+        <span className="modal-intent-placeholder">
           Pick a master group to see what this rule will do.
         </span>
       );
@@ -929,45 +979,175 @@ export function EventSyncRuleEditor({
   /** Collapsed-subgroup "N changed" badge (S2). */
   const changedBadge = (count: number) =>
     count > 0 ? (
-      <span className="badge badge-sm badge-info event-sync-subgroup-badge">
+      <span className="badge badge-sm badge-info modal-subgroup-badge">
         {count} changed
       </span>
     ) : null;
 
+  // Stale-marking (bead m1s38.1): the results reflect a config that has since
+  // diverged from the one captured when the preview ran (shared comparator).
+  const previewStale =
+    preview != null &&
+    previewSignature != null &&
+    stableStringify(buildConfig()) !== previewSignature;
+
+  /** Auto-sync verdict for a scope, rolled up across its provider junctions. */
+  const autoSyncForScope = (
+    scope: EventSyncGroupScope
+  ): 'on' | 'off' | 'mixed' | 'unknown' => {
+    const rows = junctions.filter(
+      j =>
+        j.groupId === scope.group_id &&
+        (scope.m3u_account_id == null || j.m3uAccountId === scope.m3u_account_id)
+    );
+    if (rows.length === 0) return 'unknown';
+    const on = rows.filter(r => r.autoChannelSync).length;
+    if (on === 0) return 'off';
+    if (on === rows.length) return 'on';
+    return 'mixed';
+  };
+
+  const syncChip = (verdict: ReturnType<typeof autoSyncForScope>): ReactNode => {
+    if (verdict === 'on') return <span className="badge badge-sm badge-info">Auto-sync ON</span>;
+    if (verdict === 'off') return <span className="badge badge-sm">Auto-sync OFF</span>;
+    if (verdict === 'mixed')
+      return <span className="badge badge-sm badge-warning">Auto-sync mixed</span>;
+    return <span className="badge badge-sm">Auto-sync ?</span>;
+  };
+
+  const masterProviderLabel: string | null = (() => {
+    if (masterScope == null) return null;
+    if (masterScope.m3u_account_id == null) return 'Any provider';
+    const row = junctions.find(
+      j => j.groupId === masterScope.group_id && j.m3uAccountId === masterScope.m3u_account_id
+    );
+    return row?.m3uAccountName ?? `Provider ${masterScope.m3u_account_id}`;
+  })();
+
+  const secondaryAutoSyncOnCount = secondaryScopes.filter(s => {
+    const v = autoSyncForScope(s);
+    return v === 'on' || v === 'mixed';
+  }).length;
+
+  // Persistent, step-reactive impact block (bead m1s38.1). All client-side and
+  // instant — no server round-trips (the Preview panel below is the only
+  // server dry-run).
+  const impactBlock: ReactNode = (() => {
+    if (currentStep === 1) {
+      if (masterScope == null) {
+        return (
+          <p className="form-hint">
+            Pick a master group to see its sync status and scope impact.
+          </p>
+        );
+      }
+      return (
+        <>
+          <h4 className="event-sync-impact-title">Scope impact</h4>
+          <p className="event-sync-impact-line">
+            Master <strong>{groupName(masterScope.group_id)}</strong>
+            {masterProviderLabel ? <> · {masterProviderLabel}</> : null}{' '}
+            {syncChip(autoSyncForScope(masterScope))}
+          </p>
+          <p className="event-sync-impact-line">
+            {secondaryScopes.length} secondary group
+            {secondaryScopes.length === 1 ? '' : 's'}
+            {includeMasterGroupStreams && secondaryScopes.length === 0
+              ? ' (master group’s own streams)'
+              : ''}
+          </p>
+          {secondaryAutoSyncOnCount > 0 && (
+            <p className="event-sync-impact-line">
+              <span className="badge badge-sm badge-warning">
+                {secondaryAutoSyncOnCount} secondary with auto-sync ON
+              </span>
+            </p>
+          )}
+        </>
+      );
+    }
+    if (currentStep === 2) {
+      return (
+        <>
+          <h4 className="event-sync-impact-title">Matching impact</h4>
+          <p className="event-sync-impact-line">
+            {effectivePatterns.length} parse pattern
+            {effectivePatterns.length === 1 ? '' : 's'} active
+          </p>
+          <p className="event-sync-impact-line">
+            {enforceTimeWindow
+              ? `Time window ±${currentTimeWindow} min`
+              : 'Time window ignored'}{' '}
+            · score ≥ {currentThreshold.toFixed(2)}
+          </p>
+          <p className="event-sync-impact-line">
+            {lastTestFailures == null ? (
+              <span className="form-hint">Test patterns not run yet.</span>
+            ) : lastTestFailures ? (
+              <span className="badge badge-sm badge-warning">Last test: parse failures</span>
+            ) : (
+              <span className="badge badge-sm badge-info">Last test: all parsed</span>
+            )}
+          </p>
+        </>
+      );
+    }
+    if (currentStep === 3) {
+      const chips: ReactNode[] = [];
+      if (autoRun)
+        chips.push(<span key="ar" className="badge badge-sm badge-warning">Auto-run</span>);
+      if (!enforceTimeWindow)
+        chips.push(<span key="to" className="badge badge-sm badge-warning">Title-only</span>);
+      if (assumeCurrentDate)
+        chips.push(<span key="ad" className="badge badge-sm badge-warning">Assumes date</span>);
+      if (dummyEpgProfileId != null)
+        chips.push(<span key="gd" className="badge badge-sm badge-info">Guide data</span>);
+      return (
+        <>
+          <h4 className="event-sync-impact-title">Behavior impact</h4>
+          {chips.length > 0 ? (
+            <p className="event-sync-impact-chips">{chips}</p>
+          ) : (
+            <p className="form-hint">
+              No risk flags set — manual, time-gated, no assumptions.
+            </p>
+          )}
+        </>
+      );
+    }
+    return (
+      <>
+        <h4 className="event-sync-impact-title">Ready to save</h4>
+        <p className="form-hint">
+          Run a preview below, then Save. Use the jump-back links to revisit any
+          section.
+        </p>
+      </>
+    );
+  })();
+
   return (
     <div className="event-sync-editor" data-testid="event-sync-editor">
-      <div className="event-sync-editor-content" ref={contentRef}>
-        <div className="event-sync-editor-grid">
-          <div className="event-sync-main">
-            {/* S3: sticky scroll-spy over the 3-phase spine. Degrades to a
-                plain sticky mini-header on narrow viewports (see CSS). */}
-            <nav className="event-sync-scrollspy" aria-label="Editor sections">
-              <button
-                type="button"
-                className={`event-sync-scrollspy-item${activeSection === 'scope' ? ' active' : ''}`}
-                aria-current={activeSection === 'scope' ? 'true' : undefined}
-                onClick={() => scrollToSection(scopeRef)}
-              >
-                <span className="event-sync-scrollspy-num">1</span> Scope
-              </button>
-              <button
-                type="button"
-                className={`event-sync-scrollspy-item${activeSection === 'matching' ? ' active' : ''}`}
-                aria-current={activeSection === 'matching' ? 'true' : undefined}
-                onClick={() => scrollToSection(matchingRef)}
-              >
-                <span className="event-sync-scrollspy-num">2</span> Matching
-              </button>
-              <button
-                type="button"
-                className={`event-sync-scrollspy-item${activeSection === 'behavior' ? ' active' : ''}`}
-                aria-current={activeSection === 'behavior' ? 'true' : undefined}
-                onClick={() => scrollToSection(behaviorRef)}
-              >
-                <span className="event-sync-scrollspy-num">3</span> Behavior
-              </button>
-            </nav>
+      <div className="event-sync-editor-content">
+        {/* Full-width step wizard strip — pills drive the LEFT column only.
+            Free non-linear nav: any pill is clickable at any time. */}
+        <nav className="modal-stepper" aria-label="Editor steps">
+          {WIZARD_STEPS.map(({ n, label }) => (
+            <button
+              key={n}
+              type="button"
+              className="modal-stepper-item"
+              aria-current={currentStep === n ? 'step' : undefined}
+              onClick={() => goToStep(n)}
+              data-testid={`event-sync-step-${n}`}
+            >
+              <span className="modal-stepper-num">{n}</span> {label}
+            </button>
+          ))}
+        </nav>
 
+        <div className="modal-twopane">
+          <div className="modal-main">
             <p className="form-hint event-sync-quick-path">
               Quick path: pick the master group, pick the secondary groups, keep
               the default patterns, then Preview. Preview never writes; a manual
@@ -977,14 +1157,18 @@ export function EventSyncRuleEditor({
               Behavior (off by default).
             </p>
 
-            {/* ── Phase 1: Scope ─────────────────────────────────────────── */}
+            {/* ── Step 1: Scope ──────────────────────────────────────────── */}
             <section
+              hidden={currentStep !== 1}
               className="event-sync-phase"
-              ref={scopeRef}
-              id={`${id}-scope`}
               aria-labelledby={`${id}-scope-title`}
             >
-              <h2 className="event-sync-phase-title" id={`${id}-scope-title`}>
+              <h2
+                className="event-sync-phase-title"
+                id={`${id}-scope-title`}
+                ref={scopeHeadingRef}
+                tabIndex={-1}
+              >
                 <span className="event-sync-phase-num">1</span> Scope
               </h2>
 
@@ -1097,14 +1281,18 @@ export function EventSyncRuleEditor({
               </div>
             </section>
 
-            {/* ── Phase 2: Matching ──────────────────────────────────────── */}
+            {/* ── Step 2: Matching ───────────────────────────────────────── */}
             <section
+              hidden={currentStep !== 2}
               className="event-sync-phase"
-              ref={matchingRef}
-              id={`${id}-matching`}
               aria-labelledby={`${id}-matching-title`}
             >
-              <h2 className="event-sync-phase-title" id={`${id}-matching-title`}>
+              <h2
+                className="event-sync-phase-title"
+                id={`${id}-matching-title`}
+                ref={matchingHeadingRef}
+                tabIndex={-1}
+              >
                 <span className="event-sync-phase-num">2</span> Matching
               </h2>
 
@@ -1218,6 +1406,7 @@ export function EventSyncRuleEditor({
                       patterns={effectivePatterns}
                       groupOptions={scopedGroups}
                       onParseFailuresChange={has => {
+                        setLastTestFailures(has);
                         if (has) setTestPatternsOpen(true);
                       }}
                     />
@@ -1226,7 +1415,7 @@ export function EventSyncRuleEditor({
               </div>
 
               {/* Matching-tuning subgroups (S2). */}
-              <details className="event-sync-details event-sync-subgroup">
+              <details className="modal-subgroup">
                 <summary>
                   Time tuning {changedBadge(timeTuningChanged)}
                 </summary>
@@ -1265,7 +1454,7 @@ export function EventSyncRuleEditor({
                       master event is a candidate, ranked by title/team score
                       alone.
                     </span>
-                    <details className="event-sync-details event-sync-why">
+                    <details className="modal-why">
                       <summary>Why / when to use</summary>
                       <div className="event-sync-details-body">
                         <span className="form-hint">
@@ -1286,7 +1475,7 @@ export function EventSyncRuleEditor({
                 </div>
               </details>
 
-              <details className="event-sync-details event-sync-subgroup">
+              <details className="modal-subgroup">
                 <summary>
                   Score threshold {changedBadge(scoreChanged)}
                 </summary>
@@ -1310,7 +1499,7 @@ export function EventSyncRuleEditor({
                       Auto-attach score floor on the parsed-title score. Default{' '}
                       {EVENT_ATTACH_FLOOR.toFixed(2)} (precision over recall).
                     </span>
-                    <details className="event-sync-details event-sync-why">
+                    <details className="modal-why">
                       <summary>Why / when to use</summary>
                       <div className="event-sync-details-body">
                         <span className="form-hint">
@@ -1327,7 +1516,7 @@ export function EventSyncRuleEditor({
                 </div>
               </details>
 
-              <details className="event-sync-details event-sync-subgroup">
+              <details className="modal-subgroup">
                 <summary>
                   Date handling {changedBadge(dateHandlingChanged)}
                 </summary>
@@ -1347,7 +1536,7 @@ export function EventSyncRuleEditor({
                       Places time-only listings (no date) on the current date so
                       they match same-day events.
                     </span>
-                    <details className="event-sync-details event-sync-why">
+                    <details className="modal-why">
                       <summary>Why / when to use</summary>
                       <div className="event-sync-details-body">
                         <span className="form-hint">
@@ -1369,7 +1558,7 @@ export function EventSyncRuleEditor({
                 </div>
               </details>
 
-              <details className="event-sync-details event-sync-subgroup">
+              <details className="modal-subgroup">
                 <summary>
                   Per-group pattern overrides {changedBadge(overridesChanged)}
                 </summary>
@@ -1450,19 +1639,23 @@ export function EventSyncRuleEditor({
               </details>
             </section>
 
-            {/* ── Phase 3: Behavior ──────────────────────────────────────── */}
+            {/* ── Step 3: Behavior ───────────────────────────────────────── */}
             <section
+              hidden={currentStep !== 3}
               className="event-sync-phase"
-              ref={behaviorRef}
-              id={`${id}-behavior`}
               aria-labelledby={`${id}-behavior-title`}
             >
-              <h2 className="event-sync-phase-title" id={`${id}-behavior-title`}>
+              <h2
+                className="event-sync-phase-title"
+                id={`${id}-behavior-title`}
+                ref={behaviorHeadingRef}
+                tabIndex={-1}
+              >
                 <span className="event-sync-phase-num">3</span> Behavior
               </h2>
 
               {/* Automation subgroup (S2). */}
-              <details className="event-sync-details event-sync-subgroup">
+              <details className="modal-subgroup">
                 <summary>
                   Automation {changedBadge(automationChanged)}
                 </summary>
@@ -1482,7 +1675,7 @@ export function EventSyncRuleEditor({
                       When on, the rule runs unattended after every M3U refresh —
                       same journaling, attach cap, and summary as a manual run.
                     </span>
-                    <details className="event-sync-details event-sync-why">
+                    <details className="modal-why">
                       <summary>Why / when to use</summary>
                       <div className="event-sync-details-body">
                         <span className="form-hint">
@@ -1507,7 +1700,7 @@ export function EventSyncRuleEditor({
               {/* Scope-extension subgroup (S2); controlled open for the S4b
                   secondary anchor. */}
               <details
-                className="event-sync-details event-sync-subgroup"
+                className="modal-subgroup"
                 ref={scopeExtRef}
                 open={scopeExtOpen}
                 onToggle={e => setScopeExtOpen(e.currentTarget.open)}
@@ -1533,7 +1726,7 @@ export function EventSyncRuleEditor({
                       leave the secondary list empty in the same-named
                       cross-provider case.
                     </span>
-                    <details className="event-sync-details event-sync-why">
+                    <details className="modal-why">
                       <summary>Why / when to use</summary>
                       <div className="event-sync-details-body">
                         <span className="form-hint">
@@ -1569,7 +1762,7 @@ export function EventSyncRuleEditor({
                       Reads the master event time from its first attached stream
                       instead of the channel name.
                     </span>
-                    <details className="event-sync-details event-sync-why">
+                    <details className="modal-why">
                       <summary>Why / when to use</summary>
                       <div className="event-sync-details-body">
                         <span className="form-hint">
@@ -1589,7 +1782,7 @@ export function EventSyncRuleEditor({
               </details>
 
               {/* Guide-data subgroup (S2). */}
-              <details className="event-sync-details event-sync-subgroup">
+              <details className="modal-subgroup">
                 <summary>
                   Guide data {changedBadge(guideChanged)}
                 </summary>
@@ -1616,7 +1809,7 @@ export function EventSyncRuleEditor({
                       event channels on every run, so new events get guide data
                       automatically.
                     </span>
-                    <details className="event-sync-details event-sync-why">
+                    <details className="modal-why">
                       <summary>Why / when to use</summary>
                       <div className="event-sync-details-body">
                         <span className="form-hint">
@@ -1637,14 +1830,114 @@ export function EventSyncRuleEditor({
                 </div>
               </details>
             </section>
+
+            {/* ── Step 4: Review & Preview ───────────────────────────────── */}
+            <section
+              hidden={currentStep !== 4}
+              className="event-sync-phase"
+              aria-labelledby={`${id}-review-title`}
+            >
+              <h2
+                className="event-sync-phase-title"
+                id={`${id}-review-title`}
+                ref={reviewHeadingRef}
+                tabIndex={-1}
+              >
+                <span className="event-sync-phase-num">4</span> Review &amp; Preview
+              </h2>
+              <p className="form-hint">
+                Review each section, then run the preview in the rail before
+                saving. Use a jump-back link to fix anything.
+              </p>
+              <dl className="event-sync-review" data-testid="event-sync-review">
+                <div className="event-sync-review-row">
+                  <dt>
+                    <button
+                      type="button"
+                      className="event-sync-review-jump"
+                      onClick={() => goToStep(1)}
+                      aria-label="Edit Scope"
+                    >
+                      <span className="material-icons" aria-hidden="true">arrow_back</span>
+                    </button>
+                    Scope
+                  </dt>
+                  <dd>
+                    {masterScope == null ? (
+                      <span className="event-sync-review-warn">No master group selected</span>
+                    ) : (
+                      <>
+                        Master <strong>{groupName(masterScope.group_id)}</strong>
+                        {masterProviderLabel ? ` · ${masterProviderLabel}` : ''} ·{' '}
+                        {secondaryScopes.length} secondary group
+                        {secondaryScopes.length === 1 ? '' : 's'}
+                        {includeMasterGroupStreams && secondaryScopes.length === 0
+                          ? ' · master group’s own streams'
+                          : ''}
+                      </>
+                    )}
+                  </dd>
+                </div>
+                <div className="event-sync-review-row">
+                  <dt>
+                    <button
+                      type="button"
+                      className="event-sync-review-jump"
+                      onClick={() => goToStep(2)}
+                      aria-label="Edit Matching"
+                    >
+                      <span className="material-icons" aria-hidden="true">arrow_back</span>
+                    </button>
+                    Matching
+                  </dt>
+                  <dd>
+                    {effectivePatterns.length} pattern
+                    {effectivePatterns.length === 1 ? '' : 's'} ·{' '}
+                    {enforceTimeWindow
+                      ? `time ±${currentTimeWindow} min`
+                      : 'time ignored'}{' '}
+                    · score ≥ {currentThreshold.toFixed(2)}
+                    {assumeCurrentDate ? ' · assumes date' : ''}
+                    {overridesChanged > 0
+                      ? ` · ${overridesChanged} group override${
+                          overridesChanged === 1 ? '' : 's'
+                        }`
+                      : ''}
+                  </dd>
+                </div>
+                <div className="event-sync-review-row">
+                  <dt>
+                    <button
+                      type="button"
+                      className="event-sync-review-jump"
+                      onClick={() => goToStep(3)}
+                      aria-label="Edit Behavior"
+                    >
+                      <span className="material-icons" aria-hidden="true">arrow_back</span>
+                    </button>
+                    Behavior
+                  </dt>
+                  <dd>
+                    {autoRun ? 'Auto-run after each M3U refresh' : 'Manual runs only'}
+                    {parseMasterFromStream ? ' · master time from stream' : ''}
+                    {dummyEpgProfileId != null ? ' · dummy EPG guide data' : ''}
+                  </dd>
+                </div>
+              </dl>
+            </section>
           </div>
 
-          {/* Sticky validation rail (S3): plain-language intent + always-
-              visible Preview. Drops below the main column under ~820px. */}
-          <aside className="event-sync-rail" aria-label="Validation and preview">
-            <div className="event-sync-intent" data-testid="event-sync-intent">
-              <h3 className="event-sync-intent-title">What this rule will do</h3>
-              <p className="event-sync-intent-text">{intent}</p>
+          {/* Persistent rail (bead m1s38.1): intent sentence + step-reactive
+              impacts + a single manual Preview (compact on steps 1-3, expanded
+              on Review, stale-marked when the config changes). Drops below the
+              main column under ~820px. */}
+          <aside className="modal-rail" aria-label="Rule intent, impacts, and preview">
+            <div className="modal-intent" data-testid="event-sync-intent">
+              <h3 className="modal-intent-title">What this rule will do</h3>
+              <p className="modal-intent-text">{intent}</p>
+            </div>
+            <div className="event-sync-impact" data-testid="event-sync-impact" aria-live="polite">
+              {impactBlock}
             </div>
             <div className="event-sync-rail-preview">
               <h3 className="event-sync-section-title">Preview</h3>
@@ -1654,17 +1947,19 @@ export function EventSyncRuleEditor({
                 error={previewError}
                 onRunPreview={handleRunPreview}
                 disabledReason={validationError}
+                compact={currentStep !== 4}
+                stale={previewStale}
               />
             </div>
           </aside>
         </div>
       </div>
 
-      {/* Footer */}
+      {/* Footer: Cancel (far left, dirty-guarded) · Back (hidden on step 1) ·
+          Next (steps 1-3, becomes Save on step 4). Editing an existing rule
+          also exposes Save on every step. Back/Next NEVER route through the
+          dirty guard — only Cancel/Escape/× do. */}
       <div className="event-sync-editor-footer">
-        {saveError && (
-          <span className="event-sync-save-error" role="alert">{saveError}</span>
-        )}
         <button
           type="button"
           className="btn-secondary"
@@ -1673,14 +1968,50 @@ export function EventSyncRuleEditor({
         >
           Cancel
         </button>
-        <button
-          type="button"
-          className="btn-primary"
-          onClick={handleSave}
-          disabled={saving || isLoading}
-        >
-          {saving ? 'Saving...' : 'Save'}
-        </button>
+        {saveError && (
+          <span className="event-sync-save-error" role="alert">{saveError}</span>
+        )}
+        <div className="event-sync-footer-nav">
+          {currentStep > 1 && (
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={() => goToStep((currentStep - 1) as WizardStep)}
+              disabled={saving}
+            >
+              Back
+            </button>
+          )}
+          {isEditing && currentStep < 4 && (
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={handleSave}
+              disabled={saving || isLoading}
+            >
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          )}
+          {currentStep < 4 ? (
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={() => goToStep((currentStep + 1) as WizardStep)}
+              disabled={saving}
+            >
+              Next
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={handleSave}
+              disabled={saving || isLoading}
+            >
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Guided setup (ti939.3.4): the toggle API is reachable ONLY through

--- a/frontend/src/components/channelPipeline/EventSyncTestPatternsPanel.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncTestPatternsPanel.tsx
@@ -35,6 +35,13 @@ export interface EventSyncTestPatternsPanelProps {
   patterns: LabeledEventSyncPattern[];
   /** Groups the rule scopes to (master + secondaries), for live samples. */
   groupOptions: { id: number; name: string }[];
+  /**
+   * Fires after each test run with whether any sample was a parse failure
+   * (no match, or matched but the matcher would reject the start time). The
+   * editor uses this to auto-expand the collapsed Test Patterns panel so the
+   * failures are never hidden below the fold.
+   */
+  onParseFailuresChange?: (hasParseFailures: boolean) => void;
 }
 
 interface PatternRow {
@@ -76,6 +83,7 @@ function formatTimeParts(groups: Record<string, string | null>): string | null {
 export function EventSyncTestPatternsPanel({
   patterns,
   groupOptions,
+  onParseFailuresChange,
 }: EventSyncTestPatternsPanelProps) {
   const id = useId();
   const [sampleText, setSampleText] = useState('');
@@ -149,6 +157,13 @@ export function EventSyncTestPatternsPanel({
         })
       );
       setResults(perPattern);
+      // A row is a parse failure when the matcher would not build a valid
+      // start time from it (no match, or matched-but-invalid). Surface it so
+      // the editor can auto-expand the panel.
+      const hasParseFailures = perPattern.some(result =>
+        result.rows.some(row => !(row.matched && row.startValid))
+      );
+      onParseFailuresChange?.(hasParseFailures);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Pattern test failed');
       setResults(null);

--- a/frontend/src/types/eventSync.ts
+++ b/frontend/src/types/eventSync.ts
@@ -186,6 +186,17 @@ export interface EventSyncCandidate {
   review_status: EventSyncReviewStatus;
 }
 
+/**
+ * S5 (bead sf8dj): diagnostic provenance for a `would_attach` row — the
+ * optional relaxation (`key`) that admitted it, with a short display `label`.
+ * Keys: `assume_current_date` | `time_window_ignored` | `lowered_threshold` |
+ * `master_from_stream`. Empty for a plain in-window default-threshold match.
+ */
+export interface EventSyncMatchedVia {
+  key: string;
+  label: string;
+}
+
 export interface EventSyncStreamRow {
   stream_id: number | null;
   stream_name: string;
@@ -199,6 +210,9 @@ export interface EventSyncStreamRow {
   attach_source: EventSyncAttachSource;
   would_attach_master: { channel_id: number | null; name: string } | null;
   candidates: EventSyncCandidate[];
+  /** S5 (bead sf8dj): provenance chips for a would-attach row (may be absent
+   * on older payloads → treat as empty). */
+  matched_via?: EventSyncMatchedVia[];
 }
 
 export interface EventSyncUnmatchedStream {

--- a/frontend/src/utils/configDirty.test.ts
+++ b/frontend/src/utils/configDirty.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { stableStringify, sameConfig } from './configDirty';
+
+describe('configDirty', () => {
+  it('treats object key order as irrelevant', () => {
+    expect(sameConfig({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+    expect(stableStringify({ b: 2, a: 1 })).toBe('{"a":1,"b":2}');
+  });
+
+  it('treats array order as significant', () => {
+    expect(sameConfig([1, 2], [2, 1])).toBe(false);
+  });
+
+  it('recurses into nested objects and arrays', () => {
+    const a = { patterns: [{ name: 'x', title_pattern: 't' }], master: { group_id: 1, m3u_account_id: null } };
+    const b = { master: { m3u_account_id: null, group_id: 1 }, patterns: [{ title_pattern: 't', name: 'x' }] };
+    expect(sameConfig(a, b)).toBe(true);
+  });
+
+  it('detects a changed scalar value', () => {
+    expect(sameConfig({ attach_threshold: 0.8 }, { attach_threshold: 0.9 })).toBe(false);
+  });
+
+  it('distinguishes a present-but-null key from an absent key', () => {
+    expect(sameConfig({ a: null }, {})).toBe(false);
+  });
+
+  it('handles null configs', () => {
+    expect(sameConfig(null, null)).toBe(true);
+    expect(sameConfig(null, { a: 1 })).toBe(false);
+  });
+});

--- a/frontend/src/utils/configDirty.ts
+++ b/frontend/src/utils/configDirty.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared config dirty-comparator (bead m1s38.1).
+ *
+ * A single source of truth for "did the rule config change?" so the Event
+ * Sync editor and the standard rule builder (bead m1s38.3) do not drift in
+ * what counts as a change. Its first use is stale-marking a live preview: the
+ * editor snapshots the built config when a preview runs, and marks the results
+ * stale when the current built config diverges from that snapshot.
+ *
+ * Semantics:
+ * - Object key order is irrelevant — a config rebuilt with the same values in a
+ *   different key order is NOT a change.
+ * - Array order IS significant — pattern order and scope order carry meaning in
+ *   a rule config, so reordering them is a real change.
+ */
+
+function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  const obj = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(obj).sort()) {
+    out[key] = canonicalize(obj[key]);
+  }
+  return out;
+}
+
+/** Deterministic JSON with sorted object keys (arrays kept in order). */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value)) ?? 'undefined';
+}
+
+/** True when two configs are value-equal under {@link stableStringify}. */
+export function sameConfig(a: unknown, b: unknown): boolean {
+  return stableStringify(a) === stableStringify(b);
+}

--- a/mcp-server/tests/test_ti939_event_sync_preview.py
+++ b/mcp-server/tests/test_ti939_event_sync_preview.py
@@ -131,6 +131,27 @@ class TestPreviewEventSync:
         assert "1 would attach" in text
         assert "ATTACH" in text and "REVIEW" in text and "UNMATCHED" in text
         assert "channel 55" in text
+        # A plain default-threshold in-window match carries no provenance suffix.
+        assert "matched via" not in text
+
+    @pytest.mark.asyncio
+    async def test_matched_via_provenance_suffix_on_attach_line(self):
+        # S5 (bead sf8dj): would-attach rows admitted only by an optional
+        # relaxation get a "(matched via: ...)" suffix so the operator can
+        # double-check them.
+        mcp = _make_mcp_and_register()
+        response = _preview_response()
+        response["streams"][0]["matched_via"] = [
+            {"key": "time_window_ignored", "label": "time ignored"},
+            {"key": "assume_current_date", "label": "assumed date"},
+        ]
+        client = AsyncMock()
+        client.call_endpoint.return_value = response
+        text = await _call_tool(
+            mcp, client,
+            {"event_sync_config": {"master_group_id": 10, "secondary_group_ids": [20]}},
+        )
+        assert "matched via: time ignored, assumed date" in text
 
     @pytest.mark.asyncio
     async def test_include_master_group_streams_flag_forwarded_verbatim(self):

--- a/mcp-server/tools/channel_pipeline.py
+++ b/mcp-server/tools/channel_pipeline.py
@@ -1639,6 +1639,12 @@ def register(mcp: FastMCP):
                 if row.get("disposition") == "would_attach":
                     master = row.get("would_attach_master") or {}
                     top = (row.get("candidates") or [{}])[0]
+                    # S5 (bead sf8dj): flag rows admitted only by an optional
+                    # relaxation so the operator can double-check them.
+                    via = [v.get("label") for v in (row.get("matched_via") or [])]
+                    via_suffix = (
+                        f" (matched via: {', '.join(via)})" if via else ""
+                    )
                     lines.append(
                         f"  ATTACH  [{row.get('provider')}] "
                         f"'{row.get('stream_name')}' -> channel "
@@ -1646,6 +1652,7 @@ def register(mcp: FastMCP):
                         f"(score={top.get('score')}, "
                         f"teams={top.get('team_verdict')}, "
                         f"dt={top.get('time_delta_minutes')}m)"
+                        f"{via_suffix}"
                     )
                 elif row.get("disposition") == "ambiguous":
                     top = (row.get("candidates") or [{}])[0]


### PR DESCRIPTION
Bead **enhancedchannelmanager-m1s38.1** (builds on the earlier Event Sync editor redesign that lived on this branch). Ships the full Event Sync editor modernization the PO has visually reviewed.

**Wizard (m1s38.1):**
- 4-step wizard (Scope / Matching / Behavior / Review) — full-width step pills drive the left column; free non-linear nav; all steps stay mounted and toggle via `hidden`. IntersectionObserver scroll-spy (and its step-3-never-highlights bug) deleted.
- Persistent step-reactive impacts rail: intent sentence, per-step impact block, single manual preview that stale-marks on config change.
- Extracts generic two-pane modal primitives (`.modal-twopane/-main/-rail`, `-stepper`, `-intent`, `-subgroup`, `-why`) into common `ModalBase.css` and migrates the editor onto them (retires the `event-sync-*` layout variants). New shared `configDirty` comparator.

**Fixes caught in review:**
- `.event-sync-phase` `display:flex` overrode `[hidden]`, so all four steps rendered at once in-browser (jsdom applies no CSS → vitest missed it). Re-assert `[hidden]{display:none}`.
- PO review: pattern checkboxes now inline with the title; constant modal height across all four steps.

Presentation/interaction only — buildConfig, save semantics, config fields, provider-scoped pickers, and the dirty-guard are unchanged.

Gates: vitest 1750 pass (incl. new wizard + configDirty), tsc/eslint clean. Deployed + screenshotted every step for PO visual review (approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)