### PR TITLE
v0.17.6-0169: wire all DBAS importers into the real restore-apply registry (bead enhancedchannelmanager-kxcjf)

### DIFF
--- a/backend/dbas/importers/epg_sources.py
+++ b/backend/dbas/importers/epg_sources.py
@@ -374,3 +374,149 @@ def _skip(
     cat.skip_details.append(
         SkipDetail(reason=reason, label=label, source_export_id=source_export_id)
     )
+
+
+# ---------------------------------------------------------------------------
+# EPG-download wait (bead kxcjf — the unmet 0i2vt.11 acceptance item)
+# ---------------------------------------------------------------------------
+
+# Dispatcharr EPGSource.status values that mean the fetch/parse cycle is over.
+# ``error`` is terminal too: waiting longer will not produce data, and the
+# bounded wait must never hang on a broken source.
+_EPG_TERMINAL_STATUSES = frozenset({"success", "error"})
+
+
+def _epg_download_done(source: object) -> bool:
+    """True when an EPG source row shows its data download has finished.
+
+    Terminal when the source's ``status`` is a known terminal value
+    (success/error) OR its ``epg_count`` is already positive (data landed even
+    if the status vocabulary drifts in a future Dispatcharr). An unreadable /
+    non-dict row is NOT terminal — the bounded poll (not this predicate) ends
+    the wait.
+    """
+    if not isinstance(source, dict):
+        return False
+    status = source.get("status")
+    if isinstance(status, str) and status.lower() in _EPG_TERMINAL_STATUSES:
+        return True
+    epg_count = source.get("epg_count")
+    return isinstance(epg_count, int) and epg_count > 0
+
+
+async def wait_for_epg_downloads(
+    *,
+    source_ids: list[int],
+    client: DispatcharrClient,
+    get_source_fn=None,
+    refresh_fn=None,
+    sleep_fn=None,
+    poll_interval_seconds: float = 5.0,
+    max_polls: int = 60,
+) -> list[dict]:
+    """Bounded 2-stage wait for Dispatcharr's EPG data download (restore apply).
+
+    Bead ``kxcjf`` folds in the unmet ``0i2vt.11`` acceptance item: after the
+    restore creates EPG sources, Dispatcharr downloads their EPG data
+    asynchronously — the Channels importer must not run before that download so
+    Dispatcharr's channel↔EPG matching has rows to match against. Mirrors the
+    bounded 2-stage poll in ``m3u_accounts.apply_deferred_auto_sync``:
+
+    1. **Trigger** — best-effort ``refresh_epg_source`` per created source (the
+       create usually kicks a fetch itself; the explicit trigger makes the wait
+       deterministic). A trigger failure is logged and never fatal.
+    2. **Bounded poll** — re-read each source row until it is terminal
+       (:func:`_epg_download_done`) or ``max_polls`` is exhausted. The row is
+       checked BEFORE the first sleep, so an already-downloaded source costs
+       zero waiting.
+
+    Non-silent on timeout: a source that never reached a terminal state is
+    returned with ``completed=False`` (the orchestrator reflects it into the
+    :class:`RestoreReport` notes) and logged as a WARNING. Never raises, never
+    hangs, never fails the restore — channels still restore without EPG data,
+    just without upstream EPG matching.
+
+    Args:
+        source_ids: DESTINATION ids of the EPG sources created this run.
+        client: The Dispatcharr API client.
+        get_source_fn: ``async (source_id) -> dict`` row probe seam
+            (defaults to ``client.get_epg_source``).
+        refresh_fn: ``async (source_id) -> dict`` trigger seam
+            (defaults to ``client.refresh_epg_source``).
+        sleep_fn: ``async (seconds) -> None`` sleep seam (``asyncio.sleep``).
+        poll_interval_seconds: Seconds between polls.
+        max_polls: Hard upper bound on polls per source (never an infinite loop).
+
+    Returns:
+        Per-source summaries: ``{"epg_source_id", "completed", "status",
+        "polls"}`` — safe fields only, never a url/credential.
+    """
+    if sleep_fn is None:
+        import asyncio
+
+        sleep_fn = asyncio.sleep
+    if get_source_fn is None:
+        get_source_fn = client.get_epg_source
+    if refresh_fn is None:
+        refresh_fn = client.refresh_epg_source
+
+    summaries: list[dict] = []
+    for source_id in source_ids:
+        # Stage 1 — best-effort download trigger (never fatal).
+        try:
+            await refresh_fn(source_id)
+        except Exception as exc:  # noqa: BLE001 - trigger is best-effort
+            logger.warning(
+                "[DBAS-EPG] EPG download trigger failed for source id=%s: %s",
+                source_id,
+                exc,
+            )
+
+        # Stage 2 — bounded poll; check first, sleep between polls.
+        completed = False
+        status: str | None = None
+        polls = 0
+        while polls < max_polls:
+            polls += 1
+            try:
+                source = await get_source_fn(source_id)
+            except Exception as exc:  # noqa: BLE001 - a probe error is a non-terminal poll
+                logger.warning(
+                    "[DBAS-EPG] EPG source probe failed for id=%s: %s", source_id, exc
+                )
+                source = None
+            if isinstance(source, dict):
+                raw_status = source.get("status")
+                status = raw_status if isinstance(raw_status, str) else status
+            if _epg_download_done(source):
+                completed = True
+                break
+            if polls < max_polls:
+                await sleep_fn(poll_interval_seconds)
+
+        if completed:
+            logger.info(
+                "[DBAS-EPG] EPG data download finished for source id=%s "
+                "(status=%s, polls=%d).",
+                source_id,
+                status,
+                polls,
+            )
+        else:
+            logger.warning(
+                "[DBAS-EPG] EPG data download for source id=%s did NOT finish within "
+                "the bounded wait (status=%s, polls=%d); continuing — channel EPG "
+                "matching may be incomplete.",
+                source_id,
+                status,
+                polls,
+            )
+        summaries.append(
+            {
+                "epg_source_id": source_id,
+                "completed": completed,
+                "status": status,
+                "polls": polls,
+            }
+        )
+    return summaries

--- a/backend/dbas/restore_orchestrator.py
+++ b/backend/dbas/restore_orchestrator.py
@@ -27,27 +27,32 @@ HARD ORDERING (ADR-012 D-table) + the DEFERRED phase
 
 Importers run in strict dependency order::
 
-    M3U accounts → EPG sources → channel groups/profiles/stream profiles
-      → user agents / settings → channels → logos
+    M3U accounts → EPG sources (+ bounded EPG-data download wait)
+      → channel groups/profiles/stream profiles → user agents / settings
+      → users → channels → DVR rules → logos
 
-then the DEFERRED phase applies LAST: the M3U importer (and EPG importer) return
-auto-sync/EPG-download settings that MUST NOT fire during the run (they race the
-logo import on the Dispatcharr side). The orchestrator collects each importer's
-deferred settings and applies them only after every category is done, via
-``dbas.importers.m3u_accounts.apply_deferred_auto_sync``.
+then the DEFERRED phase applies LAST: the M3U importer returns auto-sync
+settings that MUST NOT fire during the run (they race the logo import on the
+Dispatcharr side). The orchestrator collects each importer's deferred settings
+and applies them only after every category is done, via
+``dbas.importers.m3u_accounts.apply_deferred_auto_sync``. EPG data is the
+opposite: Dispatcharr's channel↔EPG matching needs the data BEFORE channels are
+created, so the apply registry's EPG step waits (bounded, non-fatal) for the
+download instead of deferring it — see :func:`_epg_step_with_download_wait`.
 
 ----------------------------------------------------------------------------
-WIRED vs SEAM (be precise — this is scaffolding for in-flight importers)
+FULL WIRING + dry-run/apply parity (bead kxcjf)
 ----------------------------------------------------------------------------
 
-The per-category importers are separate beads, not all built yet. The
-orchestrator runs whatever importer callables are registered in the
-:class:`ImporterStep` list it is given and treats a category with no registered
-importer as a no-op SEAM (logged, never a silent skip). The default registry
-(:func:`default_importer_steps`) wires the importers that EXIST today
-(M3U accounts, channels, users) and leaves explicit registration seams for the
-not-yet-built ones (EPG sources, channel groups/profiles, user agents/settings,
-logos). As each lands, it registers here without changing the orchestrator.
+Every per-category importer is WIRED into BOTH registries: the apply registry
+(:func:`default_importer_steps`) and the dry-run registry
+(:func:`dry_run_importer_steps`) cover the SAME category set, in the same
+order, through the SAME shared step builders — so the counts the default-ON
+dry-run preview promises are exactly what a confirmed apply delivers. The
+orchestrator still supports a step with ``importer=None`` as a logged no-op
+SEAM (never a silent skip) for callers that register partial step lists (e.g.
+the sync engine's config-only registry), but neither default registry carries
+one. PLUGINS are deliberately absent from both (ADR-012 D10).
 
 ----------------------------------------------------------------------------
 404-AS-SUCCESS + the credential-hygiene rule (the bead .8 lesson)
@@ -115,8 +120,9 @@ class ImporterStep:
     Attributes:
         entity_type: The category this step restores (its place in the order).
         importer: The async callable that applies the category, or ``None`` for a
-            registration SEAM — a category whose importer is a separate, not-yet-
-            built bead. A seam step is a logged no-op, never a silent skip.
+            registration SEAM — a deliberately-unwired slot in a caller-built
+            partial registry. A seam step is a logged no-op, never a silent
+            skip. (Both default registries are fully wired — bead kxcjf.)
         defers: Whether this step returns deferred settings (M3U / EPG) that the
             orchestrator must apply in the final deferred phase.
     """
@@ -193,6 +199,14 @@ def _delete_dispatch(client: DispatcharrClient) -> dict[EntityType, Callable[[in
         EntityType.CHANNEL: client.delete_channel,
         EntityType.STREAM: client.delete_stream,
         EntityType.USER: client.delete_user,
+        # kxcjf — the full-wiring bead: every ledgerable created-entity type has
+        # a compensator. SETTINGS is deliberately absent: a settings change is
+        # config, not a created entity — it is never ledgered, and run_restore
+        # surfaces "settings are not rolled back" in the report notes instead of
+        # silently claiming a full rollback.
+        EntityType.USER_AGENT: client.delete_user_agent,
+        EntityType.DVR_RULE: client.delete_dvr_rule,
+        EntityType.LOGO: client.delete_logo,
     }
 
 
@@ -593,6 +607,18 @@ async def run_restore(
                 f"rollback INCOMPLETE: {len(rollback.residue)} entity/entities could not be removed — "
                 "manual cleanup required."
             )
+        # Settings are config, not created entities — they are never ledgered
+        # and CANNOT be compensated (documented limitation, settings_agents.py).
+        # If any were applied before the failure, say so LOUDLY rather than let
+        # "rollback completed" read as a full undo (kxcjf).
+        settings_cat = next(
+            (c for c in report.categories if c.entity_type == EntityType.SETTINGS), None
+        )
+        if settings_cat is not None and settings_cat.updated > 0:
+            report.notes.append(
+                f"NOTE: {settings_cat.updated} applied setting(s) were NOT rolled back — "
+                "settings changes are not compensatable and remain applied."
+            )
 
     # --- 3b. Deferred phase (clean run only) — applied LAST. ---
     if not failure_occurred and not report.is_dry_run and ctx.deferred:
@@ -645,51 +671,113 @@ def new_restore_id() -> str:
 
 
 # ---------------------------------------------------------------------------
-# Default importer registry — WIRED vs SEAM
+# Default importer registry — the FULL apply wiring (bead kxcjf)
 # ---------------------------------------------------------------------------
 
 
+def _epg_step_with_download_wait(epg_importer: ImporterCallable) -> ImporterCallable:
+    """Wrap the shared EPG step with the bounded EPG-data download wait (APPLY only).
+
+    Bead ``kxcjf`` folds in the unmet ``0i2vt.11`` acceptance item: after the
+    EPG-sources importer creates sources on the destination, Dispatcharr
+    downloads their EPG data asynchronously. The Channels importer must not run
+    before that download finishes, or Dispatcharr's channel↔EPG matching has no
+    rows to match against. This wrapper runs
+    :func:`dbas.importers.epg_sources.wait_for_epg_downloads` (a bounded,
+    non-fatal 2-stage trigger+poll mirroring the M3U deferred-auto-sync poll)
+    over the sources CREATED this run (read from the shared ledger — an
+    already-existing, skipped source has its data already).
+
+    Apply-registry only, deliberately:
+
+    * On a dry-run the wrapper is a pass-through (zero waiting, zero triggers —
+      a plan must stay read-only and fast).
+    * The sync registry (``tasks.dbas_sync_engine``) uses the UNWRAPPED shared
+      ``epg`` builder — a per-cycle sync must never re-trigger EPG downloads on
+      the destination (ADR-013 S9).
+
+    A source that does not finish within the bounded wait is surfaced as a
+    WARN-level :class:`RestoreReport` note — never a hang, never a failure
+    (channels still restore; only upstream EPG matching may be incomplete).
+    """
+
+    async def _epg_apply(ctx: ApplyContext) -> list[dict] | None:
+        from dbas.importers.epg_sources import wait_for_epg_downloads
+
+        result = await epg_importer(ctx)
+        if ctx.is_dry_run:
+            return result
+        created_ids = [
+            entry.destination_id
+            for entry in ctx.ledger.entries
+            if entry.entity_type == EntityType.EPG_SOURCE
+        ]
+        if not created_ids:
+            return result
+        summaries = await wait_for_epg_downloads(
+            source_ids=created_ids, client=ctx.client
+        )
+        for summary in summaries:
+            if not summary.get("completed"):
+                ctx.report.notes.append(
+                    "EPG source id=%s: EPG data download did not finish within the "
+                    "bounded wait; channel EPG matching may be incomplete."
+                    % summary.get("epg_source_id")
+                )
+        return result
+
+    return _epg_apply
+
+
 def default_importer_steps() -> list[ImporterStep]:
-    """The hard Phase-2 ordering with today's importers WIRED and the rest as seams.
+    """The hard Phase-2 ordering with EVERY importer WIRED for the real apply.
 
-    WIRED (importers that exist as of bead .18):
-      * M3U accounts (``…-0i2vt.10``) — defers auto-sync.
-      * channels (``…-4vouz``).
-      * users (``…-l1p4p``) — runs in the settings/users slot.
+    Bead ``kxcjf`` closed the silent-skip defect: this registry previously wired
+    only M3U accounts / users / channels and left EPG sources, channel
+    groups/profiles/stream profiles, user agents, DVR rules, settings, and logos
+    as ``importer=None`` seams — a confirmed apply silently no-opped those
+    categories while the default-ON dry-run preview promised their counts. Both
+    registries now cover the SAME category set (the dry-run/apply parity bar);
+    ``dry_run_importer_steps`` mirrors this order exactly.
 
-    SEAM (separate beads, registered as ``importer=None`` no-ops until they land):
-      * EPG sources (``…-0i2vt.11``) — will defer EPG download.
-      * channel groups / profiles / stream profiles (``…-0i2vt.12``).
-      * user agents (``…-0i2vt.13``).
-      * logos (``…-0i2vt.15``).
+    Ordering (dependency-driven, ADR-012 D-table):
 
-    The ORDER is the contract even where a slot is a seam — when an importer
-    lands it slots into its place without reshuffling the sequence.
+      * M3U accounts first (defers auto-sync to the final phase) — everything
+        downstream remaps ``m3u_account`` FKs through it.
+      * EPG sources second, WITH the bounded EPG-data download wait
+        (:func:`_epg_step_with_download_wait`) so Dispatcharr has EPG rows
+        before channels are created.
+      * channel groups / channel profiles / stream profiles before channels —
+        they populate the IdRemapTable namespaces the channels importer resolves.
+      * user agents + settings (core settings / comskip) before channels
+        (config in place before the big entity category).
+      * users before channels (the l1p4p slot; unchanged).
+      * channels, then DVR rules (a DVR rule's ``channel`` FK remaps through the
+        just-populated ``EntityType.CHANNEL`` namespace), then logos LAST
+        (attach to the created channels; slow streaming uploads at the tail).
+
+    PLUGINS stay excluded per ADR-012 D10 (RCE-vs-config unresolved) — there is
+    deliberately no plugins row in either registry.
     """
     s = _importer_step_builders()
-    # NOTE on the EPG-sources seam (…-0i2vt.11): the EPG importer's APPLY path is
-    # still a separate bead, so EPG sources occupy a documented ordering position
-    # between M3U and channel groups but are not yet a discrete ImporterStep row in
-    # this APPLY registry. Compensation, however, IS wired: EntityType.EPG_SOURCE
-    # (and EntityType.STREAM_PROFILE) now have rollback compensators in
-    # ``_delete_dispatch`` (enhancedchannelmanager-v1uz9), so any EPG-source /
-    # stream-profile row recorded in the ledger by an in-flight importer is undone
-    # cleanly on a late-step failure instead of being left as residue.
     return [
         ImporterStep(EntityType.M3U_ACCOUNT, s["m3u"], defers=True),
-        # <- EPG sources (…-0i2vt.11) order position; SEAM, see note above.
-        ImporterStep(EntityType.CHANNEL_GROUP, None),                  # SEAM …-0i2vt.12
-        ImporterStep(EntityType.CHANNEL_PROFILE, None),               # SEAM …-0i2vt.12
-        ImporterStep(EntityType.STREAM_PROFILE, None),                # SEAM …-0i2vt.12
-        ImporterStep(EntityType.USER_AGENT, None),                    # SEAM …-0i2vt.13
-        ImporterStep(EntityType.USER, s["users"]),                    # WIRED …-l1p4p
-        ImporterStep(EntityType.CHANNEL, s["channels"]),              # WIRED …-4vouz
-        # logos SEAM …-0i2vt.15 — no EntityType row of its own; attaches to channels
+        ImporterStep(EntityType.EPG_SOURCE, _epg_step_with_download_wait(s["epg"])),
+        ImporterStep(EntityType.CHANNEL_GROUP, s["channel_groups"]),
+        ImporterStep(EntityType.CHANNEL_PROFILE, s["channel_profiles"]),
+        ImporterStep(EntityType.STREAM_PROFILE, s["stream_profiles"]),
+        ImporterStep(EntityType.USER_AGENT, s["user_agents"]),
+        ImporterStep(EntityType.SETTINGS, s["settings"]),
+        ImporterStep(EntityType.USER, s["users"]),
+        ImporterStep(EntityType.CHANNEL, s["channels"]),
+        ImporterStep(EntityType.DVR_RULE, s["dvr_rules"]),
+        ImporterStep(EntityType.LOGO, s["logos"]),
     ]
 
 
 # ---------------------------------------------------------------------------
-# Dry-run registry — bead …-0i2vt.16. EVERY importer wired, counts-only.
+# Shared per-category step builders — ONE set of callables backs the apply
+# registry, the dry-run registry, and the sync engine's config-only registry.
 # ---------------------------------------------------------------------------
 
 
@@ -713,6 +801,12 @@ def _importer_step_builders() -> dict[str, ImporterCallable]:
     )
     from dbas.importers.logos import import_logos
     from dbas.importers.m3u_accounts import import_m3u_accounts
+    from dbas.importers.settings_agents import (
+        import_comskip,
+        import_core_settings,
+        import_dvr_rules,
+        import_user_agents,
+    )
     from dbas.importers.users import import_users
 
     def _entities(ctx: ApplyContext, entity_type: EntityType) -> list[dict]:
@@ -783,6 +877,67 @@ def _importer_step_builders() -> dict[str, ImporterCallable]:
         )
         return None
 
