### PR TITLE
Add deploy-frontend.sh wrapper + document static-asset cleanup (x7pck)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,11 +133,15 @@ docker cp <local-file> ecm-ecm-1:/app/<destination-path>
 
 **Frontend deploy:**
 ```bash
+scripts/deploy-frontend.sh          # build + clean stale assets + copy, in one step
+```
+The script bakes in the stale-asset cleanup below so it can't be skipped. Equivalent manual sequence (use `--no-build` to skip the rebuild):
+```bash
 cd frontend && npm run build
 docker exec ecm-ecm-1 sh -c 'rm -rf /app/static/assets/*'
 docker cp dist/. ecm-ecm-1:/app/static/
 ```
-Always clean `/app/static/assets/` before copying — `docker cp` only adds files, never removes stale bundles.
+Always clean `/app/static/assets/` before copying — `docker cp` only adds files, never removes stale bundles. Set `ECM_CONTAINER` to target a container other than `ecm-ecm-1`.
 
 **Backend deploy** (to `/app/`, NOT `/app/backend/`):
 ```bash

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -17,6 +17,8 @@ cd frontend && npm test && npm run build
 
 **CRITICAL**: If syntax checks or tests fail, fix errors before proceeding. Never commit broken code.
 
+> **Deploying to the dev container** (the local edit→deploy→verify loop, separate from this PR flow): use `scripts/deploy-frontend.sh` for the frontend — it clears stale `/app/static/assets/*` before copying, which a hand-run `docker cp` skips. See CLAUDE.md → "Container-First Development".
+
 ### 2. Update the Bead
 
 ```bash

--- a/scripts/deploy-frontend.sh
+++ b/scripts/deploy-frontend.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Deploy the frontend SPA to the running ECM container in one atomic operation.
+#
+# WHY THIS SCRIPT EXISTS: `docker cp` only ADDS files, it never removes them. If
+# you copy a fresh Vite build over a running container without first clearing
+# /app/static/assets/, the old content-hash bundles linger and the browser can
+# load a mismatched mix of new and stale CSS/JS chunks (intermittent, hard to
+# debug). The clean step is easy to skip when the deploy is a hand-run sequence,
+# so this wrapper bakes it in: build -> clean stale assets -> copy.
+#
+# Usage:
+#   scripts/deploy-frontend.sh            # build + deploy to $ECM_CONTAINER (default ecm-ecm-1)
+#   scripts/deploy-frontend.sh --no-build # skip the build, deploy the existing frontend/dist
+#   ECM_CONTAINER=my-container scripts/deploy-frontend.sh
+#
+# Run from the repo root.
+set -euo pipefail
+
+CONTAINER="${ECM_CONTAINER:-ecm-ecm-1}"
+BUILD=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-build) BUILD=0 ;;
+    -h|--help)
+      # Print only the leading header comment block (stop at the first non-# line after the shebang).
+      awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"
+      exit 0 ;;
+    *)
+      echo "deploy-frontend.sh: unknown argument '$arg' (try --help)" >&2
+      exit 2 ;;
+  esac
+done
+
+# Resolve repo root so the script works regardless of the caller's cwd.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! docker inspect -f '{{.State.Running}}' "$CONTAINER" >/dev/null 2>&1; then
+  echo "deploy-frontend.sh: container '$CONTAINER' is not running (set ECM_CONTAINER to override)" >&2
+  exit 1
+fi
+
+if [ "$BUILD" -eq 1 ]; then
+  echo "==> Building frontend (npm run build)"
+  ( cd frontend && npm run build )
+fi
+
+if [ ! -d frontend/dist ]; then
+  echo "deploy-frontend.sh: frontend/dist not found — run without --no-build first" >&2
+  exit 1
+fi
+
+echo "==> Clearing stale assets in $CONTAINER:/app/static/assets/"
+docker exec "$CONTAINER" sh -c 'rm -rf /app/static/assets/*'
+
+echo "==> Copying frontend/dist -> $CONTAINER:/app/static/"
+docker cp frontend/dist/. "$CONTAINER:/app/static/"
+
+echo "==> Frontend deployed to $CONTAINER."


### PR DESCRIPTION
Bead **enhancedchannelmanager-x7pck**. `docker cp` only adds files, so a fresh Vite build copied over a running container leaves stale content-hash bundles in `/app/static/assets/`, causing intermittent CSS/JS chunk mismatches. The cleanup step was documented only as a hand-run command, easy to skip.

- `scripts/deploy-frontend.sh`: atomic build → clear stale assets → copy, with `--no-build`, `--help`, `ECM_CONTAINER` override, and a not-running guard.
- `CLAUDE.md`: frontend-deploy block leads with the script; manual sequence kept.
- `docs/shipping.md`: cross-reference to the script (shipping.md is the PR flow and has no container-deploy step of its own).

Docs + script only. Script syntax-checked; help/guard paths exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)