### PR TITLE
Event Sync: per-rule 'refresh providers before run' option (y8yby)

### DIFF
--- a/backend/channel_pipeline_engine.py
+++ b/backend/channel_pipeline_engine.py
@@ -2828,6 +2828,192 @@ class ChannelPipelineEngine:
                     page += 1
         return secondary_streams
 
+    async def _resolve_event_sync_refresh_accounts(
+        self, config: dict, provider_cache: dict
+    ) -> set[int]:
+        """Resolve a rule's scopes to the M3U account ids to pre-refresh (y8yby).
+
+        The rule's master + secondary scopes each identify a channel group and,
+        optionally, the ONE provider account that scope draws from:
+
+        * a provider-scoped scope (``m3u_account_id`` set) → that account id
+          directly;
+        * a whole-group scope (``m3u_account_id`` None) → EVERY provider
+          account that carries that channel group, resolved via
+          ``get_m3u_group_settings_by_provider()`` (keyed by
+          ``(m3u_account_id, channel_group_id)``).
+
+        The master group is always included (its provider(s) back the master
+        channels, and with ``include_master_group_streams`` it is also a stream
+        source). Account ids are deduped. The by-provider settings map is
+        fetched at most once per phase via ``provider_cache``.
+        """
+        master = config.get("master") or {
+            "group_id": config.get("master_group_id"), "m3u_account_id": None,
+        }
+        secondary = config.get("secondary") or [
+            {"group_id": g, "m3u_account_id": None}
+            for g in config.get("secondary_group_ids", [])
+        ]
+
+        account_ids: set[int] = set()
+        whole_group_ids: set[int] = set()
+        for scope in [master, *secondary]:
+            pid = scope.get("m3u_account_id")
+            gid = scope.get("group_id")
+            if pid is not None:
+                account_ids.add(pid)
+            elif gid is not None:
+                whole_group_ids.add(gid)
+
+        if whole_group_ids:
+            by_provider = provider_cache.get("by_provider")
+            if by_provider is None:
+                try:
+                    by_provider = (
+                        await self.client.get_m3u_group_settings_by_provider()
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "[EVENT-SYNC] Pre-refresh: failed to resolve provider "
+                        "accounts for whole-group scopes (%s) — those groups' "
+                        "providers will not be pre-refreshed", e,
+                    )
+                    by_provider = {}
+                provider_cache["by_provider"] = by_provider
+            for key in by_provider:
+                # key is (m3u_account_id, channel_group_id).
+                acc_id, group_id = key
+                if group_id in whole_group_ids and acc_id is not None:
+                    account_ids.add(acc_id)
+
+        return account_ids
+
+    async def _prerefresh_event_sync_providers(
+        self, rule, config: dict, results: dict, provider_cache: dict
+    ) -> None:
+        """Pre-refresh a rule's M3U providers before a manual run (bead y8yby).
+
+        Resolves the rule's master + secondary scopes to their backing M3U
+        account ids and refreshes exactly those via the existing
+        ``M3URefreshTask`` (``account_ids=[...]``) — synchronous refresh-then-
+        run. **Best-effort**: a single failed account (or a wholesale failure)
+        WARNs and records a run warning but never aborts the run — the run
+        proceeds against current data, mirroring the M3U refresh watermark's
+        partial-success behavior. Progress + outcome ride the execution log.
+
+        Manual-run-only: the caller gates this out of the unattended auto-run
+        path (that path already runs after a refresh).
+        """
+        account_ids = await self._resolve_event_sync_refresh_accounts(
+            config, provider_cache
+        )
+        if not account_ids:
+            logger.warning(
+                "[EVENT-SYNC] Rule '%s' (id=%s): refresh_providers_before_run "
+                "is on but no M3U provider accounts could be resolved from its "
+                "scopes — skipping pre-refresh, running against current data",
+                rule.name, rule.id,
+            )
+            results["event_sync_warnings"].append({
+                "type": "event_sync_prerefresh_no_accounts",
+                "rule_id": rule.id,
+                "rule_name": rule.name,
+                "message": (
+                    f"event_sync rule '{rule.name}': 'refresh providers "
+                    f"before run' is on but no M3U provider accounts could be "
+                    f"resolved from the rule's groups — the run proceeded "
+                    f"without a pre-refresh, against current data."
+                ),
+            })
+            return
+
+        ids = sorted(account_ids)
+        logger.info(
+            "[EVENT-SYNC] Rule '%s' (id=%s): pre-refreshing %d M3U provider "
+            "account(s) before run: %s",
+            rule.name, rule.id, len(ids), ids,
+        )
+        results["execution_log"].append({
+            "stream_id": None,
+            "stream_name": (
+                f"[EVENT-SYNC] {rule.name}: refreshing "
+                f"{len(ids)} M3U provider(s) before run"
+            ),
+            "m3u_account_id": None,
+            "rules_evaluated": [],
+            "actions_executed": [{
+                "type": "event_sync_prerefresh",
+                "description": (
+                    f"Refreshing {len(ids)} M3U provider account(s) "
+                    f"{ids} before running rule '{rule.name}'"
+                ),
+            }],
+        })
+
+        from tasks.m3u_refresh import M3URefreshTask
+        task = M3URefreshTask()
+        task.update_config({"account_ids": ids, "skip_inactive": True})
+        try:
+            task_result = await task.execute()
+        except Exception as e:
+            logger.warning(
+                "[EVENT-SYNC] Rule '%s' (id=%s): pre-refresh FAILED wholesale "
+                "(%s) — best-effort, running against current data",
+                rule.name, rule.id, e,
+            )
+            results["event_sync_warnings"].append({
+                "type": "event_sync_prerefresh_failed",
+                "rule_id": rule.id,
+                "rule_name": rule.name,
+                "message": (
+                    f"event_sync rule '{rule.name}': pre-run provider refresh "
+                    f"failed ({e}) — the run proceeded against current data "
+                    f"(best-effort)."
+                ),
+            })
+            return
+
+        ok = getattr(task_result, "success_count", 0) or 0
+        failed = getattr(task_result, "failed_count", 0) or 0
+        details = getattr(task_result, "details", None) or {}
+        errors = details.get("errors", []) if isinstance(details, dict) else []
+        if failed:
+            logger.warning(
+                "[EVENT-SYNC] Rule '%s' (id=%s): pre-refresh partial success "
+                "(%d ok, %d failed) — best-effort, running against current "
+                "data. Errors: %s",
+                rule.name, rule.id, ok, failed, errors,
+            )
+            results["event_sync_warnings"].append({
+                "type": "event_sync_prerefresh_partial",
+                "rule_id": rule.id,
+                "rule_name": rule.name,
+                "ok": ok,
+                "failed": failed,
+                "message": (
+                    f"event_sync rule '{rule.name}': pre-run provider refresh "
+                    f"partially failed ({ok} refreshed, {failed} failed) — "
+                    f"the run proceeded against current data (best-effort). "
+                    f"{'; '.join(str(x) for x in errors)}"
+                ),
+            })
+        results["execution_log"].append({
+            "stream_id": None,
+            "stream_name": (
+                f"[EVENT-SYNC] {rule.name}: provider pre-refresh complete"
+            ),
+            "m3u_account_id": None,
+            "rules_evaluated": [],
+            "actions_executed": [{
+                "type": "event_sync_prerefresh_result",
+                "description": (
+                    f"Pre-run provider refresh complete: {ok} refreshed"
+                    + (f", {failed} failed (best-effort)" if failed else "")
+                ),
+            }],
+        })
+
     async def _run_event_sync_rules(
         self,
         event_sync_rules: list,
@@ -2933,6 +3119,11 @@ class ChannelPipelineEngine:
 
         results.setdefault("event_sync", [])
         results.setdefault("event_sync_warnings", [])
+
+        # bead y8yby: per-phase cache for the (m3u_account, group) settings map
+        # used to resolve whole-group scopes to their backing provider accounts
+        # for the optional pre-refresh-on-run step. Filled lazily on first use.
+        prerefresh_provider_cache: dict = {}
 
         # Provider display names, fetched once for the whole phase.
         try:
@@ -3040,6 +3231,20 @@ class ChannelPipelineEngine:
                         ),
                     })
                     continue
