### PR TITLE
v0.17.6-0133: deflake iconOnlyButtons a11y test — explicit 60s budget for full-source static walk (bead 1lnco)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -140,7 +140,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0132",
+    version="0.17.6-0133",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -75,7 +75,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0132"
+APP_VERSION = "0.17.6-0133"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0132",
+  "version": "0.17.6-0133",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/a11y/iconOnlyButtons.a11y.test.ts
+++ b/frontend/src/a11y/iconOnlyButtons.a11y.test.ts
@@ -186,23 +186,35 @@ function findViolationsInFile(file: string): Violation[] {
 }
 
 describe('icon-only buttons have an accessible name (WCAG 4.1.2)', () => {
-  it('every button whose only content is a material-icons span has aria-label or aria-labelledby', () => {
-    const files: string[] = [];
-    walkTsxFiles(SRC_DIR, files);
+  it(
+    'every button whose only content is a material-icons span has aria-label or aria-labelledby',
+    () => {
+      const files: string[] = [];
+      walkTsxFiles(SRC_DIR, files);
 
-    const violations = files.flatMap(findViolationsInFile);
+      const violations = files.flatMap(findViolationsInFile);
 
-    if (violations.length > 0) {
-      const report = violations
-        .map((v) => `  ${v.file}:${v.line}  class="${v.className}"  icon(s)=[${v.icons.join(', ')}]`)
-        .join('\n');
-      throw new Error(
-        `${violations.length} icon-only button(s) expose the Material icon ligature as their only ` +
-          `accessible name. Add aria-label (describing the ACTION, e.g. "Delete channel" not "delete") ` +
-          `and aria-hidden="true" on the icon span:\n${report}`
-      );
-    }
+      if (violations.length > 0) {
+        const report = violations
+          .map((v) => `  ${v.file}:${v.line}  class="${v.className}"  icon(s)=[${v.icons.join(', ')}]`)
+          .join('\n');
+        throw new Error(
+          `${violations.length} icon-only button(s) expose the Material icon ligature as their only ` +
+            `accessible name. Add aria-label (describing the ACTION, e.g. "Delete channel" not "delete") ` +
+            `and aria-hidden="true" on the icon span:\n${report}`
+        );
+      }
 
-    expect(violations).toEqual([]);
-  });
+      expect(violations).toEqual([]);
+    },
+    // This is a static-analysis file walk (parse every .tsx under src/ with
+    // the TypeScript compiler API) -- I/O + CPU bound on file count and
+    // machine speed, not a hang risk. The default 5000ms vitest timeout
+    // flaked twice on busy CI runners (PR #698 run 29650141697, PR #701 run
+    // 29657847429) with zero frontend source touched by either PR -- a
+    // wall-clock budget mismatch, not a real regression. 60s gives generous
+    // headroom over the ~150-300ms this takes even on a loaded runner; if it
+    // ever legitimately takes that long, something is actually wrong.
+    60_000
+  );
 });


### PR DESCRIPTION
## Root Cause

`frontend/src/a11y/iconOnlyButtons.a11y.test.ts` walks all 133 non-test `.tsx` files under `src/` and parses each one with the full TypeScript compiler API (966 button-like elements checked). This is legitimate CPU/IO-bound static analysis with zero hang risk — it just takes longer than the default 5000ms vitest timeout under CI-runner contention.

Flaked twice at the default timeout:
- PR #698, run [29650141697](https://github.com/MotWakorb/enhancedchannelmanager/actions/runs/29650141697), job 88094980064
- PR #701, run [29657847429](https://github.com/MotWakorb/enhancedchannelmanager/actions/runs/29657847429), job 88115266894

Neither PR touched frontend source — same failure class as bead z6trk (PR #698): a wall-clock budget applied to machine-speed-dependent work.

## Fix

Gave the test an explicit 60,000ms timeout via vitest's `it(name, fn, timeout)` third-argument form. No changes to the file walker, TS-AST parser, or violation-detection logic — the diff is scoped entirely to the test's `describe`/`it` wrapper.

## Coverage Proof

Instrumented both the pre-fix (via `git show HEAD:...`) and post-fix versions with a temporary counter, ran each, then removed the instrumentation before committing:

| | files walked | buttons checked | violations |
|---|---|---|---|
| Before | 133 | 966 | 0 |
| After | 133 | 966 | 0 |

Identical — expected, since no analysis logic changed.

## Timing

10 consecutive runs of the fixed test: 408ms–460ms (avg ~440ms) — ~130x headroom under the new 60s budget, and comfortably under even the old 5s budget in normal conditions, confirming the flake was CI-runner contention, not typical runtime.

## Gates

- `npx vitest run src/a11y/iconOnlyButtons.a11y.test.ts`: pass, 453ms
- Full suite: 137 test files passed, 1968 tests passed, 0 failures
- `npx tsc --noEmit`: clean
- `eslint` on the changed file: clean
- `python scripts/check_version_consistency.py`: all 3 touchpoints agree at 0.17.6-0133
- `npm run build`: succeeds

## Version Bump

All three touchpoints bumped 0.17.6-0132 → 0.17.6-0133 per `docs/shipping.md` §3: `frontend/package.json`, `backend/routers/backup.py` (`APP_VERSION`), `backend/main.py` (`FastAPI(version=...)`).

## CHANGELOG

Skipped — test-only deflake, matching the bead-z6trk precedent (no standalone CHANGELOG entry for test-file-only changes).

Bead: enhancedchannelmanager-1lnco

🤖 Generated with [Claude Code](https://claude.com/claude-code)