### PR TITLE
Channel Pipeline: discoverable per-rule Run for Event Sync rules (utswf)

### DIFF
--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.test.tsx
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.test.tsx
@@ -434,6 +434,180 @@ describe('ChannelPipelineTab', () => {
     // The run pipeline executes all enabled rules.
   });
 
+  describe('event_sync per-rule run (utswf)', () => {
+    // Capture the bodies POSTed to the run endpoint so we can assert on
+    // dry_run / rule_ids without depending on the poll internals.
+    const installRunCapture = (): Array<{ dry_run?: boolean; rule_ids?: number[] }> => {
+      const bodies: Array<{ dry_run?: boolean; rule_ids?: number[] }> = [];
+      server.use(
+        http.post('/api/channel-pipeline/run', async ({ request }) => {
+          const body = (await request.json()) as { dry_run?: boolean; rule_ids?: number[] };
+          bodies.push(body);
+          const execution = createMockChannelPipelineExecution({
+            mode: body.dry_run ? 'dry_run' : 'execute',
+            status: 'completed',
+            channels_created: 0,
+            streams_matched: 2,
+          });
+          mockDataStore.channelPipelineExecutions.unshift(execution);
+          return HttpResponse.json(
+            { execution_id: execution.id, status: 'running', message: 'started' },
+            { status: 202 }
+          );
+        })
+      );
+      return bodies;
+    };
+
+    const pushEventSyncRule = (name: string) => {
+      const rule = createMockChannelPipelineRule({
+        name,
+        enabled: true,
+        event_sync_config: { master_group_id: 1, secondary_group_ids: [2], auto_run: false },
+      });
+      mockDataStore.channelPipelineRules.push(rule);
+      return rule;
+    };
+
+    it('renders per-rule Run and Test affordances on an event_sync row', async () => {
+      const rule = pushEventSyncRule('ES Rule');
+      renderWithProviders(<ChannelPipelineTab />);
+
+      await waitFor(() => expect(screen.getByText('ES Rule')).toBeInTheDocument());
+      const row = screen.getByText('ES Rule').closest('tr')!;
+
+      expect(within(row).getByRole('button', { name: `Run ${rule.name}` })).toBeInTheDocument();
+      expect(within(row).getByRole('button', { name: `Test ${rule.name}` })).toBeInTheDocument();
+    });
+
+    it('Test (dry run) on an event_sync row runs immediately with dry_run=true and no confirm', async () => {
+      const user = userEvent.setup();
+      const bodies = installRunCapture();
+      const rule = pushEventSyncRule('ES Rule');
+      renderWithProviders(<ChannelPipelineTab />);
+
+      await waitFor(() => expect(screen.getByText('ES Rule')).toBeInTheDocument());
+      const row = screen.getByText('ES Rule').closest('tr')!;
+
+      await user.click(within(row).getByRole('button', { name: `Test ${rule.name}` }));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toEqual({ dry_run: true, rule_ids: [rule.id] });
+      // Dry run never surfaces the live-run confirm.
+      expect(screen.queryByTestId('event-sync-run-confirm')).not.toBeInTheDocument();
+    });
+
+    it('Run on an event_sync row opens a confirm and does not run until confirmed', async () => {
+      const user = userEvent.setup();
+      const bodies = installRunCapture();
+      const rule = pushEventSyncRule('ES Rule');
+      renderWithProviders(<ChannelPipelineTab />);
+
+      await waitFor(() => expect(screen.getByText('ES Rule')).toBeInTheDocument());
+      const row = screen.getByText('ES Rule').closest('tr')!;
+
+      await user.click(within(row).getByRole('button', { name: `Run ${rule.name}` }));
+
+      // Confirm appears; nothing has run yet.
+      expect(await screen.findByTestId('event-sync-run-confirm')).toBeInTheDocument();
+      expect(bodies).toHaveLength(0);
+
+      await user.click(screen.getByTestId('event-sync-run-confirm-btn'));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toEqual({ dry_run: false, rule_ids: [rule.id] });
+    });
+
+    it('cancelling the event_sync run confirm does not run', async () => {
+      const user = userEvent.setup();
+      const bodies = installRunCapture();
+      const rule = pushEventSyncRule('ES Rule');
+      renderWithProviders(<ChannelPipelineTab />);
+
+      await waitFor(() => expect(screen.getByText('ES Rule')).toBeInTheDocument());
+      const row = screen.getByText('ES Rule').closest('tr')!;
+
+      await user.click(within(row).getByRole('button', { name: `Run ${rule.name}` }));
+      await user.click(await screen.findByRole('button', { name: /cancel/i }));
+
+      await waitFor(() =>
+        expect(screen.queryByTestId('event-sync-run-confirm')).not.toBeInTheDocument()
+      );
+      expect(bodies).toHaveLength(0);
+    });
+
+    it('a standard rule Run runs directly with no confirm (parity)', async () => {
+      const user = userEvent.setup();
+      const bodies = installRunCapture();
+      const rule = createMockChannelPipelineRule({ name: 'Std Rule', enabled: true });
+      mockDataStore.channelPipelineRules.push(rule);
+      renderWithProviders(<ChannelPipelineTab />);
+
+      await waitFor(() => expect(screen.getByText('Std Rule')).toBeInTheDocument());
+      const row = screen.getByText('Std Rule').closest('tr')!;
+
+      await user.click(within(row).getByRole('button', { name: `Run ${rule.name}` }));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toEqual({ dry_run: false, rule_ids: [rule.id] });
+      expect(screen.queryByTestId('event-sync-run-confirm')).not.toBeInTheDocument();
+    });
+
+    it('disables the per-rule Run/Test buttons while a run is in flight', async () => {
+      const user = userEvent.setup();
+      // Delay the run so the in-flight (running) state is observable.
+      server.use(
+        http.post('/api/channel-pipeline/run', async () => {
+          await new Promise(resolve => setTimeout(resolve, 500));
+          const execution = createMockChannelPipelineExecution({
+            mode: 'dry_run', status: 'completed', channels_created: 0,
+          });
+          mockDataStore.channelPipelineExecutions.unshift(execution);
+          return HttpResponse.json(
+            { execution_id: execution.id, status: 'running', message: 'started' },
+            { status: 202 }
+          );
+        })
+      );
+      const rule = pushEventSyncRule('ES Rule');
+      renderWithProviders(<ChannelPipelineTab />);
+
+      await waitFor(() => expect(screen.getByText('ES Rule')).toBeInTheDocument());
+      const row = screen.getByText('ES Rule').closest('tr')!;
+
+      // Fire the confirm-free dry run, then assert both icons go disabled.
+      await user.click(within(row).getByRole('button', { name: `Test ${rule.name}` }));
+
+      await waitFor(() => {
+        expect(within(row).getByRole('button', { name: `Run ${rule.name}` })).toBeDisabled();
+        expect(within(row).getByRole('button', { name: `Test ${rule.name}` })).toBeDisabled();
+      });
+    });
+
+    it('event_sync run completion points the operator to Execution History', async () => {
+      const user = userEvent.setup();
+      installRunCapture();
+      const rule = pushEventSyncRule('ES Rule');
+      renderWithProviders(<ChannelPipelineTab />);
+
+      await waitFor(() => expect(screen.getByText('ES Rule')).toBeInTheDocument());
+      const row = screen.getByText('ES Rule').closest('tr')!;
+
+      await user.click(within(row).getByRole('button', { name: `Run ${rule.name}` }));
+      await user.click(screen.getByTestId('event-sync-run-confirm-btn'));
+
+      // Not "Created 0 channels" — event_sync feedback points to the details.
+      // (Match the toast phrase specifically; the "Execution History" section
+      // header is always present and would otherwise collide.)
+      await waitFor(() => {
+        expect(
+          screen.getByText(/event sync run complete.*execution history for attach details/i)
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/created 0 channels/i)).not.toBeInTheDocument();
+    });
+  });
+
   describe('execution history', () => {
     it('displays execution history', async () => {
       mockDataStore.channelPipelineExecutions.push(

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
@@ -119,6 +119,12 @@ export function ChannelPipelineTab() {
   const [createRuleKind, setCreateRuleKind] = useState<'standard' | 'event_sync' | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<ChannelPipelineRule | null>(null);
   const [showRollbackConfirm, setShowRollbackConfirm] = useState<ChannelPipelineExecution | null>(null);
+  // Live-run confirm for event_sync rules (utswf). The per-rule Run on an
+  // event_sync row WRITES (attaches streams), unlike the in-editor Preview
+  // which is dry-run only — so the live run gets a one-step "this will attach"
+  // confirm. The Test (dry-run) icon stays confirm-free; standard rules keep
+  // their no-confirm parity.
+  const [showEventSyncRunConfirm, setShowEventSyncRunConfirm] = useState<ChannelPipelineRule | null>(null);
   // Snapshot-restore state (ADR-010 §D5 / uc51o.7)
   const [showRevertConfirm, setShowRevertConfirm] = useState<ChannelPipelineExecution | null>(null);
   const [revertLoading, setRevertLoading] = useState(false);
@@ -429,10 +435,26 @@ export function ChannelPipelineTab() {
         const created = response.channels_created ?? 0;
         const status = response.status;
         const succeeded = status === 'completed';
+        // Event Sync runs attach streams rather than create channels, so the
+        // "Created N channels" figure is always 0 and reads as "nothing
+        // happened". When every targeted rule is an event_sync rule, point the
+        // operator at the Execution History, where the run's
+        // `event_sync: X attached, …` summary line lives (utswf). We don't
+        // fabricate the attach count — it isn't on the client-side response.
+        const targetedRules =
+          ruleIds !== undefined ? rules.filter(r => ruleIds.includes(r.id)) : [];
+        const isEventSyncRun =
+          ruleIds !== undefined &&
+          targetedRules.length > 0 &&
+          targetedRules.every(r => r.event_sync_config);
         const msg = succeeded
-          ? (dryRun
-            ? `Dry run complete - Would create ${created} channel${created !== 1 ? 's' : ''}`
-            : `Execution complete - Created ${created} channel${created !== 1 ? 's' : ''}`)
+          ? (isEventSyncRun
+            ? (dryRun
+              ? 'Event Sync dry run complete — see Execution History for match details'
+              : 'Event Sync run complete — streams attached where matched; see Execution History for attach details')
+            : (dryRun
+              ? `Dry run complete - Would create ${created} channel${created !== 1 ? 's' : ''}`
+              : `Execution complete - Created ${created} channel${created !== 1 ? 's' : ''}`))
           : `Pipeline ${status}`;
         if (succeeded) {
           notifications.success(msg, 'Channel Pipeline');
@@ -468,7 +490,7 @@ export function ChannelPipelineTab() {
     } catch (err) {
       notifications.error(err instanceof Error ? err.message : 'Pipeline failed', 'Channel Pipeline');
     }
-  }, [runPipelineApi, fetchExecutions, fetchRules, notifications]);
+  }, [runPipelineApi, fetchExecutions, fetchRules, notifications, rules]);
 
   const handleRunSingleRule = useCallback(async (ruleId: number, dryRun: boolean) => {
     setRunningSingleRule(ruleId);
@@ -478,6 +500,16 @@ export function ChannelPipelineTab() {
       setRunningSingleRule(null);
     }
   }, [handleRun]);
+
+  // Live-run confirm (utswf): an event_sync live run attaches streams, so the
+  // row Run icon routes through a confirm. Reuses handleRunSingleRule — the
+  // run/attach semantics are unchanged.
+  const handleConfirmEventSyncRun = useCallback(async () => {
+    const rule = showEventSyncRunConfirm;
+    if (!rule) return;
+    setShowEventSyncRunConfirm(null);
+    await handleRunSingleRule(rule.id, false);
+  }, [showEventSyncRunConfirm, handleRunSingleRule]);
 
   const handleRollbackClick = useCallback((execution: ChannelPipelineExecution) => {
     setShowRollbackConfirm(execution);
@@ -926,34 +958,37 @@ export function ChannelPipelineTab() {
                       <td className="col-matches">{rule.match_count || 0}</td>
                       <td className="col-actions">
                         <div className="rule-actions-row">
-                          {/* event_sync rules hide the per-rule Run/Test
-                              icons — they execute via the pipeline-level
-                              manual Run or the single-rule API; the preview
-                              lives inside the editor. */}
-                          {!rule.event_sync_config && (
-                            <>
-                              <button
-                                className="action-btn"
-                                onClick={() => handleRunSingleRule(rule.id, false)}
-                                disabled={runningSingleRule === rule.id || runningPipeline}
-                                aria-label={`Run ${rule.name}`}
-                                title="Run rule"
-                              >
-                                <span className={`material-icons ${runningSingleRule === rule.id ? 'spinning' : ''}`}>
-                                  {runningSingleRule === rule.id ? 'sync' : 'play_arrow'}
-                                </span>
-                              </button>
-                              <button
-                                className="action-btn"
-                                onClick={() => handleRunSingleRule(rule.id, true)}
-                                disabled={runningSingleRule === rule.id || runningPipeline}
-                                aria-label={`Test ${rule.name}`}
-                                title="Test (dry run)"
-                              >
-                                <span className="material-icons">visibility</span>
-                              </button>
-                            </>
-                          )}
+                          {/* Per-rule Run/Test icons for every rule kind.
+                              Standard rules run directly; an event_sync live
+                              run WRITES (attaches streams), so it routes
+                              through a one-step confirm (utswf). The Test
+                              (dry-run) icon is confirm-free for both kinds —
+                              the richer event_sync preview still lives in the
+                              editor. */}
+                          <button
+                            className="action-btn"
+                            onClick={() =>
+                              rule.event_sync_config
+                                ? setShowEventSyncRunConfirm(rule)
+                                : handleRunSingleRule(rule.id, false)
+                            }
+                            disabled={runningSingleRule === rule.id || runningPipeline}
+                            aria-label={`Run ${rule.name}`}
+                            title={rule.event_sync_config ? 'Run rule (attaches streams)' : 'Run rule'}
+                          >
+                            <span className={`material-icons ${runningSingleRule === rule.id ? 'spinning' : ''}`}>
+                              {runningSingleRule === rule.id ? 'sync' : 'play_arrow'}
+                            </span>
+                          </button>
+                          <button
+                            className="action-btn"
+                            onClick={() => handleRunSingleRule(rule.id, true)}
+                            disabled={runningSingleRule === rule.id || runningPipeline}
+                            aria-label={`Test ${rule.name}`}
+                            title="Test (dry run)"
+                          >
+                            <span className="material-icons">visibility</span>
+                          </button>
                           <button
                             className="action-btn"
                             onClick={() => handleToggleEnabled(rule)}
@@ -1227,6 +1262,52 @@ export function ChannelPipelineTab() {
                 aria-label="Confirm"
               >
                 Delete
+              </button>
+            </div>
+          </div>
+        </ModalOverlay>
+      )}
+
+      {/* Event Sync Live-Run Confirmation Dialog (utswf). Only the LIVE run
+          hits this — the Test (dry-run) icon runs immediately. Attaches are
+          journaled and reversible via rollback, so this is a light "you're
+          about to write" gate, not a hard warning. */}
+      {showEventSyncRunConfirm && (
+        <ModalOverlay
+          onClose={() => setShowEventSyncRunConfirm(null)}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="event-sync-run-confirm-title"
+        >
+          <div className="modal-container modal-sm" data-testid="event-sync-run-confirm">
+            <div className="modal-header">
+              <h2 id="event-sync-run-confirm-title">Run Event Sync rule</h2>
+            </div>
+            <div className="modal-body">
+              <p>
+                Running &quot;{showEventSyncRunConfirm.name}&quot; will{' '}
+                <strong>attach streams</strong> to their master channels where
+                they match. Attaches are journaled and reversible via rollback.
+              </p>
+              <p>
+                To see what would attach without writing, use the Test (dry run)
+                action instead.
+              </p>
+            </div>
+            <div className="modal-footer">
+              <button
+                className="btn-secondary"
+                onClick={() => setShowEventSyncRunConfirm(null)}
+              >
+                Cancel
+              </button>
+              <button
+                className="btn-primary"
+                onClick={handleConfirmEventSyncRun}
+                aria-label="Confirm run"
+                data-testid="event-sync-run-confirm-btn"
+              >
+                Run &amp; attach
               </button>
             </div>
           </div>


### PR DESCRIPTION
Bead **enhancedchannelmanager-utswf**. Event Sync rules had no per-rule Run affordance (the per-rule Run/Test icons were hidden for `event_sync` rules), so the only UI path to attach was the global pipeline Run — not discoverable.

- Every rule row (standard + event_sync) now shows **Run** (`play_arrow`) and **Test/dry-run** (`visibility`), reusing the existing `handleRunSingleRule` — no backend/run-semantics change.
- A live event_sync run (which writes/attaches) gets a **lightweight confirm** ("Run Event Sync rule — … will attach streams … journaled and reversible via rollback", Cancel / Run & attach), preserving Event Sync's preview-first model. Dry-run **Test** runs immediately; standard rules keep their no-confirm parity.
- Completion feedback fixed: the toast quoted `channels_created` (always 0 for event_sync → "Created 0 channels"); now event_sync runs get wording pointing to Execution History.

Gates: vitest 1770 pass (7 new cases), tsc/eslint clean. Deployed; browser-verified: Run+Test render on the event_sync row, live Run confirms then Cancel aborts, Test dry-run recorded a real "Dry Run · 0 matched, 8 skipped" execution. PO reviewed.

Note: a follow-up (bead 7wuhd) will make the execution-details summary event_sync-aware (the '0 matched' confusion) — separate from this run affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)