### PR TITLE
docs: salvage orphaned PII redactions and terminology fixes from a stale worktree

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -142,7 +142,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.1-0054",
+    version="0.18.1-0056",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -90,7 +90,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.1-0054"
+APP_VERSION = "0.18.1-0056"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/docs/design/operator-workspace-information-architecture.md
+++ b/docs/design/operator-workspace-information-architecture.md
@@ -2,7 +2,7 @@
 
 Status: implementation contract for `enhancedchannelmanager-2896r.1`
 
-Visual reference: [ECM Operator Workspace mockup v16](https://ecm-operator-workspace.curt347145.chatgpt.site/?view=channels), source commit `48353d703b9c1b6ba2e33ea2b9f9bce05cf6412c`
+Visual reference: ECM Operator Workspace mockup v16 (privately hosted, link held by the PO), source commit `48353d703b9c1b6ba2e33ea2b9f9bce05cf6412c`
 
 Target viewports: 1920×1080 and 1280×720
 

--- a/docs/design/settings-information-architecture.md
+++ b/docs/design/settings-information-architecture.md
@@ -28,7 +28,7 @@ premise that is false in the current implementation, and acting on it would ship
 
 ## 2. Method and evidence base
 
-Everything asserted below was read from source at `/home/lecaptainc/ecm/wt-newui` (branch `newui`)
+Everything asserted below was read from source in a `newui`-branch worktree
 or measured against the running instance (`ecm-ecm-1`, `ECM_VERSION=0.18.1-0000`,
 `GIT_COMMIT=cbabdc17`). Where I could not verify something, I say so.
 

--- a/docs/mcp_compound_test_plan.md
+++ b/docs/mcp_compound_test_plan.md
@@ -66,13 +66,15 @@ disposably.
   `USA | Local PBS`, `NFL Game Pass 🏈`, `ESPN+`, `Entertainment`.
 - **M3U accounts (real):** `Provider 1` (Xtream, ~2624 streams), `HD Homerun`
   (~56 streams), `custom` (ERROR state).
-- **EPG sources (real):** `Teamarr`, `Jesmann Gracenote`, `Jesmann Full`, `B1G EPG`,
-  `B1G Advanced EPG` (dummy).
+- **EPG sources (real):** one XMLTV aggregator, two Gracenote-backed feeds, a
+  sport-specific feed, and one dummy EPG profile. Names are instance-specific;
+  substitute your own.
 - **Profiles (real):** channel profiles `LiveTV`, `HDHomerun`, `TestingProfile`;
   stream profiles `ffmpeg`, `VLC`.
 - **Channel Pipeline rules (real):** `Testing Rule` (matches stream name contains
   "ESPN"), `Create B1G Channels`, `USA Entertainment`.
-- **Users (real):** `home`, `kmfelmer` (Dispatcharr).
+- **Users (real):** two Dispatcharr sub-accounts. Names are instance-specific;
+  substitute your own.
 - **Tasks (real ids):** `stream_probe`, `epg_refresh`, `m3u_refresh`,
   `popularity_calculation`.
 

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -6,7 +6,7 @@
 
 Normalization is the step between "raw name from an M3U line" and "channel name on disk." It runs in three places:
 
-- **Test Rules**: Settings → Normalization → the preview panel where you paste a sample name and see what the current rule set produces. Safe to use freely; no side effects.
+- **Test Rules**: Settings → Channel Normalization → the preview panel where you paste a sample name and see what the current rule set produces. Safe to use freely; no side effects.
 - **Channel Pipeline**: the Channel Pipeline reads the stream's raw name, passes it through the same rule set, and uses the output as the channel name (or as the lookup key for matching an existing channel).
 - **Re-normalize Existing Channels**: a one-time bulk rewrite that reapplies the current rule set to channels already on disk. Manual, gated, undoable.
 
@@ -29,7 +29,7 @@ These three paths **must produce the same output for the same input**. That is t
 
 ### Your first rule
 
-1. Open **Settings → Normalization Rules**.
+1. Open **Settings → Channel Normalization**.
 2. Pick a rule group (or create one). Groups are ordering buckets: rules within a group run in priority order, groups run in group-priority order.
 3. Click **Add rule**. Choose a condition and an action.
 4. Expand the **Test Rules** panel above the rule groups, paste a sample raw name (one per line), and click **Run Test**.
@@ -174,7 +174,7 @@ Do **not** use it to force a one-off rename of a single channel. Edit the channe
 
 ### Dry-run preview walkthrough
 
-1. Settings → Normalization Rules → **Apply to existing channels**.
+1. Settings → Channel Normalization → **Apply to existing channels**.
 2. The modal opens in **dry-run** mode by default. ECM computes the diff and shows one row per channel with a proposed new name.
 
    ![Apply Normalization to Existing Channels modal with the rule-trace drawer expanded on the first row, showing current_name, proposed name, rules-fired count, and a trace panel explaining the diff cause (in this case Unicode normalization only)](images/normalization/apply-to-channels-dry-run.png)
@@ -197,7 +197,7 @@ The execute call takes an `actions[]` array keyed by `channel_id`. Only the chan
 - **Channel numbers**: preserved. A rename does not renumber; a merge folds the source channel's streams into the target and deletes the source, so the source's number becomes available.
 - **Channel groups**: preserved on rename; the merged channel stays in its original group on merge.
 - **Watch history / stats**: preserved on rename (same `channel_id`); on merge, the source's history is deleted with the source row. The target's history is not backfilled.
-- **Journal**: every rename and every merge is logged under the `normalization` category with the `rule_set_hash` computed at execute time. Use the journal view (Settings → Journal, or `GET /api/journal?category=normalization`) to audit and to drive undo.
+- **Journal**: every rename and every merge is logged under the `normalization` category with the `rule_set_hash` computed at execute time. Use the **Journal** page (or `GET /api/journal?category=normalization`) to audit and to drive undo.
 
 ### Undo via journal, rollback
 
@@ -245,7 +245,7 @@ Cause: the merge lookup compares names case-insensitively but does **not** colla
 Fix (two halves, both opt-in):
 
 1. **Stop new duplicates**: edit the rule → enable **"Ignore spacing & case differences when matching"** (`fold_match_key`). Future runs compare names by a folded key (casefold + strip all whitespace) so all four spellings merge into whichever channel exists first. Stored names are never rewritten.
-2. **Clean up existing duplicates**: Channels tab → Find Duplicates → enable **"Ignore spacing differences"**. The same folded key groups the existing spelling variants so you can bulk-merge them.
+2. **Clean up existing duplicates**: Channel Manager → select the channels → Find Duplicates → enable **"Ignore spacing differences"**. The same folded key groups the existing spelling variants so you can bulk-merge them.
 
 Leave both off if your provider uses spacing/case to distinguish genuinely different channels. Note that digit runs collide too ("Canal 5 2" and "Canal 52" fold to the same key).
 

--- a/docs/runbooks/stats-v2-deployment-safety.md
+++ b/docs/runbooks/stats-v2-deployment-safety.md
@@ -206,7 +206,7 @@ This is a misleading signal in fresh deploys. See the "useful in 30d, fully usef
 If post-deploy verification fails AND rollback fails:
 
 - This is now a P1 incident: the deploy substrate is broken.
-- Page the SRE persona via the operator's chosen channel (no rotation defined yet; routes to `curt@lecaptain.org`).
+- Page the SRE persona via the operator's chosen channel. There is no on-call rotation yet, so pages route to the instance operator directly.
 - Capture all artifacts: logs, `alembic current` output, `/metrics` snapshot, `docker ps` output.
 
 ## See also

--- a/docs/runbooks/stats-v2-write-failures.md
+++ b/docs/runbooks/stats-v2-write-failures.md
@@ -138,7 +138,7 @@ If columns are missing relative to the current code's expectations: Alembic migr
 
 If failure ratio remains > 5% after running the matching diagnosis branch:
 
-- Page the SRE persona via the operator's chosen channel (no rotation defined yet, pages route to `curt@lecaptain.org` until on-call exists).
+- Page the SRE persona via the operator's chosen channel. There is no on-call rotation yet, so pages route to the instance operator directly.
 - Provide: alert start time, branch from diagnosis tree that matched, recovery steps attempted, current `ecm_session_telemetry_writes_total{result="failure"}` 5m rate.
 
 ## Post-incident

--- a/docs/user_guide/channel-pipeline/runaway-safety-cap.md
+++ b/docs/user_guide/channel-pipeline/runaway-safety-cap.md
@@ -49,10 +49,9 @@ specific reason and understand the risk.
 > automated MCP client) that tries to change the cap is rejected. The
 > Settings UI shows the inputs as read-only for non-admins.
 