+
+            # bead y8yby: optional pre-refresh of the rule's M3U providers
+            # before a MANUAL run (live Run AND dry-run Test), so the match
+            # runs against fresh provider data — closing the refresh-ordering
+            # staleness window. NEVER on the unattended auto-run path: that
+            # path already fires right after an M3U refresh, so pre-refreshing
+            # there would be circular. Best-effort: a failed provider refresh
+            # warns but the run PROCEEDS against current data (mirrors the M3U
+            # refresh watermark's partial-success posture). Runs before the
+            # secondary fetch below so the fetch sees post-refresh streams.
+            if not unattended and config.get("refresh_providers_before_run"):
+                await self._prerefresh_event_sync_providers(
+                    rule, config, results, prerefresh_provider_cache
+                )
 
             try:
                 secondary_streams = (

--- a/backend/channel_pipeline_schema.py
+++ b/backend/channel_pipeline_schema.py
@@ -792,6 +792,7 @@ _EVENT_SYNC_ALLOWED_KEYS = frozenset({
     "max_attach_per_run",
     "enabled",
     "auto_run",
+    "refresh_providers_before_run",
     "dummy_epg_profile_id",
     "include_master_group_streams",
     "assume_current_date",
@@ -1205,6 +1206,27 @@ def validate_event_sync_config(config: Any) -> list[str]:
             "auto_run", auto_run,
             "a boolean (default false) — true opts this rule into "
             "unattended runs on the M3U refresh watermark task",
+        ))
+
+    # Pre-refresh-on-run flag (bead y8yby). DEFAULT OFF. When true, a MANUAL
+    # run of this rule (live Run AND dry-run Test) first refreshes the M3U
+    # provider accounts backing the rule's master + secondary groups, then
+    # runs the match/attach — so the run works against fresh provider data,
+    # closing the refresh-ordering staleness window. It deliberately does NOT
+    # apply to the unattended auto-run path (that already follows a refresh —
+    # pre-refreshing there would be circular). Absent == false, so stored
+    # configs that predate the key keep exactly their prior behavior. NOTE
+    # (surfaced in the UI): with this ON the dry-run Test triggers a real
+    # Dispatcharr provider refresh, so Test is no longer zero-write.
+    refresh_before_run = config.get("refresh_providers_before_run")
+    if refresh_before_run is None:
+        config["refresh_providers_before_run"] = False
+    elif not isinstance(refresh_before_run, bool):
+        errors.append(_event_sync_error(
+            "refresh_providers_before_run", refresh_before_run,
+            "a boolean (default false) — true refreshes the rule's M3U "
+            "providers before a manual Run or Test (making Test no longer "
+            "zero-write); it never applies to unattended auto-runs",
         ))
 
     # Master-group self-attach flag (bead 6xxmp). DEFAULT OFF. When true the

--- a/backend/tests/routers/test_event_sync_persistence_roundtrip.py
+++ b/backend/tests/routers/test_event_sync_persistence_roundtrip.py
@@ -45,6 +45,8 @@ def _event_sync_config(**overrides) -> dict:
         # ti939.3.1: same default-fill convention for the Phase 2 auto-run
         # opt-in — round-tripped configs carry the explicit false.
         "auto_run": False,
+        # bead y8yby: pre-refresh-on-run opt-in, same default-fill.
+        "refresh_providers_before_run": False,
         # bead 6xxmp: master-group self-attach flag, same default-fill.
         "include_master_group_streams": False,
         # bead assume-current-date: dateless opt-in, same default-fill.

--- a/backend/tests/unit/test_event_sync_attach_execution.py
+++ b/backend/tests/unit/test_event_sync_attach_execution.py
@@ -592,6 +592,210 @@ def _breaker_clear():
                  return_value=(False, ""))
 
 
