### PR TITLE
Fix flaky MultiProviderAutoSyncToggle test — settings-load race (72txx, v0.17.6-0163)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -142,7 +142,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0162",
+    version="0.17.6-0163",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -76,7 +76,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0162"
+APP_VERSION = "0.17.6-0163"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0162",
+  "version": "0.17.6-0163",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/settings/MultiProviderAutoSyncToggle.test.tsx
+++ b/frontend/src/components/settings/MultiProviderAutoSyncToggle.test.tsx
@@ -239,8 +239,16 @@ describe('Multi-provider auto-sync toggle (bd-dgs64, GH #591)', () => {
     vi.mocked(api.getSettings).mockResolvedValue(makeSettings({ allow_multi_provider_auto_sync: true }));
     renderOnGeneral();
 
+    // The checkbox is unconditionally rendered from the component's
+    // `useState(false)` default, so `findByLabelText` resolves as soon as the
+    // element exists in the DOM -- which can happen before the mocked
+    // `getSettings()` promise has resolved and re-rendered it as checked.
+    // Under CI's heavier scheduling (coverage instrumentation, loaded
+    // runner) that ordering isn't guaranteed, so read `.checked` inside
+    // `waitFor` and let it re-poll until the loaded value has actually
+    // landed, instead of asserting on a single synchronous read.
     const checkbox = await screen.findByLabelText(/Allow multi-provider auto-sync/i) as HTMLInputElement;
-    expect(checkbox.checked).toBe(true);
+    await waitFor(() => expect(checkbox.checked).toBe(true));
   });
 
   it('renders unchecked when loaded settings have it disabled (default)', async () => {


### PR DESCRIPTION
## Summary
- Fixes the CI flake in `MultiProviderAutoSyncToggle.test.tsx` ('renders checked when loaded settings have it enabled') seen on dev push `baa761e8` (Tests run 30141983946).
- Root cause: the assertion read `checkbox.checked` synchronously right after `findByLabelText`, which can resolve on the initial (unchecked) render before the mocked `getSettings()` promise resolves. Test-only race — no component change.
- Fix: `await waitFor(() => expect(checkbox.checked).toBe(true))`, matching the pattern used elsewhere in the suite.

## Testing
- Single test file 20/20 passes in a repeat loop
- `npm run lint`, `npm run typecheck`, full `npm run test:coverage` (156 files / 2223 tests) green
- `scripts/check_version_consistency.py` passes at 0.17.6-0163

Bead: enhancedchannelmanager-72txx

🤖 Generated with [Claude Code](https://claude.com/claude-code)