### PR TITLE
Event Sync matching diagnostics in debug bundle + gated resolver logging (03nji)

### DIFF
--- a/backend/routers/channel_pipeline.py
+++ b/backend/routers/channel_pipeline.py
@@ -2533,6 +2533,203 @@ async def _load_event_sync_preview_config(request: EventSyncPreviewRequest) -> d
     return config
 
 
+async def _fetch_and_resolve_event_sync(
+    config: dict,
+    client,
+    effective_master_group_id: int,
+    *,
+    decisions=None,
+) -> dict:
+    """Fetch master channels + secondary streams and resolve them — the ONE
+    fetch/resolve path shared by the preview endpoint and the debug-bundle
+    matching-diagnostics section (bead 03nji).
+
+    ZERO-WRITE: only READ Dispatcharr methods are called, and scoring runs
+    through ``services.event_sync_resolver.resolve_event_sync`` — the same
+    pure matcher the attach path uses. No scoring/band/attach policy lives
+    here; this helper only gathers the resolver's inputs and returns its
+    output, so preview and the debug bundle cannot fork a second matcher path.
+
+    ``effective_master_group_id`` is the Channel-Group-Override-resolved id
+    the caller already computed from the pre-flight group settings.
+
+    Returns a dict: ``resolution`` (EventSyncResolution), ``name_to_id``,
+    ``master_names``, ``master_channels``, ``group_names``, ``truncated``.
+    """
+    from functools import partial
+
+    from services.event_sync_resolver import (
+        SecondaryStream,
+        build_master_name_to_id,
+        resolve_event_sync,
+    )
+    from stream_prober import extract_m3u_account_id
+
+    master_group_id = config["master_group_id"]
+    secondary_group_ids = config["secondary_group_ids"]
+    truncated = False
+
+    # --- Fetch the master group's channels (capped, paginated) -----------
+    master_channels: list[dict] = []
+    try:
+        cpage = 1
+        while True:
+            resp = await client.get_channels(
+                page=cpage, page_size=_PREVIEW_FETCH_PAGE_SIZE,
+                channel_group=effective_master_group_id,
+            )
+            batch = resp.get("results", []) if isinstance(resp, dict) else (resp or [])
+            master_channels.extend(
+                ch for ch in batch
+                if ch.get("channel_group_id") == effective_master_group_id
+            )
+            if len(master_channels) >= _PREVIEW_MAX_CHANNELS:
+                master_channels = master_channels[:_PREVIEW_MAX_CHANNELS]
+                truncated = True
+                break
+            if not isinstance(resp, dict) or not resp.get("next"):
+                break
+            cpage += 1
+    except Exception as e:
+        logger.warning("[EVENT-SYNC] master-channel fetch failed: %s", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+    # Identity name -> current channel id, re-resolved on THIS call (stateless
+    # recompute; the matcher never sees ids). bead parse-from-stream: identity
+    # is the attached stream's name when parse_master_from_stream is on.
+    try:
+        name_to_id = await build_master_name_to_id(
+            master_channels, client,
+            bool(config.get("parse_master_from_stream")),
+        )
+    except Exception as e:
+        logger.warning("[EVENT-SYNC] master identity build failed: %s", e)
+        raise HTTPException(status_code=500, detail=str(e))
+    master_names = sorted(name_to_id)
+
+    # --- Fetch the secondary groups' streams (capped, paginated) ---------
+    group_names: dict[int, str | None] = {}
+    secondary_streams: list[SecondaryStream] = []
+    try:
+        accounts = await client.get_m3u_accounts() or []
+        account_names = {a.get("id"): a.get("name") for a in accounts}
+        # bead jiscc: provider-scoped secondary scopes. m3u_account_id filters
+        # the fetch to one provider; None = the whole group.
+        secondary_scopes = config.get("secondary") or [
+            {"group_id": g, "m3u_account_id": None}
+            for g in secondary_group_ids
+        ]
+        for scope in secondary_scopes:
+            gid = scope["group_id"]
+            provider_filter = scope.get("m3u_account_id")
+            gname = await client._channel_group_name_for_id(gid)
+            group_names[gid] = gname
+            if not gname:
+                logger.warning(
+                    "[EVENT-SYNC] secondary group %s has no resolvable "
+                    "channel-group name; skipping fetch", gid,
+                )
+                continue
+            if truncated:
+                break
+            spage = 1
+            while True:
+                resp = await client.get_streams(
+                    page=spage, page_size=_PREVIEW_FETCH_PAGE_SIZE,
+                    channel_group_name=gname,
+                    m3u_account=provider_filter,
+                )
+                batch = resp.get("results", []) if isinstance(resp, dict) else (resp or [])
+                for s in batch:
+                    # Mirror the engine fetch's name+id guard: a no-id stream
+                    # is unattachable and must not diverge dry-run parity.
+                    if not s.get("name") or s.get("id") is None:
+                        continue
+                    account_id = extract_m3u_account_id(s.get("m3u_account"))
+                    secondary_streams.append(SecondaryStream(
+                        name=s["name"],
+                        group_id=gid,
+                        stream_id=s.get("id"),
+                        provider=account_names.get(account_id),
+                        provider_id=account_id,
+                    ))
+                if len(secondary_streams) >= _PREVIEW_MAX_STREAMS:
+                    secondary_streams = secondary_streams[:_PREVIEW_MAX_STREAMS]
+                    truncated = True
+                    break
+                if not isinstance(resp, dict) or not resp.get("next"):
+                    break
+                spage += 1
+        # bead 6xxmp: optionally fetch the MASTER group's own streams as a
+        # self-attach source (group_id = master_group_id).
+        if config.get("include_master_group_streams") and not truncated:
+            mgname = await client._channel_group_name_for_id(master_group_id)
+            group_names[master_group_id] = mgname
+            if not mgname:
+                logger.warning(
+                    "[EVENT-SYNC] master group %s has no resolvable "
+                    "channel-group name; skipping self-attach fetch",
+                    master_group_id,
+                )
+            else:
+                spage = 1
+                while True:
+                    resp = await client.get_streams(
+                        page=spage, page_size=_PREVIEW_FETCH_PAGE_SIZE,
+                        channel_group_name=mgname,
+                    )
+                    batch = resp.get("results", []) if isinstance(resp, dict) else (resp or [])
+                    for s in batch:
+                        if not s.get("name") or s.get("id") is None:
+                            continue
+                        account_id = extract_m3u_account_id(s.get("m3u_account"))
+                        secondary_streams.append(SecondaryStream(
+                            name=s["name"],
+                            group_id=master_group_id,
+                            stream_id=s.get("id"),
+                            provider=account_names.get(account_id),
+                            provider_id=account_id,
+                        ))
+                    if len(secondary_streams) >= _PREVIEW_MAX_STREAMS:
+                        secondary_streams = secondary_streams[:_PREVIEW_MAX_STREAMS]
+                        truncated = True
+                        break
+                    if not isinstance(resp, dict) or not resp.get("next"):
+                        break
+                    spage += 1
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning("[EVENT-SYNC] stream fetch failed: %s", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+    # bead 6xxmp: stream ids already on a master channel — the resolver drops
+    # the master group's own already-attached streams so preview's would-attach
+    # count matches the run's attach count.
+    attached_stream_ids: set[int] = set()
+    for ch in master_channels:
+        for s in ch.get("streams", []):
+            sid = s["id"] if isinstance(s, dict) else s
+            if sid is not None:
+                attached_stream_ids.add(sid)
+
+    # --- Resolve (CPU-bound scoring off the event loop) ------------------
+    resolution = await run_cpu_bound(
+        partial(
+            resolve_event_sync, config, master_names, secondary_streams,
+            decisions=decisions, attached_stream_ids=attached_stream_ids,
+        )
+    )
+    return {
+        "resolution": resolution,
+        "name_to_id": name_to_id,
+        "master_names": master_names,
+        "master_channels": master_channels,
+        "group_names": group_names,
+        "truncated": truncated,
+    }
+
+
 @router.post("/event-sync-preview")
 async def preview_event_sync(
     request: EventSyncPreviewRequest, _admin=RequireAdminIfEnabled
@@ -2558,8 +2755,6 @@ async def preview_event_sync(
     call (stateless recompute — duplicate-named masters map to the lowest
     channel id, deterministically).
     """
-    from functools import partial
-
     from services.event_sync_preflight import (
         check_event_sync_group_settings,
         resolve_effective_master_group_id,
@@ -2569,9 +2764,6 @@ async def preview_event_sync(
         DISPOSITION_PARSE_FAILED,
         DISPOSITION_UNMATCHED,
         DISPOSITION_WOULD_ATTACH,
-        SecondaryStream,
-        build_master_name_to_id,
-        resolve_event_sync,
     )
     from services.event_sync_review import (
         ATTACH_SOURCE_REVIEW_QUEUE,
@@ -2586,7 +2778,6 @@ async def preview_event_sync(
         load_pending_fingerprints,
         load_review_decisions,
     )
-    from stream_prober import extract_m3u_account_id
 
     config = await _load_event_sync_preview_config(request)
     master_group_id = config["master_group_id"]
@@ -2637,172 +2828,20 @@ async def preview_event_sync(
         all_settings, master_group_id
     )
 
-    truncated = False
-
-    # --- Fetch the master group's channels (capped, paginated) -----------
-    master_channels: list[dict] = []
-    try:
-        cpage = 1
-        while True:
-            resp = await client.get_channels(
-                page=cpage, page_size=_PREVIEW_FETCH_PAGE_SIZE,
-                channel_group=effective_master_group_id,
-            )
-            batch = resp.get("results", []) if isinstance(resp, dict) else (resp or [])
-            master_channels.extend(
-                ch for ch in batch
-                if ch.get("channel_group_id") == effective_master_group_id
-            )
-            if len(master_channels) >= _PREVIEW_MAX_CHANNELS:
-                master_channels = master_channels[:_PREVIEW_MAX_CHANNELS]
-                truncated = True
-                break
-            if not isinstance(resp, dict) or not resp.get("next"):
-                break
-            cpage += 1
-    except Exception as e:
-        logger.warning("[EVENT-SYNC] preview master-channel fetch failed: %s", e)
-        raise HTTPException(status_code=500, detail=str(e))
-
-    # Identity name -> current channel id, re-resolved on THIS call (stateless
-    # recompute; the matcher never sees ids). Lowest id wins for duplicate
-    # names — deterministic. bead parse-from-stream: identity is the attached
-    # stream's name when parse_master_from_stream is on, else the channel name.
-    try:
-        name_to_id = await build_master_name_to_id(
-            master_channels, client,
-            bool(config.get("parse_master_from_stream")),
-        )
-    except Exception as e:
-        logger.warning(
-            "[EVENT-SYNC] preview master identity build failed: %s", e)
-        raise HTTPException(status_code=500, detail=str(e))
-    master_names = sorted(name_to_id)
-
-    # --- Fetch the secondary groups' streams (capped, paginated) ---------
-    group_names: dict[int, str | None] = {}
-    secondary_streams: list[SecondaryStream] = []
-    try:
-        accounts = await client.get_m3u_accounts() or []
-        account_names = {a.get("id"): a.get("name") for a in accounts}
-        # bead jiscc: provider-scoped secondary scopes (mirrors the engine
-        # fetch so preview and run stay in lockstep). m3u_account_id filters
-        # the fetch to one provider; None = the whole group.
-        secondary_scopes = config.get("secondary") or [
-            {"group_id": g, "m3u_account_id": None}
-            for g in secondary_group_ids
-        ]
-        for scope in secondary_scopes:
-            gid = scope["group_id"]
-            provider_filter = scope.get("m3u_account_id")
-            gname = await client._channel_group_name_for_id(gid)
-            group_names[gid] = gname
-            if not gname:
-                logger.warning(
-                    "[EVENT-SYNC] preview: secondary group %s has no "
-                    "resolvable channel-group name; skipping fetch", gid,
-                )
-                continue
-            if truncated:
-                break
-            spage = 1
-            while True:
-                resp = await client.get_streams(
-                    page=spage, page_size=_PREVIEW_FETCH_PAGE_SIZE,
-                    channel_group_name=gname,
-                    m3u_account=provider_filter,
-                )
-                batch = resp.get("results", []) if isinstance(resp, dict) else (resp or [])
-                for s in batch:
-                    # Mirror the engine fetch's name+id guard (PR #616
-                    # review) so preview and run see the SAME stream universe
-                    # — a no-id stream is unattachable and must not diverge
-                    # the dry-run parity.
-                    if not s.get("name") or s.get("id") is None:
-                        continue
-                    account_id = extract_m3u_account_id(s.get("m3u_account"))
-                    secondary_streams.append(SecondaryStream(
-                        name=s["name"],
-                        group_id=gid,
-                        stream_id=s.get("id"),
-                        provider=account_names.get(account_id),
-                        # ti939.3.2: review-queue fingerprint component —
-                        # mirrors the engine fetch so preview and run key
-                        # decisions identically.
-                        provider_id=account_id,
-                    ))
-                if len(secondary_streams) >= _PREVIEW_MAX_STREAMS:
-                    secondary_streams = secondary_streams[:_PREVIEW_MAX_STREAMS]
-                    truncated = True
-                    break
-                if not isinstance(resp, dict) or not resp.get("next"):
-                    break
-                spage += 1
-        # bead 6xxmp: optionally fetch the MASTER group's own streams as a
-        # self-attach source (group_id = master_group_id). Mirrors the
-        # secondary fetch above so preview matches the run; the resolver drops
-        # the ones already attached to a master channel below.
-        if config.get("include_master_group_streams") and not truncated:
-            mgname = await client._channel_group_name_for_id(master_group_id)
-            # Record the master group's name so its own streams (and any
-            # parse-failure rows they produce) render with a group name in
-            # the preview, not a blank.
-            group_names[master_group_id] = mgname
-            if not mgname:
-                logger.warning(
-                    "[EVENT-SYNC] preview: master group %s has no resolvable "
-                    "channel-group name; skipping self-attach fetch",
-                    master_group_id,
-                )
-            else:
-                spage = 1
-                while True:
-                    resp = await client.get_streams(
-                        page=spage, page_size=_PREVIEW_FETCH_PAGE_SIZE,
-                        channel_group_name=mgname,
-                    )
-                    batch = resp.get("results", []) if isinstance(resp, dict) else (resp or [])
-                    for s in batch:
-                        if not s.get("name") or s.get("id") is None:
-                            continue
-                        account_id = extract_m3u_account_id(s.get("m3u_account"))
-                        secondary_streams.append(SecondaryStream(
-                            name=s["name"],
-                            group_id=master_group_id,
-                            stream_id=s.get("id"),
-                            provider=account_names.get(account_id),
-                            provider_id=account_id,
-                        ))
-                    if len(secondary_streams) >= _PREVIEW_MAX_STREAMS:
-                        secondary_streams = secondary_streams[:_PREVIEW_MAX_STREAMS]
-                        truncated = True
-                        break
-                    if not isinstance(resp, dict) or not resp.get("next"):
-                        break
-                    spage += 1
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.warning("[EVENT-SYNC] preview stream fetch failed: %s", e)
-        raise HTTPException(status_code=500, detail=str(e))
-
-    # bead 6xxmp: stream ids already on a master channel — the resolver uses
-    # these to drop the master group's own already-attached streams so the
-    # preview's would-attach count matches the run's attach count.
-    attached_stream_ids: set[int] = set()
-    for ch in master_channels:
-        for s in ch.get("streams", []):
-            sid = s["id"] if isinstance(s, dict) else s
-            if sid is not None:
-                attached_stream_ids.add(sid)
-
-    # --- Resolve (CPU-bound scoring off the event loop) ------------------
-    resolution = await run_cpu_bound(
-        partial(
-            resolve_event_sync, config, master_names, secondary_streams,
-            decisions=decisions, attached_stream_ids=attached_stream_ids,
-        )
+    # Shared fetch + resolve (bead 03nji) — the ONE fetch/resolve path the
+    # preview endpoint and the debug-bundle matching diagnostics both call, so
+    # a second resolver invocation can never drift from this one. Master
+    # channels, secondary streams, name→id map, and the CPU-bound resolve all
+    # live in the helper; the endpoint keeps only the request-shaped
+    # serialization below.
+    fetched = await _fetch_and_resolve_event_sync(
+        config, client, effective_master_group_id, decisions=decisions,
     )
+    resolution = fetched["resolution"]
+    name_to_id = fetched["name_to_id"]
+    group_names = fetched["group_names"]
+    master_channels = fetched["master_channels"]
+    truncated = fetched["truncated"]
 
     # --- Build detail rows; counts derive from the SAME iteration so they
     # reconcile with the rows by construction. --------------------------
@@ -3412,6 +3451,212 @@ async def _fetch_stream_details(client, stream_ids: list[int], obfuscate_url) ->
     return lookup, report
 
 
+def _event_sync_matching_stream_row(r, name_to_id: dict) -> dict:
+    """Serialize one ``ResolvedStream`` into a debug-bundle matching row
+    (bead 03nji).
+
+    Pure READ of the resolver's output — no scoring, no band/attach policy.
+    ``best_candidate`` is the attach winner for a would_attach row, else the
+    top-ranked candidate so a rejected/ambiguous/unmatched row still shows
+    WHY it did not attach (score, band, reject reason). It is ``None`` only
+    when nothing was in the time window at all.
+    """
+    parsed = r.result.parsed
+    parsed_start = parsed.start.isoformat() if parsed.start else None
+    best = r.best if r.best is not None else (
+        r.result.candidates[0] if r.result.candidates else None
+    )
+    best_out = None
+    if best is not None:
+        best_out = {
+            "master_channel_name": best.master_name,
+            "master_channel_id": name_to_id.get(best.master_name),
+            "master_parsed_title": best.parsed.title,
+            "master_parsed_start": (
+                best.parsed.start.isoformat() if best.parsed.start else None
+            ),
+            "score": round(best.score, 4),
+            "band": best.band,
+            "team_verdict": best.team_verdict,
+            "time_delta_minutes": round(best.time_delta_minutes, 1),
+            "reject_reason": (
+                best.reject_reasons[0] if best.reject_reasons else None
+            ),
+        }
+    return {
+        "stream_id": r.stream.stream_id,
+        "stream_name": r.stream.name,
+        "group_id": r.stream.group_id,
+        "provider": r.stream.provider,
+        "parsed_title": parsed.title,
+        "parsed_start": parsed_start,
+        "matched_pattern": parsed.matched_pattern,
+        "disposition": r.disposition,
+        "unmatchable_reason": r.result.unmatchable_reason,
+        "ambiguous_reason": r.ambiguous_reason,
+        "attach_source": r.attach_source,
+        "matched_via": [
+            {"key": key, "label": label} for key, label in r.matched_via
+        ],
+        "best_candidate": best_out,
+    }
+
+
+async def _build_event_sync_matching_section(client) -> dict:
+    """Debug-bundle matching diagnostics for Event Sync (bead 03nji).
+
+    For each ENABLED event_sync rule, run the ZERO-WRITE resolver via the
+    shared :func:`_fetch_and_resolve_event_sync` path — the EXACT fetch/resolve
+    the preview endpoint uses, so this section can never fork the matcher — and
+    serialize the full per-stream evidence a user needs to PROVE OUT matching:
+    parsed title/time, best-candidate master, score, band, disposition, time
+    delta, team verdict, reject/parse-fail reason, ``matched_via`` provenance,
+    plus per-rule unparsed master names and summary counts.
+
+    Observability only: nothing here scores, bands, or attaches. Each rule is
+    isolated — one rule's fetch/resolve failure records an ``error`` on that
+    rule's entry and never aborts the bundle.
+    """
+    from channel_pipeline_schema import validate_event_sync_config
+    from models import ChannelPipelineRule
+    from services.event_sync_preflight import resolve_effective_master_group_id
+    from services.event_sync_resolver import (
+        DISPOSITION_AMBIGUOUS,
+        DISPOSITION_PARSE_FAILED,
+        DISPOSITION_UNMATCHED,
+        DISPOSITION_WOULD_ATTACH,
+    )
+    from services.event_sync_review_store import load_review_decisions
+
+    section: dict = {
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "rule_count": 0,
+        "rules": [],
+    }
+
+    session = get_session()
+    try:
+        rules = session.query(ChannelPipelineRule).order_by(
+            ChannelPipelineRule.priority, ChannelPipelineRule.id
+        ).all()
+        event_sync_rules = [r for r in rules if r.enabled and r.is_event_sync()]
+    finally:
+        session.close()
+
+    if not event_sync_rules:
+        section["note"] = (
+            "No enabled event_sync rules — nothing to prove out. Enable an "
+            "Event Sync rule and regenerate the bundle to capture matching "
+            "diagnostics."
+        )
+        return section
+
+    # Fetch group settings ONCE for Channel-Group-Override resolution shared
+    # across all rules (the same read the preview pre-flight performs).
+    try:
+        all_settings = await client.get_all_m3u_group_settings()
+    except Exception as e:
+        logger.warning(
+            "[EVENT-SYNC] debug bundle: group-settings fetch failed: %s", e)
+        all_settings = {}
+
+    for rule in event_sync_rules:
+        rule_entry: dict = {
+            "rule_id": rule.id,
+            "rule_name": rule.name,
+            "enabled": rule.enabled,
+        }
+        try:
+            config = rule.get_event_sync_config()
+            if config is None:
+                rule_entry["error"] = "event_sync_config is missing or corrupt"
+                section["rules"].append(rule_entry)
+                continue
+            errors = validate_event_sync_config(config)
+            if errors:
+                rule_entry["error"] = f"invalid event_sync_config: {errors}"
+                section["rules"].append(rule_entry)
+                continue
+
+            master_group_id = config["master_group_id"]
+            effective_master_group_id = resolve_effective_master_group_id(
+                all_settings, master_group_id
+            )
+            # Review-queue decisions feed the resolver so the bundle predicts
+            # exactly what a live run would do (mirrors the preview endpoint).
+            decisions = None
+            dsession = get_session()
+            try:
+                decisions = load_review_decisions(dsession, rule.id)
+            except Exception as e:
+                logger.warning(
+                    "[EVENT-SYNC] debug bundle: review-queue load failed for "
+                    "rule %s (%s) — resolving without it", rule.id, e)
+                decisions = None
+            finally:
+                dsession.close()
+
+            fetched = await _fetch_and_resolve_event_sync(
+                config, client, effective_master_group_id, decisions=decisions,
+            )
+            resolution = fetched["resolution"]
+            name_to_id = fetched["name_to_id"]
+
+            counts = {
+                DISPOSITION_WOULD_ATTACH: 0,
+                DISPOSITION_AMBIGUOUS: 0,
+                DISPOSITION_UNMATCHED: 0,
+                DISPOSITION_PARSE_FAILED: 0,
+            }
+            streams_out = []
+            for r in resolution.resolved:
+                counts[r.disposition] = counts.get(r.disposition, 0) + 1
+                streams_out.append(
+                    _event_sync_matching_stream_row(r, name_to_id))
+
+            rule_entry.update({
+                "master_group_id": master_group_id,
+                "effective_master_group_id": effective_master_group_id,
+                "secondary_group_ids": list(
+                    config.get("secondary_group_ids", [])),
+                "matching_controls": {
+                    "attach_threshold": config.get("attach_threshold"),
+                    "enforce_time_window": config.get(
+                        "enforce_time_window", True),
+                    "time_window_minutes": config.get("time_window_minutes"),
+                    "assume_current_date": config.get(
+                        "assume_current_date", False),
+                    "parse_master_from_stream": config.get(
+                        "parse_master_from_stream", False),
+                    "include_master_group_streams": config.get(
+                        "include_master_group_streams", False),
+                },
+                "summary": {
+                    "secondary_streams": len(resolution.resolved),
+                    "would_attach": counts[DISPOSITION_WOULD_ATTACH],
+                    "ambiguous_skipped": counts[DISPOSITION_AMBIGUOUS],
+                    "unmatched": counts[DISPOSITION_UNMATCHED],
+                    "parse_failed": counts[DISPOSITION_PARSE_FAILED],
+                    "master_channels": len(fetched["master_channels"]),
+                    "master_channels_unparsed": len(
+                        resolution.unparsed_master_names),
+                },
+                "streams": streams_out,
+                "unparsed_master_channels": list(
+                    resolution.unparsed_master_names),
+                "truncated": fetched["truncated"],
+            })
+        except Exception as e:  # noqa: BLE001 — one rule must not sink the bundle
+            logger.warning(
+                "[EVENT-SYNC] debug bundle: rule %s (%s) diagnostics failed: "
+                "%s", rule.id, rule.name, e)
+            rule_entry["error"] = f"{type(e).__name__}: {e}"
+        section["rules"].append(rule_entry)
+
+    section["rule_count"] = len(section["rules"])
+    return section
+
+
 async def _build_debug_bundle() -> tuple[str, bytes]:
     """Build the debug bundle and return (filename, bytes).
 
@@ -3695,6 +3940,21 @@ async def _build_debug_bundle() -> tuple[str, bytes]:
         logger.warning("[AUTO-CREATE] Debug bundle: channel groups diagnostic failed: %s", e)
         cg_diagnostic_str = json.dumps({"error": str(e)})
 
+    # -- 7b. event_sync_matching.json — per-rule matching diagnostics (bead
+    # 03nji). Runs the ZERO-WRITE resolver for every enabled event_sync rule so
+    # a user hitting a matching problem can export a bundle that PROVES OUT what
+    # the matcher decided (parse/score/band/disposition/reject reason per
+    # stream). Runs BEFORE logs.txt so its [EVENT-SYNC] lines land in the dump.
+    try:
+        event_sync_matching = await _build_event_sync_matching_section(client)
+    except Exception as e:  # noqa: BLE001 — never sink the whole bundle
+        logger.warning(
+            "[AUTO-CREATE] Debug bundle: event_sync matching section failed: %s",
+            e)
+        event_sync_matching = {"error": str(e), "rules": []}
+    event_sync_matching_str = json.dumps(event_sync_matching, indent=2, default=str)
+    event_sync_rule_count = len(event_sync_matching.get("rules", []))
+
     # -- 8. logs.txt — recent logs, obfuscated -----------------------
     log_lines = get_recent_logs()
     obfuscated_lines = [obfuscate_text(line) for line in log_lines]
@@ -3723,6 +3983,7 @@ async def _build_debug_bundle() -> tuple[str, bytes]:
         "stream_count": total_streams,
         "normalization_group_count": norm_group_count,
         "normalization_rule_count": norm_rule_count,
+        "event_sync_rule_count": event_sync_rule_count,
         "data_completeness": {
             "complete": data_complete,
             "channels": channels_report,
@@ -3753,6 +4014,7 @@ async def _build_debug_bundle() -> tuple[str, bytes]:
         _add_tar_entry(tf, "settings.json", settings_json_str)
         _add_tar_entry(tf, "task_schedules.json", task_schedules_str)
         _add_tar_entry(tf, "channel_groups_diagnostic.json", cg_diagnostic_str)
+        _add_tar_entry(tf, "event_sync_matching.json", event_sync_matching_str)
         _add_tar_entry(tf, "logs.txt", logs_text)
         _add_tar_entry(tf, "manifest.json", manifest_str)
     payload = buf.getvalue()

--- a/backend/services/event_sync_resolver.py
+++ b/backend/services/event_sync_resolver.py
@@ -48,6 +48,7 @@ channel IDs against Dispatcharr on every run.
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, replace
 from datetime import datetime
 
@@ -75,6 +76,8 @@ from services.event_sync_review import (
     master_event_key,
     stream_name_hash,
 )
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "AMBIGUOUS_REASON_BAND",
@@ -499,6 +502,47 @@ def _matched_via(
     return tuple(via)
 
 
+def _log_resolved_debug(
+    stream: SecondaryStream,
+    result: StreamMatchResult,
+    resolved: ResolvedStream,
+    via: tuple[tuple[str, str], ...],
+) -> None:
+    """Emit per-stream + per-candidate DEBUG evidence for live tailing.
+
+    OBSERVABILITY ONLY (bead 03nji) — reads what the matcher already decided;
+    never scores, bands, or attaches. Callers MUST guard this with
+    ``logger.isEnabledFor(logging.DEBUG)`` so the string/round work below costs
+    nothing when DEBUG is off (Python evaluates a log call's args eagerly
+    regardless of level, so lazy %-args alone would not spare the computation).
+    """
+    parsed = result.parsed
+    best = resolved.best
+    logger.debug(
+        "[EVENT-SYNC] resolve stream=%r group=%s -> %s parsed_title=%r "
+        "parsed_start=%s best_master=%r score=%s band=%s teams=%s dt=%s "
+        "reason=%s matched_via=%s",
+        stream.name, stream.group_id, resolved.disposition,
+        parsed.title,
+        parsed.start.isoformat() if parsed.start else None,
+        best.master_name if best is not None else None,
+        round(best.score, 4) if best is not None else None,
+        best.band if best is not None else None,
+        best.team_verdict if best is not None else None,
+        round(best.time_delta_minutes, 1) if best is not None else None,
+        result.unmatchable_reason or resolved.ambiguous_reason,
+        [key for key, _ in via],
+    )
+    for c in result.candidates:
+        logger.debug(
+            "[EVENT-SYNC]   candidate stream=%r master=%r score=%.4f band=%s "
+            "teams=%s dt=%s reject=%s",
+            stream.name, c.master_name, c.score, c.band, c.team_verdict,
+            round(c.time_delta_minutes, 1),
+            c.reject_reasons[0] if c.reject_reasons else None,
+        )
+
+
 def resolve_event_sync(
     config: dict,
     master_names: list[str],
@@ -627,6 +671,11 @@ def resolve_event_sync(
             )
             if via:
                 rs = replace(rs, matched_via=via)
+            # Gated per-candidate DEBUG evidence (bead 03nji) — no-op unless
+            # LOG_LEVEL=DEBUG. Guarded so the formatting/round work is skipped
+            # entirely below DEBUG. Observability only; the match is unchanged.
+            if logger.isEnabledFor(logging.DEBUG):
+                _log_resolved_debug(stream, result, rs, via)
             resolved.append(rs)
 
     return EventSyncResolution(

--- a/backend/tests/routers/test_channel_pipeline.py
+++ b/backend/tests/routers/test_channel_pipeline.py
@@ -2322,6 +2322,212 @@ class TestDebugBundle:
         assert settings_in_bundle["mcp_api_key"] == "***REDACTED***"
 
 
+class TestDebugBundleEventSyncMatching:
+    """event_sync_matching.json — Event Sync matching diagnostics (bead 03nji).
+
+    For each ENABLED event_sync rule the bundle runs the ZERO-WRITE resolver
+    (via the shared preview fetch/resolve path) and serializes the full
+    per-stream matching evidence a user can send to PROVE OUT matching.
+    """
+
+    def _es_mock_client(self):
+        from tests.event_sync_fixtures import (
+            GROUP_NAMES,
+            GROUP_SETTINGS_OK,
+            M3U_ACCOUNTS,
+            MASTER_CHANNELS,
+            MASTER_GROUP_ID,
+            SECONDARY_STREAMS,
+        )
+
+        client = MagicMock()
+        client.get_channel_groups = AsyncMock(return_value=[
+            {"id": gid, "name": name} for gid, name in GROUP_NAMES.items()
+        ])
+        client.get_streams_by_ids = AsyncMock(return_value=[])
+        client.get_m3u_accounts = AsyncMock(return_value=M3U_ACCOUNTS)
+        client.get_all_m3u_group_settings = AsyncMock(return_value=GROUP_SETTINGS_OK)
+
+        async def _group_name_for_id(group_id):
+            return GROUP_NAMES.get(group_id)
+
+        client._channel_group_name_for_id = AsyncMock(side_effect=_group_name_for_id)
+
+        async def _get_channels(page=1, page_size=100, search=None,
+                                channel_group=None, **kwargs):
+            if channel_group is not None:
+                results = [
+                    c for c in MASTER_CHANNELS
+                    if c["channel_group_id"] == channel_group
+                ]
+            else:
+                results = list(MASTER_CHANNELS)
+            return {"count": len(results), "next": None, "results": results}
+
+        client.get_channels = AsyncMock(side_effect=_get_channels)
+
+        async def _get_streams(page=1, page_size=100, search=None,
+                               channel_group_name=None, m3u_account=None,
+                               **kwargs):
+            results = list(SECONDARY_STREAMS.get(channel_group_name, []))
+            return {"count": len(results), "next": None, "results": results}
+
+        client.get_streams = AsyncMock(side_effect=_get_streams)
+
+        # Mutating methods — the bundle path must NEVER call them.
+        client.update_channel = AsyncMock()
+        client.create_channel = AsyncMock()
+        client.delete_channel = AsyncMock()
+        client.add_stream_to_channel = AsyncMock()
+        client.update_m3u_group_settings = AsyncMock()
+        client.update_channel_group = AsyncMock()
+        return client, MASTER_GROUP_ID
+
+    async def _run_bundle(self, async_client, client):
+        import asyncio as _asyncio
+        import io as _io
+        import tarfile as _tarfile
+
+        with patch("routers.channel_pipeline.get_client", return_value=client), \
+             patch("log_utils.get_recent_logs", return_value=[]):
+            enqueue = await async_client.post("/api/auto-creation/debug-bundle")
+            assert enqueue.status_code == 202
+            job_id = enqueue.json()["job_id"]
+            # Poll to completion. The event_sync resolve is offloaded to a
+            # thread pool (run_cpu_bound), so real (non-zero) sleeps are needed
+            # to let the worker thread finish before we read the artifact.
+            response = None
+            for _ in range(200):
+                response = await async_client.get(
+                    f"/api/auto-creation/debug-bundle/{job_id}")
+                ctype = response.headers.get("content-type", "")
+                if ctype.startswith("application/gzip"):
+                    break
+                body = response.json()
+                assert body.get("status") != "failed", body
+                await _asyncio.sleep(0.02)
+        assert response is not None
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/gzip")
+        members: dict[str, bytes] = {}
+        with _tarfile.open(fileobj=_io.BytesIO(response.content), mode="r:gz") as tf:
+            for name in tf.getnames():
+                members[name] = tf.extractfile(name).read()
+        return members, response.content
+
+    @pytest.mark.asyncio
+    async def test_bundle_includes_event_sync_matching_with_per_stream_fields(
+        self, async_client, test_session
+    ):
+        from tests.event_sync_fixtures import event_sync_config
+
+        client, master_group_id = self._es_mock_client()
+        rule = _create_rule(
+            test_session,
+            name="Test Sync",
+            event_sync_config=json.dumps(event_sync_config()),
+        )
+
+        members, _ = await self._run_bundle(async_client, client)
+        assert "event_sync_matching.json" in members, list(members)
+        section = json.loads(members["event_sync_matching.json"])
+
+        assert section["rule_count"] == 1
+        assert len(section["rules"]) == 1
+        entry = section["rules"][0]
+        assert entry["rule_id"] == rule.id
+        assert entry["rule_name"] == "Test Sync"
+        assert entry["master_group_id"] == master_group_id
+        assert "error" not in entry
+
+        # Matching controls are captured so a reader knows the effective policy.
+        controls = entry["matching_controls"]
+        assert controls["attach_threshold"] == 0.80
+        assert controls["enforce_time_window"] is True
+
+        summary = entry["summary"]
+        for key in (
+            "secondary_streams", "would_attach", "ambiguous_skipped",
+            "unmatched", "parse_failed", "master_channels",
+            "master_channels_unparsed",
+        ):
+            assert key in summary
+        # Counts reconcile with the per-stream rows by construction.
+        assert (
+            summary["would_attach"] + summary["ambiguous_skipped"]
+            + summary["unmatched"] + summary["parse_failed"]
+        ) == summary["secondary_streams"] == len(entry["streams"])
+        # The Mercury vs. Aces fixture stream attaches at score 1.0.
+        assert summary["would_attach"] >= 1
+
+        # Every per-stream row carries the full diagnostic contract.
+        row = entry["streams"][0]
+        for field in (
+            "stream_id", "stream_name", "group_id", "provider",
+            "parsed_title", "parsed_start", "matched_pattern", "disposition",
+            "unmatchable_reason", "ambiguous_reason", "attach_source",
+            "matched_via", "best_candidate",
+        ):
+            assert field in row, field
+
+        # A would_attach row proves out best-candidate evidence.
+        attach_rows = [
+            s for s in entry["streams"] if s["disposition"] == "would_attach"
+        ]
+        assert attach_rows
+        best = attach_rows[0]["best_candidate"]
+        assert best is not None
+        for field in (
+            "master_channel_name", "master_channel_id", "score", "band",
+            "team_verdict", "time_delta_minutes", "reject_reason",
+        ):
+            assert field in best
+        assert best["band"] == "attach"
+
+        # Manifest advertises the count so a reviewer needn't grep the JSON.
+        manifest = json.loads(members["manifest.json"])
+        assert manifest["event_sync_rule_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_bundle_matching_handles_no_event_sync_rules(
+        self, async_client, test_session
+    ):
+        """A standard (non-event_sync) rule yields an empty, note-bearing
+        section — never a crash or a missing member."""
+        client, _ = self._es_mock_client()
+        _create_rule(test_session, name="Standard Rule")  # no event_sync_config
+
+        members, _ = await self._run_bundle(async_client, client)
+        assert "event_sync_matching.json" in members
+        section = json.loads(members["event_sync_matching.json"])
+        assert section["rules"] == []
+        assert section["rule_count"] == 0
+        assert "note" in section
+
+        manifest = json.loads(members["manifest.json"])
+        assert manifest["event_sync_rule_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_bundle_matching_skips_disabled_event_sync_rule(
+        self, async_client, test_session
+    ):
+        """A DISABLED event_sync rule is not resolved (matches run behavior)."""
+        from tests.event_sync_fixtures import event_sync_config
+
+        client, _ = self._es_mock_client()
+        _create_rule(
+            test_session,
+            name="Disabled Sync",
+            enabled=False,
+            event_sync_config=json.dumps(event_sync_config()),
+        )
+
+        members, _ = await self._run_bundle(async_client, client)
+        section = json.loads(members["event_sync_matching.json"])
+        assert section["rules"] == []
+        assert "note" in section
+
+
 # =========================================================================
 # Rule analyzer endpoints (bd-0gntx).
 #

--- a/backend/tests/services/test_event_sync_resolver.py
+++ b/backend/tests/services/test_event_sync_resolver.py
@@ -701,3 +701,72 @@ class TestMatchedViaProvenance:
             MATCHED_VIA_TIME_WINDOW_IGNORED[0],
             MATCHED_VIA_LOWERED_THRESHOLD[0],
         ]
+
+
+class TestDebugLogging:
+    """Gated per-candidate DEBUG logging (bead 03nji) — observability only.
+
+    The resolver emits one structured DEBUG line per stream plus one per
+    candidate for live tailing. Guarded by ``logger.isEnabledFor(DEBUG)`` so
+    it is a no-op below DEBUG; it never alters the match.
+    """
+
+    _STREAMS = [
+        SecondaryStream(
+            name="WNBA TV 01: Mercury vs. Aces @ 11 Jul 06:00 PM ET",
+            group_id=20, stream_id=201, provider="FuboProvider",
+        ),
+        SecondaryStream(
+            name="Fubo Sports Network 07 : NO EVENT",
+            group_id=30, stream_id=302, provider="DaznProvider",
+        ),
+    ]
+
+    def test_emits_per_stream_and_per_candidate_records_at_debug(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.DEBUG, logger="services.event_sync_resolver"):
+            resolve_event_sync(_config(), MASTERS, self._STREAMS, now=NOW)
+
+        msgs = [
+            r.getMessage() for r in caplog.records
+            if r.name == "services.event_sync_resolver"
+        ]
+        # One resolve line per stream (2), each tagged [EVENT-SYNC].
+        resolve_lines = [m for m in msgs if "resolve stream=" in m]
+        assert len(resolve_lines) == 2
+        assert all("[EVENT-SYNC]" in m for m in resolve_lines)
+        # The attach stream's line names its winning master + disposition.
+        attach_line = next(m for m in resolve_lines if "WNBA TV 01" in m)
+        assert "would_attach" in attach_line
+        assert "Mercury vs. Aces" in attach_line
+        # At least one per-candidate line was emitted.
+        assert any("candidate stream=" in m for m in msgs)
+
+    def test_silent_below_debug(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="services.event_sync_resolver"):
+            resolve_event_sync(_config(), MASTERS, self._STREAMS, now=NOW)
+
+        assert not [
+            r for r in caplog.records
+            if r.name == "services.event_sync_resolver"
+        ]
+
+    def test_logging_does_not_change_resolution(self, caplog):
+        import logging
+
+        baseline = resolve_event_sync(_config(), MASTERS, self._STREAMS, now=NOW)
+        with caplog.at_level(logging.DEBUG, logger="services.event_sync_resolver"):
+            debugged = resolve_event_sync(_config(), MASTERS, self._STREAMS, now=NOW)
+
+        assert [
+            (r.stream.stream_id, r.disposition,
+             r.best.master_name if r.best else None)
+            for r in baseline.resolved
+        ] == [
+            (r.stream.stream_id, r.disposition,
+             r.best.master_name if r.best else None)
+            for r in debugged.resolved
+        ]


### PR DESCRIPTION
Bead **enhancedchannelmanager-03nji**. Makes Event Sync matching observable so users can export a debug bundle and send it for troubleshooting.

- **Debug bundle** gains `event_sync_matching.json`: for each enabled event_sync rule, the zero-write resolver runs via a shared `_fetch_and_resolve_event_sync` helper **extracted verbatim from the preview endpoint** (one fetch/resolve path, one scorer — the bundle is a second *reader*, never a second matcher). Per stream: parsed title/time, matched pattern, disposition, best-candidate master + score/band/team-verdict/time-delta/reject reason, `matched_via`; per rule: matching controls, summary counts, unparsed masters. Captures the **rejects the journal never records**.
- **Resolver** gains `LOG_LEVEL=DEBUG`-gated per-candidate `logger.debug` lines (isEnabledFor-guarded) for live tailing.

**Observability only — no change to scoring, bands, or attach decisions** (the resolver edit is one guarded read-only log call; matcher untouched). Zero-write.

Gates: pytest 1788 pass across matcher/resolver/preview/bundle/channel_pipeline. Deployed; sample section generated live from the Flo Racing rule (summary 41/8/0/0/33/50/45, matching the dvgri diagnosis).

Related: dvgri (the user matching report that motivated this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)