### PR TITLE
Provider catch-up badge in the M3U manager (4dpiz, v0.17.6-0156)

### DIFF
--- a/backend/dispatcharr_client.py
+++ b/backend/dispatcharr_client.py
@@ -452,8 +452,16 @@ class DispatcharrClient:
         search: Optional[str] = None,
         channel_group_name: Optional[str] = None,
         m3u_account: Optional[int] = None,
+        is_catchup: Optional[bool] = None,
     ) -> dict:
-        """Get paginated list of streams."""
+        """Get paginated list of streams.
+
+        ``is_catchup`` filters by Dispatcharr's catch-up flag when set. The flag
+        is ``db_index=True`` upstream, so a ``page_size=1`` request with
+        ``is_catchup=True`` is a cheap indexed count query — used by the
+        provider catch-up badge (bead 4dpiz) to detect whether a provider has
+        any catch-up stream via the paginated ``count``.
+        """
         params = {"page": page, "page_size": page_size}
         if search:
             params["search"] = search
@@ -464,6 +472,9 @@ class DispatcharrClient:
         # channel_group=0 bug in get_channels).
         if m3u_account is not None:
             params["m3u_account"] = m3u_account
+        # Dispatcharr's BooleanFilter expects the lowercase string form.
+        if is_catchup is not None:
+            params["is_catchup"] = "true" if is_catchup else "false"
 
         response = await self._request("GET", "/api/channels/streams/", params=params)
         response.raise_for_status()