+class TestEnginePhasePreRefresh:
+    """bead y8yby: optional pre-refresh of the rule's M3U providers before a
+    MANUAL run (live Run AND dry-run Test). Never on the unattended auto-run
+    path. Best-effort — a failed refresh warns but the run still proceeds.
+    """
+
+    @staticmethod
+    def _refresh_instance(*, success_count=1, failed_count=0, errors=None):
+        inst = MagicMock()
+        inst.update_config = MagicMock()
+        result = MagicMock()
+        result.success_count = success_count
+        result.failed_count = failed_count
+        result.details = {"errors": errors or []}
+        inst.execute = AsyncMock(return_value=result)
+        return inst
+
+    def test_manual_run_with_flag_triggers_provider_refresh(self):
+        """Flag on + manual run → M3URefreshTask fires with exactly the rule's
+        provider-scoped account ids, BEFORE the attach still happens."""
+        channels = [_master_channel(100, MASTER_MERCURY, streams=[9001])]
+        batch = [{"id": 7001, "name": STREAM_MERCURY, "m3u_account": 1}]
+        engine, executor, client = _engine_with_client(channels, batch)
+        config = _config(
+            master={"group_id": 10, "m3u_account_id": 3},
+            secondary=[{"group_id": 20, "m3u_account_id": 7}],
+            refresh_providers_before_run=True,
+        )
+        results = _results()
+        inst = self._refresh_instance(success_count=2)
+
+        with patch("tasks.m3u_refresh.M3URefreshTask",
+                   return_value=inst) as mock_cls:
+            _run(engine._run_event_sync_rules(
+                [_event_rule(config=config)], executor, results,
+                dry_run=False, triggered_by="manual",
+                channels_touched_ids=set(),
+            ))
+
+        # Refresh fired with exactly the rule's provider accounts (deduped,
+        # sorted); no whole-group resolution was needed.
+        mock_cls.assert_called_once()
+        inst.execute.assert_awaited_once()
+        passed = inst.update_config.call_args[0][0]
+        assert passed["account_ids"] == [3, 7]
+        client.get_m3u_group_settings_by_provider.assert_not_called()
+        # The attach still ran after the refresh.
+        assert results["event_sync"][0]["attached"] == 1
+        client.update_channel.assert_awaited_once()
+
+    def test_whole_group_scopes_resolve_all_backing_providers(self):
+        """Whole-group scopes (m3u_account_id None) resolve to EVERY provider
+        account carrying that channel group via the by-provider settings."""
+        channels = [_master_channel(100, MASTER_MERCURY, streams=[9001])]
+        batch = [{"id": 7001, "name": STREAM_MERCURY, "m3u_account": 1}]
+        engine, executor, client = _engine_with_client(channels, batch)
+        client.get_m3u_group_settings_by_provider = AsyncMock(return_value={
+            (3, 10): {}, (5, 10): {}, (7, 20): {},
+        })
+        config = _config(refresh_providers_before_run=True)  # flat → whole-group
+        results = _results()
+        inst = self._refresh_instance()
+
+        with patch("tasks.m3u_refresh.M3URefreshTask", return_value=inst):
+            _run(engine._run_event_sync_rules(
+                [_event_rule(config=config)], executor, results,
+                dry_run=False, triggered_by="manual",
+                channels_touched_ids=set(),
+            ))
+
+        passed = inst.update_config.call_args[0][0]
+        assert passed["account_ids"] == [3, 5, 7]
+
+    def test_manual_run_without_flag_never_refreshes(self):
+        """Flag off (absent → false) → no refresh; the run is unchanged."""
+        channels = [_master_channel(100, MASTER_MERCURY, streams=[9001])]
+        batch = [{"id": 7001, "name": STREAM_MERCURY, "m3u_account": 1}]
+        engine, executor, client = _engine_with_client(channels, batch)
+        results = _results()
+
+        with patch("tasks.m3u_refresh.M3URefreshTask") as mock_cls:
+            _run(engine._run_event_sync_rules(
+                [_event_rule(config=_config())], executor, results,
+                dry_run=False, triggered_by="manual",
+                channels_touched_ids=set(),
+            ))
+
+        mock_cls.assert_not_called()
+        assert results["event_sync"][0]["attached"] == 1
+
+    def test_dry_run_test_with_flag_still_refreshes(self):
+        """PO decision: the flag applies to the dry-run Test too — so a Test
+        with the flag on triggers a real refresh (Test is not zero-write)."""
+        channels = [_master_channel(100, MASTER_MERCURY, streams=[9001])]
+        batch = [{"id": 7001, "name": STREAM_MERCURY, "m3u_account": 1}]
+        engine, executor, client = _engine_with_client(channels, batch)
+        config = _config(
+            master={"group_id": 10, "m3u_account_id": 3},
+            secondary=[{"group_id": 20, "m3u_account_id": 3}],
+            refresh_providers_before_run=True,
+        )
+        results = _results()
+        inst = self._refresh_instance()
+
+        with patch("tasks.m3u_refresh.M3URefreshTask", return_value=inst):
+            _run(engine._run_event_sync_rules(
+                [_event_rule(config=config)], executor, results,
+                dry_run=True, triggered_by="manual",
+                channels_touched_ids=set(),
+            ))
+
+        inst.execute.assert_awaited_once()
+        # Dry run writes nothing itself (the attach is simulated).
+        client.update_channel.assert_not_awaited()
+
+    def test_failed_refresh_warns_but_run_proceeds(self):
+        """Best-effort: a failed provider refresh warns but the attach still
+        runs against current data (mirrors the watermark partial-success)."""
+        channels = [_master_channel(100, MASTER_MERCURY, streams=[9001])]
+        batch = [{"id": 7001, "name": STREAM_MERCURY, "m3u_account": 1}]
+        engine, executor, client = _engine_with_client(channels, batch)
+        config = _config(
+            master={"group_id": 10, "m3u_account_id": 3},
+            secondary=[{"group_id": 20, "m3u_account_id": 7}],
+            refresh_providers_before_run=True,
+        )
+        results = _results()
+        inst = self._refresh_instance(
+            success_count=1, failed_count=1, errors=["ProvB: boom"],
+        )
+
+        with patch("tasks.m3u_refresh.M3URefreshTask", return_value=inst):
+            _run(engine._run_event_sync_rules(
+                [_event_rule(config=config)], executor, results,
+                dry_run=False, triggered_by="manual",
+                channels_touched_ids=set(),
+            ))
+
+        # Run proceeded: the stream still attached.
+        assert results["event_sync"][0]["attached"] == 1
+        client.update_channel.assert_awaited_once()
+        # A best-effort partial-failure warning was recorded.
+        partial = [
+            w for w in results["event_sync_warnings"]
+            if w["type"] == "event_sync_prerefresh_partial"
+        ]
+        assert len(partial) == 1
+        assert partial[0]["failed"] == 1
+
+    def test_wholesale_refresh_exception_warns_but_run_proceeds(self):
+        """If the refresh raises entirely, the run still proceeds (best-effort);
+        a event_sync_prerefresh_failed warning is recorded."""
+        channels = [_master_channel(100, MASTER_MERCURY, streams=[9001])]
+        batch = [{"id": 7001, "name": STREAM_MERCURY, "m3u_account": 1}]
+        engine, executor, client = _engine_with_client(channels, batch)
+        config = _config(
+            master={"group_id": 10, "m3u_account_id": 3},
+            secondary=[{"group_id": 20, "m3u_account_id": 7}],
+            refresh_providers_before_run=True,
+        )
+        results = _results()
+        inst = MagicMock()
+        inst.update_config = MagicMock()
+        inst.execute = AsyncMock(side_effect=RuntimeError("dispatcharr down"))
+
+        with patch("tasks.m3u_refresh.M3URefreshTask", return_value=inst):
+            _run(engine._run_event_sync_rules(
+                [_event_rule(config=config)], executor, results,
+                dry_run=False, triggered_by="manual",
+                channels_touched_ids=set(),
+            ))
+
+        assert results["event_sync"][0]["attached"] == 1
+        failed = [
+            w for w in results["event_sync_warnings"]
+            if w["type"] == "event_sync_prerefresh_failed"
+        ]
+        assert len(failed) == 1
+
+    def test_auto_run_path_never_prerefreshes(self):
+        """The unattended auto-run path must NOT pre-refresh even when the rule
+        carries the flag — pre-refreshing after a refresh would be circular."""
+        channels = [_master_channel(100, MASTER_MERCURY, streams=[9001])]
+        batch = [{"id": 7001, "name": STREAM_MERCURY, "m3u_account": 1}]
+        engine, executor, client = _engine_with_client(channels, batch)
+        client.get_all_m3u_group_settings = AsyncMock(
+            return_value=GROUP_SETTINGS_OK
+        )
+        config = _config(auto_run=True, refresh_providers_before_run=True)
+        results = _results()
+
+        with _breaker_clear(), \
+                patch("tasks.m3u_refresh.M3URefreshTask") as mock_cls:
+            _run(engine._run_event_sync_rules(
+                [_event_rule(config=config)], executor, results,
+                dry_run=False, triggered_by="m3u_refresh",
+                channels_touched_ids=set(),
+            ))
+
+        # Auto-run attached, but NO pre-refresh task was constructed.
+        assert results["event_sync"][0]["attached"] == 1
+        mock_cls.assert_not_called()
+
+
 class TestEnginePhaseAutoRun:
     """ti939.3.1 + ixujz: the attach phase on the UNATTENDED watermark
     trigger — per-rule opt-in, circuit-breaker gate, and pre-flight.

--- a/backend/tests/unit/test_event_sync_config_schema.py
+++ b/backend/tests/unit/test_event_sync_config_schema.py
@@ -357,6 +357,46 @@ class TestAutoRunFlag:
         assert stored["auto_run"] is False
 
 
+class TestRefreshProvidersBeforeRunFlag:
+    """refresh_providers_before_run opt-in flag (bead y8yby).
+
+    Pre-refreshes the rule's M3U providers before a MANUAL run (live Run AND
+    dry-run Test). Same default-off / absent-reads-false / backward-compat
+    convention as auto_run: an absent key must always read as false and
+    pre-existing stored configs must validate unchanged.
+    """
+
+    def test_default_filled_false(self):
+        config = _valid_config()
+        assert validate_event_sync_config(config) == []
+        assert config["refresh_providers_before_run"] is False
+
+    @pytest.mark.parametrize("good", [True, False])
+    def test_bool_accepted_and_round_trips(self, good):
+        config = _valid_config(refresh_providers_before_run=good)
+        assert validate_event_sync_config(config) == []
+        assert config["refresh_providers_before_run"] is good
+
+    @pytest.mark.parametrize("bad", ["true", 1, 0])
+    def test_non_bool_rejected(self, bad):
+        config = _valid_config()
+        config["refresh_providers_before_run"] = bad
+        errors = validate_event_sync_config(config)
+        assert any("refresh_providers_before_run" in e for e in errors)
+
+    def test_existing_stored_config_without_key_still_validates(self):
+        """Backward compat: a stored config that predates the flag validates
+        clean and reads as false — manual-run behavior unchanged."""
+        stored = _valid_config(
+            time_window_minutes=30,
+            attach_threshold=0.85,
+            max_attach_per_run=50,
+            enabled=True,
+        )
+        assert validate_event_sync_config(stored) == []
+        assert stored["refresh_providers_before_run"] is False
+
+
 class TestIncludeMasterGroupStreamsFlag:
     """include_master_group_streams flag (bead 6xxmp — master self-attach).
 