+    async def _user_agents(ctx: ApplyContext) -> list[dict] | None:
+        await import_user_agents(
+            archive_user_agents=_entities(ctx, EntityType.USER_AGENT),
+            client=ctx.client,
+            selected=_selected(ctx, EntityType.USER_AGENT),
+            report=ctx.report,
+            ledger=ctx.ledger,
+            remap=ctx.remap,
+            is_dry_run=ctx.is_dry_run,
+        )
+        return None
+
+    async def _dvr_rules(ctx: ApplyContext) -> list[dict] | None:
+        await import_dvr_rules(
+            archive_dvr_rules=_entities(ctx, EntityType.DVR_RULE),
+            client=ctx.client,
+            selected=_selected(ctx, EntityType.DVR_RULE),
+            report=ctx.report,
+            ledger=ctx.ledger,
+            remap=ctx.remap,
+            is_dry_run=ctx.is_dry_run,
+        )
+        return None
+
+    async def _settings(ctx: ApplyContext) -> list[dict] | None:
+        # The SETTINGS plan slice carries the key/value blobs, not entity rows.
+        # Contract: each entity is ``{"section": "core_settings"|"comskip",
+        # "values": {...}}`` — self-describing so one plan category carries both
+        # blobs in a fixed apply order. Results land on the shared
+        # ``EntityType.SETTINGS`` report category (updated/skipped, never
+        # created, never ledgered — settings rollback is out of scope, see
+        # ``settings_agents.py``).
+        selected = _selected(ctx, EntityType.SETTINGS)
+        for record in _entities(ctx, EntityType.SETTINGS):
+            section = record.get("section")
+            values = record.get("values") or {}
+            if section == "core_settings":
+                await import_core_settings(
+                    archive_core_settings=values,
+                    client=ctx.client,
+                    selected=selected,
+                    report=ctx.report,
+                    ledger=ctx.ledger,
+                    is_dry_run=ctx.is_dry_run,
+                )
+            elif section == "comskip":
+                await import_comskip(
+                    archive_comskip=values,
+                    client=ctx.client,
+                    selected=selected,
+                    report=ctx.report,
+                    ledger=ctx.ledger,
+                    is_dry_run=ctx.is_dry_run,
+                )
+            else:
+                logger.warning(
+                    "[DBAS-RESTORE] Unknown settings section %r in plan; skipped.",
+                    section,
+                )
+        return None
+
     async def _users(ctx: ApplyContext) -> list[dict] | None:
         await import_users(
             archive_users=_entities(ctx, EntityType.USER),
@@ -829,6 +984,9 @@ def _importer_step_builders() -> dict[str, ImporterCallable]:
         "channel_groups": _channel_groups,
         "channel_profiles": _channel_profiles,
         "stream_profiles": _stream_profiles,
+        "user_agents": _user_agents,
+        "dvr_rules": _dvr_rules,
+        "settings": _settings,
         "users": _users,
         "channels": _channels,
         "logos": _logos,
@@ -838,25 +996,17 @@ def _importer_step_builders() -> dict[str, ImporterCallable]:
 def dry_run_importer_steps() -> list[ImporterStep]:
     """The Phase-2 ordering with EVERY importer WIRED for the counts-only dry-run.
 
-    Bead ``…-0i2vt.16``. Unlike :func:`default_importer_steps` — whose seams for
-    EPG sources / groups-profiles / logos await each importer's apply-path +
-    rollback wiring (bead ``.18`` / their own beads) — the dry-run registry wires
-    ALL importers, because every importer is provably zero-mutation on a dry-run
-    (it only reads to plan and increments ``would_*``). Wiring them here lets the
-    dry-run aggregate the ``would_*`` counts for the WHOLE archive into one
-    :class:`RestoreReport`, which is the point of the engine.
+    Bead ``…-0i2vt.16`` (extended by ``kxcjf``). Mirrors
+    :func:`default_importer_steps` category-for-category and in the SAME order —
+    the dry-run/apply parity contract: the counts the operator previews are
+    produced by the same importers, over the same category set, that a confirmed
+    apply runs. Every importer is provably zero-mutation on a dry-run (it only
+    reads to plan and increments ``would_*``).
 
-    The order is the same hard Phase-2 sequence
-    (``M3U → EPG → groups/profiles → user-agents → users → channels → logos``);
-    on a dry-run the order is not load-bearing for mutation (there is none) but is
-    kept identical so the plan the operator previews mirrors what apply will do.
-
-    This registry is for DRY-RUN ONLY. It must not be handed to an apply
-    (``confirm_apply=True``) run until each wired importer's apply/rollback path is
-    registered in :func:`default_importer_steps` — the guardrail in
-    :func:`run_restore` forces ``is_dry_run`` when apply is not confirmed, so a
-    misuse degrades safely to a dry-run rather than mutating through an unwired
-    rollback path.
+    The only deliberate difference from the apply registry is the EPG step: the
+    dry-run uses the plain importer (no download trigger, no wait — a plan must
+    stay read-only and fast), while the apply wraps it with the bounded
+    EPG-data download wait (:func:`_epg_step_with_download_wait`).
     """
     s = _importer_step_builders()
     return [
@@ -865,9 +1015,11 @@ def dry_run_importer_steps() -> list[ImporterStep]:
         ImporterStep(EntityType.CHANNEL_GROUP, s["channel_groups"]),
         ImporterStep(EntityType.CHANNEL_PROFILE, s["channel_profiles"]),
         ImporterStep(EntityType.STREAM_PROFILE, s["stream_profiles"]),
-        ImporterStep(EntityType.USER_AGENT, None),  # SEAM …-0i2vt.13 (no importer yet)
+        ImporterStep(EntityType.USER_AGENT, s["user_agents"]),
+        ImporterStep(EntityType.SETTINGS, s["settings"]),
         ImporterStep(EntityType.USER, s["users"]),
         ImporterStep(EntityType.CHANNEL, s["channels"]),
+        ImporterStep(EntityType.DVR_RULE, s["dvr_rules"]),
         ImporterStep(EntityType.LOGO, s["logos"]),
     ]
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -142,7 +142,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.17.6-0168",
+    version="0.17.6-0169",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -76,7 +76,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.17.6-0168"
+APP_VERSION = "0.17.6-0169"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/tests/dbas/test_epg_sources_importer.py
+++ b/backend/tests/dbas/test_epg_sources_importer.py
@@ -547,3 +547,140 @@ async def test_failure_message_does_not_leak_url_or_credentials(caplog):
     for marker in ("secret-provider", "token=abc123", "secret-user", "s3cr3t-pass"):
         assert marker not in message
         assert marker not in log_text
+
+
+# ---------------------------------------------------------------------------
+# 7. wait_for_epg_downloads (bead kxcjf — the unmet 0i2vt.11 acceptance item):
+# bounded 2-stage trigger+poll for Dispatcharr's EPG data download. Never hangs,
+# never raises, non-silent on timeout (completed=False for the caller to note).
+# ---------------------------------------------------------------------------
+
+
+def _wait_client(source_row):
+    client = AsyncMock()
+    client.refresh_epg_source = AsyncMock(return_value={})
+    client.get_epg_source = AsyncMock(return_value=source_row)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_wait_completes_immediately_on_terminal_status():
+    from dbas.importers.epg_sources import wait_for_epg_downloads
+
+    sleeps = []
+
+    async def _sleep(seconds):
+        sleeps.append(seconds)
+
+    client = _wait_client({"id": 7, "status": "success", "epg_count": 0})
+    summaries = await wait_for_epg_downloads(
+        source_ids=[7], client=client, sleep_fn=_sleep
+    )
+    assert summaries == [
+        {"epg_source_id": 7, "completed": True, "status": "success", "polls": 1}
+    ]
+    # Terminal on the FIRST check — zero sleeping (check-first, sleep-between).
+    assert sleeps == []
+    client.refresh_epg_source.assert_awaited_once_with(7)
+
+
+@pytest.mark.asyncio
+async def test_wait_epg_count_is_terminal_even_with_unknown_status():
+    # Future-proofing: if Dispatcharr's status vocabulary drifts, a positive
+    # epg_count still terminates the wait (data actually landed).
+    from dbas.importers.epg_sources import wait_for_epg_downloads
+
+    client = _wait_client({"id": 8, "status": "somenewstate", "epg_count": 120})
+
+    async def _sleep(_):
+        raise AssertionError("must not sleep when the first check is terminal")
+
+    summaries = await wait_for_epg_downloads(
+        source_ids=[8], client=client, sleep_fn=_sleep
+    )
+    assert summaries[0]["completed"] is True
+
+
+@pytest.mark.asyncio
+async def test_wait_polls_until_download_finishes():
+    from dbas.importers.epg_sources import wait_for_epg_downloads
+
+    rows = [
+        {"id": 9, "status": "fetching", "epg_count": 0},
+        {"id": 9, "status": "parsing", "epg_count": 0},
+        {"id": 9, "status": "success", "epg_count": 500},
+    ]
+    client = AsyncMock()
+    client.refresh_epg_source = AsyncMock(return_value={})
+    client.get_epg_source = AsyncMock(side_effect=rows)
+    sleeps = []
+
+    async def _sleep(seconds):
+        sleeps.append(seconds)
+
+    summaries = await wait_for_epg_downloads(
+        source_ids=[9], client=client, sleep_fn=_sleep, poll_interval_seconds=0.5
+    )
+    assert summaries[0]["completed"] is True
+    assert summaries[0]["polls"] == 3
+    # Two sleeps BETWEEN the three polls, at the configured interval.
+    assert sleeps == [0.5, 0.5]
+
+
+@pytest.mark.asyncio
+async def test_wait_times_out_bounded_and_reports_incomplete():
+    from dbas.importers.epg_sources import wait_for_epg_downloads
+
+    client = _wait_client({"id": 10, "status": "fetching", "epg_count": 0})
+
+    async def _sleep(_):
+        return None
+
+    summaries = await wait_for_epg_downloads(
+        source_ids=[10], client=client, sleep_fn=_sleep, max_polls=4
+    )
+    # Bounded: exactly max_polls probes, then a NON-SILENT incomplete result.
+    assert summaries[0]["completed"] is False
+    assert summaries[0]["polls"] == 4
+    assert client.get_epg_source.await_count == 4
+
+
+@pytest.mark.asyncio
+async def test_wait_trigger_and_probe_errors_are_nonfatal():
+    # A failing refresh trigger and failing probes never raise — the wait runs
+    # its bounded course and reports incomplete.
+    from dbas.importers.epg_sources import wait_for_epg_downloads
+
+    client = AsyncMock()
+    client.refresh_epg_source = AsyncMock(side_effect=RuntimeError("boom"))
+    client.get_epg_source = AsyncMock(side_effect=RuntimeError("probe down"))
+
+    async def _sleep(_):
+        return None
+
+    summaries = await wait_for_epg_downloads(
+        source_ids=[11], client=client, sleep_fn=_sleep, max_polls=2
+    )
+    assert summaries[0]["completed"] is False
+    assert summaries[0]["polls"] == 2
+
+
+@pytest.mark.asyncio
+async def test_wait_covers_every_source_id():
+    from dbas.importers.epg_sources import wait_for_epg_downloads
+
+    client = AsyncMock()
+    client.refresh_epg_source = AsyncMock(return_value={})
+    client.get_epg_source = AsyncMock(
+        side_effect=lambda sid: {"id": sid, "status": "success", "epg_count": 1}
+    )
+
+    async def _sleep(_):
+        return None
+
+    summaries = await wait_for_epg_downloads(
+        source_ids=[21, 22, 23], client=client, sleep_fn=_sleep
+    )
+    assert [s["epg_source_id"] for s in summaries] == [21, 22, 23]
+    assert all(s["completed"] for s in summaries)
+    assert client.refresh_epg_source.await_count == 3

--- a/backend/tests/dbas/test_restore_orchestrator.py
+++ b/backend/tests/dbas/test_restore_orchestrator.py
@@ -677,20 +677,295 @@ async def test_seam_step_is_noop(tmp_path):
 
 
 def test_default_importer_steps_order_and_wiring():
+    """kxcjf — the apply registry wires EVERY category; no seam rows remain.
+
+    Before kxcjf only M3U/users/channels were wired: a confirmed apply silently
+    no-opped EPG sources, groups/profiles, user agents, DVR rules, settings, and
+    logos while the dry-run preview promised their counts. This pins the full
+    wiring and the dependency order.
+    """
     from dbas.restore_orchestrator import default_importer_steps
 
     steps = default_importer_steps()
     order = [s.entity_type for s in steps]
-    # Hard ordering: M3U first, channels last; channel groups/profiles before
-    # channels; users before channels.
+    # Hard dependency ordering.
     assert order[0] == EntityType.M3U_ACCOUNT
-    assert order[-1] == EntityType.CHANNEL
+    assert order.index(EntityType.EPG_SOURCE) < order.index(EntityType.CHANNEL)
     assert order.index(EntityType.CHANNEL_GROUP) < order.index(EntityType.CHANNEL)
+    assert order.index(EntityType.CHANNEL_PROFILE) < order.index(EntityType.CHANNEL)
+    assert order.index(EntityType.STREAM_PROFILE) < order.index(EntityType.CHANNEL)
+    assert order.index(EntityType.USER_AGENT) < order.index(EntityType.CHANNEL)
+    assert order.index(EntityType.SETTINGS) < order.index(EntityType.CHANNEL)
     assert order.index(EntityType.USER) < order.index(EntityType.CHANNEL)
-    # M3U is wired and defers; groups/profiles/user-agents are seams.
-    wired = {s.entity_type for s in steps if s.importer is not None}
-    seams = {s.entity_type for s in steps if s.importer is None}
-    assert {EntityType.M3U_ACCOUNT, EntityType.USER, EntityType.CHANNEL} <= wired
-    assert {EntityType.CHANNEL_GROUP, EntityType.CHANNEL_PROFILE, EntityType.STREAM_PROFILE, EntityType.USER_AGENT} <= seams
+    # A DVR rule's ``channel`` FK remaps through the CHANNEL namespace, so DVR
+    # rules run AFTER channels; logos attach last.
+    assert order.index(EntityType.DVR_RULE) > order.index(EntityType.CHANNEL)
+    assert order[-1] == EntityType.LOGO
+    # EVERY step is wired — no importer=None seam remains in the apply registry.
+    seams = [s.entity_type for s in steps if s.importer is None]
+    assert seams == [], "apply registry still carries seam rows: %s" % seams
     m3u_step = next(s for s in steps if s.entity_type == EntityType.M3U_ACCOUNT)
     assert m3u_step.defers is True
+    # Plugins stay excluded (ADR-012 D10) — no plugins category exists at all.
+    assert not any("plugin" in s.entity_type.value for s in steps)
+
+
+def test_dry_run_and_apply_registries_cover_the_same_categories():
+    """kxcjf parity bar: both registries cover the SAME category set, same order."""
+    from dbas.restore_orchestrator import default_importer_steps, dry_run_importer_steps
+
+    apply_order = [s.entity_type for s in default_importer_steps()]
+    dry_order = [s.entity_type for s in dry_run_importer_steps()]
+    assert apply_order == dry_order
+    # And the dry-run registry is fully wired too (no seam rows).
+    assert all(s.importer is not None for s in dry_run_importer_steps())
+
+
+def test_delete_dispatch_registers_all_ledgerable_types():
+    """kxcjf — every ledgerable created-entity type has a rollback compensator.
+
+    SETTINGS is deliberately absent (config, never ledgered, not compensatable —
+    surfaced via a report note instead; see
+    test_rollback_notes_settings_not_rolled_back).
+    """
+    from dbas.restore_orchestrator import _delete_dispatch
+
+    dispatch = _delete_dispatch(_client())
+    for entity_type in (
+        EntityType.M3U_ACCOUNT,
+        EntityType.EPG_SOURCE,
+        EntityType.CHANNEL_GROUP,
+        EntityType.CHANNEL_PROFILE,
+        EntityType.STREAM_PROFILE,
+        EntityType.CHANNEL,
+        EntityType.STREAM,
+        EntityType.USER,
+        EntityType.USER_AGENT,
+        EntityType.DVR_RULE,
+        EntityType.LOGO,
+    ):
+        assert entity_type in dispatch, "no compensator for %s" % entity_type.value
+    assert EntityType.SETTINGS not in dispatch
+
+
+@pytest.mark.asyncio
+async def test_late_failure_rolls_back_user_agent_dvr_rule_and_logo(tmp_path):
+    # kxcjf — the three newly-compensable types are cleanly rolled back on a
+    # late-step failure (COMPLETE rollback, not residue).
+    client = _client()
+    for name in ("delete_user_agent", "delete_dvr_rule", "delete_logo"):
+        setattr(client, name, AsyncMock(return_value=None))
+    plan = _plan(_cat(EntityType.M3U_ACCOUNT, [{"id": 1, "name": "Prov"}]))
+    report = _report()
+    ledger = _ledger()
+    steps = [
+        _creating_step(EntityType.USER_AGENT, 601),
+        _creating_step(EntityType.DVR_RULE, 602),
+        _creating_step(EntityType.LOGO, 603),
+        _raising_step(EntityType.CHANNEL),
+    ]
+    out = await run_restore(
+        plan=plan,
+        client=client,
+        steps=steps,
+        report=report,
+        ledger=ledger,
+        remap=IdRemapTable(),
+        confirm_apply=True,
+        ledger_dir=tmp_path,
+    )
+    assert out.outcome == RestoreOutcome.PARTIAL_FAILED_ROLLED_BACK
+    client.delete_user_agent.assert_awaited_once_with(601)
+    client.delete_dvr_rule.assert_awaited_once_with(602)
+    client.delete_logo.assert_awaited_once_with(603)
+    assert all(e.compensated for e in ledger.entries)
+
+
+@pytest.mark.asyncio
+async def test_rollback_notes_settings_not_rolled_back(tmp_path):
+    # kxcjf — settings are applied config, never ledgered, NOT compensatable.
+    # When a rollback runs after settings were applied, the report must SAY the
+    # settings remain applied rather than let "rollback completed" read as a
+    # full undo.
+    client = _client()
+
+    async def _settings_step(ctx: ApplyContext):
+        ctx.report.category(EntityType.SETTINGS).updated += 3
+        return None
+
+    plan = _plan(_cat(EntityType.M3U_ACCOUNT, [{"id": 1, "name": "Prov"}]))
+    report = _report()
+    out = await run_restore(
+        plan=plan,
+        client=client,
+        steps=[
+            ImporterStep(EntityType.SETTINGS, _settings_step),
+            _creating_step(EntityType.M3U_ACCOUNT, 901),
+            _raising_step(EntityType.CHANNEL),
+        ],
+        report=report,
+        ledger=_ledger(),
+        remap=IdRemapTable(),
+        confirm_apply=True,
+        ledger_dir=tmp_path,
+    )
+    assert out.outcome == RestoreOutcome.PARTIAL_FAILED_ROLLED_BACK
+    assert any(
+        "NOT rolled back" in note and "3 applied setting(s)" in note
+        for note in out.notes
+    )
+
+
+@pytest.mark.asyncio
+async def test_rollback_without_applied_settings_has_no_settings_note(tmp_path):
+    client = _client()
+    plan = _plan(_cat(EntityType.M3U_ACCOUNT, [{"id": 1, "name": "Prov"}]))
+    out = await run_restore(
+        plan=plan,
+        client=client,
+        steps=[
+            _creating_step(EntityType.M3U_ACCOUNT, 901),
+            _raising_step(EntityType.CHANNEL),
+        ],
+        report=_report(),
+        ledger=_ledger(),
+        remap=IdRemapTable(),
+        confirm_apply=True,
+        ledger_dir=tmp_path,
+    )
+    assert out.outcome == RestoreOutcome.PARTIAL_FAILED_ROLLED_BACK
+    assert not any("setting" in note.lower() for note in out.notes)
+
+
+# ---------------------------------------------------------------------------
+# 10. EPG-download wait wiring (kxcjf — the 0i2vt.11 acceptance item)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_epg_apply_step_waits_for_created_sources(tmp_path):
+    # The apply registry's EPG step polls the created sources' rows after the
+    # import; a terminal row (status=success) means zero sleeping.
+    from dbas.restore_orchestrator import _epg_step_with_download_wait
+
+    async def _epg_import(ctx: ApplyContext):
+        cat = ctx.report.category(EntityType.EPG_SOURCE)
+        cat.created += 1
+        ctx.ledger.record_created(EntityType.EPG_SOURCE, 701, "epg-1")
+        return None
+
+    client = _client()
+    client.refresh_epg_source = AsyncMock(return_value={})
+    client.get_epg_source = AsyncMock(
+        return_value={"id": 701, "status": "success", "epg_count": 42}
+    )
+    report = _report()
+    out = await run_restore(
+        plan=_plan(_cat(EntityType.EPG_SOURCE, [{"id": 1, "name": "EPG"}])),
+        client=client,
+        steps=[ImporterStep(EntityType.EPG_SOURCE, _epg_step_with_download_wait(_epg_import))],
+        report=report,
+        ledger=_ledger(),
+        remap=IdRemapTable(),
+        confirm_apply=True,
+        ledger_dir=tmp_path,
+    )
+    assert out.outcome == RestoreOutcome.SUCCESS
+    client.refresh_epg_source.assert_awaited_once_with(701)
+    client.get_epg_source.assert_awaited_once_with(701)
+    # Download completed — no incomplete-wait note.
+    assert not any("did not finish" in n for n in out.notes)
+
+
+@pytest.mark.asyncio
+async def test_epg_apply_step_timeout_is_nonfatal_and_noted(tmp_path):
+    # A source that never reaches a terminal state must NOT hang or fail the
+    # restore — bounded polls, WARN note in the report, restore continues.
+    from dbas.restore_orchestrator import _epg_step_with_download_wait
+    from dbas.importers import epg_sources as epg_mod
+
+    async def _epg_import(ctx: ApplyContext):
+        ctx.report.category(EntityType.EPG_SOURCE).created += 1
+        ctx.ledger.record_created(EntityType.EPG_SOURCE, 702, "epg-2")
+        return None
+
+    client = _client()
+    client.refresh_epg_source = AsyncMock(return_value={})
+    client.get_epg_source = AsyncMock(
+        return_value={"id": 702, "status": "fetching", "epg_count": 0}
+    )
+
+    # Patch the wait's defaults down so the bounded timeout is instant in-test.
+    orig_wait = epg_mod.wait_for_epg_downloads
+
+    async def _fast_wait(**kwargs):
+        async def _no_sleep(_seconds):
+            return None
+
+        kwargs.setdefault("sleep_fn", _no_sleep)
+        kwargs.setdefault("max_polls", 3)
+        return await orig_wait(**kwargs)
+
+    from unittest.mock import patch
+
+    with patch.object(epg_mod, "wait_for_epg_downloads", _fast_wait):
+        out = await run_restore(
+            plan=_plan(_cat(EntityType.EPG_SOURCE, [{"id": 1, "name": "EPG"}])),
+            client=client,
+            steps=[ImporterStep(EntityType.EPG_SOURCE, _epg_step_with_download_wait(_epg_import))],
+            report=_report(),
+            ledger=_ledger(),
+            remap=IdRemapTable(),
+            confirm_apply=True,
+            ledger_dir=tmp_path,
+        )
+    assert out.outcome == RestoreOutcome.SUCCESS  # non-fatal
+    assert any("did not finish" in n and "702" in n for n in out.notes)
+
+
+@pytest.mark.asyncio
+async def test_epg_wait_skipped_on_dry_run_and_when_nothing_created(tmp_path):
+    # Dry-run: the wrapper is a pass-through — no trigger, no poll, no wait.
+    from dbas.restore_orchestrator import _epg_step_with_download_wait
+
+    async def _epg_import(ctx: ApplyContext):
+        ctx.report.category(EntityType.EPG_SOURCE).would_create += 1
+        return None
+
+    client = _client()
+    client.refresh_epg_source = AsyncMock(return_value={})
+    client.get_epg_source = AsyncMock(return_value={})
+    report = RestoreReport(is_dry_run=True)
+    await run_restore(
+        plan=_plan(_cat(EntityType.EPG_SOURCE, [{"id": 1, "name": "EPG"}])),
+        client=client,
+        steps=[ImporterStep(EntityType.EPG_SOURCE, _epg_step_with_download_wait(_epg_import))],
+        report=report,
+        ledger=_ledger(),
+        remap=IdRemapTable(),
+        confirm_apply=False,
+        ledger_dir=tmp_path,
+    )
+    client.refresh_epg_source.assert_not_awaited()
+    client.get_epg_source.assert_not_awaited()
+
+    # Apply with zero CREATED sources (e.g. all already existed): no wait either.
+    async def _epg_import_skip(ctx: ApplyContext):
+        ctx.report.category(EntityType.EPG_SOURCE).skipped += 1
+        return None
+
+    client2 = _client()
+    client2.refresh_epg_source = AsyncMock(return_value={})
+    client2.get_epg_source = AsyncMock(return_value={})
+    await run_restore(
+        plan=_plan(_cat(EntityType.EPG_SOURCE, [{"id": 1, "name": "EPG"}])),
+        client=client2,
+        steps=[ImporterStep(EntityType.EPG_SOURCE, _epg_step_with_download_wait(_epg_import_skip))],
+        report=_report(),
+        ledger=_ledger(),
+        remap=IdRemapTable(),
+        confirm_apply=True,
+        ledger_dir=tmp_path,
+    )
+    client2.refresh_epg_source.assert_not_awaited()
+    client2.get_epg_source.assert_not_awaited()

--- a/backend/tests/dbas/test_restore_roundtrip.py
+++ b/backend/tests/dbas/test_restore_roundtrip.py
@@ -201,3 +201,204 @@ def test_producer_importer_category_parity():
         assert _SECTION_TO_ENTITY.get(section) is entity, (
             "decoder mapping for %s changed" % section
         )
+
+
+# ---------------------------------------------------------------------------
+# kxcjf — REAL-APPLY round trip: confirm_apply=True through the FULL apply
+# registry. Proves (a) every category actually MUTATES the (mock) destination,
+# (b) per-entity counts land in the RestoreReport, and (c) the key parity bar:
+# dry-run counts == subsequent apply counts across ALL registry categories.
+# ---------------------------------------------------------------------------
+
+_ALL_REGISTRY_CATEGORIES = (
+    EntityType.M3U_ACCOUNT,
+    EntityType.EPG_SOURCE,
+    EntityType.CHANNEL_GROUP,
+    EntityType.CHANNEL_PROFILE,
+    EntityType.STREAM_PROFILE,
+    EntityType.USER_AGENT,
+    EntityType.SETTINGS,
+    EntityType.USER,
+    EntityType.CHANNEL,
+    EntityType.DVR_RULE,
+    EntityType.LOGO,
+)
+
+
+def _augment_plan_all_categories(plan):
+    """Extend the artifact-decoded plan so EVERY registry category has work.
+
+    The artifact producer emits M3U/EPG/groups/profiles/channels/users/logos;
+    the user-agent / DVR-rule / settings sections have no producer yet (their
+    importers are wired through the plan seam — bead kxcjf), so this test feeds
+    them plan slices directly, plus one row for each empty artifact category.
+    """
+    from dbas.preflight import PlanCategory
+
+    plan.category(EntityType.EPG_SOURCE).entities.append(
+        {"id": 51, "name": "EPG Main", "source_type": "xmltv",
+         "url": "http://epg.example/guide.xml"}
+    )
+    plan.category(EntityType.CHANNEL_GROUP).entities.append({"id": 61, "name": "News"})
+    plan.category(EntityType.CHANNEL_PROFILE).entities.append({"id": 62, "name": "Main"})
+    plan.category(EntityType.STREAM_PROFILE).entities.append({"id": 63, "name": "Direct"})
+    plan.categories.append(
+        PlanCategory(
+            entity_type=EntityType.USER_AGENT,
+            entities=[{"id": 31, "name": "ECM UA", "user_agent": "ECM/1.0"}],
+        )
+    )
+    plan.categories.append(
+        PlanCategory(
+            entity_type=EntityType.DVR_RULE,
+            # ``channel`` FK points at the archived channel (source id 5); it must
+            # remap through the CHANNEL namespace on BOTH dry-run and apply.
+            entities=[{"id": 41, "name": "Record CNN", "channel": 5}],
+        )
+    )
+    plan.categories.append(
+        PlanCategory(
+            entity_type=EntityType.SETTINGS,
+            entities=[
+                # default_user_agent is safe -> applied; the api_key-marked key is
+                # denylisted -> skipped (by name only).
+                {"section": "core_settings",
+                 "values": {"default_user_agent": "ECM/1.0",
+                            "provider_api_key": "sekrit"}},
+                {"section": "comskip", "values": {"comskip_ini": "[main]"}},
+            ],
+        )
+    )
+    return plan
+
+
+def _apply_client():
+    """An empty-destination mock whose creates return destination ids."""
+    client = _restore_client()
+    client.create_m3u_account = AsyncMock(side_effect=[{"id": 901}, {"id": 902}])
+    client.create_epg_source = AsyncMock(return_value={"id": 751})
+    # EPG-download wait probes (terminal on first check — zero sleeping).
+    client.refresh_epg_source = AsyncMock(return_value={})
+    client.get_epg_source = AsyncMock(
+        return_value={"id": 751, "status": "success", "epg_count": 10}
+    )
+    client.create_channel_group = AsyncMock(return_value={"id": 761})
+    client.create_channel_profile = AsyncMock(return_value={"id": 762})
+    client.create_stream_profile = AsyncMock(return_value={"id": 763})
+    client.get_user_agents = AsyncMock(return_value=[])
+    client.create_user_agent = AsyncMock(return_value={"id": 771})
+    client.get_dvr_rules = AsyncMock(return_value=[])
+    client.create_dvr_rule = AsyncMock(return_value={"id": 781})
+    client.update_core_setting = AsyncMock(return_value={})
+    client.create_user = AsyncMock(return_value={"id": 791})
+    client.create_channel = AsyncMock(return_value={"id": 505})
+    # One destination stream whose name Tier-3 matches the archived embedded
+    # stream, so the attach path exercises update_channel (no fallback synth).
+    client.get_streams = AsyncMock(
+        return_value={"results": [{"id": 990, "name": "CNN HD"}], "count": 1}
+    )
+    client.update_channel = AsyncMock(return_value={})
+    client.update_profile_channel = AsyncMock(return_value={})
+    client.upload_logo_file = AsyncMock(return_value={"id": 995})
+    return client
+
+
+@pytest.mark.asyncio
+async def test_real_apply_roundtrip_mutates_every_category_with_dry_run_parity(tmp_path):
+    from dbas.restore_contracts import (
+        IdRemapTable,
+        RestoreOutcome,
+        RestoreReport,
+        RollbackLedger,
+    )
+    from dbas.restore_orchestrator import (
+        default_importer_steps,
+        new_restore_id,
+        run_dry_run,
+        run_restore,
+    )
+
+    art = await _build_real_artifact(tmp_path)
+    with zipfile.ZipFile(art.zip_path, "r") as zf:
+        validate_artifact_manifest(zf)
+        plan = decode_artifact_to_plan(zf)
+    plan = _augment_plan_all_categories(plan)
+
+    # --- 1. Dry-run first (the default-ON preview the operator sees). --------
+    dry_report = await run_dry_run(plan=plan, client=_restore_client())
+    assert dry_report.is_dry_run is True
+
+    # Every registry category has non-zero planned work — nothing previews empty.
+    for entity_type in _ALL_REGISTRY_CATEGORIES:
+        dry_cat = dry_report.category(entity_type)
+        planned = dry_cat.would_create + dry_cat.would_update + dry_cat.would_skip
+        assert planned > 0, "dry-run planned nothing for %s" % entity_type.value
+
+    # --- 2. Real apply (confirm_apply=True) through the FULL apply registry. --
+    client = _apply_client()
+    apply_report = await run_restore(
+        plan=plan,
+        client=client,
+        steps=default_importer_steps(),
+        report=RestoreReport(is_dry_run=False),
+        ledger=RollbackLedger(restore_id=new_restore_id()),
+        remap=IdRemapTable(),
+        confirm_apply=True,
+        ledger_dir=tmp_path,
+    )
+    assert apply_report.is_dry_run is False
+    assert apply_report.outcome == RestoreOutcome.SUCCESS
+
+    # --- 3. THE parity bar: dry-run counts == apply counts, ALL categories. ---
+    for entity_type in _ALL_REGISTRY_CATEGORIES:
+        dry_cat = dry_report.category(entity_type)
+        apply_cat = apply_report.category(entity_type)
+        assert (
+            apply_cat.created,
+            apply_cat.updated,
+            apply_cat.skipped,
+            apply_cat.failed,
+        ) == (
+            dry_cat.would_create,
+            dry_cat.would_update,
+            dry_cat.would_skip,
+            0,
+        ), "dry-run/apply divergence for %s" % entity_type.value
+
+    # --- 4. Every category actually MUTATED the destination (the silent-skip
+    # defect this bead closes: pre-kxcjf only M3U/users/channels mutated). -----
+    assert client.create_m3u_account.await_count == 2
+    client.create_epg_source.assert_awaited_once()
+    client.create_channel_group.assert_awaited_once()
+    client.create_channel_profile.assert_awaited_once()
+    client.create_stream_profile.assert_awaited_once()
+    client.create_user_agent.assert_awaited_once()
+    client.create_dvr_rule.assert_awaited_once()
+    assert client.update_core_setting.await_count == 2  # safe keys only
+    client.create_user.assert_awaited_once()
+    client.create_channel.assert_awaited_once()
+    client.upload_logo_file.assert_awaited_once()
+    # The stream layer attached the Tier-3-matched destination stream.
+    client.update_channel.assert_awaited_once_with(505, {"streams": [990]})
+
+    # The denylisted settings key was skipped by NAME and its value never sent.
+    sent_keys = [c.args[0] for c in client.update_core_setting.await_args_list]
+    assert "provider_api_key" not in sent_keys
+    assert set(sent_keys) == {"default_user_agent", "comskip_ini"}
+
+    # --- 5. EPG-download wait ran for the CREATED source, before channels. ----
+    client.refresh_epg_source.assert_awaited_once_with(751)
+    client.get_epg_source.assert_awaited_once_with(751)
+    # Terminal on first probe -> no incomplete-download note.
+    assert not any("did not finish" in n for n in apply_report.notes)
+
+    # --- 6. The DVR rule's channel FK was remapped source(5) -> dest(505). ----
+    dvr_payload = client.create_dvr_rule.await_args.args[0]
+    assert dvr_payload["channel"] == 505
+
+    # --- 7. Per-entity counts landed in the report (spot totals). -------------
+    assert apply_report.category(EntityType.M3U_ACCOUNT).created == 2
+    assert apply_report.category(EntityType.EPG_SOURCE).created == 1
+    assert apply_report.category(EntityType.SETTINGS).updated == 2
+    assert apply_report.category(EntityType.SETTINGS).skipped == 1
+    assert apply_report.category(EntityType.LOGO).created == 1

--- a/backend/tests/fixtures/sync_harness.py
+++ b/backend/tests/fixtures/sync_harness.py
@@ -406,6 +406,18 @@ class StatefulDispatcharrFake:
         # references ``client.delete_user``. A 404 is the correct "already gone".
         raise FakeNotFoundError("user", user_id)
 
+    # ----- user agents / DVR rules / logos (not in the sync category set, but
+    #        _delete_dispatch references their compensators eagerly — kxcjf) ---
+
+    async def delete_user_agent(self, user_agent_id: int) -> None:
+        raise FakeNotFoundError("user_agent", user_agent_id)
+
+    async def delete_dvr_rule(self, rule_id: int) -> None:
+        raise FakeNotFoundError("dvr_rule", rule_id)
+
+    async def delete_logo(self, logo_id: int) -> None:
+        raise FakeNotFoundError("logo", logo_id)
+
     # ----- state snapshot (the convergence assertion surface) --------------
 
     def state_by_key(self) -> dict[str, set]:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.17.6-0168",
+  "version": "0.17.6-0169",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## [enhancedchannelmanager-kxcjf] Wire all DBAS importers into the real restore-apply registry (dry-run/apply parity)

### The defect (silent skip)
`default_importer_steps()` in `backend/dbas/restore_orchestrator.py` was never updated as the per-category importers landed: only **M3U_ACCOUNT, USER, CHANNEL** were wired into the real (`confirm_apply=True`) restore path. EPG sources, channel groups, channel/stream profiles, user agents were `importer=None` seams, DVR rules and settings had no registry row at all, and logos were absent from the apply registry entirely. A confirmed restore silently no-opped 9 of 13 categories **while reporting SUCCESS** — and the default-ON dry-run preview DID wire most of them, so the operator was promised "would create N" counts that a real apply never delivered.

### The fix (parity)
- **Apply registry fully wired**, dependency-ordered: M3U → EPG (+ bounded EPG-data download wait) → channel groups/profiles/stream profiles → user agents → settings (core + comskip) → users → channels → DVR rules (channel-FK remap needs channels first) → logos.
- **Dry-run registry gains USER_AGENT / SETTINGS / DVR_RULE** rows — both registries now cover the same category set in the same order, through the same shared step builders. Parity is pinned by tests.
- **EPG-download wait** (unmet 0i2vt.11 acceptance): `wait_for_epg_downloads` runs a bounded 2-stage trigger+poll (mirrors the M3U `apply_deferred_auto_sync` pattern) over sources created this run, so Dispatcharr has EPG rows before channels are created. Timeout is non-fatal and non-silent (WARN + RestoreReport note). Apply-only — dry-run and the per-cycle sync engine keep the unwrapped EPG step (ADR-013 S9).
- **Rollback coverage**: USER_AGENT / DVR_RULE / LOGO compensators registered in `_delete_dispatch`. SETTINGS remains deliberately non-compensatable (config, never ledgered); a rollback that follows applied settings now appends an explicit "N applied setting(s) were NOT rolled back" report note instead of implying a full undo.
- Fixed the now-false WIRED-vs-SEAM module docs/comments. Plugins stay excluded per ADR-012 D10.

### Tests
- Flipped `test_default_importer_steps_order_and_wiring` to pin the full wiring + order (proven red against the pre-fix registry).
- New: registry-parity test, all-compensators test, settings-not-rolled-back note tests, EPG-wait wiring tests (apply waits / dry-run doesn't / timeout is noted), 6 `wait_for_epg_downloads` unit tests.
- New real-apply round-trip: `confirm_apply=True` through the full apply registry over an artifact-decoded plan augmented to cover every registry category — asserts every category mutates the mock destination, per-entity counts land in the report, and **dry-run counts == apply counts across ALL registry categories**.

Full backend suite under the project venv: **7934 passed, 4 skipped**. Deployed to `ecm-ecm-1` and `/api/health/ready` confirmed; in-container smoke shows both registries at parity with zero seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)