-## Older versions
+## If you set the cap by hand
 
-Before this control existed, the only way to change the cap was to hand-edit
-`max_auto_created_channels_per_run` in `/config/settings.json` and restart ECM.
-That is no longer necessary. Use **Settings → Channel Pipeline** instead. (The
-underlying settings key is unchanged, so an install that previously set it by
-hand keeps its value and now shows it in the UI.)
+The cap is stored as `max_auto_created_channels_per_run` in
+`/config/settings.json`. You do not need to edit that file: use
+**Settings → Channel Pipeline** instead. An install that had the key set by
+hand keeps its value, and the UI shows it.

--- a/docs/user_guide/operator-workspace.md
+++ b/docs/user_guide/operator-workspace.md
@@ -51,7 +51,8 @@ notification controls:
 | **● Offline** | The API returned an error. |
 | **● <status>** | ECM answered with a status other than healthy; the reported status is shown as-is. |
 
-The pill also shows the running ECM version, for example **● Online · v0.18.1**.
+The pill also shows the running ECM version, after the status word
+(**● Online · <version>**).
 The coloured dot repeats what the words already say, so the status is readable
 without relying on colour.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.1-0054",
+  "version": "0.18.1-0056",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Recovers documentation work written on 2026-08-01, never committed, and orphaned for nine days.

