### PR TITLE
CI: bounded retry/backoff on registry-network steps in Docker build workflow (n6197, v0.17.6-0165)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -398,7 +398,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # Retry on transient registry timeouts pulling the buildkit builder image
+      # (e.g. "net/http: request canceled while waiting for connection" against
+      # registry-1.docker.io). See bd-n6197: run 30144328147 failed here on a
+      # one-off Docker Hub blip while the build/push jobs on the same commit
+      # succeeded. docker/setup-buildx-action has no built-in retry input, so
+      # this duplicates the step with continue-on-error, matching the
+      # build-push-action retry pattern used elsewhere in this file.
       - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+        continue-on-error: true
+
+      - name: Wait before Buildx retry
+        if: steps.buildx.outcome == 'failure'
+        run: |
+          echo "::warning::Docker Buildx setup failed (likely transient registry timeout pulling the buildkit image). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Set up Docker Buildx — retry
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
 
       - name: Extract version and set release channel
@@ -506,11 +525,48 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # Retry on transient registry timeouts pulling the buildkit builder image
+      # (e.g. "net/http: request canceled while waiting for connection" against
+      # registry-1.docker.io). See bd-n6197: run 30144328147 failed here on a
+      # one-off Docker Hub blip while the build/push jobs on the same commit
+      # succeeded. docker/setup-buildx-action has no built-in retry input, so
+      # this duplicates the step with continue-on-error, matching the
+      # build-push-action retry pattern used elsewhere in this file.
       - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+        continue-on-error: true
+
+      - name: Wait before Buildx retry
+        if: steps.buildx.outcome == 'failure'
+        run: |
+          echo "::warning::Docker Buildx setup failed (likely transient registry timeout pulling the buildkit image). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Set up Docker Buildx — retry
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
 
+      # Retry on transient registry-connect timeouts (bd-n6197), mirroring the
+      # Buildx-setup retry above and the build-push-action retry pattern.
       - name: Log in to Container Registry
+        id: login
         if: github.event_name != 'pull_request'
+        continue-on-error: true
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait before registry login retry
+        if: github.event_name != 'pull_request' && steps.login.outcome == 'failure'
+        run: |
+          echo "::warning::Container registry login failed (likely transient network timeout). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Log in to Container Registry — retry
+        if: github.event_name != 'pull_request' && steps.login.outcome == 'failure'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -630,7 +686,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # Retry on transient registry timeouts pulling the buildkit builder image
+      # (e.g. "net/http: request canceled while waiting for connection" against
+      # registry-1.docker.io). See bd-n6197: run 30144328147 failed here on a
+      # one-off Docker Hub blip while the build/push jobs on the same commit
+      # succeeded. docker/setup-buildx-action has no built-in retry input, so
+      # this duplicates the step with continue-on-error, matching the
+      # build-push-action retry pattern used elsewhere in this file.
       - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+        continue-on-error: true
+
+      - name: Wait before Buildx retry
+        if: steps.buildx.outcome == 'failure'
+        run: |
+          echo "::warning::Docker Buildx setup failed (likely transient registry timeout pulling the buildkit image). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Set up Docker Buildx — retry
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
 
       - name: Extract version and set release channel
@@ -684,11 +759,48 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # Retry on transient registry timeouts pulling the buildkit builder image
+      # (e.g. "net/http: request canceled while waiting for connection" against
+      # registry-1.docker.io). See bd-n6197: run 30144328147 failed here on a
+      # one-off Docker Hub blip while the build/push jobs on the same commit
+      # succeeded. docker/setup-buildx-action has no built-in retry input, so
+      # this duplicates the step with continue-on-error, matching the
+      # build-push-action retry pattern used elsewhere in this file.
       - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+        continue-on-error: true
+
+      - name: Wait before Buildx retry
+        if: steps.buildx.outcome == 'failure'
+        run: |
+          echo "::warning::Docker Buildx setup failed (likely transient registry timeout pulling the buildkit image). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Set up Docker Buildx — retry
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
 
+      # Retry on transient registry-connect timeouts (bd-n6197), mirroring the
+      # Buildx-setup retry above and the build-push-action retry pattern.
       - name: Log in to Container Registry
+        id: login
         if: github.event_name != 'pull_request'
