### PR TITLE
Channel Pipeline: event_sync-aware execution summary (7wuhd)

### DIFF
--- a/backend/alembic/versions/20260713_1200_0033_event_sync_execution_summary.py
+++ b/backend/alembic/versions/20260713_1200_0033_event_sync_execution_summary.py
@@ -1,0 +1,118 @@
+"""auto_creation: persist event_sync summary + kind flag on executions
+
+Revision ID: 0033
+Revises: 0032
+Create Date: 2026-07-13 12:00:00.000000
+
+enhancedchannelmanager-7wuhd (product footgun): an Event Sync run's execution
+details showed ``Streams Evaluated: 0 / Streams Matched: 0 / Channels Created:
+0`` while the log showed real activity (already-attached streams). The standard
+Pass 1/2 counters don't map to the event_sync model, and the real event_sync
+counters (secondary_streams, attached, already_attached, ambiguous_skipped,
+unmatched, parse_failed, ...) were only emitted as a TEXT summary line, never
+persisted as structured fields on the ``auto_creation_executions`` row.
+
+This migration adds two backward-compatible columns to
+``auto_creation_executions``:
+
+* ``event_sync_summary`` — nullable TEXT. JSON array of the per-rule event_sync
+  summary dicts the attach phase computes, so the executions UI can render an
+  event_sync-aware summary. NULL reads as "no event_sync activity"
+  (``get_event_sync_summary()`` returns ``[]``).
+* ``is_event_sync`` — NOT NULL BOOLEAN, server_default 0. True only for a PURE
+  event_sync run (event_sync rule(s) ran, no standard rules in scope) so the UI
+  can swap the standard counter block for the event_sync block reliably even
+  after the source rule is deleted (rule_id is ON DELETE SET NULL). Every
+  existing row reads as 0 (standard run).
+
+SQLite specifics: both are single ``ALTER TABLE ADD COLUMN`` operations — no
+batch rebuild needed. ``server_default="0"`` lets the NOT NULL add succeed on
+tables with existing rows (every row gets 0 inline).
+
+Idempotency (mirrors 0021/0028 / bd-5w6jz): long-running installs may already
+have a column via ``create_all()`` against a newer ORM snapshot; each add is
+guarded so it returns rather than raising ``duplicate column name``.
+
+Bead: ``enhancedchannelmanager-7wuhd``.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0033"
+down_revision: Union[str, Sequence[str], None] = "0032"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+_TABLE = "auto_creation_executions"
+_SUMMARY_COLUMN = "event_sync_summary"
+_KIND_COLUMN = "is_event_sync"
+
+
+def _execution_columns(connection) -> set[str]:
+    """Return the set of column names currently on ``auto_creation_executions``.
+
+    Returns the empty set if the table is missing — the guard treats a missing
+    table as "no column to add" so this migration becomes a no-op rather than
+    raising; the next ``create_all()`` + schema-parity pass surfaces the missing
+    table.
+    """
+    insp = inspect(connection)
+    if not insp.has_table(_TABLE):
+        return set()
+    return {c["name"] for c in insp.get_columns(_TABLE)}
+
+
+def upgrade() -> None:
+    """Add the nullable ``event_sync_summary`` TEXT + NOT NULL ``is_event_sync``
+    BOOLEAN columns.
+
+    Idempotent: each add is skipped if the column already exists (e.g.
+    materialised by ``create_all()`` against a newer ORM snapshot on a
+    long-running install).
+    """
+    conn = op.get_bind()
+    existing = _execution_columns(conn)
+
+    if _SUMMARY_COLUMN not in existing:
+        op.add_column(
+            _TABLE,
+            sa.Column(_SUMMARY_COLUMN, sa.Text(), nullable=True),
+        )
+
+    if _KIND_COLUMN not in existing:
+        # server_default="0" so the NOT NULL add succeeds on tables with
+        # existing rows (every row gets 0 inline). The ORM declares
+        # default=False; the drift test filters modify_default noise.
+        op.add_column(
+            _TABLE,
+            sa.Column(
+                _KIND_COLUMN,
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+        )
+
+
+def downgrade() -> None:
+    """Drop the ``event_sync_summary`` and ``is_event_sync`` columns.
+
+    Defensive: inspect first; skip a column that is already absent so a
+    partial-rerun cleans up rather than raising. SQLite 3.35+ supports native
+    ``ALTER TABLE DROP COLUMN`` via ``op.drop_column`` without a full rebuild.
+    """
+    conn = op.get_bind()
+    existing = _execution_columns(conn)
+
+    if _KIND_COLUMN in existing:
+        op.drop_column(_TABLE, _KIND_COLUMN)
+
+    if _SUMMARY_COLUMN in existing:
+        op.drop_column(_TABLE, _SUMMARY_COLUMN)

--- a/backend/channel_pipeline_engine.py
+++ b/backend/channel_pipeline_engine.py
@@ -510,6 +510,24 @@ class ChannelPipelineEngine:
         )
         execution.set_warnings(run_warnings)
 
+        # enhancedchannelmanager-7wuhd: persist the structured event_sync
+        # per-rule summaries + the pure-event_sync kind flag so the executions
+        # UI renders an event_sync-aware summary (secondary streams evaluated /
+        # attached / already-attached / ambiguous / unmatched / parse failures)
+        # instead of the standard evaluated/matched/created counters, which are
+        # structurally 0 for event_sync runs. The heavy ``review_candidates``
+        # payloads are stripped — they are already enqueued to the review table
+        # on live runs and the UI needs only the counters. A run is PURE
+        # event_sync when event_sync rule(s) ran and NO standard rules were in
+        # scope; a mixed run keeps ``is_event_sync`` False so the UI stacks both
+        # summary blocks.
+        event_sync_summaries = [
+            {k: v for k, v in summary.items() if k != "review_candidates"}
+            for summary in results.get("event_sync", [])
+        ]
+        execution.set_event_sync_summary(event_sync_summaries)
+        execution.is_event_sync = bool(event_sync_to_run) and not bool(rules)
+
         if dry_run:
             execution.set_dry_run_results(results["dry_run_results"])
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -2207,6 +2207,28 @@ class ChannelPipelineExecution(Base):
     # completes; these are advisory config problems the operator should fix.
     warnings = Column(Text, nullable=True)
 
+    # Structured Event Sync per-rule run summaries (enhancedchannelmanager-7wuhd).
+    # JSON array of the per-rule summary dicts the event_sync attach phase
+    # computes (secondary_streams, attached, already_attached, ambiguous_skipped,
+    # unmatched, parse_failed, attach_errors, capped, review_enqueued, ...) —
+    # persisted so the executions UI can render an event_sync-aware summary
+    # instead of the standard evaluated/matched/created counters, which are
+    # structurally 0 for event_sync runs. Nullable; get_event_sync_summary()
+    # returns [] for NULL.
+    event_sync_summary = Column(Text, nullable=True)
+
+    # True only for a PURE event_sync run — event_sync rule(s) ran and NO
+    # standard rules were in scope. Lets the executions UI swap the standard
+    # counter block for the event_sync block reliably even after the source
+    # rule is deleted (rule_id is ON DELETE SET NULL, so the rule kind can't be
+    # re-derived from the rule). A MIXED run (both kinds in one execution) is
+    # False so the UI stacks both blocks. server_default="0" so the NOT NULL
+    # add succeeds on tables with existing rows; the drift test filters the
+    # modify_default noise.
+    is_event_sync = Column(
+        Boolean, nullable=False, server_default=sa_text("0"), default=False
+    )
+
     # Rollback tracking
     rolled_back_at = Column(DateTime, nullable=True)
     rolled_back_by = Column(String(100), nullable=True)  # username or "system"
@@ -2310,6 +2332,19 @@ class ChannelPipelineExecution(Base):
         """Set warnings from list."""
         self.warnings = json.dumps(warnings) if warnings else None
 
+    def get_event_sync_summary(self) -> list:
+        """Parse event_sync_summary JSON into list (empty list when none)."""
+        if not self.event_sync_summary:
+            return []
+        try:
+            return json.loads(self.event_sync_summary)
+        except (ValueError, TypeError):
+            return []
+
+    def set_event_sync_summary(self, summaries: list) -> None:
+        """Set event_sync_summary from list (JSON), NULL when empty."""
+        self.event_sync_summary = json.dumps(summaries) if summaries else None
+
     def to_dict(self, include_entities: bool = False, include_log: bool = False) -> dict:
         """Convert to dictionary for API responses."""
         result = {
@@ -2338,6 +2373,15 @@ class ChannelPipelineExecution(Base):
             # Advisory, non-fatal run warnings (e.g. disabled normalization
             # groups). Always present so the UI can render unconditionally.
             "warnings": self.get_warnings(),
+            # Event Sync run-kind flag + structured per-rule summaries
+            # (enhancedchannelmanager-7wuhd). Always present so the executions
+            # UI can branch its layout unconditionally: is_event_sync True ⇒
+            # pure event_sync run (swap the standard counter block), and
+            # event_sync_summary is [] for standard runs.
+            # bool() coerces the pre-flush None (Python default not yet applied)
+            # and any legacy NULL row to a real boolean.
+            "is_event_sync": bool(self.is_event_sync),
+            "event_sync_summary": self.get_event_sync_summary(),
         }
         if include_entities:
             result["created_entities"] = self.get_created_entities()

--- a/backend/tests/integration/test_alembic_smoke.py
+++ b/backend/tests/integration/test_alembic_smoke.py
@@ -1775,6 +1775,19 @@ class TestSmartBootstrapFastPath:
                     "ALTER TABLE auto_creation_rules "
                     "ADD COLUMN event_sync_config TEXT"
                 ))
+                # 0033 (enhancedchannelmanager-7wuhd): persisted event_sync run
+                # summary + pure-event_sync kind flag on the pre-0005
+                # auto_creation_executions table — create_all() can't add
+                # columns to an already-existing table, so add both by hand so
+                # the live schema genuinely matches head for the fast-path.
+                conn.execute(text(
+                    "ALTER TABLE auto_creation_executions "
+                    "ADD COLUMN event_sync_summary TEXT"
+                ))
+                conn.execute(text(
+                    "ALTER TABLE auto_creation_executions "
+                    "ADD COLUMN is_event_sync BOOLEAN NOT NULL DEFAULT 0"
+                ))
 
             # Sanity: alembic_version is still at 0005 (create_all does not
             # touch the version row), but every model table is now present.

--- a/backend/tests/integration/test_event_sync_reviews_migration.py
+++ b/backend/tests/integration/test_event_sync_reviews_migration.py
@@ -170,8 +170,11 @@ class TestMigration0032:
 
         db_url = f"sqlite:///{tmp_path / 'mig0032_roundtrip.db'}"
         cfg = _make_alembic_config(db_url)
-        command.upgrade(cfg, "head")
-        command.downgrade(cfg, "-1")
+        # Target 0032 explicitly (not "head"/"-1") so this round-trip stays
+        # pinned to the 0032 migration under test even as newer revisions
+        # (0033+) land on top of it.
+        command.upgrade(cfg, "0032")
+        command.downgrade(cfg, "0031")
 
         engine = _engine(db_url)
         try:
@@ -179,7 +182,7 @@ class TestMigration0032:
         finally:
             engine.dispose()
 
-        command.upgrade(cfg, "head")
+        command.upgrade(cfg, "0032")
         engine = _engine(db_url)
         try:
             assert TABLE in set(inspect(engine).get_table_names())

--- a/backend/tests/unit/test_channel_pipeline_event_sync_summary.py
+++ b/backend/tests/unit/test_channel_pipeline_event_sync_summary.py
@@ -1,0 +1,149 @@
+"""enhancedchannelmanager-7wuhd — persist Event Sync run counters + kind flag
+on the execution record.
+
+Product footgun: an Event Sync run's execution details showed
+``Streams Evaluated: 0 / Streams Matched: 0 / Channels Created: 0`` while the
+log showed real activity, because the standard Pass 1/2 counters don't map to
+the event_sync model and the real event_sync counters (secondary_streams,
+attached, already_attached, ambiguous_skipped, unmatched, parse_failed, ...)
+were never persisted as structured fields.
+
+This module pins the additive *persistence* behavior on
+``ChannelPipelineExecution``:
+
+  * ``set_event_sync_summary`` / ``get_event_sync_summary`` round-trip a JSON
+    array of per-rule summary dicts; NULL reads as ``[]``.
+  * ``is_event_sync`` defaults to False (standard run) and persists True for a
+    pure event_sync run.
+  * ``to_dict`` always exposes both ``is_event_sync`` and ``event_sync_summary``
+    so the executions UI can branch its layout unconditionally.
+"""
+from datetime import datetime
+
+from models import ChannelPipelineExecution
+
+
+def _make_execution(**overrides) -> ChannelPipelineExecution:
+    kwargs = dict(
+        mode="execute",
+        triggered_by="manual",
+        started_at=datetime.utcnow(),
+        status="completed",
+    )
+    kwargs.update(overrides)
+    return ChannelPipelineExecution(**kwargs)
+
+
+class TestEventSyncSummaryAccessors:
+    """In-memory get/set accessors (no session required)."""
+
+    def test_get_returns_empty_list_when_unset(self):
+        """A fresh row with NULL event_sync_summary reads as []."""
+        execution = _make_execution()
+        assert execution.get_event_sync_summary() == []
+
+    def test_set_then_get_round_trips(self):
+        """set_event_sync_summary stores JSON; get parses it back."""
+        summaries = [
+            {
+                "rule_id": 7,
+                "rule_name": "NFL Sunday",
+                "secondary_streams": 12,
+                "attached": 0,
+                "already_attached": 9,
+                "ambiguous_skipped": 0,
+                "unmatched": 0,
+                "parse_failed": 0,
+                "attach_errors": 0,
+            }
+        ]
+        execution = _make_execution()
+        execution.set_event_sync_summary(summaries)
+        assert isinstance(execution.event_sync_summary, str)
+        assert execution.get_event_sync_summary() == summaries
+
+    def test_set_empty_stores_null(self):
+        """An empty list persists as NULL (mirrors set_warnings)."""
+        execution = _make_execution()
+        execution.set_event_sync_summary([])
+        assert execution.event_sync_summary is None
+        assert execution.get_event_sync_summary() == []
+
+    def test_get_tolerates_corrupt_json(self):
+        """Malformed JSON reads as [] rather than raising."""
+        execution = _make_execution(event_sync_summary="{not valid json")
+        assert execution.get_event_sync_summary() == []
+
+
+class TestEventSyncSummaryToDict:
+    """to_dict must always expose both new fields."""
+
+    def test_standard_run_defaults(self):
+        """A standard run: is_event_sync False, event_sync_summary []."""
+        result = _make_execution().to_dict()
+        assert result["is_event_sync"] is False
+        assert result["event_sync_summary"] == []
+
+    def test_event_sync_run_exposes_summary_and_flag(self):
+        """A pure event_sync run round-trips the flag + summaries in to_dict."""
+        summaries = [{"rule_id": 3, "attached": 4, "already_attached": 2}]
+        execution = _make_execution(is_event_sync=True)
+        execution.set_event_sync_summary(summaries)
+        result = execution.to_dict()
+        assert result["is_event_sync"] is True
+        assert result["event_sync_summary"] == summaries
+
+
+class TestEventSyncSummaryPersistence:
+    """Full DB round-trip: the columns survive commit + reload."""
+
+    def test_columns_persist_across_reload(self, test_session):
+        """Persisting an execution with the new columns and reloading returns
+        the same values (proves the migration column mapping works)."""
+        summaries = [
+            {
+                "rule_id": 11,
+                "rule_name": "MLB",
+                "secondary_streams": 20,
+                "attached": 5,
+                "already_attached": 3,
+                "ambiguous_skipped": 1,
+                "unmatched": 2,
+                "parse_failed": 0,
+            }
+        ]
+        execution = _make_execution(is_event_sync=True)
+        execution.set_event_sync_summary(summaries)
+        test_session.add(execution)
+        test_session.commit()
+        exec_id = execution.id
+        test_session.expunge_all()
+
+        reloaded = (
+            test_session.query(ChannelPipelineExecution)
+            .filter(ChannelPipelineExecution.id == exec_id)
+            .first()
+        )
+        assert reloaded is not None
+        assert reloaded.is_event_sync is True
+        assert reloaded.get_event_sync_summary() == summaries
+
+        d = reloaded.to_dict()
+        assert d["is_event_sync"] is True
+        assert d["event_sync_summary"] == summaries
+
+    def test_standard_run_persists_false_and_empty(self, test_session):
+        """A standard run persists is_event_sync=False and empty summary."""
+        execution = _make_execution()
+        test_session.add(execution)
+        test_session.commit()
+        exec_id = execution.id
+        test_session.expunge_all()
+
+        reloaded = (
+            test_session.query(ChannelPipelineExecution)
+            .filter(ChannelPipelineExecution.id == exec_id)
+            .first()
+        )
+        assert reloaded.is_event_sync is False
+        assert reloaded.get_event_sync_summary() == []

--- a/backend/tests/unit/test_event_sync_lifecycle.py
+++ b/backend/tests/unit/test_event_sync_lifecycle.py
@@ -457,6 +457,70 @@ class TestDryRunParity:
         assert len(run_pairs) == run_summary["attached"] == 1
 
 
+class TestExecutionSummaryPersistence:
+    """enhancedchannelmanager-7wuhd: a live event_sync run must persist the
+    structured per-rule counters + the pure-event_sync kind flag on the
+    execution row, so the executions UI can render an event_sync-aware summary
+    (compute -> persist -> serialize, end to end through the real attach path)."""
+
+    @pytest.mark.asyncio
+    async def test_pure_event_sync_run_persists_summary_and_flag(
+        self, test_session
+    ):
+        from models import ChannelPipelineExecution
+
+        config = event_sync_config()
+        rule = ChannelPipelineRule(
+            name="Event Rule", enabled=True, priority=0,
+            conditions=json.dumps([{"type": "always"}]),
+            actions=json.dumps([{"type": "skip"}]),
+            event_sync_config=json.dumps(config),
+        )
+        test_session.add(rule)
+        test_session.commit()
+
+        state = FakeDispatcharrState(
+            channels=live_master_channels(),
+            secondary_streams=SECONDARY_STREAMS,
+        )
+        engine = ChannelPipelineEngine(make_stateful_client(state))
+        with patch("channel_pipeline_engine.get_session",
+                   return_value=test_session), \
+             patch("journal.log_entries"), \
+             patch("services.event_sync_resolver.datetime") as mock_dt:
+            mock_dt.now.return_value = FROZEN_NOW
+            result = await engine.run_pipeline(
+                dry_run=False, triggered_by="manual"
+            )
+        assert result["success"] is True
+        run_summary = result["event_sync"][0]
+
+        # The persisted execution row (what the executions API reads) must
+        # carry the pure-event_sync flag and the structured counters.
+        execution = (
+            test_session.query(ChannelPipelineExecution)
+            .order_by(ChannelPipelineExecution.id.desc())
+            .first()
+        )
+        assert execution is not None
+        assert execution.is_event_sync is True, (
+            "a run scoped to only event_sync rules must persist is_event_sync=True"
+        )
+        persisted = execution.get_event_sync_summary()
+        assert len(persisted) == 1
+        # Counters survive the round-trip and match the live run summary.
+        for key in ("secondary_streams", "attached", "already_attached",
+                    "ambiguous_skipped", "unmatched", "parse_failed"):
+            assert persisted[0][key] == run_summary[key]
+        # Heavy review_candidates payload is stripped from the persisted copy.
+        assert "review_candidates" not in persisted[0]
+
+        # to_dict (the API serialization) exposes both fields.
+        d = execution.to_dict()
+        assert d["is_event_sync"] is True
+        assert d["event_sync_summary"] == persisted
+
+
 class TestManualRunOnly:
     def test_unattended_watermark_task_never_executes_event_sync_rules(
         self, db_session_factory

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.css
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.css
@@ -413,6 +413,37 @@
   color: var(--error-color, #dc3545);
 }
 
+/* Warning-styled counter row (e.g. Parse Failures > 0, Capped) in the
+   event_sync execution summary (enhancedchannelmanager-7wuhd). */
+.detail-row.warning {
+  color: var(--status-warning, #f59e0b);
+}
+
+/* "Fully in sync" success line in the event_sync execution summary
+   (enhancedchannelmanager-7wuhd). Icon + text (never color alone) so an
+   idempotent all-already-attached run reads as success, not "nothing
+   matched". */
+.event-sync-sync-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  background: rgba(34, 197, 94, 0.08);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  border-radius: var(--radius-lg);
+  margin: 14px 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+
+.event-sync-sync-icon {
+  color: var(--status-success, #22c55e);
+  font-size: 20px;
+  flex-shrink: 0;
+}
+
 /* Import/Export textarea styling */
 .modal-body textarea {
   width: 100%;

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.test.tsx
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.test.tsx
@@ -719,6 +719,154 @@ describe('ChannelPipelineTab', () => {
       expect(screen.queryByText(/normalization applied no changes/i)).toBeNull();
     });
 
+    // enhancedchannelmanager-7wuhd: event_sync runs need an event_sync-aware
+    // summary — the standard evaluated/matched/created counters are
+    // structurally 0 for them and read as "nothing happened".
+    const eventSyncSummary = (over = {}) => [{
+      rule_id: 7,
+      rule_name: 'NFL Sunday',
+      secondary_streams: 12,
+      attached: 3,
+      already_attached: 6,
+      ambiguous_skipped: 1,
+      unmatched: 2,
+      parse_failed: 0,
+      attach_errors: 0,
+      ...over,
+    }];
+
+    it('renders an event_sync-aware summary and drops Channels Created', async () => {
+      const user = userEvent.setup();
+      mockDataStore.channelPipelineExecutions.push(
+        createMockChannelPipelineExecution({
+          is_event_sync: true,
+          streams_evaluated: 0,
+          streams_matched: 0,
+          channels_created: 0,
+          event_sync_summary: eventSyncSummary(),
+        }),
+      );
+
+      renderWithProviders(<ChannelPipelineTab />);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /view details/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/secondary streams evaluated/i)).toBeInTheDocument();
+      });
+      // Scope to the details dialog — the compact list chip also carries
+      // event_sync words (e.g. "already attached").
+      const dialog = within(screen.getByRole('dialog'));
+      expect(dialog.getByText(/^attached:?$/i)).toBeInTheDocument();
+      expect(dialog.getByText(/^already attached:?$/i)).toBeInTheDocument();
+      expect(dialog.getByText(/ambiguous/i)).toBeInTheDocument();
+      expect(dialog.getByText(/^unmatched:?$/i)).toBeInTheDocument();
+      // Standard counters are gone for a pure event_sync run.
+      expect(dialog.queryByText(/channels created/i)).toBeNull();
+      expect(dialog.queryByText(/streams matched/i)).toBeNull();
+      // Exact match: the event_sync block's "Secondary Streams Evaluated:"
+      // contains this substring, so only the standard label must be absent.
+      expect(dialog.queryByText('Streams Evaluated:')).toBeNull();
+    });
+
+    it('shows the fully-in-sync success banner when everything is already attached', async () => {
+      const user = userEvent.setup();
+      mockDataStore.channelPipelineExecutions.push(
+        createMockChannelPipelineExecution({
+          is_event_sync: true,
+          streams_evaluated: 0,
+          streams_matched: 0,
+          channels_created: 0,
+          event_sync_summary: eventSyncSummary({
+            attached: 0,
+            already_attached: 9,
+            ambiguous_skipped: 0,
+            unmatched: 0,
+            parse_failed: 0,
+          }),
+        }),
+      );
+
+      renderWithProviders(<ChannelPipelineTab />);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /view details/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('event-sync-fully-in-sync')).toBeInTheDocument();
+      });
+      expect(screen.getByText(/fully in sync/i)).toBeInTheDocument();
+      expect(screen.getByText(/9 streams already attached/i)).toBeInTheDocument();
+    });
+
+    it('does not show the fully-in-sync banner when there is new work', async () => {
+      const user = userEvent.setup();
+      mockDataStore.channelPipelineExecutions.push(
+        createMockChannelPipelineExecution({
+          is_event_sync: true,
+          event_sync_summary: eventSyncSummary({ attached: 2, already_attached: 3, ambiguous_skipped: 0, unmatched: 0, parse_failed: 0 }),
+        }),
+      );
+
+      renderWithProviders(<ChannelPipelineTab />);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /view details/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/secondary streams evaluated/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('event-sync-fully-in-sync')).toBeNull();
+    });
+
+    it('uses "Would Attach" wording for a dry-run event_sync execution', async () => {
+      const user = userEvent.setup();
+      mockDataStore.channelPipelineExecutions.push(
+        createMockChannelPipelineExecution({
+          mode: 'dry_run',
+          is_event_sync: true,
+          event_sync_summary: eventSyncSummary(),
+        }),
+      );
+
+      renderWithProviders(<ChannelPipelineTab />);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /view details/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/secondary streams evaluated/i)).toBeInTheDocument();
+      });
+      const dialog = within(screen.getByRole('dialog'));
+      expect(dialog.getByText(/^would attach:?$/i)).toBeInTheDocument();
+      expect(dialog.queryByText(/^attached:?$/i)).toBeNull();
+    });
+
+    it('keeps the standard summary for a standard (non-event_sync) execution', async () => {
+      const user = userEvent.setup();
+      mockDataStore.channelPipelineExecutions.push(
+        createMockChannelPipelineExecution({ streams_matched: 25, channels_created: 10 }),
+      );
+
+      renderWithProviders(<ChannelPipelineTab />);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /view details/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/channels created/i)).toBeInTheDocument();
+      });
+      // No event_sync block for a standard run.
+      expect(screen.queryByText(/secondary streams evaluated/i)).toBeNull();
+      expect(screen.queryByTestId('event-sync-fully-in-sync')).toBeNull();
+    });
+
     it('allows rolling back an execution', async () => {
       const user = userEvent.setup();
       mockDataStore.channelPipelineExecutions.push(

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
@@ -11,6 +11,7 @@ import type {
   BulkUpdateRulesPatch,
   RestoreSnapshotResponse,
   FailedChannel,
+  EventSyncExecutionSummary,
 } from '../../types/channelPipeline';
 import type { CircuitBreakerState } from '../../services/channelPipelineApi';
 import { useAuth } from '../../hooks/useAuth';
@@ -47,6 +48,153 @@ const EXECUTION_STATUS_LABEL: Partial<Record<string, string>> = {
   capped: 'Capped',
   abandoned: 'Abandoned',
 };
+
+/**
+ * Aggregated event_sync run counters across an execution's per-rule summaries
+ * (enhancedchannelmanager-7wuhd). One execution can span several event_sync
+ * rules; the executions UI shows the run-level totals.
+ */
+interface EventSyncTotals {
+  secondary_streams: number;
+  attached: number;
+  already_attached: number;
+  ambiguous_skipped: number;
+  unmatched: number;
+  parse_failed: number;
+  attach_errors: number;
+  review_enqueued: number;
+  cap_overage: number;
+  capped: boolean;
+}
+
+/** Sum the per-rule event_sync summaries; null when there is no event_sync activity. */
+function aggregateEventSyncSummary(
+  summaries: EventSyncExecutionSummary[] | undefined | null,
+): EventSyncTotals | null {
+  if (!summaries || summaries.length === 0) return null;
+  const totals: EventSyncTotals = {
+    secondary_streams: 0, attached: 0, already_attached: 0,
+    ambiguous_skipped: 0, unmatched: 0, parse_failed: 0,
+    attach_errors: 0, review_enqueued: 0, cap_overage: 0, capped: false,
+  };
+  for (const s of summaries) {
+    totals.secondary_streams += s.secondary_streams ?? 0;
+    totals.attached += s.attached ?? 0;
+    totals.already_attached += s.already_attached ?? 0;
+    totals.ambiguous_skipped += s.ambiguous_skipped ?? 0;
+    totals.unmatched += s.unmatched ?? 0;
+    totals.parse_failed += s.parse_failed ?? 0;
+    totals.attach_errors += s.attach_errors ?? 0;
+    totals.review_enqueued += s.review_enqueued ?? 0;
+    totals.cap_overage += s.cap_overage ?? 0;
+    totals.capped = totals.capped || Boolean(s.capped);
+  }
+  return totals;
+}
+
+/**
+ * The PO's key case: an idempotent run where everything the rule targets is
+ * already attached — nothing new, nothing wrong. Surfaced as an explicit
+ * success line so it never reads as "nothing evaluated / nothing matched".
+ */
+function isFullyInSync(t: EventSyncTotals): boolean {
+  return t.attached === 0 && t.already_attached > 0 &&
+    t.ambiguous_skipped === 0 && t.unmatched === 0 && t.parse_failed === 0;
+}
+
+/**
+ * Event-sync-aware execution summary rows (enhancedchannelmanager-7wuhd).
+ * Replaces the standard evaluated/matched/created block for event_sync runs;
+ * vocabulary matches the Event Sync preview panel taxonomy. Dry-run swaps
+ * "Attached" for "Would Attach".
+ */
+function EventSyncSummaryDetails(
+  { totals, isDryRun }: { totals: EventSyncTotals; isDryRun: boolean },
+) {
+  const attachLabel = isDryRun ? 'Would Attach' : 'Attached';
+  return (
+    <>
+      {isFullyInSync(totals) && (
+        <div
+          className="event-sync-sync-banner"
+          role="status"
+          data-testid="event-sync-fully-in-sync"
+        >
+          <span className="material-icons event-sync-sync-icon" aria-hidden="true">
+            check_circle
+          </span>
+          <span>
+            Fully in sync — {totals.already_attached} stream
+            {totals.already_attached === 1 ? '' : 's'} already attached, nothing
+            new to do this run.
+          </span>
+        </div>
+      )}
+      <div className="detail-row">
+        <span className="detail-label">Secondary Streams Evaluated:</span>
+        <span>{totals.secondary_streams}</span>
+      </div>
+      <div className="detail-row">
+        <span className="detail-label">{attachLabel}:</span>
+        <span>{totals.attached}</span>
+      </div>
+      <div className="detail-row">
+        <span className="detail-label">Already Attached:</span>
+        <span>{totals.already_attached}</span>
+      </div>
+      <div className="detail-row">
+        <span className="detail-label">Ambiguous &rarr; Review:</span>
+        <span>{totals.ambiguous_skipped}</span>
+      </div>
+      <div className="detail-row">
+        <span className="detail-label">Unmatched:</span>
+        <span>{totals.unmatched}</span>
+      </div>
+      <div className={`detail-row${totals.parse_failed > 0 ? ' warning' : ''}`}>
+        <span className="detail-label">Parse Failures:</span>
+        <span>{totals.parse_failed}</span>
+      </div>
+      {totals.review_enqueued > 0 && (
+        <div className="detail-row">
+          <span className="detail-label">Queued for Review:</span>
+          <span>{totals.review_enqueued}</span>
+        </div>
+      )}
+      {totals.attach_errors > 0 && (
+        <div className="detail-row error">
+          <span className="detail-label">Attach Errors:</span>
+          <span>{totals.attach_errors}</span>
+        </div>
+      )}
+      {totals.cap_overage > 0 && (
+        <div className="detail-row warning">
+          <span className="detail-label">Capped (deferred to next run):</span>
+          <span>{totals.cap_overage}</span>
+        </div>
+      )}
+      {/* Parse failures are the operator's broken-pattern drift detector —
+          surface them prominently with the same visual as the norm-warning
+          banner, not just a counter row. */}
+      {totals.parse_failed > 0 && (
+        <div className="norm-warning-banner" role="alert" data-testid="event-sync-parse-failure-banner">
+          <span className="material-icons norm-warning-icon">warning</span>
+          <div className="norm-warning-content">
+            <p className="norm-warning-title">
+              {totals.parse_failed} secondary stream
+              {totals.parse_failed === 1 ? '' : 's'} could not be parsed
+            </p>
+            <p className="norm-warning-detail">
+              Their names did not match the rule&apos;s parse pattern, so no
+              title or start time could be read and they were skipped. A parse
+              failure count this size usually means a broken pattern — check the
+              Event Sync preview&apos;s test panel.
+            </p>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
 
 /** Categorize a log action into a filter bucket. */
 function getActionCategory(action: ActionLogEntry): string | null {
@@ -1083,11 +1231,30 @@ export function ChannelPipelineTab() {
                       {new Date(execution.started_at).toLocaleString(getDateLocale())}
                     </span>
                     <span className="execution-stats">
-                      {execution.streams_matched} matched
-                      {execution.channels_updated > 0 && `, ${execution.channels_updated} merged`}
-                      {execution.channels_created > 0 && `, ${execution.channels_created} created`}
-                      {execution.streams_skipped > 0 && `, ${execution.streams_skipped} skipped`}
-                      {execution.streams_excluded > 0 && `, ${execution.streams_excluded} excluded`}
+                      {(() => {
+                        // enhancedchannelmanager-7wuhd: a PURE event_sync run's
+                        // standard counters are structurally 0 ("0 matched" is
+                        // the bug); show event_sync counts instead.
+                        const esTotals = aggregateEventSyncSummary(execution.event_sync_summary);
+                        if (execution.is_event_sync && esTotals) {
+                          const attachWord = execution.mode === 'dry_run' ? 'would attach' : 'attached';
+                          const parts = [`${esTotals.attached} ${attachWord}`];
+                          if (esTotals.already_attached > 0) parts.push(`${esTotals.already_attached} already attached`);
+                          if (esTotals.ambiguous_skipped > 0) parts.push(`${esTotals.ambiguous_skipped} ambiguous`);
+                          if (esTotals.unmatched > 0) parts.push(`${esTotals.unmatched} unmatched`);
+                          if (esTotals.parse_failed > 0) parts.push(`${esTotals.parse_failed} parse failed`);
+                          return parts.join(', ');
+                        }
+                        return (
+                          <>
+                            {execution.streams_matched} matched
+                            {execution.channels_updated > 0 && `, ${execution.channels_updated} merged`}
+                            {execution.channels_created > 0 && `, ${execution.channels_created} created`}
+                            {execution.streams_skipped > 0 && `, ${execution.streams_skipped} skipped`}
+                            {execution.streams_excluded > 0 && `, ${execution.streams_excluded} excluded`}
+                          </>
+                        );
+                      })()}
                     </span>
                   </div>
                   <div className="execution-actions">
@@ -1474,6 +1641,9 @@ export function ChannelPipelineTab() {
       {showExecutionDetails && (() => {
         const details = executionDetails || showExecutionDetails;
         const log = details.execution_log || [];
+        // enhancedchannelmanager-7wuhd: run-level event_sync totals drive the
+        // event_sync-aware summary block (null for a standard-only run).
+        const eventSyncTotals = aggregateEventSyncSummary(details.event_sync_summary);
 
         // Categorize each entry by its action types for filtering
         const getEntryCategories = (entry: ExecutionLogEntry): Set<string> => {
@@ -1580,35 +1750,50 @@ export function ChannelPipelineTab() {
                   <span>{details.duration_seconds.toFixed(1)}s</span>
                 </div>
               )}
-              <div className="detail-row">
-                <span className="detail-label">Streams Evaluated:</span>
-                <span>{details.streams_evaluated}</span>
-              </div>
-              <div className="detail-row">
-                <span className="detail-label">Streams Matched:</span>
-                <span>{details.streams_matched}</span>
-              </div>
-              <div className="detail-row">
-                <span className="detail-label">Channels Created:</span>
-                <span>{details.channels_created}</span>
-              </div>
-              {details.channels_updated > 0 && (
-                <div className="detail-row">
-                  <span className="detail-label">Channels Updated:</span>
-                  <span>{details.channels_updated}</span>
-                </div>
+              {/* Mode-aware summary (enhancedchannelmanager-7wuhd). The
+                  standard evaluated/matched/created counters are structurally 0
+                  for event_sync runs, so a PURE event_sync run hides them and
+                  shows the event_sync block instead. A MIXED run (is_event_sync
+                  false but event_sync activity present) stacks both. */}
+              {!details.is_event_sync && (
+                <>
+                  <div className="detail-row">
+                    <span className="detail-label">Streams Evaluated:</span>
+                    <span>{details.streams_evaluated}</span>
+                  </div>
+                  <div className="detail-row">
+                    <span className="detail-label">Streams Matched:</span>
+                    <span>{details.streams_matched}</span>
+                  </div>
+                  <div className="detail-row">
+                    <span className="detail-label">Channels Created:</span>
+                    <span>{details.channels_created}</span>
+                  </div>
+                  {details.channels_updated > 0 && (
+                    <div className="detail-row">
+                      <span className="detail-label">Channels Updated:</span>
+                      <span>{details.channels_updated}</span>
+                    </div>
+                  )}
+                  {details.groups_created > 0 && (
+                    <div className="detail-row">
+                      <span className="detail-label">Groups Created:</span>
+                      <span>{details.groups_created}</span>
+                    </div>
+                  )}
+                  {details.streams_excluded > 0 && (
+                    <div className="detail-row">
+                      <span className="detail-label">Streams Excluded:</span>
+                      <span>{details.streams_excluded}</span>
+                    </div>
+                  )}
+                </>
               )}
-              {details.groups_created > 0 && (
-                <div className="detail-row">
-                  <span className="detail-label">Groups Created:</span>
-                  <span>{details.groups_created}</span>
-                </div>
-              )}
-              {details.streams_excluded > 0 && (
-                <div className="detail-row">
-                  <span className="detail-label">Streams Excluded:</span>
-                  <span>{details.streams_excluded}</span>
-                </div>
+              {eventSyncTotals && (
+                <EventSyncSummaryDetails
+                  totals={eventSyncTotals}
+                  isDryRun={details.mode === 'dry_run'}
+                />
               )}
               {details.error_message && (
                 <div className="detail-row error">

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -188,6 +188,8 @@ export function createMockChannelPipelineExecution(overrides: Partial<MockChanne
     error: overrides.error ?? undefined,
     has_snapshot: overrides.has_snapshot ?? false,
     warnings: overrides.warnings ?? undefined,
+    is_event_sync: overrides.is_event_sync ?? false,
+    event_sync_summary: overrides.event_sync_summary ?? undefined,
   }
 }
 
@@ -360,6 +362,23 @@ interface MockChannelPipelineExecution {
     rule_id: number
     rule_name: string
     disabled_groups: { id: number; name: string | null; missing: boolean }[]
+  }[]
+  /** enhancedchannelmanager-7wuhd — pure-event_sync run flag. */
+  is_event_sync?: boolean
+  /** enhancedchannelmanager-7wuhd — structured per-rule event_sync counters. */
+  event_sync_summary?: {
+    rule_id: number | null
+    rule_name?: string | null
+    secondary_streams: number
+    attached: number
+    already_attached: number
+    ambiguous_skipped: number
+    unmatched: number
+    parse_failed: number
+    attach_errors: number
+    review_enqueued?: number
+    capped?: boolean
+    cap_overage?: number
   }[]
 }
 

--- a/frontend/src/types/channelPipeline.ts
+++ b/frontend/src/types/channelPipeline.ts
@@ -442,6 +442,54 @@ export interface ChannelPipelineExecution {
    * the run still completes. Always present (empty array when none).
    */
   warnings?: NormalizationWarning[];
+  /**
+   * True only for a PURE event_sync run — event_sync rule(s) ran and NO
+   * standard rules were in scope (enhancedchannelmanager-7wuhd). The
+   * executions UI swaps the standard evaluated/matched/created block for the
+   * event_sync summary block when this is true. A MIXED run (both kinds) is
+   * false, so both blocks stack. Survives source-rule deletion (rule_id is
+   * ON DELETE SET NULL). Absent/false for legacy rows and standard runs.
+   */
+  is_event_sync?: boolean;
+  /**
+   * Structured per-rule event_sync run summaries (enhancedchannelmanager-7wuhd).
+   * One entry per event_sync rule that ran; empty/absent for standard runs.
+   * Persisted so the executions UI can render an event_sync-aware summary
+   * instead of the standard counters, which are structurally 0 for event_sync
+   * runs.
+   */
+  event_sync_summary?: EventSyncExecutionSummary[];
+}
+
+/**
+ * One event_sync rule's persisted run counters (enhancedchannelmanager-7wuhd).
+ * Mirrors the backend attach-phase summary dict (minus the heavy
+ * review_candidates payload, which is stripped before persistence). Vocabulary
+ * matches the Event Sync preview panel + debug-bundle taxonomy.
+ */
+export interface EventSyncExecutionSummary {
+  rule_id: number | null;
+  rule_name?: string | null;
+  /** Secondary-provider streams evaluated against the master channels. */
+  secondary_streams: number;
+  /** Newly attached this run (live) / would-attach (dry-run). */
+  attached: number;
+  /** Already attached before this run — the idempotent no-op count. */
+  already_attached: number;
+  /** Matched >1 master in-band; skipped and (live) enqueued for review. */
+  ambiguous_skipped: number;
+  /** Matched no master above threshold. */
+  unmatched: number;
+  /** Secondary stream name could not be parsed into a title/start. */
+  parse_failed: number;
+  /** Attach attempts that errored against Dispatcharr. */
+  attach_errors: number;
+  /** Pairings enqueued to the review queue this run (live). */
+  review_enqueued?: number;
+  /** True when the per-run attach cap was reached. */
+  capped?: boolean;
+  /** Would-attach streams deferred because the cap tripped. */
+  cap_overage?: number;
 }
 
 /**


### PR DESCRIPTION
Bead **enhancedchannelmanager-7wuhd**. Fixes the confusing Event Sync execution details (Streams Evaluated 0 / Matched 0 / Channels Created 0 while the log showed real already-attached activity).

- **Backend** (persist what was already computed — no matcher/run change): new `ChannelPipelineExecution` columns `event_sync_summary` (Text JSON, mirrors the `warnings` idiom) + `is_event_sync` (Boolean); engine sets both at finalization; **Alembic migration 0033** (nullable/defaulted, no backfill). `is_event_sync` True only for a pure event_sync run (mixed → False so the UI stacks both blocks).
- **Frontend** (mode-aware details + list chip): Secondary Streams Evaluated / Attached (Would Attach on dry-run) / **Already Attached** (own row) / Ambiguous → Review / Unmatched / Parse Failures (warning callout when >0) + conditional Queued/Errors/Capped; drops Channels Created for event_sync. "✓ Fully in sync — N already attached, nothing new to do this run" banner when everything's already attached. Standard runs unchanged.

Gates: full backend suite 6763 pass / 0 fail; frontend tsc/eslint clean, vitest 1775 pass. Migration applied in-container (schema rev 0033, up_to_date). Browser-verified on the live Test Sync rule (41 evaluated / 8 already attached / 33 parse failures, was 0/0/0). PO reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)