## Provenance

A docs commit was made on a *pipeline bugfix* branch whose PR had already merged. Its content later reached `dev` as `cb3bcebb` (identical tree hash, verified), so the articles shipped. But edits made in that worktree AFTER that commit were never committed, and a rebase moves commits rather than working-tree changes, so they were stranded.

All 102 orphaned edits were triaged: 67 sat on files `dev` has since changed and were discarded as superseded. Of the 35 remaining, 25 were screenshots, discarded by PO decision because they predate the 2026-08-02 PII audit (bead `enhancedchannelmanager-2mluw`) and are roughly 45 builds stale. They will be re-shot against current `dev`.

This PR is what survived: 7 files taken whole, 1 partially, 2 rejected.

## What it does

Primarily a **PII redaction sweep**: a privately-hosted mockup URL, an absolute local filesystem path, real EPG source and Dispatcharr account names, and a personal email address in two runbooks.

Plus terminology corrections that had drifted against the operator-workspace rework: the "Channel Normalization" relabel, Journal being a top-level tab rather than a Settings destination, and "Channels tab" becoming "Channel Manager". Each was re-verified against current source rather than taken from the nine-day-old edit.

## Deliberately not included

`docs/normalization.md` was taken **partially**. Two image alt-text hunks were dropped: the live `dev` screenshots were rendered and their content matches the OLD alt text, so the rewritten text would have described screenshots that are not being shipped.

`scripts/check-operator-docs.mjs` and its test were **rejected**. The feature validates `github.com/.../blob/<branch>/...` links as local paths, which is a good idea, but it hardcodes the prefix to `/blob/dev/`. Measured on the base commit: 160 `/blob/main/`, 2 `/blob/master/`, 1 `/blob/dev/` — and that single hit is explicitly labelled "on the dev branch; not yet on main". As written the checker would validate one link while appearing to guard 163. Worth a follow-up with corrected prefix logic.

## Not covered here

`.beads/issues.jsonl` carries the same email in two bead descriptions. Tracked separately as bead `enhancedchannelmanager-il1xz`, which also adds a CI guard against new personal identifiers.

Existing exposure in git history is accepted by PO decision and is not being rewritten.

## Verification

Reviewed independently, with every claim re-checked against current source rather than taken from the report, including the blob-prefix ratio above. Confirmed zero PII remains in the touched files, checked per identifier.

Gates: `npm run docs:check` 8/8, `check_em_dashes.py` PASS, `check_version_consistency.py` all three at `0.18.1-0056`, `check_version_advances.py` OK, `mkdocs build --strict` green. Because bead `h2jjg` records that `--strict` passes on links into excluded files, every markdown link in all 8 touched files was additionally existence-checked on disk.

No CHANGELOG entry: all changed docs are internal or developer reference prose with no behaviour change, which `docs/shipping.md` scopes out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)