+        continue-on-error: true
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait before registry login retry
+        if: github.event_name != 'pull_request' && steps.login.outcome == 'failure'
+        run: |
+          echo "::warning::Container registry login failed (likely transient network timeout). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Log in to Container Registry — retry
+        if: github.event_name != 'pull_request' && steps.login.outcome == 'failure'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -804,7 +916,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # Retry on transient registry timeouts pulling the buildkit builder image
+      # (e.g. "net/http: request canceled while waiting for connection" against
+      # registry-1.docker.io). See bd-n6197: run 30144328147 failed here on a
+      # one-off Docker Hub blip while the build/push jobs on the same commit
+      # succeeded. docker/setup-buildx-action has no built-in retry input, so
+      # this duplicates the step with continue-on-error, matching the
+      # build-push-action retry pattern used elsewhere in this file.
       - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+        continue-on-error: true
+
+      - name: Wait before Buildx retry
+        if: steps.buildx.outcome == 'failure'
+        run: |
+          echo "::warning::Docker Buildx setup failed (likely transient registry timeout pulling the buildkit image). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Set up Docker Buildx — retry
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
 
       - name: Extract version and set release channel
@@ -854,10 +985,47 @@ jobs:
       packages: write
 
     steps:
+      # Retry on transient registry timeouts pulling the buildkit builder image
+      # (e.g. "net/http: request canceled while waiting for connection" against
+      # registry-1.docker.io). See bd-n6197: run 30144328147 failed here on a
+      # one-off Docker Hub blip while the build/push jobs on the same commit
+      # succeeded. docker/setup-buildx-action has no built-in retry input, so
+      # this duplicates the step with continue-on-error, matching the
+      # build-push-action retry pattern used elsewhere in this file.
       - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+        continue-on-error: true
+
+      - name: Wait before Buildx retry
+        if: steps.buildx.outcome == 'failure'
+        run: |
+          echo "::warning::Docker Buildx setup failed (likely transient registry timeout pulling the buildkit image). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Set up Docker Buildx — retry
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
 
+      # Retry on transient registry-connect timeouts (bd-n6197), mirroring the
+      # Buildx-setup retry above and the build-push-action retry pattern.
       - name: Log in to Container Registry
+        id: login
+        continue-on-error: true
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait before registry login retry
+        if: steps.login.outcome == 'failure'
+        run: |
+          echo "::warning::Container registry login failed (likely transient network timeout). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Log in to Container Registry — retry
+        if: steps.login.outcome == 'failure'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -900,13 +1068,32 @@ jobs:
             type=raw,value=${{ steps.version.outputs.minor }}-dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=raw,value=${{ steps.version.outputs.minor }},enable=${{ github.ref == 'refs/heads/main' }}
 
+      # Bounded retry with backoff on transient registry timeouts (bd-n6197):
+      # run 30144328147 failed this job's "Set up Docker Buildx" step, but
+      # `docker buildx imagetools create` talks to the registry too and can
+      # hit the same class of blip. A bash loop is simpler here than
+      # duplicating a `uses:` step, since this is already a `run:` step.
       - name: Create manifest list and push
         working-directory: /tmp
         run: |
-          docker buildx imagetools create \
-            $(echo "${{ steps.meta.outputs.tags }}" | xargs -I {} echo --tag {}) \
-            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}@${{ needs.build-amd64.outputs.digest }} \
-            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}@${{ needs.build-arm64.outputs.digest }}
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | xargs -I {} echo --tag {})
+          SRC1="${{ env.REGISTRY }}/${{ steps.image.outputs.name }}@${{ needs.build-amd64.outputs.digest }}"
+          SRC2="${{ env.REGISTRY }}/${{ steps.image.outputs.name }}@${{ needs.build-arm64.outputs.digest }}"
+
+          MAX_ATTEMPTS=3
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            if docker buildx imagetools create $TAGS "$SRC1" "$SRC2"; then
+              exit 0
+            fi
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              WAIT=$((attempt * 30))
+              echo "::warning::docker buildx imagetools create failed (attempt $attempt/$MAX_ATTEMPTS, likely transient registry timeout). Sleeping ${WAIT}s before retry."
+              sleep "$WAIT"
+            fi
+          done
+
+          echo "::error::docker buildx imagetools create failed after $MAX_ATTEMPTS attempts"
+          exit 1
 
   # ─── MCP Server Build Pipeline ───────────────────────────────────────
 
@@ -929,11 +1116,48 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # Retry on transient registry timeouts pulling the buildkit builder image
+      # (e.g. "net/http: request canceled while waiting for connection" against
+      # registry-1.docker.io). See bd-n6197: run 30144328147 failed here on a
+      # one-off Docker Hub blip while the build/push jobs on the same commit
+      # succeeded. docker/setup-buildx-action has no built-in retry input, so
+      # this duplicates the step with continue-on-error, matching the
+      # build-push-action retry pattern used elsewhere in this file.
       - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+        continue-on-error: true