--- a/docs/event_sync.md
+++ b/docs/event_sync.md
@@ -377,6 +377,7 @@ backward compatibility; the rule editor now reads and writes the nested shape.
 | `max_attach_per_run` | no (default 100) | Per-run attach cap (1–1000). On overage the run stops attaching, warns in the execution log, and records the overage count. Runs are idempotent — run again to continue. |
 | `enabled` | no (default true) | Feature toggle within the rule. |
 | `auto_run` | no (default **false**) | Phase 2 opt-in (bead ti939.3.1): when true, the rule also runs **unattended** after each M3U refresh (the watermark task). Absent means false — manual-run-only. See [Automatic runs after refresh](#automatic-runs-after-refresh-phase-2-opt-in). |
+| `refresh_providers_before_run` | no (default **false**) | bead y8yby: when true, a **manual** run of this rule (live **Run** AND dry-run **Test**) first refreshes the M3U provider accounts backing the rule's master + secondary groups, then runs the match/attach — closing the refresh-ordering staleness window. **Consequence:** with this on, **Test is no longer zero-write** (it triggers a real Dispatcharr provider refresh). Best-effort (a failed provider warns, the run proceeds). Never applies to unattended auto-runs (that path already follows a refresh). Absent means false. See [Refresh ordering, self-healing, and refresh-before-run](#refresh-ordering-self-healing-and-refresh-before-run). |
 | `dummy_epg_profile_id` | no (absent = off) | Phase 2 (bead ti939.3.3): id of a [dummy EPG profile](template_engine.md) auto-assigned to the master group's channels on every run. Must reference an **existing** profile (teaching error otherwise); the key is never default-filled — omit it to disable. See [Automatic guide data for master channels](#automatic-guide-data-for-master-channels-dummy-epg). |
 | `include_master_group_streams` | no (default **false**) | bead 6xxmp: when true, the **master group's own streams** (from *any* provider) are also matched to the master channels; streams already attached are skipped. A whole-group catch-all for a same-named cross-provider group — now usually superseded by adding the same group under the other provider as a `secondary` scope (which targets exactly one provider). Still useful when a same-named group spans **three or more** providers and you want them all. See [Two providers, one group name](#two-providers-one-group-name) below. |
 | `assume_current_date` | no (default **false**) | When true, a listing that carries a **time but no date** is placed on the **current date** so it becomes matchable — deliberately relaxing the never-guess-the-date rail. Accepts the cross-day match risk. See [Dateless live listings](#dateless-live-listings). |
@@ -916,6 +917,78 @@ engineered around: the stream counts as `unmatched` that run (zero writes,
 never a guess) and attaches on the **next** run — convergence, not
 immediacy. Covered by the lifecycle race tests
 (`backend/tests/unit/test_event_sync_lifecycle.py`).
+
+## Refresh ordering, self-healing, and refresh-before-run
+
+Event Sync's matching and Dispatcharr's M3U refresh are **decoupled**. ECM's
+watermark task advances `last_m3u_refresh_completed_at` after a refresh
+completes, and the pipeline recomputes matches statelessly on each tick. Two
+consequences fall out of that design, and one new per-rule option lets you
+tighten it when you need to.
+
+### Why misordered refreshes self-heal
+
+Refreshes for different providers are independent, so they can land in any
+order — a **secondary** provider can refresh before its **master**. That
+"misordering" is not an error state and needs no coordination:
+
+* Matching is a **stateless, idempotent recompute** — Event Sync stores no
+  durable cluster state; the master channels are the identity anchor and every
+  run re-derives the full match set from live data. A run never depends on the
+  result of a prior run.
+* When a secondary stream's master channel does not exist yet (the master
+  provider hasn't refreshed, or Dispatcharr's post-refresh Celery sync hasn't
+  materialized the channel), that stream is simply counted `unmatched` for that
+  run — **zero writes, never a guess**. It attaches on the **next** pipeline
+  tick after the master exists.
+* Because the recompute is idempotent, repeated runs **converge**: once every
+  provider has refreshed and the master channels exist, the same rule against
+  the same names produces the complete match set. A stream already on its
+  master is a no-op. So a misordered refresh only ever *delays* an attach to a
+  later tick — it never produces a wrong or duplicated attach.
+
+This is convergence, not immediacy: the system heals itself on the next run
+rather than trying to order the refreshes. It is the same property that makes
+[opt-in auto-runs](#automatic-runs-after-refresh-phase-2-opt-in) safe to run
+unattended after every refresh.
+
+### The "refresh providers before run" option (per rule)
+
+The self-healing above resolves *within a few ticks*. If you would rather a
+**single manual run** work against freshly-refreshed provider data — closing
+the staleness window in one shot instead of waiting for the next tick — turn on
+**"Refresh this rule's M3U providers before running"** in the rule editor's
+**Behavior → Automation** area (config key `refresh_providers_before_run`,
+default off).
+
+With it on, a manual run of the rule first refreshes exactly the M3U accounts
+backing that rule's **master + secondary** groups (resolved from the rule's
+scopes: a provider-scoped scope refreshes that one account; a whole-group scope
+refreshes every provider account carrying the group), waits for the refresh,
+then runs the match/attach. Key properties:
+
+* **Applies to the live Run AND the dry-run Test.** Both are manual triggers,
+  so both pre-refresh.
+* **Test is no longer zero-write.** A refresh is a real write to Dispatcharr's
+  stream list, so with this flag on the **Test** action triggers that write
+  before previewing. The editor toggle, the per-rule **Test** button, and its
+  confirm dialog all say so — Test with this flag on is not a dry preview of
+  current data. If you want a genuinely read-only preview, leave the flag off
+  and use the editor's **Preview** (which never refreshes).
+* **Auto-runs are excluded.** The unattended watermark auto-run path is *already*
+  triggered by a completed refresh, so pre-refreshing there would be circular.
+  This flag only ever affects manual Run/Test; the auto-run path is untouched.
+* **Best-effort.** A single failed provider refresh **warns** (a run warning on
+  the execution record + a log line) but the run **still proceeds** against
+  current data — the same partial-success posture as the M3U refresh watermark
+  (one failed account never aborts the batch).
+* **Still converges, not instant.** Dispatcharr materializes brand-new master
+  channels from a Celery task *after* the refresh, so a run landing immediately
+  after the pre-refresh can still precede a new event's master channel — that
+  stream attaches on a later run, exactly as in the [timing
+  note](#timing-note--refresh-ordering) above. The flag freshens the provider
+  *streams* the run sees; it does not force Dispatcharr's channel sync to finish
+  first.
 
 ## Automatic guide data for master channels (dummy EPG)
 

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.test.tsx
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.test.tsx
@@ -459,11 +459,17 @@ describe('ChannelPipelineTab', () => {
       return bodies;
     };
 
-    const pushEventSyncRule = (name: string) => {
+    const pushEventSyncRule = (
+      name: string,
+      extraConfig: Record<string, unknown> = {}
+    ) => {
       const rule = createMockChannelPipelineRule({
         name,
         enabled: true,
-        event_sync_config: { master_group_id: 1, secondary_group_ids: [2], auto_run: false },
+        event_sync_config: {
+          master_group_id: 1, secondary_group_ids: [2], auto_run: false,
+          ...extraConfig,
+        },
       });
       mockDataStore.channelPipelineRules.push(rule);
       return rule;
@@ -534,6 +540,52 @@ describe('ChannelPipelineTab', () => {
         expect(screen.queryByTestId('event-sync-run-confirm')).not.toBeInTheDocument()
       );
       expect(bodies).toHaveLength(0);
+    });
+
+    it('Test on an event_sync row with refresh_providers_before_run routes through a confirm that warns Test is not zero-write (bead y8yby)', async () => {
+      const user = userEvent.setup();
+      const bodies = installRunCapture();
+      const rule = pushEventSyncRule('ES Refresh Rule', {
+        refresh_providers_before_run: true,
+      });
+      renderWithProviders(<ChannelPipelineTab />);
+
+      await waitFor(() => expect(screen.getByText('ES Refresh Rule')).toBeInTheDocument());
+      const row = screen.getByText('ES Refresh Rule').closest('tr')!;
+
+      await user.click(within(row).getByRole('button', { name: `Test ${rule.name}` }));
+
+      // A confirm appears (Test is no longer zero-write) and nothing has run.
+      expect(await screen.findByTestId('event-sync-run-confirm')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('event-sync-test-refresh-warning')
+      ).toBeInTheDocument();
+      expect(bodies).toHaveLength(0);
+
+      await user.click(screen.getByTestId('event-sync-run-confirm-btn'));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      // Still a dry run — the refresh happens server-side, no attaches.
+      expect(bodies[0]).toEqual({ dry_run: true, rule_ids: [rule.id] });
+    });
+
+    it('Run confirm on a refresh-before-run rule notes the pre-refresh (bead y8yby)', async () => {
+      const user = userEvent.setup();
+      installRunCapture();
+      const rule = pushEventSyncRule('ES Refresh Rule', {
+        refresh_providers_before_run: true,
+      });
+      renderWithProviders(<ChannelPipelineTab />);
+
+      await waitFor(() => expect(screen.getByText('ES Refresh Rule')).toBeInTheDocument());
+      const row = screen.getByText('ES Refresh Rule').closest('tr')!;
+
+      await user.click(within(row).getByRole('button', { name: `Run ${rule.name}` }));
+
+      expect(await screen.findByTestId('event-sync-run-confirm')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('event-sync-run-refresh-note')
+      ).toBeInTheDocument();
     });
 
     it('a standard rule Run runs directly with no confirm (parity)', async () => {

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
@@ -267,12 +267,15 @@ export function ChannelPipelineTab() {
   const [createRuleKind, setCreateRuleKind] = useState<'standard' | 'event_sync' | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<ChannelPipelineRule | null>(null);
   const [showRollbackConfirm, setShowRollbackConfirm] = useState<ChannelPipelineExecution | null>(null);
-  // Live-run confirm for event_sync rules (utswf). The per-rule Run on an
-  // event_sync row WRITES (attaches streams), unlike the in-editor Preview
-  // which is dry-run only — so the live run gets a one-step "this will attach"
-  // confirm. The Test (dry-run) icon stays confirm-free; standard rules keep
-  // their no-confirm parity.
-  const [showEventSyncRunConfirm, setShowEventSyncRunConfirm] = useState<ChannelPipelineRule | null>(null);
+  // Run/Test confirm for event_sync rules (utswf + bead y8yby). The per-rule
+  // Run on an event_sync row WRITES (attaches streams), unlike the in-editor
+  // Preview which is dry-run only — so the live run gets a one-step "this will
+  // attach" confirm. The Test (dry-run) icon stays confirm-free EXCEPT when the
+  // rule has refresh_providers_before_run on: then Test triggers a real
+  // Dispatcharr provider refresh before the dry preview (no longer zero-write),
+  // so it also routes through a confirm. Standard rules keep no-confirm parity.
+  const [showEventSyncRunConfirm, setShowEventSyncRunConfirm] =
+    useState<{ rule: ChannelPipelineRule; dryRun: boolean } | null>(null);
   // Snapshot-restore state (ADR-010 §D5 / uc51o.7)
   const [showRevertConfirm, setShowRevertConfirm] = useState<ChannelPipelineExecution | null>(null);
   const [revertLoading, setRevertLoading] = useState(false);
@@ -653,10 +656,10 @@ export function ChannelPipelineTab() {
   // row Run icon routes through a confirm. Reuses handleRunSingleRule — the
   // run/attach semantics are unchanged.
   const handleConfirmEventSyncRun = useCallback(async () => {
-    const rule = showEventSyncRunConfirm;
-    if (!rule) return;
+    const pending = showEventSyncRunConfirm;
+    if (!pending) return;
     setShowEventSyncRunConfirm(null);
-    await handleRunSingleRule(rule.id, false);
+    await handleRunSingleRule(pending.rule.id, pending.dryRun);
   }, [showEventSyncRunConfirm, handleRunSingleRule]);
 
   const handleRollbackClick = useCallback((execution: ChannelPipelineExecution) => {
@@ -1117,7 +1120,7 @@ export function ChannelPipelineTab() {
                             className="action-btn"
                             onClick={() =>
                               rule.event_sync_config
-                                ? setShowEventSyncRunConfirm(rule)
+                                ? setShowEventSyncRunConfirm({ rule, dryRun: false })
                                 : handleRunSingleRule(rule.id, false)
                             }
                             disabled={runningSingleRule === rule.id || runningPipeline}
@@ -1130,10 +1133,22 @@ export function ChannelPipelineTab() {
                           </button>
                           <button
                             className="action-btn"
-                            onClick={() => handleRunSingleRule(rule.id, true)}
+                            onClick={() =>
+                              // bead y8yby: a Test on an event_sync rule with
+                              // refresh_providers_before_run on is NOT zero-write
+                              // (it refreshes providers first) — route it through
+                              // a confirm. Otherwise Test runs immediately.
+                              rule.event_sync_config?.refresh_providers_before_run
+                                ? setShowEventSyncRunConfirm({ rule, dryRun: true })
+                                : handleRunSingleRule(rule.id, true)
+                            }
                             disabled={runningSingleRule === rule.id || runningPipeline}
                             aria-label={`Test ${rule.name}`}
-                            title="Test (dry run)"
+                            title={
+                              rule.event_sync_config?.refresh_providers_before_run
+                                ? 'Test (dry run — refreshes this rule’s M3U providers first, not a preview of current data)'
+                                : 'Test (dry run)'
+                            }
                           >
                             <span className="material-icons">visibility</span>
                           </button>
@@ -1448,18 +1463,52 @@ export function ChannelPipelineTab() {
         >
           <div className="modal-container modal-sm" data-testid="event-sync-run-confirm">
             <div className="modal-header">
-              <h2 id="event-sync-run-confirm-title">Run Event Sync rule</h2>
+              <h2 id="event-sync-run-confirm-title">
+                {showEventSyncRunConfirm.dryRun
+                  ? 'Test Event Sync rule (refreshes providers)'
+                  : 'Run Event Sync rule'}
+              </h2>
             </div>
             <div className="modal-body">
-              <p>
-                Running &quot;{showEventSyncRunConfirm.name}&quot; will{' '}
-                <strong>attach streams</strong> to their master channels where
-                they match. Attaches are journaled and reversible via rollback.
-              </p>
-              <p>
-                To see what would attach without writing, use the Test (dry run)
-                action instead.
-              </p>
+              {showEventSyncRunConfirm.dryRun ? (
+                <>
+                  <p data-testid="event-sync-test-refresh-warning">
+                    Testing &quot;{showEventSyncRunConfirm.rule.name}&quot; will
+                    first <strong>refresh this rule&apos;s M3U providers</strong>{' '}
+                    — a real write to Dispatcharr&apos;s stream list — and then
+                    run a dry-run match. This is <strong>not</strong> a
+                    zero-write preview of current data.
+                  </p>
+                  <p>
+                    No streams are attached by the Test itself. To preview
+                    against current data without any refresh, turn off
+                    &quot;Refresh this rule&apos;s M3U providers before
+                    running&quot; in the rule editor, or use the editor&apos;s
+                    Preview.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p>
+                    Running &quot;{showEventSyncRunConfirm.rule.name}&quot; will{' '}
+                    <strong>attach streams</strong> to their master channels
+                    where they match. Attaches are journaled and reversible via
+                    rollback.
+                  </p>
+                  {showEventSyncRunConfirm.rule.event_sync_config
+                    ?.refresh_providers_before_run && (
+                    <p data-testid="event-sync-run-refresh-note">
+                      This rule will first <strong>refresh its M3U
+                      providers</strong> (a write to Dispatcharr&apos;s stream
+                      list), then run.
+                    </p>
+                  )}
+                  <p>
+                    To see what would attach without writing, use the Test (dry
+                    run) action instead.
+                  </p>
+                </>
+              )}
             </div>
             <div className="modal-footer">
               <button
@@ -1471,10 +1520,10 @@ export function ChannelPipelineTab() {
               <button
                 className="btn-primary"
                 onClick={handleConfirmEventSyncRun}
-                aria-label="Confirm run"
+                aria-label={showEventSyncRunConfirm.dryRun ? 'Confirm test' : 'Confirm run'}
                 data-testid="event-sync-run-confirm-btn"
               >
-                Run &amp; attach
+                {showEventSyncRunConfirm.dryRun ? 'Refresh & test' : 'Run & attach'}
               </button>
             </div>
           </div>

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.css
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.css
@@ -156,6 +156,12 @@
   font-weight: 600;
 }
 
+/* bead y8yby: emphasise the "Test is no longer zero-write" consequence of the
+   refresh-providers-before-run toggle. */
+.event-sync-warning-hint {
+  color: var(--warning, #f59e0b);
+}
+
 .event-sync-review-jump {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
@@ -534,6 +534,76 @@ describe('EventSyncRuleEditor', () => {
     });
   });
 
+  describe('refresh_providers_before_run toggle (bead y8yby)', () => {
+    it('defaults OFF and omits the key for a rule that never had it', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onSave = vi.fn();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
+
+      await user.click(screen.getByText('Automation'));
+      expect(
+        screen.getByTestId('event-sync-refresh-providers-before-run')
+      ).not.toBeChecked();
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+      expect(onSave.mock.calls[0][0].event_sync_config).not.toHaveProperty(
+        'refresh_providers_before_run'
+      );
+    });
+
+    it('emits refresh_providers_before_run: true when checked, and surfaces the Test-writes warning', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onSave = vi.fn();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
+
+      await user.click(screen.getByText('Automation'));
+      await user.click(
+        screen.getByTestId('event-sync-refresh-providers-before-run')
+      );
+      // The "Test is no longer zero-write" consequence is surfaced inline.
+      expect(
+        screen.getByTestId('event-sync-refresh-test-writes-note')
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+      expect(
+        onSave.mock.calls[0][0].event_sync_config.refresh_providers_before_run
+      ).toBe(true);
+    });
+
+    it('initializes checked from a stored true and round-trips it', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onSave = vi.fn();
+      const rule = {
+        ...EXISTING_RULE,
+        event_sync_config: {
+          ...EXISTING_RULE.event_sync_config!,
+          refresh_providers_before_run: true,
+        },
+      };
+      render(<EventSyncRuleEditor rule={rule} onSave={onSave} onCancel={vi.fn()} />);
+
+      await user.click(screen.getByText('Automation'));
+      expect(
+        screen.getByTestId('event-sync-refresh-providers-before-run')
+      ).toBeChecked();
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+      expect(
+        onSave.mock.calls[0][0].event_sync_config.refresh_providers_before_run
+      ).toBe(true);
+    });
+  });
+
   describe('inline auto-sync status (picker; toggles ONLY via the confirmed fix)', () => {
     it('shows an inline mismatch + Fix when the master scope has auto-sync OFF', async () => {
       seedGroups();

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
@@ -330,6 +330,12 @@ export function EventSyncRuleEditor({
   // Phase 2 opt-in (ti939.3.1): unattended auto-run on the refresh
   // watermark. Default OFF — the backend treats an absent key as false.
   const [autoRun, setAutoRun] = useState(config?.auto_run ?? false);
+  // bead y8yby: refresh the rule's M3U providers before a MANUAL run (live Run
+  // AND dry-run Test). Default OFF — the backend treats an absent key as false.
+  // With it on, Test is no longer zero-write (it triggers a real refresh).
+  const [refreshProvidersBeforeRun, setRefreshProvidersBeforeRun] = useState(
+    config?.refresh_providers_before_run ?? false
+  );
   // bead 6xxmp: also match the master group's own streams (a second provider
   // sharing the master group's name) to the master channels.
   const [includeMasterGroupStreams, setIncludeMasterGroupStreams] = useState(
@@ -599,6 +605,16 @@ export function EventSyncRuleEditor({
     if (autoRun || config?.auto_run != null) {
       built.auto_run = autoRun;
     }
+    // bead y8yby: emit refresh_providers_before_run when checked, and preserve
+    // an explicit stored value (the backend validator fills the key on save).
+    // A legacy config without the key stays without it while the box is
+    // unchecked — absent means false on the backend.
+    if (
+      refreshProvidersBeforeRun ||
+      config?.refresh_providers_before_run != null
+    ) {
+      built.refresh_providers_before_run = refreshProvidersBeforeRun;
+    }
     // ti939.3.3: emit the dummy EPG profile reference when selected; a
     // cleared selection omits the key (absent means OFF on the backend —
     // the key is never emitted as null).
@@ -838,6 +854,7 @@ export function EventSyncRuleEditor({
       thresholdText !== (config?.attach_threshold ?? EVENT_ATTACH_FLOOR).toFixed(2) ||
       enforceTimeWindow !== (config?.enforce_time_window ?? true) ||
       autoRun !== (config?.auto_run ?? false) ||
+      refreshProvidersBeforeRun !== (config?.refresh_providers_before_run ?? false) ||
       includeMasterGroupStreams !== (config?.include_master_group_streams ?? false) ||
       assumeCurrentDate !== (config?.assume_current_date ?? false) ||
       parseMasterFromStream !== (config?.parse_master_from_stream ?? false) ||
@@ -846,8 +863,8 @@ export function EventSyncRuleEditor({
   }, [
     name, description, enabled, masterScope, secondaryScopes, selectedPatternIds,
     customShared, groupOverrides, timeWindowText, thresholdText, enforceTimeWindow,
-    autoRun, includeMasterGroupStreams, assumeCurrentDate, parseMasterFromStream,
-    dummyEpgProfileId, config, rule, initial, customSharedMeta,
+    autoRun, refreshProvidersBeforeRun, includeMasterGroupStreams, assumeCurrentDate,
+    parseMasterFromStream, dummyEpgProfileId, config, rule, initial, customSharedMeta,
   ]);
   const dirtyRef = useRef(dirty);
   dirtyRef.current = dirty;
@@ -939,6 +956,10 @@ export function EventSyncRuleEditor({
         ) : (
           <>Runs only when you run it manually.</>
         )}
+        {refreshProvidersBeforeRun && (
+          <> <strong>Refreshes this rule&apos;s M3U providers before each
+          manual Run/Test</strong> (so Test is no longer zero-write).</>
+        )}
         {includeMasterGroupStreams && secCount > 0 && (
           <> Also matches the master group&apos;s own streams.</>
         )}
@@ -956,6 +977,7 @@ export function EventSyncRuleEditor({
     currentTimeWindow,
     currentThreshold,
     autoRun,
+    refreshProvidersBeforeRun,
     assumeCurrentDate,
     dummyEpgProfileId,
     groupName,
@@ -971,7 +993,8 @@ export function EventSyncRuleEditor({
   const overridesChanged = scopedGroups.filter(
     g => (groupOverrides[g.id]?.title_pattern ?? '').trim().length > 0
   ).length;
-  const automationChanged = autoRun ? 1 : 0;
+  const automationChanged =
+    (autoRun ? 1 : 0) + (refreshProvidersBeforeRun ? 1 : 0);
   const scopeExtChanged =
     (includeMasterGroupStreams ? 1 : 0) + (parseMasterFromStream ? 1 : 0);
   const guideChanged = dummyEpgProfileId != null ? 1 : 0;
@@ -1096,6 +1119,8 @@ export function EventSyncRuleEditor({
       const chips: ReactNode[] = [];
       if (autoRun)
         chips.push(<span key="ar" className="badge badge-sm badge-warning">Auto-run</span>);
+      if (refreshProvidersBeforeRun)
+        chips.push(<span key="rp" className="badge badge-sm badge-warning">Refresh before run</span>);
       if (!enforceTimeWindow)
         chips.push(<span key="to" className="badge badge-sm badge-warning">Title-only</span>);
       if (assumeCurrentDate)
@@ -1694,6 +1719,62 @@ export function EventSyncRuleEditor({
                       </div>
                     </details>
                   </div>
+
+                  {/* bead y8yby: pre-refresh the rule's M3U providers before a
+                      manual Run/Test. */}
+                  <div className="form-group">
+                    <label className="checkbox-option">
+                      <input
+                        type="checkbox"
+                        checked={refreshProvidersBeforeRun}
+                        onChange={e => setRefreshProvidersBeforeRun(e.target.checked)}
+                        disabled={isLoading}
+                        data-testid="event-sync-refresh-providers-before-run"
+                      />
+                      <span>Refresh this rule&apos;s M3U providers before running</span>
+                    </label>
+                    <span className="form-hint">
+                      Before each <strong>manual</strong> Run or Test, refresh
+                      the M3U accounts backing this rule&apos;s master +
+                      secondary groups, then run — so the match works against
+                      fresh provider data.
+                    </span>
+                    {refreshProvidersBeforeRun && (
+                      <span
+                        className="form-hint event-sync-warning-hint"
+                        data-testid="event-sync-refresh-test-writes-note"
+                      >
+                        Heads up: with this on, <strong>Test is no longer a
+                        zero-write dry run</strong> — it triggers a real
+                        Dispatcharr provider refresh (a write to the stream
+                        list) before previewing.
+                      </span>
+                    )}
+                    <details className="modal-why">
+                      <summary>Why / when to use</summary>
+                      <div className="event-sync-details-body">
+                        <span className="form-hint">
+                          Off by default. Turn this on to close the
+                          refresh-ordering staleness window: without it, a run
+                          matches against whatever streams Dispatcharr last
+                          fetched, so a secondary provider refreshed after the
+                          run (or a master refreshed after a secondary) leaves
+                          events attaching only on a later run. With it on, ECM
+                          refreshes exactly this rule&apos;s providers first,
+                          then runs. It applies to the live Run <em>and</em> the
+                          dry-run Test — so <strong>Test is no longer
+                          zero-write</strong> when this is on. It does{' '}
+                          <strong>not</strong> apply to unattended auto-runs
+                          (those already follow a refresh). The refresh is
+                          best-effort: a single failed provider warns but the
+                          run still proceeds against current data. A run landing
+                          right after the refresh can still precede Dispatcharr
+                          creating a brand-new event&apos;s master channel — that
+                          stream is picked up on a later run (convergence).
+                        </span>
+                      </div>
+                    </details>
+                  </div>
                 </div>
               </details>
 
@@ -1919,6 +2000,7 @@ export function EventSyncRuleEditor({
                   </dt>
                   <dd>
                     {autoRun ? 'Auto-run after each M3U refresh' : 'Manual runs only'}
+                    {refreshProvidersBeforeRun ? ' · refresh providers before run (Test writes)' : ''}
                     {parseMasterFromStream ? ' · master time from stream' : ''}
                     {dummyEpgProfileId != null ? ' · dummy EPG guide data' : ''}
                   </dd>

--- a/frontend/src/types/eventSync.ts
+++ b/frontend/src/types/eventSync.ts
@@ -82,6 +82,17 @@ export interface EventSyncConfig {
    */
   auto_run?: boolean;
   /**
+   * bead y8yby: when true, a MANUAL run of this rule (live Run AND dry-run
+   * Test) first refreshes the M3U provider accounts backing the rule's
+   * master + secondary groups, then runs the match/attach — closing the
+   * refresh-ordering staleness window. Never applies to unattended auto-runs
+   * (that path already follows a refresh). Backend default false.
+   *
+   * Consequence surfaced in the UI: with this ON the dry-run Test triggers a
+   * real Dispatcharr provider refresh, so Test is no longer zero-write.
+   */
+  refresh_providers_before_run?: boolean;
+  /**
    * Phase 2 (bead ti939.3.3): dummy EPG profile auto-assigned to master
    * event channels on every run. OPTIONAL — absent means off (the backend
    * never default-fills it). Must reference an existing dummy EPG profile.


### PR DESCRIPTION
Bead **enhancedchannelmanager-y8yby**. New per-rule config flag `refresh_providers_before_run` (default false): when on, a **manual** run of the rule (live **Run** and dry-run **Test**) first refreshes the M3U accounts backing the rule's master + secondary groups, then runs the match/attach — closing the refresh-ordering staleness window.

- **Engine**: pre-refresh hook in `_run_event_sync_rules`, per rule, gated by `not unattended` so the watermark **auto-run path never pre-refreshes** (test-pinned). Reuses `M3URefreshTask(account_ids=[...])`; group→account resolution via the existing by-provider group-settings map. **Best-effort** — a failed/partial provider refresh warns but the attach still proceeds.
- **UI**: editor Advanced (Behavior/Automation) toggle with an inline "Test is no longer zero-write" note; the per-rule **Test** gains a "Refresh & test" confirm explaining it triggers a real provider refresh; live-Run confirm gains a pre-refresh note — all only when the flag is on.
- **Docs**: `docs/event_sync.md` gains a "Refresh ordering, self-healing, and refresh-before-run" subsection + config-table row (documents the watermark self-heal behavior + this option).

No change to the matcher/resolver or what an attach does; auto-run path untouched. Gates: full backend suite 6778 pass / 0 fail; frontend tsc/eslint clean, vitest 1780 pass. Browser-verified (toggle + both warning surfaces; real refresh cancelled, rule restored). PO reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)