### PR TITLE
Fix flaky EPG preview-token tamper test — base64 padding-bit no-op (zfp2z, v0.17.6-0164)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -142,7 +142,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0162",
+    version="0.17.6-0164",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -76,7 +76,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0162"
+APP_VERSION = "0.17.6-0164"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/tests/routers/test_epg.py
+++ b/backend/tests/routers/test_epg.py
@@ -6,6 +6,7 @@ Tests: 12 endpoints covering EPG sources CRUD, refresh, import,
 Mocks: get_client() to isolate from Dispatcharr.
 """
 import asyncio
+import base64
 import httpx
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -100,6 +101,28 @@ async def _poll_migration(async_client, accepted):
             return body
         await asyncio.sleep(0)
     raise AssertionError("migration job did not reach a terminal state")
+
+
+def _tamper_preview_signature(token: str) -> str:
+    """Return ``token`` with a genuinely-different signature.
+
+    Decoding the signature, flipping a byte, and re-encoding guarantees the
+    HMAC bytes differ. Flipping the last *base64 char* of the signature is not
+    a reliable tamper: the final char of a 32-byte signature only carries the
+    low nibble of the last byte, so its two low bits are padding. Changing it
+    within the same nibble group (e.g. "A" -> "B") re-encodes to identical
+    signature bytes, leaving the token valid ~1/16 of the time (flaky 202
+    instead of 409). See bead enhancedchannelmanager-zfp2z.
+    """
+    encoded, encoded_signature = token.split(".", 1)
+    signature = bytearray(
+        base64.urlsafe_b64decode(
+            encoded_signature + "=" * (-len(encoded_signature) % 4)
+        )
+    )
+    signature[0] ^= 0xFF
+    flipped = base64.urlsafe_b64encode(bytes(signature)).rstrip(b"=").decode()
+    return f"{encoded}.{flipped}"
 
 
 class TestGuideMigration:
@@ -743,7 +766,7 @@ class TestGuideMigration:
             now=0 if token_kind == "expired" else None,
         )
         if token_kind == "tampered":
-            token = token[:-1] + ("A" if token[-1] != "A" else "B")
+            token = _tamper_preview_signature(token)
         with patch("routers.epg.get_jwt_secret_key", return_value=secret):
             response = await async_client.post(
                 "/api/epg/migration/apply",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0162",
+  "version": "0.17.6-0164",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Fixes the CI flake in `test_epg.py::TestGuideMigration::test_apply_rejects_invalid_preview_tokens_at_acceptance[tampered]` (202 vs 409) seen on dev push `17075ce3` (Tests run 30066263282).
- Root cause (reproduced deterministically): the test tampered the token by flipping the last base64 char of the HMAC signature. When that char is `A` (~1/16 of tokens), replacing it with `B` only changes padding bits that `urlsafe_b64decode` ignores — the decoded signature bytes are identical, so the 'tampered' token is genuinely valid and the 202 is CORRECT. Measured 6.09% flake rate over 20k tokens, matching 1/16.
- **Not a product validation gap** — `verify_preview_token` is unchanged and correct. The Dispatcharr 'missing http:// protocol' errors in the failing run were downstream symptoms of the correctly-accepted apply running against the unconfigured test client.
- Fix: new `_tamper_preview_signature` helper decodes the signature, flips a byte (`^= 0xFF`), re-encodes — guaranteed-different HMAC bytes.

## Testing
- Fixed test 20/20 in a repeat loop (pre-fix: failure deterministically reproduced by forcing last-char `A`)
- Full CI-equivalent backend suite: 7824 passed, 12 skipped (pre-existing env skips), 2 deselected
- `scripts/check_version_consistency.py` passes at 0.17.6-0164

Bead: enhancedchannelmanager-zfp2z

🤖 Generated with [Claude Code](https://claude.com/claude-code)