+
+      - name: Wait before Buildx retry
+        if: steps.buildx.outcome == 'failure'
+        run: |
+          echo "::warning::Docker Buildx setup failed (likely transient registry timeout pulling the buildkit image). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Set up Docker Buildx — retry
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
 
+      # Retry on transient registry-connect timeouts (bd-n6197), mirroring the
+      # Buildx-setup retry above and the build-push-action retry pattern.
       - name: Log in to Container Registry
+        id: login
         if: github.event_name != 'pull_request'
+        continue-on-error: true
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait before registry login retry
+        if: github.event_name != 'pull_request' && steps.login.outcome == 'failure'
+        run: |
+          echo "::warning::Container registry login failed (likely transient network timeout). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Log in to Container Registry — retry
+        if: github.event_name != 'pull_request' && steps.login.outcome == 'failure'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -1035,11 +1259,48 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # Retry on transient registry timeouts pulling the buildkit builder image
+      # (e.g. "net/http: request canceled while waiting for connection" against
+      # registry-1.docker.io). See bd-n6197: run 30144328147 failed here on a
+      # one-off Docker Hub blip while the build/push jobs on the same commit
+      # succeeded. docker/setup-buildx-action has no built-in retry input, so
+      # this duplicates the step with continue-on-error, matching the
+      # build-push-action retry pattern used elsewhere in this file.
       - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+        continue-on-error: true
+
+      - name: Wait before Buildx retry
+        if: steps.buildx.outcome == 'failure'
+        run: |
+          echo "::warning::Docker Buildx setup failed (likely transient registry timeout pulling the buildkit image). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Set up Docker Buildx — retry
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
 
+      # Retry on transient registry-connect timeouts (bd-n6197), mirroring the
+      # Buildx-setup retry above and the build-push-action retry pattern.
       - name: Log in to Container Registry
+        id: login
         if: github.event_name != 'pull_request'
+        continue-on-error: true
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait before registry login retry
+        if: github.event_name != 'pull_request' && steps.login.outcome == 'failure'
+        run: |
+          echo "::warning::Container registry login failed (likely transient network timeout). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Log in to Container Registry — retry
+        if: github.event_name != 'pull_request' && steps.login.outcome == 'failure'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -1135,10 +1396,47 @@ jobs:
       packages: write
 
     steps:
+      # Retry on transient registry timeouts pulling the buildkit builder image
+      # (e.g. "net/http: request canceled while waiting for connection" against
+      # registry-1.docker.io). See bd-n6197: run 30144328147 failed here on a
+      # one-off Docker Hub blip while the build/push jobs on the same commit
+      # succeeded. docker/setup-buildx-action has no built-in retry input, so
+      # this duplicates the step with continue-on-error, matching the
+      # build-push-action retry pattern used elsewhere in this file.
       - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+        continue-on-error: true
+
+      - name: Wait before Buildx retry
+        if: steps.buildx.outcome == 'failure'
+        run: |
+          echo "::warning::Docker Buildx setup failed (likely transient registry timeout pulling the buildkit image). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Set up Docker Buildx — retry
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
 
+      # Retry on transient registry-connect timeouts (bd-n6197), mirroring the
+      # Buildx-setup retry above and the build-push-action retry pattern.
       - name: Log in to Container Registry
+        id: login
+        continue-on-error: true
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait before registry login retry
+        if: steps.login.outcome == 'failure'
+        run: |
+          echo "::warning::Container registry login failed (likely transient network timeout). Sleeping 15s before retry."
+          sleep 15
+
+      - name: Log in to Container Registry — retry
+        if: steps.login.outcome == 'failure'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -1174,10 +1472,28 @@ jobs:
             type=raw,value=${{ steps.version.outputs.minor }}-dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=raw,value=${{ steps.version.outputs.minor }},enable=${{ github.ref == 'refs/heads/main' }}
 
+      # Bounded retry with backoff on transient registry timeouts (bd-n6197):
+      # run 30144328147 failed THIS job's "Set up Docker Buildx" step. A bash
+      # loop is simpler here than duplicating a `uses:` step, since this is
+      # already a `run:` step.
       - name: Create manifest list and push
         working-directory: /tmp
         run: |