--- a/backend/main.py
+++ b/backend/main.py
@@ -142,7 +142,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0155",
+    version="0.17.6-0156",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -76,7 +76,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0155"
+APP_VERSION = "0.17.6-0156"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/routers/streams.py
+++ b/backend/routers/streams.py
@@ -4,6 +4,7 @@ Streams & providers router — stream listing and provider endpoints.
 Extracted from main.py (Phase 2 of v0.13.0 backend refactor).
 Enriched with server-side normalization in v0.15.0.
 """
+import asyncio
 import logging
 import time
 from enum import Enum
@@ -396,6 +397,68 @@ async def get_providers():
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.get("/api/providers/catchup-status", tags=["Providers"])
+async def get_provider_catchup_status():
+    """Per-M3U-account catch-up availability for the M3U manager badge (bead 4dpiz).
+
+    For each provider we ask Dispatcharr for a single catch-up stream
+    (``is_catchup=true``, ``page_size=1``) and read the paginated ``count``:
+    ``count > 0`` means the provider has at least one catch-up stream. The one
+    returned row's ``catchup_days`` is sampled as the provider's catch-up depth
+    — Dispatcharr sets catch-up depth per-provider (verified provider-uniform on
+    live data), and its streams endpoint does NOT honour an ``ordering`` param,
+    so a guaranteed maximum would require an O(catch-up-streams) scan we
+    deliberately avoid.
+
+    ``is_catchup`` is ``db_index=True`` upstream, so each probe is a cheap
+    indexed count query — O(providers) total, run concurrently. Best-effort per
+    account: a probe failure degrades that account to ``has_catchup=false``
+    (logged), never 500s the whole M3U manager.
+
+    Returns ``{ "<account_id>": {"has_catchup": bool, "catchup_days": int|null} }``.
+    """
+    logger.debug("[STREAMS] GET /api/providers/catchup-status")
+    client = get_client()
+    try:
+        accounts = await client.get_m3u_accounts()
+    except Exception as e:
+        logger.warning("[STREAMS] catchup-status: could not list M3U accounts: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+    async def _probe(account: dict):
+        account_id = account.get("id")
+        try:
+            page = await client.get_streams(
+                m3u_account=account_id, is_catchup=True, page_size=1
+            )
+            count = page.get("count") or 0
+            results = page.get("results") or []
+            days = results[0].get("catchup_days") if results else None
+            return account_id, {
+                "has_catchup": count > 0,
+                "catchup_days": days if count > 0 else None,
+            }
+        except Exception as e:
+            logger.warning(
+                "[STREAMS] catchup-status: probe failed for account %s: %s",
+                account_id, e,
+            )
+            return account_id, {"has_catchup": False, "catchup_days": None}
+
+    start = time.time()
+    probes = await asyncio.gather(*(_probe(a) for a in accounts))
+    elapsed_ms = (time.time() - start) * 1000
+    logger.debug(
+        "[STREAMS] Probed catch-up status for %d providers in %.1fms",
+        len(probes), elapsed_ms,
+    )
+    return {
+        str(account_id): status
+        for account_id, status in probes
+        if account_id is not None
+    }
 
 
 @router.get("/api/providers/group-settings", tags=["Providers"])

--- a/backend/tests/routers/test_streams.py
+++ b/backend/tests/routers/test_streams.py
@@ -243,6 +243,86 @@ class TestGetProviders:
         assert response.status_code == 500
 
 
+class TestGetProviderCatchupStatus:
+    """Tests for GET /api/providers/catchup-status endpoint (bead 4dpiz)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_has_catchup_per_account(self, async_client):
+        """has_catchup=true for an account with a catch-up stream, false without."""
+        mock_client = AsyncMock()
+        mock_client.get_m3u_accounts.return_value = [
+            {"id": 1, "name": "HasCatchup"},
+            {"id": 2, "name": "NoCatchup"},
+        ]
+
+        def fake_get_streams(*, m3u_account, is_catchup, page_size):
+            # The endpoint must ask for exactly one catch-up stream.
+            assert is_catchup is True
+            assert page_size == 1
+            if m3u_account == 1:
+                return {"count": 42, "results": [{"catchup_days": 5}]}
+            return {"count": 0, "results": []}
+
+        mock_client.get_streams.side_effect = fake_get_streams
+
+        with patch("routers.streams.get_client", return_value=mock_client):
+            response = await async_client.get("/api/providers/catchup-status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["1"] == {"has_catchup": True, "catchup_days": 5}
+        assert data["2"] == {"has_catchup": False, "catchup_days": None}
+
+    @pytest.mark.asyncio
+    async def test_account_probe_failure_degrades_to_false(self, async_client):
+        """A per-account upstream failure degrades to has_catchup=false, not a 500."""
+        mock_client = AsyncMock()
+        mock_client.get_m3u_accounts.return_value = [
+            {"id": 1, "name": "Healthy"},
+            {"id": 2, "name": "Broken"},
+        ]
+
+        def fake_get_streams(*, m3u_account, is_catchup, page_size):
+            if m3u_account == 2:
+                raise Exception("upstream 500")
+            return {"count": 3, "results": [{"catchup_days": 2}]}
+
+        mock_client.get_streams.side_effect = fake_get_streams
+
+        with patch("routers.streams.get_client", return_value=mock_client):
+            response = await async_client.get("/api/providers/catchup-status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["1"] == {"has_catchup": True, "catchup_days": 2}
+        assert data["2"] == {"has_catchup": False, "catchup_days": None}
+
+    @pytest.mark.asyncio
+    async def test_accounts_list_failure_returns_500(self, async_client):
+        """If the account list itself can't be fetched, surface a 500."""
+        mock_client = AsyncMock()
+        mock_client.get_m3u_accounts.side_effect = Exception("Timeout")
+
+        with patch("routers.streams.get_client", return_value=mock_client):
+            response = await async_client.get("/api/providers/catchup-status")
+
+        assert response.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_catchup_days_omitted_when_no_catchup(self, async_client):
+        """catchup_days is null when the provider has no catch-up streams even if
+        a stray row is returned (count is authoritative)."""
+        mock_client = AsyncMock()
+        mock_client.get_m3u_accounts.return_value = [{"id": 7, "name": "Empty"}]
+        mock_client.get_streams.return_value = {"count": 0, "results": []}
+
+        with patch("routers.streams.get_client", return_value=mock_client):
+            response = await async_client.get("/api/providers/catchup-status")
+
+        assert response.status_code == 200
+        assert response.json()["7"] == {"has_catchup": False, "catchup_days": None}
+
+
 class TestGetProviderGroupSettings:
     """Tests for GET /api/providers/group-settings endpoint."""
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0155",
+  "version": "0.17.6-0156",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/CatchupBadge.test.tsx
+++ b/frontend/src/components/CatchupBadge.test.tsx
@@ -77,4 +77,17 @@ describe('CatchupBadge', () => {
     const { container } = render(<CatchupBadge isCatchup={true} catchupDays={7} className="my-extra-class" />);
     expect(container.querySelector('.catchup-badge.my-extra-class')).toBeInTheDocument();
   });
+
+  // --- title override (bead 4dpiz provider badge) ---
+
+  it('overrides the tooltip/aria-label with the title prop, leaving the compact label intact', () => {
+    const { container } = render(
+      <CatchupBadge isCatchup={true} catchupDays={7} title="Provider supports catch-up — up to 7 days" />
+    );
+    const badge = container.querySelector('.catchup-badge');
+    expect(badge?.getAttribute('title')).toBe('Provider supports catch-up — up to 7 days');
+    expect(badge?.getAttribute('aria-label')).toBe('Provider supports catch-up — up to 7 days');
+    // Visible compact label is unaffected by the title override.
+    expect(container.querySelector('.catchup-badge__text')?.textContent).toBe('7d');
+  });
 });

