### PR TITLE
Surface real Dispatcharr errors on channel-profile edits (lsctv, v0.17.6-0154)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -142,7 +142,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0153",
+    version="0.17.6-0154",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -76,7 +76,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0153"
+APP_VERSION = "0.17.6-0154"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/routers/profiles.py
+++ b/backend/routers/profiles.py
@@ -62,6 +62,12 @@ async def get_channel_profiles():
         logger.debug("[PROFILES] Fetched channel profiles in %.1fms", elapsed_ms)
         return result
     except Exception as e:
+        # An upstream 4xx (e.g. auth/validation) surfaces the actionable status
+        # + detail instead of an opaque 500 (bd-lsctv, GH #720).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[PROFILES] Fetch channel profiles rejected by Dispatcharr: %s", e)
+            raise mapped
         logger.exception("[PROFILES] Failed to fetch channel profiles")
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -79,6 +85,12 @@ async def create_channel_profile(request: Request):
         logger.info("[PROFILES] Created channel profile id=%s name=%s in %.1fms", result.get("id"), result.get("name"), elapsed_ms)
         return result
     except Exception as e:
+        # An upstream 4xx (e.g. validation, name conflict) surfaces the
+        # actionable status + detail instead of an opaque 500 (bd-lsctv, GH #720).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[PROFILES] Create channel profile rejected by Dispatcharr: %s", e)
+            raise mapped
         logger.exception("[PROFILES] Failed to create channel profile")
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -95,6 +107,12 @@ async def get_channel_profile(profile_id: int):
         logger.debug("[PROFILES] Fetched channel profile id=%s in %.1fms", profile_id, elapsed_ms)
         return result
     except Exception as e:
+        # An upstream 4xx (e.g. a 404 for a missing profile) surfaces the
+        # actionable status + detail instead of an opaque 500 (bd-lsctv, GH #720).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[PROFILES] Fetch channel profile %s rejected by Dispatcharr: %s", profile_id, e)
+            raise mapped
         logger.exception("[PROFILES] Failed to fetch channel profile id=%s", profile_id)
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -112,6 +130,13 @@ async def update_channel_profile(profile_id: int, request: Request):
         logger.info("[PROFILES] Updated channel profile id=%s in %.1fms", profile_id, elapsed_ms)
         return result
     except Exception as e:
+        # An upstream 4xx (e.g. validation, name conflict, missing profile)
+        # surfaces the actionable status + detail instead of an opaque 500
+        # (bd-lsctv, GH #720).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[PROFILES] Update channel profile %s rejected by Dispatcharr: %s", profile_id, e)
+            raise mapped
         logger.exception("[PROFILES] Failed to update channel profile id=%s", profile_id)
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -128,6 +153,13 @@ async def delete_channel_profile(profile_id: int):
         logger.info("[PROFILES] Deleted channel profile id=%s in %.1fms", profile_id, elapsed_ms)
         return {"status": "deleted"}
     except Exception as e:
+        # An upstream 4xx (e.g. a 404 for a missing profile, or a conflict)
+        # surfaces the actionable status + detail instead of an opaque 500
+        # (bd-lsctv, GH #720).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[PROFILES] Delete channel profile %s rejected by Dispatcharr: %s", profile_id, e)
+            raise mapped
         logger.exception("[PROFILES] Failed to delete channel profile id=%s", profile_id)
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -168,5 +200,12 @@ async def update_profile_channel(profile_id: int, channel_id: int, request: Requ
         logger.info("[PROFILES] Updated channel %s in profile %s in %.1fms", channel_id, profile_id, elapsed_ms)
         return result
     except Exception as e:
+        # An upstream 4xx (e.g. a missing profile/channel id, or validation)
+        # surfaces the actionable status + detail instead of an opaque 500
+        # (bd-lsctv, GH #720).
+        mapped = upstream_http_exception(e)
+        if mapped is not None:
+            logger.warning("[PROFILES] Update profile %s channel %s rejected by Dispatcharr: %s", profile_id, channel_id, e)
+            raise mapped
         logger.exception("[PROFILES] Failed to update profile channel profile_id=%s channel_id=%s", profile_id, channel_id)
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/tests/routers/test_profiles.py
+++ b/backend/tests/routers/test_profiles.py
@@ -86,7 +86,7 @@ class TestGetChannelProfiles:
 
     @pytest.mark.asyncio
     async def test_client_error(self, async_client):
-        """Returns 500 on client error."""
+        """Returns 500 on a genuine (non-HTTP) client error."""
         mock_client = AsyncMock()
         mock_client.get_channel_profiles.side_effect = Exception("Timeout")
 
@@ -94,6 +94,23 @@ class TestGetChannelProfiles:
             response = await async_client.get("/api/channel-profiles")
 
         assert response.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_upstream_4xx_surfaces_status_and_detail(self, async_client):
+        """An upstream 4xx surfaces its real status + detail, not an opaque 500
+        (bd-lsctv, GH #720)."""
+        request = httpx.Request("GET", "http://disp/api/channels/profiles/")
+        upstream = httpx.Response(400, request=request, text='{"detail": "Invalid filter param."}')
+        mock_client = AsyncMock()
+        mock_client.get_channel_profiles.side_effect = httpx.HTTPStatusError(
+            "400 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.profiles.get_client", return_value=mock_client):
+            response = await async_client.get("/api/channel-profiles")
+
+        assert response.status_code == 400
+        assert "Invalid filter param" in response.json()["detail"]
 
 
 class TestCreateChannelProfile:
@@ -117,6 +134,43 @@ class TestCreateChannelProfile:
         assert response.json() == {"id": 3, "name": "New Profile"}
         mock_client.create_channel_profile.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_upstream_4xx_surfaces_status_and_detail(self, async_client):
+        """An upstream 4xx (e.g. name conflict) surfaces its real status +
+        detail, not an opaque 500 (bd-lsctv, GH #720)."""
+        request = httpx.Request("POST", "http://disp/api/channels/profiles/")
+        upstream = httpx.Response(
+            400, request=request,
+            text='{"name": ["channel profile with this name already exists."]}',
+        )
+        mock_client = AsyncMock()
+        mock_client.create_channel_profile.side_effect = httpx.HTTPStatusError(
+            "400 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.profiles.get_client", return_value=mock_client):
+            response = await async_client.post(
+                "/api/channel-profiles",
+                json={"name": "Default"},
+            )
+
+        assert response.status_code == 400
+        assert "already exists" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_genuine_server_error_still_500(self, async_client):
+        """A non-upstream error stays a 500 (bd-lsctv, GH #720)."""
+        mock_client = AsyncMock()
+        mock_client.create_channel_profile.side_effect = RuntimeError("boom")
+
+        with patch("routers.profiles.get_client", return_value=mock_client):
+            response = await async_client.post(
+                "/api/channel-profiles",
+                json={"name": "New Profile"},
+            )
+
+        assert response.status_code == 500
+
 
 class TestGetChannelProfile:
     """Tests for GET /api/channel-profiles/{profile_id}."""
@@ -138,7 +192,7 @@ class TestGetChannelProfile:
 
     @pytest.mark.asyncio
     async def test_client_error(self, async_client):
-        """Returns 500 when client raises."""
+        """Returns 500 on a genuine (non-HTTP) client error."""
         mock_client = AsyncMock()
         mock_client.get_channel_profile.side_effect = Exception("Not found")
 
@@ -146,6 +200,23 @@ class TestGetChannelProfile:
             response = await async_client.get("/api/channel-profiles/999")
 
         assert response.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_upstream_4xx_surfaces_status_and_detail(self, async_client):
+        """An upstream 404 for a missing profile surfaces as 404 with detail,
+        not an opaque 500 (bd-lsctv, GH #720)."""
+        request = httpx.Request("GET", "http://disp/api/channels/profiles/999/")
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.get_channel_profile.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.profiles.get_client", return_value=mock_client):
+            response = await async_client.get("/api/channel-profiles/999")
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
 
 
 class TestUpdateChannelProfile:
@@ -168,6 +239,43 @@ class TestUpdateChannelProfile:
         assert response.status_code == 200
         mock_client.update_channel_profile.assert_called_once_with(1, {"name": "Updated Name"})
 
+    @pytest.mark.asyncio
+    async def test_upstream_4xx_surfaces_status_and_detail(self, async_client):
+        """An upstream 4xx (e.g. rename conflict) surfaces its real status +
+        detail, not an opaque 500 (bd-lsctv, GH #720)."""
+        request = httpx.Request("PATCH", "http://disp/api/channels/profiles/1/")
+        upstream = httpx.Response(
+            400, request=request,
+            text='{"name": ["channel profile with this name already exists."]}',
+        )
+        mock_client = AsyncMock()
+        mock_client.update_channel_profile.side_effect = httpx.HTTPStatusError(
+            "400 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.profiles.get_client", return_value=mock_client):
+            response = await async_client.patch(
+                "/api/channel-profiles/1",
+                json={"name": "Kids"},
+            )
+
+        assert response.status_code == 400
+        assert "already exists" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_genuine_server_error_still_500(self, async_client):
+        """A non-upstream error stays a 500 (bd-lsctv, GH #720)."""
+        mock_client = AsyncMock()
+        mock_client.update_channel_profile.side_effect = RuntimeError("boom")
+
+        with patch("routers.profiles.get_client", return_value=mock_client):
+            response = await async_client.patch(
+                "/api/channel-profiles/1",
+                json={"name": "Updated Name"},
+            )
+
+        assert response.status_code == 500
+
 
 class TestDeleteChannelProfile:
     """Tests for DELETE /api/channel-profiles/{profile_id}."""
@@ -186,7 +294,7 @@ class TestDeleteChannelProfile:
 
     @pytest.mark.asyncio
     async def test_client_error(self, async_client):
-        """Returns 500 when client raises."""
+        """Returns 500 on a genuine (non-HTTP) client error."""
         mock_client = AsyncMock()
         mock_client.delete_channel_profile.side_effect = Exception("Error")
 
@@ -194,6 +302,23 @@ class TestDeleteChannelProfile:
             response = await async_client.delete("/api/channel-profiles/999")
 
         assert response.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_upstream_4xx_surfaces_status_and_detail(self, async_client):
+        """An upstream 404 for a missing profile surfaces as 404 with detail,
+        not an opaque 500 (bd-lsctv, GH #720)."""
+        request = httpx.Request("DELETE", "http://disp/api/channels/profiles/999/")
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.delete_channel_profile.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.profiles.get_client", return_value=mock_client):
+            response = await async_client.delete("/api/channel-profiles/999")
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]
 
 
 class TestBulkUpdateProfileChannels:
@@ -292,7 +417,7 @@ class TestUpdateProfileChannel:
 
     @pytest.mark.asyncio
     async def test_client_error(self, async_client):
-        """Returns 500 when client raises."""
+        """Returns 500 on a genuine (non-HTTP) client error."""
         mock_client = AsyncMock()
         mock_client.update_profile_channel.side_effect = Exception("Error")
 
@@ -303,3 +428,23 @@ class TestUpdateProfileChannel:
             )
 
         assert response.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_upstream_4xx_surfaces_status_and_detail(self, async_client):
+        """An upstream 4xx (e.g. missing profile/channel id) surfaces its real
+        status + detail, not an opaque 500 (bd-lsctv, GH #720)."""
+        request = httpx.Request("PATCH", "http://disp/api/channels/profiles/1/channels/999/")
+        upstream = httpx.Response(404, request=request, text='{"detail": "Not found."}')
+        mock_client = AsyncMock()
+        mock_client.update_profile_channel.side_effect = httpx.HTTPStatusError(
+            "404 Client Error", request=request, response=upstream
+        )
+
+        with patch("routers.profiles.get_client", return_value=mock_client):
+            response = await async_client.patch(
+                "/api/channel-profiles/1/channels/999",
+                json={"enabled": False},
+            )
+
+        assert response.status_code == 404
+        assert "Not found" in response.json()["detail"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0153",
+  "version": "0.17.6-0154",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Surface real Dispatcharr errors on channel-profile edits (bead lsctv, GH #720 follow-up)

Editing Channel Profiles in the Channel Manager threw a red "Profiles" toast whose only detail was **"Internal server error"** — because `backend/routers/profiles.py` blanket-mapped almost every upstream (Dispatcharr) failure to `HTTPException(500, "Internal server error")`, discarding the real status code and body. So a 4xx from Dispatcharr (a validation error, a name conflict, a 404) reached the operator as an opaque 500 with no clue what actually failed.

### Fix
Extend the **`upstream_http_exception`** idiom — already used correctly by `bulk_update_profile_channels` — to the six masking channel-profile handlers, so a genuine upstream 4xx surfaces its **true status + detail**, with the generic 500 kept only for genuinely-unexpected (non-HTTP) errors.

Handlers fixed (each: `mapped = upstream_http_exception(e); if mapped: log + raise mapped;` else the existing `logger.exception` + `HTTPException(500)`):
- `get_channel_profiles` (LIST)
- `create_channel_profile` (CREATE)
- `get_channel_profile` (GET single)
- `update_channel_profile` (UPDATE / rename)
- `delete_channel_profile` (DELETE)
- `update_profile_channel` (single-membership)

Success paths, logging, and responses are untouched — the change is confined to each `except` block. Stream-profile handlers are out of scope (left as-is). No info leak: only Dispatcharr's own 4xx body is surfaced (via `_format_upstream_detail`); 5xx / connection / internal errors still yield the generic 500.

### Scope note
This is a **diagnosability** fix — it makes the true error visible. It does not itself fix the reporter's environment-specific upstream failure (that needs their logs, which the surfaced detail will now provide).

### Tests
Per handler: a real `httpx.HTTPStatusError` (4xx + body) now surfaces that status + detail (would fail against the pre-fix bare-500); plus the "genuine non-HTTP error still 500" contract retained for each. `test_profiles.py`: **25 passed**.

### Gates
- Backend full suite: **7860 passed, 13 skipped**
- Frontend `tsc --noEmit`: clean (only `package.json` version touched)
- Version consistency: all three touchpoints at **0.17.6-0154**

Version bumped `0.17.6-0153 → 0.17.6-0154`. No closing keyword — GH #720 is already closed for the original issue; this is the separately-tracked edit-error follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