-          docker buildx imagetools create \
-            $(echo "${{ steps.meta.outputs.tags }}" | xargs -I {} echo --tag {}) \
-            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}@${{ needs.build-mcp-amd64.outputs.digest }} \
-            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}@${{ needs.build-mcp-arm64.outputs.digest }}
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | xargs -I {} echo --tag {})
+          SRC1="${{ env.REGISTRY }}/${{ steps.image.outputs.name }}@${{ needs.build-mcp-amd64.outputs.digest }}"
+          SRC2="${{ env.REGISTRY }}/${{ steps.image.outputs.name }}@${{ needs.build-mcp-arm64.outputs.digest }}"
+
+          MAX_ATTEMPTS=3
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            if docker buildx imagetools create $TAGS "$SRC1" "$SRC2"; then
+              exit 0
+            fi
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              WAIT=$((attempt * 30))
+              echo "::warning::docker buildx imagetools create failed (attempt $attempt/$MAX_ATTEMPTS, likely transient registry timeout). Sleeping ${WAIT}s before retry."
+              sleep "$WAIT"
+            fi
+          done
+
+          echo "::error::docker buildx imagetools create failed after $MAX_ATTEMPTS attempts"
+          exit 1

--- a/backend/main.py
+++ b/backend/main.py
@@ -142,7 +142,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0162",
+    version="0.17.6-0164",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/main.py
+++ b/backend/main.py
@@ -142,7 +142,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0162",
+    version="0.17.6-0165",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -76,7 +76,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0162"
+APP_VERSION = "0.17.6-0164"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -76,7 +76,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0162"
+APP_VERSION = "0.17.6-0165"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/tests/routers/test_epg.py
+++ b/backend/tests/routers/test_epg.py
@@ -6,6 +6,7 @@ Tests: 12 endpoints covering EPG sources CRUD, refresh, import,
 Mocks: get_client() to isolate from Dispatcharr.
 """
 import asyncio
+import base64
 import httpx
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -100,6 +101,28 @@ async def _poll_migration(async_client, accepted):
             return body
         await asyncio.sleep(0)
     raise AssertionError("migration job did not reach a terminal state")
+
+
+def _tamper_preview_signature(token: str) -> str:
+    """Return ``token`` with a genuinely-different signature.
+
+    Decoding the signature, flipping a byte, and re-encoding guarantees the
+    HMAC bytes differ. Flipping the last *base64 char* of the signature is not
+    a reliable tamper: the final char of a 32-byte signature only carries the
+    low nibble of the last byte, so its two low bits are padding. Changing it
+    within the same nibble group (e.g. "A" -> "B") re-encodes to identical
+    signature bytes, leaving the token valid ~1/16 of the time (flaky 202
+    instead of 409). See bead enhancedchannelmanager-zfp2z.
+    """
+    encoded, encoded_signature = token.split(".", 1)
+    signature = bytearray(
+        base64.urlsafe_b64decode(
+            encoded_signature + "=" * (-len(encoded_signature) % 4)
+        )
+    )
+    signature[0] ^= 0xFF
+    flipped = base64.urlsafe_b64encode(bytes(signature)).rstrip(b"=").decode()
+    return f"{encoded}.{flipped}"
 
 
 class TestGuideMigration:
@@ -743,7 +766,7 @@ class TestGuideMigration:
             now=0 if token_kind == "expired" else None,
         )
         if token_kind == "tampered":
-            token = token[:-1] + ("A" if token[-1] != "A" else "B")
+            token = _tamper_preview_signature(token)
         with patch("routers.epg.get_jwt_secret_key", return_value=secret):
             response = await async_client.post(
                 "/api/epg/migration/apply",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0162",
+  "version": "0.17.6-0164",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0162",
+  "version": "0.17.6-0165",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Hardens the 'Build and Push Docker Image' workflow against transient Docker Hub timeouts (run 30144328147 failed in 'Create MCP Multi-Arch Manifest' > 'Set up Docker Buildx' with a registry-1.docker.io connect timeout).
- Retry treatment: all 9 'Set up Docker Buildx' steps and all 6 'Log in to Container Registry' steps (2 attempts, 15s backoff, repo's existing duplicate-step + `continue-on-error` convention from bd-42aai); `docker buildx imagetools create` manifest pushes in both manifest jobs get a bash retry loop (3 attempts, 30s/60s backoff).
- Deliberately NOT retried: tests, CodeQL, Checkov, Trivy, ZAP, npm/pip audit — retrying gates that carry meaningful signal would mask real findings.
- No new third-party actions introduced; existing pin style (version tags) preserved.

## Testing
- YAML parses cleanly (PyYAML), 14 jobs preserved, no step-id collisions (verified programmatically)
- `scripts/check_version_consistency.py` passes at 0.17.6-0165

Bead: enhancedchannelmanager-n6197

🤖 Generated with [Claude Code](https://claude.com/claude-code)