--- a/frontend/src/components/CatchupBadge.tsx
+++ b/frontend/src/components/CatchupBadge.tsx
@@ -28,16 +28,24 @@ export interface CatchupBadgeProps {
   catchupDays?: number;
   /** Additional CSS class names on the outer <span>. */
   className?: string;
+  /**
+   * Tooltip / aria-label override. When omitted the badge derives its own
+   * copy from the day count (e.g. "Catch-up: 5 days"). Callers that need
+   * context-specific wording — the provider badge (bead 4dpiz) says
+   * "Provider supports catch-up …" — pass it here instead of forking the
+   * component. The visible compact label is unaffected.
+   */
+  title?: string;
 }
 
-export function CatchupBadge({ isCatchup, catchupDays, className }: CatchupBadgeProps) {
+export function CatchupBadge({ isCatchup, catchupDays, className, title }: CatchupBadgeProps) {
   // Flag is authoritative — never infer support from catchupDays.
   if (isCatchup !== true) return null;
 
   const hasDays = typeof catchupDays === 'number' && catchupDays > 0;
-  const label = hasDays
+  const label = title ?? (hasDays
     ? `Catch-up: ${catchupDays} day${catchupDays === 1 ? '' : 's'}`
-    : 'Catch-up available';
+    : 'Catch-up available');
   const classes = ['catchup-badge', className].filter(Boolean).join(' ');
 
   return (

--- a/frontend/src/components/tabs/M3UManagerTab.test.tsx
+++ b/frontend/src/components/tabs/M3UManagerTab.test.tsx
@@ -76,6 +76,8 @@ describe('M3UManagerTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(api.getSettings).mockResolvedValue({} as never);
+    // Default: no catch-up anywhere (bead 4dpiz). Individual tests override.
+    vi.mocked(api.getProviderCatchupStatus).mockResolvedValue({});
   });
 
   describe('Server Groups management (bead hq3de.c)', () => {
@@ -176,6 +178,42 @@ describe('M3UManagerTab', () => {
       await waitFor(() => expect(screen.getByText('Xtream Account')).toBeInTheDocument());
 
       expect(screen.getByLabelText('Refresh VOD content')).toBeDisabled();
+    });
+  });
+
+  describe('Provider catch-up badge (bead 4dpiz)', () => {
+    it('renders the catch-up badge on a provider row when has_catchup is true', async () => {
+      vi.mocked(api.getM3UAccounts).mockResolvedValue([
+        makeAccount({ id: 1, name: 'Catchup Provider' }),
+      ]);
+      vi.mocked(api.getServerGroups).mockResolvedValue([]);
+      vi.mocked(api.getProviderCatchupStatus).mockResolvedValue({
+        '1': { has_catchup: true, catchup_days: 5 },
+      });
+
+      renderWithProviders(<M3UManagerTab />);
+      await waitFor(() => expect(screen.getByText('Catchup Provider')).toBeInTheDocument());
+
+      await waitFor(() =>
+        expect(
+          screen.getByLabelText('Provider supports catch-up — up to 5 days')
+        ).toBeInTheDocument()
+      );
+    });
+
+    it('renders NO catch-up badge when has_catchup is false', async () => {
+      vi.mocked(api.getM3UAccounts).mockResolvedValue([
+        makeAccount({ id: 1, name: 'No Catchup Provider' }),
+      ]);
+      vi.mocked(api.getServerGroups).mockResolvedValue([]);
+      vi.mocked(api.getProviderCatchupStatus).mockResolvedValue({
+        '1': { has_catchup: false, catchup_days: null },
+      });
+
+      renderWithProviders(<M3UManagerTab />);
+      await waitFor(() => expect(screen.getByText('No Catchup Provider')).toBeInTheDocument());
+
+      expect(screen.queryByLabelText(/provider supports catch-up/i)).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/tabs/M3UManagerTab.tsx
+++ b/frontend/src/components/tabs/M3UManagerTab.tsx
@@ -11,6 +11,7 @@ import { M3UFiltersModal } from '../M3UFiltersModal';
 import { M3ULinkedAccountsModal } from '../M3ULinkedAccountsModal';
 import { M3UProfileModal } from '../M3UProfileModal';
 import { CustomSelect } from '../CustomSelect';
+import { CatchupBadge } from '../CatchupBadge';
 import { PageHeader } from '../PageHeader';
 import { OverflowMenu } from '../OverflowMenu';
 import type { OverflowMenuItem } from '../OverflowMenu';
@@ -49,6 +50,10 @@ interface M3UAccountRowProps {
   onPriorityChange?: (accountId: number, priority: number) => void;
   isBeingRefreshed?: boolean;  // Whether we're tracking this account as still refreshing
   isRefreshingVod?: boolean;
+  // Provider catch-up badge (bead 4dpiz): true when ANY stream on this provider
+  // supports catch-up; catchupDays is the provider's sampled catch-up depth.
+  hasCatchup?: boolean;
+  catchupDays?: number;
 }
 
 function M3UAccountRow({
@@ -67,6 +72,8 @@ function M3UAccountRow({
   onPriorityChange,
   isBeingRefreshed = false,
   isRefreshingVod = false,
+  hasCatchup = false,
+  catchupDays,
 }: M3UAccountRowProps) {
   // Consider refreshing if status says so OR if we're tracking it as refreshing
   const isRefreshing = isBeingRefreshed || account.status === 'fetching' || account.status === 'parsing';
@@ -148,6 +155,15 @@ function M3UAccountRow({
               <span className="profile-count">{account.profiles.length - 1}</span>
             </span>
           )}
+          <CatchupBadge
+            isCatchup={hasCatchup}
+            catchupDays={catchupDays}
+            title={
+              typeof catchupDays === 'number' && catchupDays > 0
+                ? `Provider supports catch-up — up to ${catchupDays} day${catchupDays === 1 ? '' : 's'}`
+                : 'Provider supports catch-up'
+            }
+          />
         </div>
         <div className="account-details">
           <span className={`account-type ${account.account_type.toLowerCase()}`}>
@@ -307,6 +323,8 @@ export function M3UManagerTab({
 }: M3UManagerTabProps) {
   const notifications = useNotifications();
   const [accounts, setAccounts] = useState<M3UAccount[]>([]);
+  // Per-provider catch-up status (bead 4dpiz), keyed by account id string.
+  const [catchupStatus, setCatchupStatus] = useState<Record<string, api.ProviderCatchupStatus>>({});
   const [serverGroups, setServerGroups] = useState<ServerGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
@@ -366,6 +384,13 @@ export function M3UManagerTab({
       notifications.error(err instanceof Error ? err.message : 'Failed to load M3U accounts', 'M3U Manager');
     } finally {
       setLoading(false);
+    }
+    // Best-effort catch-up badges (bead 4dpiz): a failure here must never block
+    // or fault the M3U manager — degrade silently to no badges.
+    try {
+      setCatchupStatus((await api.getProviderCatchupStatus()) ?? {});
+    } catch {
+      setCatchupStatus({});
     }
   }, [notifications]);
 
@@ -881,6 +906,8 @@ export function M3UManagerTab({
                 priority={pendingPriorities[String(account.id)] ?? 0}
                 onPriorityChange={handlePriorityChange}
                 isBeingRefreshed={refreshingAccounts.has(account.id)}
+                hasCatchup={catchupStatus[String(account.id)]?.has_catchup ?? false}
+                catchupDays={catchupStatus[String(account.id)]?.catchup_days ?? undefined}
               />
             ))}
           </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -732,6 +732,19 @@ export async function getProviderGroupSettings(): Promise<Record<number, M3UGrou
   return fetchJson(`${API_BASE}/providers/group-settings`);
 }
 
+/** Per-provider catch-up availability for the M3U manager badge (bead 4dpiz).
+ *  `has_catchup` is authoritative (true when the provider has ≥1 catch-up
+ *  stream); `catchup_days` is the provider's sampled catch-up depth (null when
+ *  no catch-up). Keyed by M3U account id as a string. */
+export interface ProviderCatchupStatus {
+  has_catchup: boolean;
+  catchup_days: number | null;
+}
+
+export async function getProviderCatchupStatus(): Promise<Record<string, ProviderCatchupStatus>> {
+  return fetchJson(`${API_BASE}/providers/catchup-status`);
+}
+
 /** One (provider, channel-group) junction row — NON-collapsed. bead 38dzi:
  *  powers the provider-scoped Event Sync group picker (the same channel-group
  *  id can appear under multiple providers). Join on channel_group_id against


### PR DESCRIPTION
## Provider catch-up badge in the M3U manager (bead 4dpiz)

Follow-on to the channel/stream catch-up badges (sy1sz). Shows a catch-up badge on an M3U provider/account row when ECM detects that any stream for that provider supports catch-up.

### Approach — cheap indexed aggregation (investigated first)
Confirmed (verified live against Dispatcharr) that its streams endpoint honors an `is_catchup=true` filter, and `is_catchup` is `db_index=True` upstream. So the per-provider check is a **cheap O(providers) indexed count query** (`GET /api/channels/streams/?m3u_account=X&is_catchup=true&page_size=1` → `count > 0`), run concurrently — not a scan of all streams.

### Backend
- `dispatcharr_client.get_streams()` gains an optional `is_catchup` filter param.
- New read-only endpoint **`GET /api/providers/catchup-status`** → `{ "<account_id>": { "has_catchup": bool, "catchup_days": int|null } }`. Per-account probes run via `asyncio.gather`. **Resilient:** a per-account probe failure degrades that account to `has_catchup:false` (logged), never 500s the manager; only a failed account-list fetch 500s. No user input to the endpoint (account IDs come from Dispatcharr's own account list).

### Frontend
- Renders the shared `CatchupBadge` on each provider row in `M3UManagerTab` when `has_catchup === true` (flag authoritative). `CatchupBadge` gained an optional `title` prop so provider-context tooltip copy is passed in without forking the component. Fetch is best-effort — a catchup-status failure degrades to no provider badges, never faults the manager.

### Known simplification (transparent)
`catchup_days` is **sampled** from the single returned stream row, not a guaranteed max across the provider's streams — Dispatcharr doesn't honor an `ordering` param on that query, so a cheap max isn't available, and provider catch-up depth is uniform in practice (verified). The field is named `catchup_days` (not `_max`) to avoid overclaiming. If a provider ever mixed depths, the tooltip's day count could reflect one stream's value rather than the max — acceptable for the home-lab tier; flagging for review.

### Tests
- Backend (`test_streams.py::TestGetProviderCatchupStatus`): per-account has_catchup true/false + days; a per-account probe failure degrades to false (200, not 500); account-list failure → 500; days omitted when no catch-up.
- Frontend: provider row with `has_catchup:true` shows the badge, without it none; `CatchupBadge` title-override test.

### Gates
- Backend full suite: **7864 passed, 13 skipped**
- Frontend: **2200 passed**; `tsc`, `vite build`, `eslint --max-warnings 0` clean
- Version consistency: all three touchpoints at **0.17.6-0156**
- Live end-to-end verified against real Dispatcharr (providers correctly flagged true/false with their day counts).

Version bumped `0.17.6-0155 → 0.17.6-0156`. Reuses the `CatchupBadge` from sy1sz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
