### PR TITLE
test(css): repair the CSS measurement layer — contrast parser, animation freeze, baseline refresh

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -142,7 +142,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.1-0056",
+    version="0.18.1-0057",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -90,7 +90,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # frontend/package.json and backend/main.py. Do NOT rename it, change its
 # shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.1-0056"
+APP_VERSION = "0.18.1-0057"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -316,6 +316,20 @@ cd frontend && npx vite --config vite.harness.config.ts
 Baseline artefact:
 `frontend/src/devHarness/baseline/modal-typography.baseline.json`.
 
+**Every capture is animation-frozen, and captures made before that was true
+have untrustworthy GEOMETRY.** `ModalBase.css` opens each dialog with
+`modal-container-slide-in` (0.2s, `scale(0.98)` to `scale(1)`), and a capture
+taken mid-flight multiplies every box in the dialog by a run-dependent scale
+factor. Measured on bead `enhancedchannelmanager-iotbh`: one unfrozen run
+reported the 32px close button at seven different sizes across the 81 dialogs,
+and a change that could only shrink type by 0.33px moved 214 of 281 boxes by 1
+to 11px. The script now suppresses animations and transitions before it
+measures, with no flag to turn that off, and stamps `animationsFrozen: true`
+into the payload. A capture without that field predates the fix. Two
+consecutive frozen runs over an unchanged tree now move 0 of 411 geometry rows.
+Typography rows were never affected, since `font-size` and `font-weight` are
+not scaled by a transform.
+
 **It is not in the production bundle, and cannot be.** `vite.config.ts` has a
 single entry (`index.html`); the harness is built only by the separate
 `vite.harness.config.ts` into the gitignored `.modal-harness-dist/`.

--- a/e2e/contrast-aa.spec.ts
+++ b/e2e/contrast-aa.spec.ts
@@ -35,9 +35,14 @@
  *    calls a near-white surface near-BLACK. Both mistakes are live in this
  *    repo's history: the first under-read the sticky-nav pill backdrop as
  *    #f0f0ff instead of the #e7e8f7 that is actually painted (reporting 3.96
- *    where the truth is 3.68), and the second is still latent in
- *    `computedTextContrast` in `operator-shell.spec.ts`, harmless only because
- *    none of its listed selectors currently sits under a `color-mix` layer.
+ *    where the truth is 3.68), and the second sat latent in
+ *    `computedTextContrast` in `operator-shell.spec.ts` until bead
+ *    `enhancedchannelmanager-pbkwo` replaced it with this technique. That
+ *    function now carries its own copy of the core below. A `page.evaluate`
+ *    body is serialised into the browser and cannot reach a module import, and
+ *    this file runs its copy inside ONE whole-page evaluate over thousands of
+ *    nodes rather than per element, so the two cannot share one definition.
+ *    A change to the model belongs in both.
  *    So no colour is parsed here at all. Each one is handed to a 1x1 canvas and
  *    the pixel is read back, which means the engine that painted the page is
  *    the thing that resolves the syntax — `color()`, `oklch()`, `color-mix()`,

--- a/e2e/operator-shell.spec.ts
+++ b/e2e/operator-shell.spec.ts
@@ -442,53 +442,203 @@ function requestOwner(normalizedKey: string): PeriodicRequestPolicy['owner'] | n
   return intendedPeriodicRequests[normalizedKey]?.owner ?? null
 }
 
-async function computedTextContrast(page: Page, selector: string) {
+/**
+ * Freeze every transition and animation before measuring a colour.
+ *
+ * Both contrast tests below flip `data-theme` on `<html>` and measure straight
+ * afterwards, and theme tokens are animated: an element caught inside a
+ * `background-color` transition reports a colour that is on its way somewhere
+ * and that no user is ever asked to read. `e2e/contrast-aa.spec.ts` shipped an
+ * allowlist entry off exactly that mistake. `.failed-streams-alert` measured
+ * 4.40 light and 3.72 high-contrast 180ms after a theme switch, and 4.75 at
+ * rest; that guard added this same override in response.
+ *
+ * `!important` because route chunk stylesheets are appended to <head> AFTER
+ * this tag on first visit, so ordinary specificity would let them win.
+ */
+const FREEZE_ANIMATION = `
+*, *::before, *::after {
+  transition: none !important;
+  animation: none !important;
+}`
+
+/**
+ * True composited contrast for one element. NOTHING HERE PARSES A COLOUR.
+ *
+ * The previous implementation grepped `/[\d.]+/g` out of the computed value and
+ * read the captures as 0-255 channels. Chrome serialises `color-mix(in srgb,
+ * ...)` as `color(srgb 0.96 0.96 0.96 / 0.94)`, so that resolver read a
+ * near-WHITE surface as very nearly BLACK. Every assertion it made over a
+ * `color-mix` surface was therefore meaningless in either direction, and the app
+ * paints `color-mix` on the primary rail, the dashboard card glyphs and the
+ * selected nav states. Repairing the regex only defers the problem to the next colour
+ * syntax CSS ships (`lab()`, `oklch()`, relative colours), so this measures the
+ * way `e2e/contrast-aa.spec.ts` does instead: paint the stacking chain into a
+ * 1x1 canvas and read the pixel back, letting the engine that painted the page
+ * resolve the syntax and do the alpha arithmetic. Bead
+ * `enhancedchannelmanager-pbkwo`.
+ *
+ * The model is deliberately identical to `contrast-aa`'s, including the two
+ * things that guard learned the hard way:
+ *
+ *   - `accepts()` uses TWO sentinels. `fillStyle` silently KEEPS ITS PREVIOUS
+ *     VALUE on an unparseable string, so a single assignment cannot tell
+ *     "accepted" from "ignored".
+ *   - group `opacity` accumulates from the ROOT DOWN. The alpha a node's
+ *     background is painted at is the product of its own `opacity` and its
+ *     ANCESTORS', never its descendants' (bead
+ *     `enhancedchannelmanager-0zq1p`). The measured element's ink, by contrast,
+ *     really is inside every group in the chain, so it carries the full
+ *     product.
+ *
+ * The core is duplicated rather than imported because a `page.evaluate` body is
+ * serialised and re-parsed in the browser: it cannot reach a module import, and
+ * `contrast-aa` runs its copy inside one whole-page evaluate over thousands of
+ * nodes rather than per element. Any change to the model belongs in both.
+ *
+ * WHAT THE SWAP ACTUALLY MOVED, measured rather than assumed: both resolvers
+ * were run over the same DOM in the same page, 132 measurements across both
+ * tests, both viewports, three themes and both states. 42 moved, all of them by
+ * 0.01-0.15, and NONE of them because of `color-mix`: every computed background
+ * in every ancestor chain these selectors walk is plain `rgb()` or `rgba()`
+ * today, so the mis-parse really was latent here, exactly as `contrast-aa`'s
+ * header note claimed. What moved instead is precision. The canvas composites at
+ * the compositor's 8-bit depth, so `rgba(16,185,129,.12)` over `#252530` reads
+ * the #263a3e that is painted rather than the fractional rgb(39,59,62) a float
+ * blend carries. No verdict changed; every listed selector still clears 4.5 with
+ * room. Latent is not the same as harmless. The app paints `color-mix` on the
+ * primary rail, the selected nav states and the dashboard card glyphs, so the
+ * trap was one selector away.
+ */
+async function measureCompositedContrast(page: Page, selector: string) {
   return page.locator(selector).first().evaluate((element, evaluatedSelector) => {
-    type Rgba = { r: number; g: number; b: number; a: number }
-    const parse = (value: string): Rgba => {
-      // Detached/non-painting ancestors can report an empty computed
-      // background during a concurrent React commit; it is equivalent to a
-      // transparent paint layer, not an unsupported foreground color.
-      if (value === '' || value === 'transparent') return { r: 0, g: 0, b: 0, a: 0 }
-      const channels = value.match(/[\d.]+/g)?.map(Number) ?? []
-      if (channels.length < 3) throw new Error(`Unsupported computed color: ${value}`)
-      return { r: channels[0], g: channels[1], b: channels[2], a: channels[3] ?? 1 }
+    const canvas = document.createElement('canvas')
+    canvas.width = 1
+    canvas.height = 1
+    const ctx = canvas.getContext('2d', { willReadFrequently: true })!
+
+    const accepts = (value: string) => {
+      ctx.fillStyle = '#010203'
+      ctx.fillStyle = value
+      const first = ctx.fillStyle
+      ctx.fillStyle = '#040506'
+      ctx.fillStyle = value
+      return first === ctx.fillStyle
     }
-    const blend = (foreground: Rgba, background: Rgba): Rgba => {
-      const alpha = foreground.a + background.a * (1 - foreground.a)
-      if (alpha === 0) return { r: 0, g: 0, b: 0, a: 0 }
-      return {
-        r: (foreground.r * foreground.a + background.r * background.a * (1 - foreground.a)) / alpha,
-        g: (foreground.g * foreground.a + background.g * background.a * (1 - foreground.a)) / alpha,
-        b: (foreground.b * foreground.a + background.b * background.a * (1 - foreground.a)) / alpha,
-        a: alpha,
+    const read = () => {
+      const data = ctx.getImageData(0, 0, 1, 1).data
+      return { r: data[0], g: data[1], b: data[2] }
+    }
+    type Channels = { r: number; g: number; b: number }
+    const linear = (channel: number) => {
+      const value = channel / 255
+      return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+    }
+    const luminance = (colour: Channels) =>
+      0.2126 * linear(colour.r) + 0.7152 * linear(colour.g) + 0.0722 * linear(colour.b)
+    const hex = (colour: Channels) =>
+      `#${[colour.r, colour.g, colour.b].map((v) => v.toString(16).padStart(2, '0')).join('')}`
+
+    // A React commit can detach the matched node between the locator resolving
+    // and this body running, and `getComputedStyle` on a node outside the
+    // document returns an EMPTY declaration, every property the empty string.
+    // Reading '' as a colour is precisely the confidently-wrong number this
+    // function exists to stop producing, so say so and let the caller re-read.
+    if (!element.isConnected || getComputedStyle(element).color === '') {
+      return { detached: true as const, selector: evaluatedSelector }
+    }
+
+    // Collect upward, the only direction the DOM offers, then accumulate the
+    // group alphas downward from the root.
+    const chain: Array<{ colour: string; opacity: number }> = []
+    let gradient: string | null = null
+    for (let node: Element | null = element; node; node = node.parentElement) {
+      const style = getComputedStyle(node)
+      const opacity = Number.parseFloat(style.opacity)
+      if (!gradient && style.backgroundImage && style.backgroundImage !== 'none') {
+        gradient = `${node.tagName.toLowerCase()}: ${style.backgroundImage.slice(0, 48)}`
       }
+      chain.push({ colour: style.backgroundColor, opacity: Number.isFinite(opacity) ? opacity : 1 })
+      if (node === document.documentElement) break
     }
-    const layers: Rgba[] = []
-    for (let current: Element | null = element; current; current = current.parentElement) {
-      layers.push(parse(getComputedStyle(current).backgroundColor))
+    const layers: Array<{ colour: string; groupAlpha: number }> = new Array(chain.length)
+    let selfOpacity = 1
+    for (let i = chain.length - 1; i >= 0; i -= 1) {
+      selfOpacity *= chain[i].opacity
+      layers[i] = { colour: chain[i].colour, groupAlpha: selfOpacity }
     }
-    let background: Rgba = { r: 255, g: 255, b: 255, a: 1 }
-    for (const layer of layers.reverse()) background = blend(layer, background)
-    const foreground = blend(parse(getComputedStyle(element).color), background)
-    const luminance = (color: Rgba) => {
-      const linear = [color.r, color.g, color.b].map((channel) => {
-        const value = channel / 255
-        return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
-      })
-      return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+    // The CSS initial canvas surface. `html`/`body` paint over it on every
+    // route here, so it only shows through where nothing paints at all.
+    ctx.globalAlpha = 1
+    ctx.fillStyle = '#ffffff'
+    ctx.fillRect(0, 0, 1, 1)
+    for (let i = layers.length - 1; i >= 0; i -= 1) {
+      const { colour, groupAlpha } = layers[i]
+      // Detached/non-painting ancestors can report an empty computed background
+      // during a concurrent React commit; that is a transparent paint layer,
+      // not an unsupported colour. Painting `transparent` is a no-op either way.
+      if (colour === '' || colour === 'transparent') continue
+      if (!accepts(colour)) throw new Error(`Unsupported computed background: ${colour}`)
+      ctx.globalAlpha = groupAlpha
+      ctx.fillStyle = colour
+      ctx.fillRect(0, 0, 1, 1)
     }
+    ctx.globalAlpha = 1
+    const background = read()
+
+    const declaredColor = getComputedStyle(element).color
+    if (!accepts(declaredColor)) throw new Error(`Unsupported computed color: ${declaredColor}`)
+    ctx.globalAlpha = selfOpacity
+    ctx.fillStyle = declaredColor
+    ctx.fillRect(0, 0, 1, 1)
+    ctx.globalAlpha = 1
+    const foreground = read()
+
     const foregroundLuminance = luminance(foreground)
     const backgroundLuminance = luminance(background)
     return {
+      detached: false as const,
       selector: evaluatedSelector,
-      foreground: getComputedStyle(element).color,
-      background: `rgb(${background.r} ${background.g} ${background.b})`,
-      ratio: (Math.max(foregroundLuminance, backgroundLuminance) + 0.05)
-        / (Math.min(foregroundLuminance, backgroundLuminance) + 0.05),
+      foreground: hex(foreground),
+      declaredColor,
+      background: hex(background),
+      // A gradient anywhere in the chain cannot be reduced to one colour, so
+      // `background` is the solid layers only and the ratio is not the whole
+      // story. Reported rather than swallowed; `contrast-aa` skips such sites
+      // outright for the same reason.
+      backgroundGradient: gradient,
+      opacity: Math.round(selfOpacity * 1000) / 1000,
+      ratio: Math.round(((Math.max(foregroundLuminance, backgroundLuminance) + 0.05)
+        / (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)) * 100) / 100,
       text: element.textContent?.trim() ?? '',
     }
   }, selector)
+}
+
+/**
+ * `measureCompositedContrast`, re-read until the element presents a resolved
+ * computed style.
+ *
+ * Not defensive padding: caught in the field on the very first full-file run of
+ * this change, `--workers=2`, Channel Manager at 1920x1080: the locator
+ * matched, React re-committed the group list, and the evaluate landed on a node
+ * that was no longer in the document. The measurement that would have been
+ * reported is black-on-black. A re-read is correct because the locator is
+ * re-resolved on every attempt, so the retry measures the element that replaced
+ * it rather than the corpse of the one that went away.
+ */
+async function computedTextContrast(page: Page, selector: string) {
+  const attempts = 10
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const reading = await measureCompositedContrast(page, selector)
+    if (!reading.detached) return reading
+    await page.waitForTimeout(100)
+  }
+  throw new Error(
+    `${selector} never presented a resolved computed style in ${attempts} reads: it was detached ` +
+      'from the document on every attempt, so no contrast measurement was taken.',
+  )
 }
 
 async function expectSettledRoute(page: Page, consumer: RouteConsumer) {
@@ -1108,6 +1258,9 @@ for (const viewport of [{ width: 1280, height: 720 }, { width: 1920, height: 108
       await dismissFirstRunPromptIfPresent(page)
       await page.getByRole('link', { name: 'Channel Manager' }).click()
       await expectSettledRoute(page, routeConsumers[1])
+      // Applied once, before any theme flip: a colour caught mid-transition is
+      // not a state anybody is asked to read (see FREEZE_ANIMATION).
+      await page.addStyleTag({ content: FREEZE_ANIMATION })
 
       const states = [
         {
@@ -1281,6 +1434,10 @@ for (const viewport of [{ width: 1280, height: 720 }, { width: 1920, height: 108
           await expect(page.locator('.dashboard-card-error')).toHaveCount(1)
           await expect(page.locator('.header-update-available')).toHaveCount(0)
         }
+        // Re-applied per state, not once per test: the partial-failure arm
+        // reloads the page, which discards the previous tag (see
+        // FREEZE_ANIMATION).
+        await page.addStyleTag({ content: FREEZE_ANIMATION })
 
         for (const theme of ['dark', 'light', 'high-contrast'] as const) {
           await page.evaluate((selectedTheme) => {

--- a/e2e/operator-shell.spec.ts
+++ b/e2e/operator-shell.spec.ts
@@ -490,6 +490,12 @@ const FREEZE_ANIMATION = `
  *     `enhancedchannelmanager-0zq1p`). The measured element's ink, by contrast,
  *     really is inside every group in the chain, so it carries the full
  *     product.
+ *   - a `background-image` anywhere in the chain means the site is NOT
+ *     MEASURED. It cannot be reduced to one colour, so a canvas fed only the
+ *     `backgroundColor` layers would describe a surface that is not on screen.
+ *     `contrast-aa` skips such sites; this throws, which is the same refusal
+ *     in a function whose caller has already asserted the selector must be
+ *     measured.
  *
  * The core is duplicated rather than imported because a `page.evaluate` body is
  * serialised and re-parsed in the browser: it cannot reach a module import, and
@@ -561,6 +567,25 @@ async function measureCompositedContrast(page: Page, selector: string) {
       chain.push({ colour: style.backgroundColor, opacity: Number.isFinite(opacity) ? opacity : 1 })
       if (node === document.documentElement) break
     }
+    // REFUSE TO MEASURE rather than measure the wrong surface. A
+    // `background-image` cannot be reduced to one colour, so only the
+    // `backgroundColor` layers would reach the canvas and the ratio would
+    // describe a surface that is not on screen. If that surface happens to
+    // clear 4.5 the test passes and certifies a genuine contrast failure as
+    // good, which is the exact failure class this function was rewritten to
+    // eliminate. `e2e/contrast-aa.spec.ts` skips such sites for the same
+    // reason; here there is no allowlist to route them to, and the caller has
+    // asserted this selector must be measured, so the honest answer is to say
+    // the measurement could not be taken. Latent today (all gradients in the
+    // tree are on leaf elements, never ancestors of measured text) and
+    // deliberately guarded before that stops being true.
+    if (gradient) {
+      throw new Error(
+        `${evaluatedSelector}: a background-image in the ancestor chain cannot be reduced to one ` +
+          `colour, so no contrast measurement was taken. Found on ${gradient}`,
+      )
+    }
+
     const layers: Array<{ colour: string; groupAlpha: number }> = new Array(chain.length)
     let selfOpacity = 1
     for (let i = chain.length - 1; i >= 0; i -= 1) {
@@ -603,11 +628,6 @@ async function measureCompositedContrast(page: Page, selector: string) {
       foreground: hex(foreground),
       declaredColor,
       background: hex(background),
-      // A gradient anywhere in the chain cannot be reduced to one colour, so
-      // `background` is the solid layers only and the ratio is not the whole
-      // story. Reported rather than swallowed; `contrast-aa` skips such sites
-      // outright for the same reason.
-      backgroundGradient: gradient,
       opacity: Math.round(selfOpacity * 1000) / 1000,
       ratio: Math.round(((Math.max(foregroundLuminance, backgroundLuminance) + 0.05)
         / (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)) * 100) / 100,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.1-0056",
+  "version": "0.18.1-0057",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/devHarness/baseline/modal-typography.baseline.json
+++ b/frontend/src/devHarness/baseline/modal-typography.baseline.json
@@ -1,10 +1,11 @@
 {
-  "capturedAt": "2026-07-30T14:27:26.048Z",
+  "capturedAt": "2026-08-10T15:21:29.059Z",
   "viewport": {
     "width": 1440,
     "height": 900
   },
   "theme": "dark (app default)",
+  "animationsFrozen": true,
   "counts": {
     "filesMatchingDialogMarkers": 61,
     "cataloguedDialogs": 82,
@@ -29,43 +30,42 @@
       "consoleErrors": [],
       "elementCount": 78,
       "fontSizeHistogram": {
-        "16px": 28,
-        "18px": 8,
-        "13px": 31,
-        "13.3333px": 2,
+        "16px": 29,
+        "13px": 33,
+        "18px": 7,
         "11px": 9
       },
       "geometry": {
         "container": {
-          "w": 548.97,
-          "h": 763.57
+          "w": 550,
+          "h": 757.98
         },
         "header": {
-          "w": 546.98,
-          "h": 78.43
+          "w": 548,
+          "h": 59.98
         },
         "body": {
-          "w": 546.98,
-          "h": 617.27
+          "w": 548,
+          "h": 630
         },
         "footer": {
-          "w": 546.98,
-          "h": 65.88
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.94,
-          "h": 31.94
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 3,
-            "min": 30.94,
-            "max": 32.94
+            "min": 31,
+            "max": 33
           },
           ".modal-form-group": {
             "n": 9,
-            "min": 23.96,
-            "max": 281.66
+            "min": 24,
+            "max": 282.19
           }
         },
         "horizontalOverflow": false,
@@ -132,7 +132,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -146,9 +146,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -156,20 +156,6 @@
           },
           "count": 1,
           "sample": "Auto-Sync Settings"
-        },
-        {
-          "signature": "input",
-          "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": ""
         },
         {
           "signature": "input",
@@ -182,7 +168,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 3,
+          "count": 4,
           "sample": ""
         },
         {
@@ -295,45 +281,50 @@
       "consoleErrors": [],
       "elementCount": 15,
       "fontSizeHistogram": {
-        "16px": 8,
-        "18px": 2,
-        "13.3333px": 2,
+        "16px": 9,
+        "13px": 3,
+        "18px": 1,
         "64px": 1,
-        "13px": 1,
         "11px": 1
       },
       "geometry": {
         "container": {
-          "w": 546.53,
-          "h": 356.74
+          "w": 550,
+          "h": 357
         },
         "header": {
-          "w": 544.54,
-          "h": 64.59
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 544.54,
-          "h": 238.49
+          "w": 548,
+          "h": 240
         },
         "footer": {
-          "w": 544.54,
-          "h": 51.67
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
-        "rowHeights": {},
+        "rowHeights": {
+          ".modal-btn": {
+            "n": 1,
+            "min": 33,
+            "max": 33
+          }
+        },
         "horizontalOverflow": false,
         "scrollWidth": 1440,
         "clientWidth": 1440
       },
       "rows": [
         {
-          "signature": "button.modal-btn-secondary",
+          "signature": "button.modal-btn.modal-btn-secondary",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
+            "font-size": "13px",
+            "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
@@ -346,7 +337,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -360,9 +351,9 @@
         {
           "signature": "h3.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -439,38 +430,37 @@
       "consoleErrors": [],
       "elementCount": 30,
       "fontSizeHistogram": {
-        "16px": 15,
-        "18px": 3,
-        "13.3333px": 3,
-        "13px": 7,
+        "16px": 16,
+        "13px": 10,
+        "18px": 2,
         "11px": 2
       },
       "geometry": {
         "container": {
-          "w": 993.7,
-          "h": 354.13
+          "w": 1000,
+          "h": 352
         },
         "header": {
-          "w": 991.71,
-          "h": 64.59
+          "w": 998,
+          "h": 49
         },
         "body": {
-          "w": 991.71,
-          "h": 218.99
+          "w": 998,
+          "h": 232
         },
         "footer": {
-          "w": 991.71,
-          "h": 68.57
+          "w": 998,
+          "h": 69
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.79,
-            "max": 35.77
+            "min": 33,
+            "max": 36
           }
         },
         "horizontalOverflow": false,
@@ -509,7 +499,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -537,9 +527,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -551,7 +541,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -616,7 +606,7 @@
             "font-style": "normal"
           },
           "count": 2,
-          "sample": "Schedules Direct \u2014 United Kingdom"
+          "sample": "Schedules Direct — United Kingdom"
         }
       ]
     },
@@ -632,44 +622,43 @@
       "consoleErrors": [],
       "elementCount": 47,
       "fontSizeHistogram": {
-        "16px": 15,
-        "18px": 12,
-        "13.3333px": 1,
-        "13px": 14,
+        "16px": 16,
+        "13px": 15,
+        "18px": 11,
         "15px": 3,
         "11px": 2
       },
       "geometry": {
         "container": {
-          "w": 692.84,
-          "h": 460.24
+          "w": 700,
+          "h": 449
         },
         "header": {
-          "w": 690.86,
-          "h": 64.34
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 690.86,
-          "h": 328.6
+          "w": 698,
+          "h": 332
         },
         "footer": {
-          "w": 690.86,
-          "h": 65.32
+          "w": 698,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.67,
-          "h": 31.67
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.66,
-            "max": 32.66
+            "min": 33,
+            "max": 33
           },
           ".modal-summary-item": {
             "n": 4,
-            "min": 19.3,
-            "max": 19.3
+            "min": 19.5,
+            "max": 19.5
           }
         },
         "horizontalOverflow": false,
@@ -708,7 +697,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -750,9 +739,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -843,32 +832,31 @@
       "consoleErrors": [],
       "elementCount": 44,
       "fontSizeHistogram": {
-        "16px": 26,
-        "18px": 3,
-        "13.3333px": 7,
-        "13px": 5,
+        "16px": 27,
+        "13px": 12,
+        "18px": 2,
         "11px": 3
       },
       "geometry": {
         "container": {
-          "w": 692.84,
-          "h": 692.84
+          "w": 700,
+          "h": 700
         },
         "header": {
-          "w": 690.86,
-          "h": 64.33
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 690.86,
-          "h": 496.86
+          "w": 698,
+          "h": 518
         },
         "footer": {
-          "w": 690.86,
-          "h": 32.66
+          "w": 698,
+          "h": 33
         },
         "closeBtn": {
-          "w": 31.67,
-          "h": 31.67
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {},
         "horizontalOverflow": false,
@@ -893,7 +881,7 @@
         {
           "signature": "button.danger.modal-icon-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -907,7 +895,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -921,7 +909,7 @@
         {
           "signature": "button.modal-icon-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -935,9 +923,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -1056,45 +1044,50 @@
       "consoleErrors": [],
       "elementCount": 48,
       "fontSizeHistogram": {
-        "16px": 10,
-        "18px": 2,
-        "13.3333px": 2,
+        "16px": 11,
+        "13px": 13,
+        "18px": 1,
         "15px": 2,
-        "13px": 11,
         "11px": 21
       },
       "geometry": {
         "container": {
-          "w": 546.53,
-          "h": 541.1
+          "w": 550,
+          "h": 542.53
         },
         "header": {
-          "w": 544.54,
-          "h": 64.59
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 544.54,
-          "h": 422.85
+          "w": 548,
+          "h": 425.53
         },
         "footer": {
-          "w": 544.54,
-          "h": 51.67
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
-        "rowHeights": {},
+        "rowHeights": {
+          ".modal-btn": {
+            "n": 1,
+            "min": 33,
+            "max": 33
+          }
+        },
         "horizontalOverflow": false,
         "scrollWidth": 1440,
         "clientWidth": 1440
       },
       "rows": [
         {
-          "signature": "button.modal-btn-secondary",
+          "signature": "button.modal-btn.modal-btn-secondary",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
+            "font-size": "13px",
+            "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
@@ -1107,7 +1100,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -1121,16 +1114,16 @@
         {
           "signature": "h3.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Channel Details \u2014 BBC One HD (London)"
+          "sample": "Channel Details — BBC One HD (London)"
         },
         {
           "signature": "h4",
@@ -1228,41 +1221,39 @@
       "consoleErrors": [],
       "elementCount": 20,
       "fontSizeHistogram": {
-        "16px": 9,
+        "16px": 10,
         "18px": 3,
-        "24px": 1,
-        "13.3333px": 2,
+        "13px": 4,
         "64px": 1,
         "15px": 1,
-        "11px": 1,
-        "13px": 2
+        "11px": 1
       },
       "geometry": {
         "container": {
-          "w": 695.59,
-          "h": 373.63
+          "w": 700,
+          "h": 360
         },
         "header": {
-          "w": 693.6,
-          "h": 64.59
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 693.6,
-          "h": 238.49
+          "w": 698,
+          "h": 240
         },
         "footer": {
-          "w": 693.6,
-          "h": 68.56
+          "w": 698,
+          "h": 69
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.79,
-            "max": 35.77
+            "min": 33,
+            "max": 36
           }
         },
         "horizontalOverflow": false,
@@ -1301,7 +1292,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -1315,9 +1306,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -1329,7 +1320,7 @@
         {
           "signature": "input.csv-file-input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -1393,21 +1384,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 2,
-          "sample": "close"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
+          "count": 3,
           "sample": "upload_file"
         }
       ]
@@ -1422,45 +1399,50 @@
       "consoleErrors": [],
       "elementCount": 15,
       "fontSizeHistogram": {
-        "16px": 8,
-        "18px": 2,
-        "13.3333px": 2,
+        "16px": 9,
+        "13px": 3,
+        "18px": 1,
         "64px": 1,
-        "13px": 1,
         "11px": 1
       },
       "geometry": {
         "container": {
-          "w": 543.16,
-          "h": 354.53
+          "w": 550,
+          "h": 357
         },
         "header": {
-          "w": 541.18,
-          "h": 64.19
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 541.18,
-          "h": 237.01
+          "w": 548,
+          "h": 240
         },
         "footer": {
-          "w": 541.18,
-          "h": 51.35
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.6,
-          "h": 31.6
+          "w": 32,
+          "h": 32
         },
-        "rowHeights": {},
+        "rowHeights": {
+          ".modal-btn": {
+            "n": 1,
+            "min": 33,
+            "max": 33
+          }
+        },
         "horizontalOverflow": false,
         "scrollWidth": 1440,
         "clientWidth": 1440
       },
       "rows": [
         {
-          "signature": "button.modal-btn-secondary",
+          "signature": "button.modal-btn.modal-btn-secondary",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
+            "font-size": "13px",
+            "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
@@ -1473,7 +1455,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -1487,9 +1469,9 @@
         {
           "signature": "h3.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -1564,46 +1546,51 @@
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 20,
+      "elementCount": 34,
       "fontSizeHistogram": {
-        "16px": 9,
-        "18px": 3,
-        "13.3333px": 4,
-        "13px": 2,
-        "11px": 2
+        "16px": 14,
+        "13px": 13,
+        "18px": 2,
+        "11px": 5
       },
       "geometry": {
         "container": {
-          "w": 546.53,
-          "h": 290.34
+          "w": 550,
+          "h": 564.38
         },
         "header": {
-          "w": 544.54,
-          "h": 64.59
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 544.54,
-          "h": 172.09
+          "w": 548,
+          "h": 447.38
         },
         "footer": {
-          "w": 544.54,
-          "h": 51.67
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
-        "rowHeights": {},
+        "rowHeights": {
+          ".modal-btn": {
+            "n": 2,
+            "min": 33,
+            "max": 33
+          }
+        },
         "horizontalOverflow": false,
         "scrollWidth": 1440,
         "clientWidth": 1440
       },
       "rows": [
         {
-          "signature": "button.modal-btn-primary",
+          "signature": "button.modal-btn.modal-btn-primary",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
+            "font-size": "13px",
+            "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
@@ -1614,10 +1601,10 @@
           "sample": "Run preview"
         },
         {
-          "signature": "button.modal-btn-secondary",
+          "signature": "button.modal-btn.modal-btn-secondary",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
+            "font-size": "13px",
+            "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
@@ -1630,7 +1617,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -1672,9 +1659,9 @@
         {
           "signature": "h3.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -1686,7 +1673,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -1694,7 +1681,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 1,
+          "count": 3,
           "sample": ""
         },
         {
@@ -1712,6 +1699,20 @@
           "sample": "This backup is encrypted"
         },
         {
+          "signature": "legend.crm-legend",
+          "style": {
+            "font-size": "13px",
+            "font-weight": "500",
+            "line-height": "18.2px",
+            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
+            "letter-spacing": "normal",
+            "text-transform": "none",
+            "font-style": "normal"
+          },
+          "count": 1,
+          "sample": "Channels that already exist here"
+        },
+        {
           "signature": "p.brm-file-meta",
           "style": {
             "font-size": "11px",
@@ -1723,7 +1724,35 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Runs a preview (dry run) first \u2014 no changes are made until y"
+          "sample": "Runs a preview (dry run) first — no changes are made until y"
+        },
+        {
+          "signature": "p.crm-help",
+          "style": {
+            "font-size": "11px",
+            "font-weight": "400",
+            "line-height": "16.5px",
+            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
+            "letter-spacing": "normal",
+            "text-transform": "none",
+            "font-style": "normal"
+          },
+          "count": 1,
+          "sample": "Some channels in this backup may already exist on this insta"
+        },
+        {
+          "signature": "span.dbr-mode-hint",
+          "style": {
+            "font-size": "11px",
+            "font-weight": "400",
+            "line-height": "16.5px",
+            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
+            "letter-spacing": "normal",
+            "text-transform": "none",
+            "font-style": "normal"
+          },
+          "count": 2,
+          "sample": "Leaves channels you already have exactly as they are. The re"
         },
         {
           "signature": "span.material-icons",
@@ -1738,6 +1767,20 @@
           },
           "count": 2,
           "sample": "close"
+        },
+        {
+          "signature": "strong",
+          "style": {
+            "font-size": "13px",
+            "font-weight": "700",
+            "line-height": "19.5px",
+            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
+            "letter-spacing": "normal",
+            "text-transform": "none",
+            "font-style": "normal"
+          },
+          "count": 2,
+          "sample": "Keep their current guide data, logos, and grouping"
         }
       ]
     },
@@ -1751,38 +1794,37 @@
       "consoleErrors": [],
       "elementCount": 30,
       "fontSizeHistogram": {
-        "16px": 14,
-        "18px": 3,
-        "13.3333px": 3,
-        "13px": 7,
+        "16px": 15,
+        "13px": 10,
+        "18px": 2,
         "11px": 3
       },
       "geometry": {
         "container": {
-          "w": 543.16,
-          "h": 396.88
+          "w": 550,
+          "h": 385.88
         },
         "header": {
-          "w": 541.19,
-          "h": 64.19
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 541.19,
-          "h": 262.57
+          "w": 548,
+          "h": 265.88
         },
         "footer": {
-          "w": 541.19,
-          "h": 68.14
+          "w": 548,
+          "h": 69
         },
         "closeBtn": {
-          "w": 31.6,
-          "h": 31.6
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.59,
-            "max": 35.55
+            "min": 33,
+            "max": 36
           }
         },
         "horizontalOverflow": false,
@@ -1835,7 +1877,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -1877,9 +1919,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -1891,7 +1933,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -1956,37 +1998,34 @@
       "consoleErrors": [],
       "elementCount": 42,
       "fontSizeHistogram": {
-        "16px": 17,
-        "18px": 6,
-        "13.3333px": 4,
-        "14.4px": 2,
-        "12.8px": 10,
-        "14px": 2,
-        "13px": 1
+        "16px": 18,
+        "13px": 17,
+        "18px": 5,
+        "15px": 2
       },
       "geometry": {
         "container": {
-          "w": 894.32,
-          "h": 404.23
+          "w": 900,
+          "h": 392
         },
         "header": {
-          "w": 892.34,
-          "h": 64.59
+          "w": 898,
+          "h": 49
         },
         "body": null,
         "footer": {
-          "w": 892.34,
-          "h": 65.58
+          "w": 898,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 1,
-            "min": 32.79,
-            "max": 32.79
+            "min": 33,
+            "max": 33
           }
         },
         "horizontalOverflow": false,
@@ -1997,7 +2036,7 @@
         {
           "signature": "button.channel-picker-remove",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -2011,7 +2050,7 @@
         {
           "signature": "button.custom-select-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -2039,7 +2078,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -2053,23 +2092,23 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Channels - 24/7 filler \u2014 movies"
+          "sample": "Channels - 24/7 filler — movies"
         },
         {
           "signature": "h3",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "15px",
             "font-weight": "700",
-            "line-height": "21.6px",
+            "line-height": "22.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -2081,7 +2120,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -2095,9 +2134,9 @@
         {
           "signature": "p.channel-picker-empty",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
-            "line-height": "19.2px",
+            "line-height": "19.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -2109,9 +2148,9 @@
         {
           "signature": "span.channel-picker-name",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
-            "line-height": "19.2px",
+            "line-height": "19.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -2137,7 +2176,7 @@
         {
           "signature": "span.custom-select-value",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -2188,49 +2227,44 @@
       "consoleErrors": [],
       "elementCount": 141,
       "fontSizeHistogram": {
-        "16px": 50,
-        "18px": 14,
-        "13.3333px": 4,
-        "13px": 32,
-        "10px": 6,
-        "11px": 12,
-        "15px": 12,
-        "12.8px": 4,
-        "13.6px": 1,
-        "12px": 5,
-        "11.2px": 1
+        "16px": 51,
+        "13px": 42,
+        "18px": 13,
+        "10px": 8,
+        "11px": 15,
+        "15px": 12
       },
       "geometry": {
         "container": {
-          "w": 894.32,
-          "h": 758.19
+          "w": 900,
+          "h": 747
         },
         "header": {
-          "w": 892.34,
-          "h": 64.59
+          "w": 898,
+          "h": 49
         },
         "body": {
-          "w": 892.34,
-          "h": 626.03
+          "w": 898,
+          "h": 630
         },
         "footer": {
-          "w": 892.34,
-          "h": 65.58
+          "w": 898,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 3,
-            "min": 32.79,
-            "max": 32.79
+            "min": 33,
+            "max": 33
           },
           ".modal-form-group": {
             "n": 12,
-            "min": 18.07,
-            "max": 118.44
+            "min": 24,
+            "max": 119.19
           }
         },
         "horizontalOverflow": false,
@@ -2283,7 +2317,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -2311,7 +2345,7 @@
         {
           "signature": "button.pb-examples-add-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -2325,7 +2359,7 @@
         {
           "signature": "button.pb-mode-toggle",
           "style": {
-            "font-size": "12px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -2339,7 +2373,7 @@
         {
           "signature": "button.pb-variant-tab-add",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -2353,9 +2387,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -2363,20 +2397,6 @@
           },
           "count": 1,
           "sample": "New Dummy EPG Profile"
-        },
-        {
-          "signature": "input",
-          "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": ""
         },
         {
           "signature": "input",
@@ -2389,13 +2409,13 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 7,
+          "count": 8,
           "sample": ""
         },
         {
           "signature": "input.pb-examples-input",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "\"JetBrains Mono\", \"Fira Code\", monospace",
@@ -2451,9 +2471,9 @@
         {
           "signature": "p.pb-hint",
           "style": {
-            "font-size": "12px",
+            "font-size": "11px",
             "font-weight": "400",
-            "line-height": "16.8px",
+            "line-height": "15.4px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -2479,9 +2499,9 @@
         {
           "signature": "span",
           "style": {
-            "font-size": "12px",
+            "font-size": "11px",
             "font-weight": "400",
-            "line-height": "18px",
+            "line-height": "16.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -2591,9 +2611,9 @@
         {
           "signature": "span.pb-examples-count",
           "style": {
-            "font-size": "11.2px",
+            "font-size": "10px",
             "font-weight": "400",
-            "line-height": "16.8px",
+            "line-height": "15px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -2605,11 +2625,11 @@
         {
           "signature": "span.pb-examples-title",
           "style": {
-            "font-size": "12px",
+            "font-size": "10px",
             "font-weight": "600",
-            "line-height": "18px",
+            "line-height": "15px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "0.36px",
+            "letter-spacing": "0.3px",
             "text-transform": "uppercase",
             "font-style": "normal"
           },
@@ -2619,9 +2639,9 @@
         {
           "signature": "span.pb-header-title",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "600",
-            "line-height": "20.4px",
+            "line-height": "19.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -2633,9 +2653,9 @@
         {
           "signature": "span.pb-variant-tab-name",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "600",
-            "line-height": "19.2px",
+            "line-height": "19.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -2647,7 +2667,7 @@
         {
           "signature": "textarea",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "\"JetBrains Mono\", \"Fira Code\", monospace",
@@ -2684,45 +2704,44 @@
       "consoleErrors": [],
       "elementCount": 112,
       "fontSizeHistogram": {
-        "16px": 37,
-        "18px": 10,
-        "13.3333px": 2,
-        "13px": 37,
+        "16px": 38,
+        "13px": 39,
+        "18px": 9,
         "10px": 4,
         "11px": 14,
         "15px": 8
       },
       "geometry": {
         "container": {
-          "w": 696.77,
-          "h": 759.48
+          "w": 700,
+          "h": 747
         },
         "header": {
-          "w": 694.78,
-          "h": 64.7
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 694.78,
-          "h": 627.09
+          "w": 698,
+          "h": 630
         },
         "footer": {
-          "w": 694.78,
-          "h": 65.7
+          "w": 698,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.85,
-          "h": 31.85
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.85,
-            "max": 32.85
+            "min": 33,
+            "max": 33
           },
           ".modal-form-group": {
             "n": 13,
-            "min": 18.1,
-            "max": 124.11
+            "min": 24,
+            "max": 124.69
           }
         },
         "horizontalOverflow": false,
@@ -2789,7 +2808,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -2831,9 +2850,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -2841,20 +2860,6 @@
           },
           "count": 1,
           "sample": "Add Dummy EPG Source"
-        },
-        {
-          "signature": "input",
-          "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": ""
         },
         {
           "signature": "input",
@@ -2867,7 +2872,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 8,
+          "count": 9,
           "sample": ""
         },
         {
@@ -3056,40 +3061,39 @@
       ],
       "elementCount": 85,
       "fontSizeHistogram": {
-        "16px": 46,
-        "18px": 3,
-        "13.3333px": 1,
+        "16px": 47,
+        "13px": 23,
+        "18px": 2,
         "10px": 7,
-        "13px": 22,
         "15px": 1,
         "11px": 5
       },
       "geometry": {
         "container": {
-          "w": 593.86,
-          "h": 755.19
+          "w": 600,
+          "h": 747
         },
         "header": {
-          "w": 591.88,
-          "h": 64.33
+          "w": 598,
+          "h": 49
         },
         "body": {
-          "w": 591.88,
-          "h": 623.55
+          "w": 598,
+          "h": 630
         },
         "footer": {
-          "w": 591.88,
-          "h": 65.32
+          "w": 598,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.67,
-          "h": 31.67
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 1,
-            "min": 32.66,
-            "max": 32.66
+            "min": 33,
+            "max": 33
           }
         },
         "horizontalOverflow": false,
@@ -3226,7 +3230,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -3254,9 +3258,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -3478,39 +3482,38 @@
       ],
       "elementCount": 44,
       "fontSizeHistogram": {
-        "16px": 17,
-        "18px": 4,
-        "13px": 10,
-        "13.3333px": 5,
+        "16px": 18,
+        "18px": 3,
+        "13px": 15,
         "11px": 7,
         "10px": 1
       },
       "geometry": {
         "container": {
-          "w": 691.3,
-          "h": 406.12
+          "w": 700,
+          "h": 402.95
         },
         "header": {
-          "w": 689.32,
-          "h": 78.9
+          "w": 698,
+          "h": 61.3
         },
         "body": {
-          "w": 689.32,
-          "h": 260.07
+          "w": 698,
+          "h": 273.66
         },
         "footer": {
-          "w": 689.32,
-          "h": 65.18
+          "w": 698,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.6,
-          "h": 31.6
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.59,
-            "max": 32.59
+            "min": 33,
+            "max": 33
           }
         },
         "horizontalOverflow": false,
@@ -3549,7 +3552,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -3591,9 +3594,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -3605,7 +3608,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -3740,38 +3743,37 @@
       "consoleErrors": [],
       "elementCount": 31,
       "fontSizeHistogram": {
-        "16px": 12,
-        "18px": 4,
-        "13.3333px": 2,
-        "13px": 11,
+        "16px": 13,
+        "13px": 13,
+        "18px": 3,
         "10px": 2
       },
       "geometry": {
         "container": {
-          "w": 546.53,
-          "h": 358.72
+          "w": 550,
+          "h": 345
         },
         "header": {
-          "w": 544.54,
-          "h": 64.59
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 544.54,
-          "h": 226.56
+          "w": 548,
+          "h": 228
         },
         "footer": {
-          "w": 544.54,
-          "h": 65.58
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 4,
-            "min": 32.79,
-            "max": 32.79
+            "min": 33,
+            "max": 33
           }
         },
         "horizontalOverflow": false,
@@ -3810,7 +3812,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -3824,9 +3826,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -3838,7 +3840,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -3932,11 +3934,8 @@
       "elementCount": 23,
       "fontSizeHistogram": {
         "16px": 8,
-        "13px": 5,
-        "9.6px": 1,
-        "13.6px": 4,
-        "12px": 2,
-        "13.3333px": 3
+        "13px": 14,
+        "9.6px": 1
       },
       "geometry": {
         "container": null,
@@ -3953,7 +3952,7 @@
         {
           "signature": "button.filter-dropdown-action",
           "style": {
-            "font-size": "12px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -3976,12 +3975,12 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "1 group selected\u25b2"
+          "sample": "1 group selected▲"
         },
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -3989,21 +3988,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 3,
-          "sample": ""
-        },
-        {
-          "signature": "input",
-          "style": {
-            "font-size": "13.6px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
+          "count": 4,
           "sample": ""
         },
         {
@@ -4032,7 +4017,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "\u25b2"
+          "sample": "▲"
         },
         {
           "signature": "span.filter-option-name",
@@ -4046,7 +4031,7 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "United Kingdom \u2014 Entertainment"
+          "sample": "United Kingdom — Entertainment"
         },
         {
           "signature": "span.material-icons.search-icon",
@@ -4074,37 +4059,36 @@
       "consoleErrors": [],
       "elementCount": 20,
       "fontSizeHistogram": {
-        "16px": 9,
-        "18px": 2,
-        "13.3333px": 1,
-        "13px": 8
+        "16px": 10,
+        "13px": 9,
+        "18px": 1
       },
       "geometry": {
         "container": {
-          "w": 698.69,
-          "h": 370.49
+          "w": 700,
+          "h": 355.19
         },
         "header": {
-          "w": 696.69,
-          "h": 64.88
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 696.69,
-          "h": 235.74
+          "w": 698,
+          "h": 236.19
         },
         "footer": {
-          "w": 696.69,
-          "h": 67.87
+          "w": 698,
+          "h": 68
         },
         "closeBtn": {
-          "w": 31.94,
-          "h": 31.94
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-form-group": {
             "n": 1,
-            "min": 65.07,
-            "max": 65.07
+            "min": 65.19,
+            "max": 65.19
           }
         },
         "horizontalOverflow": false,
@@ -4143,7 +4127,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -4157,9 +4141,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -4194,7 +4178,7 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "Choose a target\u2026"
+          "sample": "Choose a target…"
         },
         {
           "signature": "p",
@@ -4222,7 +4206,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Choose a target\u2026Schedules Direct \u2014 United Kingdom (Gracenote"
+          "sample": "Choose a target…Schedules Direct — United Kingdom (Gracenote"
         },
         {
           "signature": "span.material-icons",
@@ -4250,38 +4234,37 @@
       "consoleErrors": [],
       "elementCount": 17,
       "fontSizeHistogram": {
-        "16px": 8,
-        "18px": 3,
-        "13.3333px": 1,
-        "13px": 4,
+        "16px": 9,
+        "13px": 5,
+        "18px": 2,
         "64px": 1
       },
       "geometry": {
         "container": {
-          "w": 546.53,
-          "h": 443.19
+          "w": 550,
+          "h": 430
         },
         "header": {
-          "w": 544.54,
-          "h": 64.59
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 544.54,
-          "h": 308.04
+          "w": 548,
+          "h": 310
         },
         "footer": {
-          "w": 544.54,
-          "h": 68.56
+          "w": 548,
+          "h": 69
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.79,
-            "max": 35.77
+            "min": 33,
+            "max": 36
           }
         },
         "horizontalOverflow": false,
@@ -4320,7 +4303,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -4334,9 +4317,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -4413,42 +4396,41 @@
       "consoleErrors": [],
       "elementCount": 18,
       "fontSizeHistogram": {
-        "16px": 9,
-        "18px": 2,
-        "13.3333px": 1,
-        "13px": 6
+        "16px": 10,
+        "13px": 7,
+        "18px": 1
       },
       "geometry": {
         "container": {
-          "w": 548.28,
-          "h": 314.39
+          "w": 550,
+          "h": 299.38
         },
         "header": {
-          "w": 546.29,
-          "h": 64.8
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 546.29,
-          "h": 181.8
+          "w": 548,
+          "h": 182.38
         },
         "footer": {
-          "w": 546.29,
-          "h": 65.79
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.9,
-            "max": 32.9
+            "min": 33,
+            "max": 33
           },
           ".modal-form-group": {
             "n": 2,
-            "min": 62.99,
-            "max": 62.99
+            "min": 63.19,
+            "max": 63.19
           }
         },
         "horizontalOverflow": false,
@@ -4487,7 +4469,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -4501,9 +4483,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -4566,43 +4548,42 @@
       "consoleErrors": [],
       "elementCount": 77,
       "fontSizeHistogram": {
-        "16px": 26,
-        "18px": 3,
-        "13.3333px": 9,
-        "13px": 36,
+        "16px": 27,
+        "13px": 45,
+        "18px": 2,
         "11px": 3
       },
       "geometry": {
         "container": {
-          "w": 546.53,
-          "h": 758.19
+          "w": 550,
+          "h": 747
         },
         "header": {
-          "w": 544.54,
-          "h": 64.59
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 544.54,
-          "h": 626.02
+          "w": 548,
+          "h": 630
         },
         "footer": {
-          "w": 544.54,
-          "h": 65.58
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.79,
-            "max": 32.79
+            "min": 33,
+            "max": 33
           },
           ".modal-form-group": {
             "n": 14,
-            "min": 18.07,
-            "max": 123.9
+            "min": 24,
+            "max": 138.19
           }
         },
         "horizontalOverflow": false,
@@ -4655,7 +4636,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -4669,9 +4650,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -4679,20 +4660,6 @@
           },
           "count": 1,
           "sample": "Edit M3U Account"
-        },
-        {
-          "signature": "input",
-          "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 8,
-          "sample": ""
         },
         {
           "signature": "input",
@@ -4705,7 +4672,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 7,
+          "count": 15,
           "sample": ""
         },
         {
@@ -4804,35 +4771,34 @@
       "consoleErrors": [],
       "elementCount": 35,
       "fontSizeHistogram": {
-        "16px": 17,
-        "18px": 2,
-        "13px": 5,
-        "13.3333px": 3,
+        "16px": 18,
+        "13px": 8,
+        "18px": 1,
         "10px": 8
       },
       "geometry": {
         "container": {
-          "w": 546.53,
-          "h": 299.18
+          "w": 550,
+          "h": 282.48
         },
         "header": {
-          "w": 544.54,
-          "h": 78.08
+          "w": 548,
+          "h": 59.98
         },
         "body": {
-          "w": 544.54,
-          "h": 133.15
+          "w": 548,
+          "h": 134
         },
         "footer": null,
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 1,
-            "min": 29.81,
-            "max": 29.81
+            "min": 30,
+            "max": 30
           }
         },
         "horizontalOverflow": false,
@@ -4843,7 +4809,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -4857,7 +4823,7 @@
         {
           "signature": "button.action-btn.delete",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -4885,7 +4851,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -4927,9 +4893,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -5104,41 +5070,39 @@
       "consoleErrors": [],
       "elementCount": 41,
       "fontSizeHistogram": {
-        "16px": 19,
-        "18px": 4,
-        "13px": 9,
-        "13.3333px": 4,
-        "14px": 2,
+        "16px": 20,
+        "13px": 15,
+        "18px": 3,
         "11px": 1,
         "24px": 1,
-        "15.2px": 1
+        "15px": 1
       },
       "geometry": {
         "container": {
-          "w": 692.83,
-          "h": 712.63
+          "w": 700,
+          "h": 720
         },
         "header": {
-          "w": 690.85,
-          "h": 77.77
+          "w": 698,
+          "h": 59.98
         },
         "body": {
-          "w": 690.85,
-          "h": 472.53
+          "w": 698,
+          "h": 496.02
         },
         "footer": {
-          "w": 690.85,
-          "h": 65.32
+          "w": 698,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.67,
-          "h": 31.67
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 1,
-            "min": 32.66,
-            "max": 32.66
+            "min": 33,
+            "max": 33
           }
         },
         "horizontalOverflow": false,
@@ -5177,7 +5141,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -5191,7 +5155,7 @@
         {
           "signature": "button.toast-dismiss",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -5205,9 +5169,9 @@
         {
           "signature": "div.toast-message",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
-            "line-height": "19.6px",
+            "line-height": "18.2px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -5219,9 +5183,9 @@
         {
           "signature": "div.toast-title",
           "style": {
-            "font-size": "15.2px",
+            "font-size": "15px",
             "font-weight": "600",
-            "line-height": "22.8px",
+            "line-height": "22.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -5233,9 +5197,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -5247,7 +5211,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -5255,21 +5219,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 2,
-          "sample": ""
-        },
-        {
-          "signature": "input",
-          "style": {
-            "font-size": "14px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
+          "count": 3,
           "sample": ""
         },
         {
@@ -5368,29 +5318,28 @@
       "consoleErrors": [],
       "elementCount": 23,
       "fontSizeHistogram": {
-        "16px": 14,
-        "18px": 2,
-        "13.3333px": 3,
-        "10px": 3,
-        "13px": 1
+        "16px": 15,
+        "13px": 4,
+        "18px": 1,
+        "10px": 3
       },
       "geometry": {
         "container": {
-          "w": 543.16,
-          "h": 257.76
+          "w": 550,
+          "h": 245
         },
         "header": {
-          "w": 541.19,
-          "h": 64.19
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 541.19,
-          "h": 191.59
+          "w": 548,
+          "h": 194
         },
         "footer": null,
         "closeBtn": {
-          "w": 31.6,
-          "h": 31.6
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {},
         "horizontalOverflow": false,
@@ -5415,7 +5364,7 @@
         {
           "signature": "button.btn-icon",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -5429,7 +5378,7 @@
         {
           "signature": "button.btn-icon.delete",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -5443,7 +5392,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -5457,9 +5406,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -5536,33 +5485,31 @@
       "consoleErrors": [],
       "elementCount": 31,
       "fontSizeHistogram": {
-        "16px": 14,
+        "16px": 15,
         "18px": 5,
-        "24px": 1,
-        "13.3333px": 3,
+        "13px": 5,
         "15px": 1,
-        "13px": 2,
         "10px": 1,
         "14px": 1,
         "11px": 3
       },
       "geometry": {
         "container": {
-          "w": 697.81,
-          "h": 242.43
+          "w": 700,
+          "h": 227.19
         },
         "header": {
-          "w": 695.82,
-          "h": 64.8
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 695.82,
-          "h": 175.64
+          "w": 698,
+          "h": 176.19
         },
         "footer": null,
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {},
         "horizontalOverflow": false,
@@ -5573,7 +5520,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -5587,7 +5534,7 @@
         {
           "signature": "button.action-btn.active.toggle",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -5615,7 +5562,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -5643,9 +5590,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -5749,21 +5696,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 4,
-          "sample": "close"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
+          "count": 5,
           "sample": "account_circle"
         }
       ]
@@ -5780,44 +5713,42 @@
       ],
       "elementCount": 71,
       "fontSizeHistogram": {
-        "16px": 26,
-        "18px": 4,
-        "13.3333px": 7,
-        "13px": 28,
-        "14px": 4,
+        "16px": 27,
+        "13px": 39,
+        "18px": 3,
         "11px": 2
       },
       "geometry": {
         "container": {
-          "w": 695.59,
-          "h": 758.19
+          "w": 700,
+          "h": 747
         },
         "header": {
-          "w": 693.6,
-          "h": 64.59
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 693.6,
-          "h": 626.03
+          "w": 698,
+          "h": 630
         },
         "footer": {
-          "w": 693.6,
-          "h": 65.58
+          "w": 698,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.79,
-            "max": 32.79
+            "min": 33,
+            "max": 33
           },
           ".modal-form-group": {
             "n": 8,
-            "min": 61.8,
-            "max": 134.52
+            "min": 62.19,
+            "max": 152.19
           }
         },
         "horizontalOverflow": false,
@@ -5828,7 +5759,7 @@
         {
           "signature": "button.custom-select-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -5837,7 +5768,7 @@
             "font-style": "normal"
           },
           "count": 2,
-          "sample": "United Kingdom \u2014 Entertainmentexpand_more"
+          "sample": "United Kingdom — Entertainmentexpand_more"
         },
         {
           "signature": "button.modal-btn.modal-btn-primary",
@@ -5870,7 +5801,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -5884,9 +5815,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -5894,20 +5825,6 @@
           },
           "count": 1,
           "sample": "Merge 2 Channels"
-        },
-        {
-          "signature": "input",
-          "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 6,
-          "sample": ""
         },
         {
           "signature": "input",
@@ -5920,7 +5837,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 1,
+          "count": 7,
           "sample": ""
         },
         {
@@ -5982,7 +5899,7 @@
         {
           "signature": "span.custom-select-value",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -5991,7 +5908,7 @@
             "font-style": "normal"
           },
           "count": 2,
-          "sample": "United Kingdom \u2014 Entertainment"
+          "sample": "United Kingdom — Entertainment"
         },
         {
           "signature": "span.form-hint",
@@ -6005,7 +5922,7 @@
             "font-style": "normal"
           },
           "count": 2,
-          "sample": "(Schedules Direct \u2014 United Kingdom)"
+          "sample": "(Schedules Direct — United Kingdom)"
         },
         {
           "signature": "span.material-icons",
@@ -6089,38 +6006,37 @@
       "consoleErrors": [],
       "elementCount": 15,
       "fontSizeHistogram": {
-        "16px": 8,
-        "18px": 2,
-        "13.3333px": 1,
-        "64px": 1,
-        "13px": 3
+        "16px": 9,
+        "13px": 4,
+        "18px": 1,
+        "64px": 1
       },
       "geometry": {
         "container": {
-          "w": 546.53,
-          "h": 420.83
+          "w": 550,
+          "h": 407.5
         },
         "header": {
-          "w": 544.54,
-          "h": 64.59
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 544.54,
-          "h": 288.67
+          "w": 548,
+          "h": 290.5
         },
         "footer": {
-          "w": 544.54,
-          "h": 65.58
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 1,
-            "min": 32.79,
-            "max": 32.79
+            "min": 33,
+            "max": 33
           }
         },
         "horizontalOverflow": false,
@@ -6145,7 +6061,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -6159,9 +6075,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -6242,42 +6158,41 @@
       ],
       "elementCount": 48,
       "fontSizeHistogram": {
-        "16px": 18,
-        "18px": 9,
-        "13.3333px": 1,
+        "16px": 19,
+        "18px": 8,
+        "13px": 13,
         "14px": 2,
         "48px": 1,
         "12px": 1,
         "15px": 2,
-        "13px": 12,
         "11px": 2
       },
       "geometry": {
         "container": {
-          "w": 695.58,
-          "h": 758.18
+          "w": 700,
+          "h": 747
         },
         "header": {
-          "w": 693.59,
-          "h": 64.59
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 693.59,
-          "h": 626.02
+          "w": 698,
+          "h": 630
         },
         "footer": {
-          "w": 693.59,
-          "h": 65.58
+          "w": 698,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 1,
-            "min": 32.79,
-            "max": 32.79
+            "min": 33,
+            "max": 33
           }
         },
         "horizontalOverflow": false,
@@ -6302,7 +6217,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -6316,9 +6231,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -6521,39 +6436,38 @@
       "consoleErrors": [],
       "elementCount": 74,
       "fontSizeHistogram": {
-        "16px": 36,
-        "18px": 3,
-        "13.3333px": 5,
-        "13px": 20,
+        "16px": 37,
+        "13px": 25,
+        "18px": 2,
         "11px": 4,
         "10px": 6
       },
       "geometry": {
         "container": {
-          "w": 546.53,
-          "h": 623.67
+          "w": 550,
+          "h": 617.44
         },
         "header": {
-          "w": 544.54,
-          "h": 64.59
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 544.54,
-          "h": 488.53
+          "w": 548,
+          "h": 497.44
         },
         "footer": {
-          "w": 544.54,
-          "h": 68.56
+          "w": 548,
+          "h": 69
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.79,
-            "max": 35.77
+            "min": 33,
+            "max": 36
           }
         },
         "horizontalOverflow": false,
@@ -6606,7 +6520,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -6634,9 +6548,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -6644,20 +6558,6 @@
           },
           "count": 1,
           "sample": "Print Channel Guide"
-        },
-        {
-          "signature": "input",
-          "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 4,
-          "sample": ""
         },
         {
           "signature": "input",
@@ -6670,7 +6570,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 6,
+          "count": 10,
           "sample": ""
         },
         {
@@ -6741,7 +6641,7 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "United Kingdom \u2014 Entertainment"
+          "sample": "United Kingdom — Entertainment"
         },
         {
           "signature": "span.material-icons",
@@ -6783,29 +6683,27 @@
       "consoleErrors": [],
       "elementCount": 22,
       "fontSizeHistogram": {
-        "16px": 12,
-        "18px": 1,
-        "13px": 3,
-        "13.3333px": 2,
+        "16px": 13,
+        "13px": 5,
         "15px": 2,
         "11px": 2
       },
       "geometry": {
         "container": {
-          "w": 546.54,
-          "h": 390.42
+          "w": 550,
+          "h": 385.5
         },
         "header": {
-          "w": 544.55,
-          "h": 56.04
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 544.55,
-          "h": 264.82
+          "w": 548,
+          "h": 266.5
         },
         "footer": {
-          "w": 544.55,
-          "h": 67.57
+          "w": 548,
+          "h": 68
         },
         "closeBtn": null,
         "rowHeights": {},
@@ -6845,9 +6743,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -6859,7 +6757,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -6925,10 +6823,9 @@
       "elementCount": 79,
       "fontSizeHistogram": {
         "16px": 11,
-        "13.6px": 31,
+        "13px": 42,
         "18px": 23,
-        "11.2px": 3,
-        "12.8px": 11
+        "10px": 3
       },
       "geometry": {
         "container": null,
@@ -6945,7 +6842,7 @@
         {
           "signature": "button.is-open.selection-bar-btn.selection-bar-btn--more",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -6959,7 +6856,7 @@
         {
           "signature": "button.is-open.selection-bar-menu-item.selection-bar-menu-item--submenu",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -6973,7 +6870,7 @@
         {
           "signature": "button.selection-bar-btn",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -6987,7 +6884,7 @@
         {
           "signature": "button.selection-bar-btn.selection-bar-btn--clear",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7001,7 +6898,7 @@
         {
           "signature": "button.selection-bar-btn.selection-bar-btn--danger",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7015,7 +6912,7 @@
         {
           "signature": "button.selection-bar-menu-item",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7029,7 +6926,7 @@
         {
           "signature": "button.selection-bar-menu-item.selection-bar-menu-item--sub",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7043,7 +6940,7 @@
         {
           "signature": "button.selection-bar-menu-item.selection-bar-menu-item--submenu",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7057,11 +6954,11 @@
         {
           "signature": "div.selection-bar-menu-section-label",
           "style": {
-            "font-size": "11.2px",
+            "font-size": "10px",
             "font-weight": "400",
-            "line-height": "16.8px",
+            "line-height": "15px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "0.56px",
+            "letter-spacing": "0.5px",
             "text-transform": "uppercase",
             "font-style": "normal"
           },
@@ -7071,7 +6968,7 @@
         {
           "signature": "input.selection-bar-move-filter-input",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7085,7 +6982,7 @@
         {
           "signature": "span",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7093,21 +6990,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 5,
-          "sample": "Uncategorized"
-        },
-        {
-          "signature": "span",
-          "style": {
-            "font-size": "13.6px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 15,
+          "count": 20,
           "sample": "Delete"
         },
         {
@@ -7141,9 +7024,9 @@
         {
           "signature": "span.selection-action-bar-count",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "600",
-            "line-height": "20.4px",
+            "line-height": "19.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -7164,34 +7047,39 @@
       "consoleErrors": [],
       "elementCount": 31,
       "fontSizeHistogram": {
-        "16px": 19,
+        "16px": 20,
+        "13px": 8,
         "18px": 2,
-        "13.3333px": 8,
-        "11px": 1,
-        "24px": 1
+        "11px": 1
       },
       "geometry": {
         "container": {
-          "w": 548.28,
-          "h": 342.32
+          "w": 550,
+          "h": 344.39
         },
         "header": {
-          "w": 546.29,
-          "h": 64.8
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 546.29,
-          "h": 223.69
+          "w": 548,
+          "h": 227.39
         },
         "footer": {
-          "w": 546.29,
-          "h": 51.84
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
-        "rowHeights": {},
+        "rowHeights": {
+          ".modal-btn": {
+            "n": 2,
+            "min": 33,
+            "max": 36
+          }
+        },
         "horizontalOverflow": false,
         "scrollWidth": 1440,
         "clientWidth": 1440
@@ -7200,7 +7088,7 @@
         {
           "signature": "button.danger.modal-icon-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7212,10 +7100,10 @@
           "sample": "delete"
         },
         {
-          "signature": "button.modal-btn-primary",
+          "signature": "button.modal-btn.modal-btn-primary",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
+            "font-size": "13px",
+            "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
@@ -7226,10 +7114,10 @@
           "sample": "addCreate"
         },
         {
-          "signature": "button.modal-btn-secondary",
+          "signature": "button.modal-btn.modal-btn-secondary",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
+            "font-size": "13px",
+            "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
@@ -7242,7 +7130,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7256,7 +7144,7 @@
         {
           "signature": "button.modal-icon-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7270,9 +7158,9 @@
         {
           "signature": "h2.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -7284,7 +7172,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7334,22 +7222,8 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 1,
+          "count": 2,
           "sample": "close"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "add"
         },
         {
           "signature": "span.server-group-name",
@@ -7377,42 +7251,41 @@
       "consoleErrors": [],
       "elementCount": 29,
       "fontSizeHistogram": {
-        "16px": 14,
-        "18px": 2,
-        "13.3333px": 1,
-        "13px": 12
+        "16px": 15,
+        "13px": 13,
+        "18px": 1
       },
       "geometry": {
         "container": {
-          "w": 543.15,
-          "h": 533.52
+          "w": 550,
+          "h": 524.25
         },
         "header": {
-          "w": 541.18,
-          "h": 64.19
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 541.18,
-          "h": 398.23
+          "w": 548,
+          "h": 403.25
         },
         "footer": {
-          "w": 541.18,
-          "h": 69.13
+          "w": 548,
+          "h": 70
         },
         "closeBtn": {
-          "w": 31.6,
-          "h": 31.6
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 3,
-            "min": 33.58,
-            "max": 36.54
+            "min": 34,
+            "max": 37
           },
           ".modal-form-group": {
             "n": 4,
-            "min": 62.4,
-            "max": 124.12
+            "min": 63.19,
+            "max": 125.69
           }
         },
         "horizontalOverflow": false,
@@ -7493,7 +7366,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7507,9 +7380,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -7601,9 +7474,8 @@
       "elementCount": 24,
       "fontSizeHistogram": {
         "16px": 7,
-        "13.6px": 10,
-        "18px": 6,
-        "12.8px": 1
+        "13px": 11,
+        "18px": 6
       },
       "geometry": {
         "container": null,
@@ -7620,7 +7492,7 @@
         {
           "signature": "button.is-open.stream-create-menu-trigger",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7629,12 +7501,12 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "playlist_addCreate in\u2026expand_less"
+          "sample": "playlist_addCreate in…expand_less"
         },
         {
           "signature": "button.stream-create-menu-item",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7643,12 +7515,12 @@
             "font-style": "normal"
           },
           "count": 4,
-          "sample": "folderUnited Kingdom \u2014 Entertainment"
+          "sample": "folderUnited Kingdom — Entertainment"
         },
         {
           "signature": "input.stream-create-menu-filter-input",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7662,7 +7534,7 @@
         {
           "signature": "span",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7671,12 +7543,12 @@
             "font-style": "normal"
           },
           "count": 4,
-          "sample": "United Kingdom \u2014 Entertainment"
+          "sample": "United Kingdom — Entertainment"
         },
         {
           "signature": "span",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7685,7 +7557,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Create in\u2026"
+          "sample": "Create in…"
         },
         {
           "signature": "span.material-icons",
@@ -7727,43 +7599,42 @@
       "consoleErrors": [],
       "elementCount": 21,
       "fontSizeHistogram": {
-        "16px": 10,
-        "18px": 2,
-        "13.3333px": 1,
-        "13px": 7,
+        "16px": 11,
+        "13px": 8,
+        "18px": 1,
         "10px": 1
       },
       "geometry": {
         "container": {
-          "w": 548.28,
-          "h": 324.55
+          "w": 550,
+          "h": 309.56
         },
         "header": {
-          "w": 546.29,
-          "h": 64.8
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 546.29,
-          "h": 191.96
+          "w": 548,
+          "h": 192.56
         },
         "footer": {
-          "w": 546.29,
-          "h": 65.79
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 3,
-            "min": 32.9,
-            "max": 32.9
+            "min": 33,
+            "max": 33
           },
           ".modal-form-group": {
             "n": 2,
-            "min": 66.17,
-            "max": 69.97
+            "min": 66.38,
+            "max": 70.19
           }
         },
         "horizontalOverflow": false,
@@ -7788,7 +7659,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7816,9 +7687,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -7895,45 +7766,50 @@
       "consoleErrors": [],
       "elementCount": 24,
       "fontSizeHistogram": {
-        "16px": 14,
+        "16px": 15,
+        "13px": 3,
         "18px": 2,
-        "13.3333px": 3,
         "11px": 2,
-        "10px": 2,
-        "24px": 1
+        "10px": 2
       },
       "geometry": {
         "container": {
-          "w": 546.53,
-          "h": 329.3
+          "w": 550,
+          "h": 332.39
         },
         "header": {
-          "w": 544.54,
-          "h": 64.59
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 544.54,
-          "h": 211.05
+          "w": 548,
+          "h": 215.39
         },
         "footer": {
-          "w": 544.54,
-          "h": 51.67
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
-        "rowHeights": {},
+        "rowHeights": {
+          ".modal-btn": {
+            "n": 2,
+            "min": 33,
+            "max": 36
+          }
+        },
         "horizontalOverflow": false,
         "scrollWidth": 1440,
         "clientWidth": 1440
       },
       "rows": [
         {
-          "signature": "button.modal-btn-primary",
+          "signature": "button.modal-btn.modal-btn-primary",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
+            "font-size": "13px",
+            "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
@@ -7944,10 +7820,10 @@
           "sample": "addNew Stream Profile"
         },
         {
-          "signature": "button.modal-btn-secondary",
+          "signature": "button.modal-btn.modal-btn-secondary",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
+            "font-size": "13px",
+            "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
@@ -7960,7 +7836,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -7974,9 +7850,9 @@
         {
           "signature": "h2.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -8010,22 +7886,8 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 1,
+          "count": 2,
           "sample": "close"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "add"
         },
         {
           "signature": "span.stream-profile-command",
@@ -8067,43 +7929,48 @@
       "consoleErrors": [],
       "elementCount": 16,
       "fontSizeHistogram": {
-        "16px": 8,
-        "18px": 2,
-        "13.3333px": 3,
-        "13px": 3
+        "16px": 9,
+        "13px": 6,
+        "18px": 1
       },
       "geometry": {
         "container": {
-          "w": 398.75,
-          "h": 305.23
+          "w": 400,
+          "h": 304.19
         },
         "header": {
-          "w": 396.76,
-          "h": 64.8
+          "w": 398,
+          "h": 49
         },
         "body": {
-          "w": 396.76,
-          "h": 186.6
+          "w": 398,
+          "h": 187.19
         },
         "footer": {
-          "w": 396.76,
-          "h": 51.84
+          "w": 398,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
-        "rowHeights": {},
+        "rowHeights": {
+          ".modal-btn": {
+            "n": 2,
+            "min": 33,
+            "max": 33
+          }
+        },
         "horizontalOverflow": false,
         "scrollWidth": 1440,
         "clientWidth": 1440
       },
       "rows": [
         {
-          "signature": "button.modal-btn-danger",
+          "signature": "button.modal-btn.modal-btn-danger",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
+            "font-size": "13px",
+            "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
@@ -8114,10 +7981,10 @@
           "sample": "Restore now"
         },
         {
-          "signature": "button.modal-btn-secondary",
+          "signature": "button.modal-btn.modal-btn-secondary",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
+            "font-size": "13px",
+            "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
@@ -8130,7 +7997,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -8158,9 +8025,9 @@
         {
           "signature": "h3.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -8237,40 +8104,39 @@
       "consoleErrors": [],
       "elementCount": 59,
       "fontSizeHistogram": {
-        "16px": 18,
-        "18px": 11,
-        "13.3333px": 2,
+        "16px": 19,
+        "13px": 22,
+        "18px": 10,
         "64px": 1,
-        "13px": 20,
         "15px": 3,
         "11px": 4
       },
       "geometry": {
         "container": {
-          "w": 698.69,
-          "h": 764.57
+          "w": 700,
+          "h": 750
         },
         "header": {
-          "w": 696.7,
-          "h": 64.88
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 696.7,
-          "h": 628.82
+          "w": 698,
+          "h": 630
         },
         "footer": {
-          "w": 696.7,
-          "h": 68.87
+          "w": 698,
+          "h": 69
         },
         "closeBtn": {
-          "w": 31.94,
-          "h": 31.94
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 3,
-            "min": 32.94,
-            "max": 35.93
+            "min": 33,
+            "max": 36
           }
         },
         "horizontalOverflow": false,
@@ -8323,7 +8189,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -8337,7 +8203,7 @@
         {
           "signature": "button.vlc-copy-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Consolas, Monaco, \"Courier New\", monospace",
@@ -8393,9 +8259,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -8556,44 +8422,42 @@
       "consoleErrors": [],
       "elementCount": 49,
       "fontSizeHistogram": {
-        "16px": 18,
-        "18px": 4,
-        "13.3333px": 2,
-        "13px": 22,
-        "14px": 2,
+        "16px": 19,
+        "13px": 26,
+        "18px": 3,
         "15px": 1
       },
       "geometry": {
         "container": {
-          "w": 695.58,
-          "h": 758.19
+          "w": 700,
+          "h": 747
         },
         "header": {
-          "w": 693.6,
-          "h": 64.59
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 693.6,
-          "h": 626.03
+          "w": 698,
+          "h": 630
         },
         "footer": {
-          "w": 693.6,
-          "h": 65.58
+          "w": 698,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 3,
-            "min": 32.79,
-            "max": 35.77
+            "min": 33,
+            "max": 36
           },
           ".modal-form-group": {
             "n": 9,
-            "min": 35.77,
-            "max": 62.79
+            "min": 36,
+            "max": 63.19
           }
         },
         "horizontalOverflow": false,
@@ -8604,7 +8468,7 @@
         {
           "signature": "button.custom-select-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -8646,7 +8510,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -8660,9 +8524,9 @@
         {
           "signature": "h3",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -8670,20 +8534,6 @@
           },
           "count": 1,
           "sample": "New Cloud Target"
-        },
-        {
-          "signature": "input",
-          "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": ""
         },
         {
           "signature": "input",
@@ -8696,7 +8546,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 7,
+          "count": 8,
           "sample": ""
         },
         {
@@ -8758,7 +8608,7 @@
         {
           "signature": "span.custom-select-value",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -8809,31 +8659,30 @@
       "consoleErrors": [],
       "elementCount": 38,
       "fontSizeHistogram": {
-        "16px": 25,
-        "18px": 2,
-        "13.3333px": 7,
-        "13px": 4
+        "16px": 26,
+        "13px": 11,
+        "18px": 1
       },
       "geometry": {
         "container": {
-          "w": 556.47,
-          "h": 739
+          "w": 560,
+          "h": 727.69
         },
         "header": {
-          "w": 554.48,
-          "h": 64.59
+          "w": 558,
+          "h": 49
         },
         "body": {
-          "w": 554.48,
-          "h": 604.85
+          "w": 558,
+          "h": 608.69
         },
         "footer": {
-          "w": 554.48,
-          "h": 67.57
+          "w": 558,
+          "h": 68
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {},
         "horizontalOverflow": false,
@@ -8872,7 +8721,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -8886,9 +8735,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -8900,7 +8749,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -8980,10 +8829,8 @@
       "elementCount": 15,
       "fontSizeHistogram": {
         "16px": 7,
-        "24px": 1,
-        "13px": 5,
-        "18px": 1,
-        "14px": 1
+        "18px": 2,
+        "13px": 6
       },
       "geometry": {
         "container": null,
@@ -9051,7 +8898,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Channel pipeline suspended \u2014 the previous run was abandoned "
+          "sample": "Channel pipeline suspended — the previous run was abandoned "
         },
         {
           "signature": "h3",
@@ -9070,9 +8917,9 @@
         {
           "signature": "p",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
-            "line-height": "21px",
+            "line-height": "19.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -9084,9 +8931,9 @@
         {
           "signature": "span.circuit-breaker-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -9135,44 +8982,49 @@
       "consoleErrors": [],
       "elementCount": 18,
       "fontSizeHistogram": {
-        "16px": 10,
-        "18px": 2,
-        "13.3333px": 3,
-        "13px": 1,
+        "16px": 11,
+        "13px": 4,
+        "18px": 1,
         "11px": 2
       },
       "geometry": {
         "container": {
-          "w": 398.75,
-          "h": 331.46
+          "w": 400,
+          "h": 330.5
         },
         "header": {
-          "w": 396.76,
-          "h": 64.8
+          "w": 398,
+          "h": 49
         },
         "body": {
-          "w": 396.76,
-          "h": 212.83
+          "w": 398,
+          "h": 213.5
         },
         "footer": {
-          "w": 396.76,
-          "h": 51.84
+          "w": 398,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
-        "rowHeights": {},
+        "rowHeights": {
+          ".modal-btn": {
+            "n": 2,
+            "min": 33,
+            "max": 33
+          }
+        },
         "horizontalOverflow": false,
         "scrollWidth": 1440,
         "clientWidth": 1440
       },
       "rows": [
         {
-          "signature": "button.modal-btn-danger",
+          "signature": "button.modal-btn.modal-btn-danger",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
+            "font-size": "13px",
+            "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
@@ -9183,10 +9035,10 @@
           "sample": "Turn auto-sync OFF"
         },
         {
-          "signature": "button.modal-btn-secondary",
+          "signature": "button.modal-btn.modal-btn-secondary",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
+            "font-size": "13px",
+            "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
@@ -9199,7 +9051,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -9227,16 +9079,16 @@
         {
           "signature": "h3.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Turn auto-sync OFF for \u2018\u2019?"
+          "sample": "Turn auto-sync OFF for ‘’?"
         },
         {
           "signature": "p",
@@ -9250,7 +9102,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Turn OFF auto_channel_sync for \u2018\u2019 ()? Dispatcharr will stop "
+          "sample": "Turn OFF auto_channel_sync for ‘’ ()? Dispatcharr will stop "
         },
         {
           "signature": "p.form-hint",
@@ -9321,13 +9173,10 @@
       "elementCount": 326,
       "fontSizeHistogram": {
         "16px": 119,
-        "13px": 66,
+        "13px": 111,
         "10px": 5,
         "11px": 73,
         "15px": 9,
-        "14.4px": 19,
-        "13.3333px": 20,
-        "14px": 6,
         "18px": 9
       },
       "geometry": {
@@ -9393,7 +9242,7 @@
         {
           "signature": "button.custom-select-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -9416,12 +9265,12 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "No separate secondary? Use the master group's own streams \u2192"
+          "sample": "No separate secondary? Use the master group's own streams →"
         },
         {
           "signature": "button.event-sync-review-jump",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -9472,7 +9321,7 @@
             "font-style": "normal"
           },
           "count": 2,
-          "sample": "3 patterns \u00b7 time \u00b130 min \u00b7 score \u2265 0.80"
+          "sample": "3 patterns · time ±30 min · score ≥ 0.80"
         },
         {
           "signature": "dt",
@@ -9547,20 +9396,6 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 17,
-          "sample": ""
-        },
-        {
-          "signature": "input",
-          "style": {
             "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
@@ -9569,7 +9404,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 6,
+          "count": 23,
           "sample": ""
         },
         {
@@ -9660,6 +9495,20 @@
           "signature": "span",
           "style": {
             "font-size": "13px",
+            "font-weight": "400",
+            "line-height": "19.5px",
+            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
+            "letter-spacing": "normal",
+            "text-transform": "none",
+            "font-style": "normal"
+          },
+          "count": 2,
+          "sample": "Enabled"
+        },
+        {
+          "signature": "span",
+          "style": {
+            "font-size": "13px",
             "font-weight": "500",
             "line-height": "18.2px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -9669,20 +9518,6 @@
           },
           "count": 8,
           "sample": "Ignore time window (match on title only)"
-        },
-        {
-          "signature": "span",
-          "style": {
-            "font-size": "14.4px",
-            "font-weight": "400",
-            "line-height": "21.6px",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 2,
-          "sample": "Enabled"
         },
         {
           "signature": "span.custom-select-arrow.material-icons",
@@ -9701,7 +9536,7 @@
         {
           "signature": "span.custom-select-value",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -9757,9 +9592,9 @@
         {
           "signature": "span.event-sync-pattern-label",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "600",
-            "line-height": "21.6px",
+            "line-height": "19.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -9935,13 +9770,12 @@
       "elementCount": 159,
       "fontSizeHistogram": {
         "16px": 58,
-        "13px": 42,
-        "13.3333px": 9,
+        "13px": 59,
         "11px": 24,
         "10px": 4,
         "15px": 5,
-        "14px": 11,
         "18px": 5,
+        "14px": 3,
         "9.6px": 1
       },
       "geometry": {
@@ -10007,7 +9841,7 @@
         {
           "signature": "button.custom-select-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -10016,7 +9850,7 @@
             "font-style": "normal"
           },
           "count": 4,
-          "sample": "Auto \u2014 use the Create Channel action's target groupexpand_mo"
+          "sample": "Auto — use the Create Channel action's target groupexpand_mo"
         },
         {
           "signature": "button.filter-dropdown-button",
@@ -10030,7 +9864,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "No groups selected\u25bc"
+          "sample": "No groups selected▼"
         },
         {
           "signature": "button.modal-stepper-item",
@@ -10105,20 +9939,6 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 9,
-          "sample": ""
-        },
-        {
-          "signature": "input",
-          "style": {
             "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
@@ -10127,7 +9947,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 1,
+          "count": 10,
           "sample": ""
         },
         {
@@ -10245,7 +10065,7 @@
         {
           "signature": "span.custom-select-value",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -10254,7 +10074,7 @@
             "font-style": "normal"
           },
           "count": 4,
-          "sample": "Auto \u2014 use the Create Channel action's target group"
+          "sample": "Auto — use the Create Channel action's target group"
         },
         {
           "signature": "span.dropdown-arrow",
@@ -10268,7 +10088,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "\u25bc"
+          "sample": "▼"
         },
         {
           "signature": "span.field-hint",
@@ -10380,7 +10200,7 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "warningNo scope group will resolve \u2014 this rule has no Create"
+          "sample": "warningNo scope group will resolve — this rule has no Create"
         },
         {
           "signature": "span.rule-phase-num",
@@ -10448,41 +10268,40 @@
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 77,
+      "elementCount": 78,
       "fontSizeHistogram": {
-        "16px": 51,
-        "18px": 2,
-        "13px": 5,
-        "13.3333px": 14,
+        "16px": 53,
+        "13px": 19,
+        "18px": 1,
         "11px": 3,
         "10px": 2
       },
       "geometry": {
         "container": {
-          "w": 548.97,
-          "h": 776.43
+          "w": 550,
+          "h": 759.3
         },
         "header": {
-          "w": 546.97,
-          "h": 79.74
+          "w": 548,
+          "h": 61.3
         },
         "body": {
-          "w": 546.97,
-          "h": 628.82
+          "w": 548,
+          "h": 630
         },
         "footer": {
-          "w": 546.97,
-          "h": 65.88
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.94,
-          "h": 31.94
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.94,
-            "max": 32.94
+            "min": 33,
+            "max": 33
           }
         },
         "horizontalOverflow": false,
@@ -10507,7 +10326,7 @@
         {
           "signature": "button.delete.schedule-action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -10549,7 +10368,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -10563,7 +10382,7 @@
         {
           "signature": "button.schedule-action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -10647,9 +10466,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -10661,7 +10480,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -10761,50 +10580,46 @@
     "task-schedule-add": {
       "status": "rendered",
       "file": "src/components/TaskEditorModal.tsx",
-      "label": "Task editor \u2192 add schedule",
+      "label": "Task editor → add schedule",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 121,
+      "elementCount": 122,
       "fontSizeHistogram": {
-        "16px": 63,
-        "18px": 6,
-        "13px": 12,
-        "13.3333px": 16,
+        "16px": 66,
+        "13px": 42,
+        "18px": 4,
         "11px": 3,
         "10px": 2,
-        "12.8px": 10,
-        "20px": 5,
-        "14.4px": 2,
-        "14px": 2
+        "20px": 5
       },
       "geometry": {
         "container": {
-          "w": 549.87,
-          "h": 777.7
+          "w": 550,
+          "h": 759.3
         },
         "header": {
-          "w": 547.87,
-          "h": 79.87
+          "w": 548,
+          "h": 61.3
         },
         "body": {
-          "w": 547.87,
-          "h": 629.85
+          "w": 548,
+          "h": 630
         },
         "footer": {
-          "w": 547.87,
-          "h": 65.98
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.99,
-          "h": 31.99
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 4,
-            "min": 32.99,
-            "max": 35.99
+            "min": 33,
+            "max": 36
           }
         },
         "horizontalOverflow": false,
@@ -10815,7 +10630,7 @@
         {
           "signature": "button.active.type-button",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -10843,7 +10658,7 @@
         {
           "signature": "button.custom-select-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -10857,7 +10672,7 @@
         {
           "signature": "button.delete.schedule-action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -10899,7 +10714,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -10913,7 +10728,7 @@
         {
           "signature": "button.schedule-action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -10927,7 +10742,7 @@
         {
           "signature": "button.type-button",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11011,9 +10826,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -11025,7 +10840,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11053,7 +10868,7 @@
         {
           "signature": "input.time-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11109,7 +10924,7 @@
         {
           "signature": "span",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11179,7 +10994,7 @@
         {
           "signature": "span.custom-select-value",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11237,32 +11052,28 @@
     "task-schedule-edit": {
       "status": "rendered",
       "file": "src/components/TaskEditorModal.tsx",
-      "label": "Task editor \u2192 edit schedule",
+      "label": "Task editor → edit schedule",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 121,
+      "elementCount": 122,
       "fontSizeHistogram": {
-        "16px": 63,
-        "18px": 6,
-        "13px": 12,
-        "13.3333px": 16,
+        "16px": 66,
+        "13px": 42,
+        "18px": 4,
         "11px": 3,
         "10px": 2,
-        "12.8px": 10,
-        "20px": 5,
-        "14.4px": 2,
-        "14px": 2
+        "20px": 5
       },
       "geometry": {
         "container": {
           "w": 550,
-          "h": 777.89
+          "h": 759.3
         },
         "header": {
           "w": 548,
-          "h": 79.89
+          "h": 61.3
         },
         "body": {
           "w": 548,
@@ -11291,7 +11102,7 @@
         {
           "signature": "button.active.type-button",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11319,7 +11130,7 @@
         {
           "signature": "button.custom-select-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11333,7 +11144,7 @@
         {
           "signature": "button.delete.schedule-action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11375,7 +11186,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11389,7 +11200,7 @@
         {
           "signature": "button.schedule-action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11403,7 +11214,7 @@
         {
           "signature": "button.type-button",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11487,9 +11298,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -11501,7 +11312,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11529,7 +11340,7 @@
         {
           "signature": "input.time-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11585,7 +11396,7 @@
         {
           "signature": "span",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11655,7 +11466,7 @@
         {
           "signature": "span.custom-select-value",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11720,44 +11531,43 @@
       "consoleErrors": [],
       "elementCount": 32,
       "fontSizeHistogram": {
-        "16px": 14,
+        "16px": 15,
         "64px": 1,
         "15px": 1,
-        "13px": 9,
-        "18px": 6,
-        "13.3333px": 1
+        "13px": 10,
+        "18px": 5
       },
       "geometry": {
         "container": {
-          "w": 399.25,
-          "h": 353.21
+          "w": 400,
+          "h": 337.88
         },
         "header": {
-          "w": 397.26,
-          "h": 64.88
+          "w": 398,
+          "h": 49
         },
         "body": {
-          "w": 397.26,
-          "h": 217.47
+          "w": 398,
+          "h": 217.88
         },
         "footer": {
-          "w": 397.26,
-          "h": 68.87
+          "w": 398,
+          "h": 69
         },
         "closeBtn": {
-          "w": 31.94,
-          "h": 31.94
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.94,
-            "max": 35.93
+            "min": 33,
+            "max": 36
           },
           ".modal-form-group": {
             "n": 2,
-            "min": 63.07,
-            "max": 63.07
+            "min": 63.19,
+            "max": 63.19
           }
         },
         "horizontalOverflow": false,
@@ -11810,7 +11620,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -11838,9 +11648,9 @@
         {
           "signature": "h2.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -11938,44 +11748,42 @@
     "cloud-targets-card-delete": {
       "status": "rendered",
       "file": "src/components/settings/CloudTargetsCard.tsx",
-      "label": "Cloud targets \u2192 delete confirm",
+      "label": "Cloud targets → delete confirm",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 34,
       "fontSizeHistogram": {
-        "16px": 19,
+        "16px": 21,
         "15px": 1,
-        "13px": 4,
+        "13px": 8,
         "18px": 2,
-        "24px": 2,
-        "11px": 2,
-        "13.3333px": 4
+        "11px": 2
       },
       "geometry": {
         "container": {
-          "w": 397.48,
-          "h": 234.9
+          "w": 400,
+          "h": 229
         },
         "header": {
-          "w": 395.49,
-          "h": 56.03
+          "w": 398,
+          "h": 49
         },
         "body": {
-          "w": 395.49,
-          "h": 111.29
+          "w": 398,
+          "h": 112
         },
         "footer": {
-          "w": 395.49,
-          "h": 65.58
+          "w": 398,
+          "h": 66
         },
         "closeBtn": null,
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.79,
-            "max": 32.79
+            "min": 33,
+            "max": 33
           }
         },
         "horizontalOverflow": false,
@@ -11986,7 +11794,7 @@
         {
           "signature": "button.btn.btn-icon.btn-sm",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12014,7 +11822,7 @@
         {
           "signature": "button.btn.btn-sm",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12070,9 +11878,9 @@
         {
           "signature": "h3",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -12098,9 +11906,9 @@
         {
           "signature": "span.cloud-target-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -12120,8 +11928,8 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 3,
-          "sample": "toggle_on"
+          "count": 4,
+          "sample": "wifi_tethering"
         },
         {
           "signature": "span.material-icons",
@@ -12136,20 +11944,6 @@
           },
           "count": 1,
           "sample": "add"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "wifi_tethering"
         },
         {
           "signature": "span.profile-card-name",
@@ -12184,46 +11978,45 @@
     "dummy-epg-delete-confirm": {
       "status": "rendered",
       "file": "src/components/DummyEPGManagerSection.tsx",
-      "label": "Dummy EPG \u2192 delete confirm",
+      "label": "Dummy EPG → delete confirm",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 55,
       "fontSizeHistogram": {
-        "16px": 24,
+        "16px": 25,
         "15px": 1,
-        "13px": 11,
-        "18px": 10,
-        "11px": 3,
-        "13.3333px": 6
+        "13px": 17,
+        "18px": 9,
+        "11px": 3
       },
       "geometry": {
         "container": {
-          "w": 398.75,
-          "h": 276.13
+          "w": 400,
+          "h": 261
         },
         "header": {
-          "w": 396.76,
-          "h": 64.8
+          "w": 398,
+          "h": 49
         },
         "body": {
-          "w": 396.76,
-          "h": 143.55
+          "w": 398,
+          "h": 144
         },
         "footer": {
-          "w": 396.76,
-          "h": 65.79
+          "w": 398,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.9,
-            "max": 32.9
+            "min": 33,
+            "max": 33
           }
         },
         "horizontalOverflow": false,
@@ -12234,7 +12027,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12248,7 +12041,7 @@
         {
           "signature": "button.action-btn.delete",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12262,7 +12055,7 @@
         {
           "signature": "button.action-btn.toggle",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12332,7 +12125,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12355,7 +12148,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "24/7 filler \u2014 movies"
+          "sample": "24/7 filler — movies"
         },
         {
           "signature": "h2",
@@ -12374,9 +12167,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -12397,7 +12190,7 @@
             "font-style": "normal"
           },
           "count": 2,
-          "sample": "Are you sure you want to delete 24/7 filler \u2014 movies?"
+          "sample": "Are you sure you want to delete 24/7 filler — movies?"
         },
         {
           "signature": "p.header-description",
@@ -12481,47 +12274,46 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "24/7 filler \u2014 movies"
+          "sample": "24/7 filler — movies"
         }
       ]
     },
     "dummy-epg-export": {
       "status": "rendered",
       "file": "src/components/DummyEPGManagerSection.tsx",
-      "label": "Dummy EPG \u2192 export",
+      "label": "Dummy EPG → export",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 54,
       "fontSizeHistogram": {
-        "16px": 21,
+        "16px": 22,
         "15px": 1,
-        "13px": 12,
-        "18px": 11,
-        "11px": 3,
-        "13.3333px": 6
+        "13px": 18,
+        "18px": 10,
+        "11px": 3
       },
       "geometry": {
         "container": {
-          "w": 996.88,
-          "h": 576.19
+          "w": 1000,
+          "h": 562
         },
         "header": {
-          "w": 994.88,
-          "h": 64.8
+          "w": 998,
+          "h": 49
         },
         "body": {
-          "w": 994.88,
-          "h": 438.63
+          "w": 998,
+          "h": 440
         },
         "footer": {
-          "w": 994.88,
-          "h": 70.78
+          "w": 998,
+          "h": 71
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {},
         "horizontalOverflow": false,
@@ -12532,7 +12324,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12546,7 +12338,7 @@
         {
           "signature": "button.action-btn.delete",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12560,7 +12352,7 @@
         {
           "signature": "button.action-btn.toggle",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12602,7 +12394,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12625,7 +12417,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "24/7 filler \u2014 movies"
+          "sample": "24/7 filler — movies"
         },
         {
           "signature": "h2",
@@ -12644,9 +12436,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -12744,46 +12536,45 @@
     "dummy-epg-import-yaml": {
       "status": "rendered",
       "file": "src/components/DummyEPGManagerSection.tsx",
-      "label": "Dummy EPG \u2192 import YAML",
+      "label": "Dummy EPG → import YAML",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 55,
       "fontSizeHistogram": {
-        "16px": 22,
+        "16px": 23,
         "15px": 1,
-        "13px": 13,
-        "18px": 10,
-        "11px": 3,
-        "13.3333px": 6
+        "13px": 19,
+        "18px": 9,
+        "11px": 3
       },
       "geometry": {
         "container": {
-          "w": 548.28,
-          "h": 382.99
+          "w": 550,
+          "h": 368.19
         },
         "header": {
-          "w": 546.29,
-          "h": 64.8
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 546.29,
-          "h": 248.41
+          "w": 548,
+          "h": 249.19
         },
         "footer": {
-          "w": 546.29,
-          "h": 67.79
+          "w": 548,
+          "h": 68
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-form-group": {
             "n": 1,
-            "min": 208.53,
-            "max": 208.53
+            "min": 209.19,
+            "max": 209.19
           }
         },
         "horizontalOverflow": false,
@@ -12794,7 +12585,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12808,7 +12599,7 @@
         {
           "signature": "button.action-btn.delete",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12822,7 +12613,7 @@
         {
           "signature": "button.action-btn.toggle",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12864,7 +12655,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -12887,7 +12678,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "24/7 filler \u2014 movies"
+          "sample": "24/7 filler — movies"
         },
         {
           "signature": "h2",
@@ -12906,9 +12697,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -13020,7 +12811,7 @@
     "logo-delete-confirm": {
       "status": "rendered",
       "file": "src/components/tabs/LogoManagerTab.tsx",
-      "label": "Logo manager \u2192 delete confirm",
+      "label": "Logo manager → delete confirm",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
@@ -13029,20 +12820,19 @@
       ],
       "elementCount": 101,
       "fontSizeHistogram": {
-        "16px": 44,
-        "13px": 22,
+        "16px": 45,
+        "13px": 36,
         "18px": 7,
-        "24px": 3,
-        "14px": 2,
-        "13.3333px": 13,
         "10px": 8,
+        "14px": 1,
+        "24px": 2,
         "11px": 2
       },
       "geometry": {
         "container": null,
         "header": {
           "w": 352,
-          "h": 56.39
+          "h": 49
         },
         "body": {
           "w": 352,
@@ -13062,7 +12852,7 @@
         {
           "signature": "button",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13076,7 +12866,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13090,7 +12880,7 @@
         {
           "signature": "button.action-btn.delete",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13104,7 +12894,7 @@
         {
           "signature": "button.active",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13160,7 +12950,7 @@
         {
           "signature": "button.close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13169,12 +12959,12 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "\u00d7"
+          "sample": "×"
         },
         {
           "signature": "button.copy-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13188,7 +12978,7 @@
         {
           "signature": "button.page-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13258,9 +13048,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -13272,7 +13062,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13420,7 +13210,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 6,
+          "count": 7,
           "sample": "add"
         },
         {
@@ -13434,8 +13224,8 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 3,
-          "sample": "check_circle"
+          "count": 2,
+          "sample": "broken_image"
         },
         {
           "signature": "span.material-icons.sort-icon",
@@ -13477,7 +13267,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "1\u20132 of 2"
+          "sample": "1–2 of 2"
         },
         {
           "signature": "strong",
@@ -13505,46 +13295,44 @@
       "consoleErrors": [],
       "elementCount": 165,
       "fontSizeHistogram": {
-        "16px": 59,
-        "13px": 32,
-        "18px": 19,
+        "16px": 60,
+        "13px": 51,
+        "18px": 18,
         "15px": 2,
         "10px": 10,
-        "11px": 24,
-        "13.3333px": 17,
-        "14px": 2
+        "11px": 24
       },
       "geometry": {
         "container": {
-          "w": 698.69,
-          "h": 529.94
+          "w": 700,
+          "h": 520.75
         },
         "header": {
-          "w": 696.69,
-          "h": 64.88
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 696.69,
-          "h": 397.19
+          "w": 698,
+          "h": 403.75
         },
         "footer": {
-          "w": 696.69,
-          "h": 65.88
+          "w": 698,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.94,
-          "h": 31.94
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.94,
-            "max": 32.94
+            "min": 33,
+            "max": 33
           },
           ".modal-form-group": {
             "n": 6,
-            "min": 18.15,
-            "max": 102.99
+            "min": 24,
+            "max": 103.19
           }
         },
         "horizontalOverflow": false,
@@ -13555,7 +13343,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13569,7 +13357,7 @@
         {
           "signature": "button.action-btn.active.toggle",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13583,7 +13371,7 @@
         {
           "signature": "button.action-btn.delete",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13597,7 +13385,7 @@
         {
           "signature": "button.action-btn.toggle",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13639,7 +13427,7 @@
         {
           "signature": "button.custom-select-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13681,7 +13469,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -13704,7 +13492,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "24/7 filler \u2014 movies"
+          "sample": "24/7 filler — movies"
         },
         {
           "signature": "div.source-message",
@@ -13765,9 +13553,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -13775,20 +13563,6 @@
           },
           "count": 1,
           "sample": "Add Standard EPG"
-        },
-        {
-          "signature": "input",
-          "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": ""
         },
         {
           "signature": "input",
@@ -13801,7 +13575,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 4,
+          "count": 5,
           "sample": ""
         },
         {
@@ -13961,7 +13735,7 @@
         {
           "signature": "span.custom-select-value",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -14159,53 +13933,50 @@
     "scheduled-tasks-run": {
       "status": "rendered",
       "file": "src/components/ScheduledTasksSection.tsx",
-      "label": "Scheduled tasks \u2192 run now",
+      "label": "Scheduled tasks → run now",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 116,
       "fontSizeHistogram": {
-        "16px": 43,
-        "13px": 4,
-        "24px": 3,
-        "13.6px": 57,
-        "14px": 3,
-        "18px": 3,
-        "13.3333px": 1,
-        "12.8px": 2
+        "16px": 41,
+        "13px": 64,
+        "18px": 5,
+        "10px": 3,
+        "14px": 3
       },
       "geometry": {
         "container": {
-          "w": 398.75,
-          "h": 354.08
+          "w": 400,
+          "h": 339.19
         },
         "header": {
-          "w": 396.76,
-          "h": 64.8
+          "w": 398,
+          "h": 49
         },
         "body": {
-          "w": 396.76,
-          "h": 218.5
+          "w": 398,
+          "h": 219.19
         },
         "footer": {
-          "w": 396.76,
-          "h": 68.78
+          "w": 398,
+          "h": 69
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 4,
-            "min": 24.92,
-            "max": 35.89
+            "min": 25,
+            "max": 36
           },
           ".modal-form-group": {
             "n": 1,
-            "min": 178.63,
-            "max": 178.63
+            "min": 179.19,
+            "max": 179.19
           }
         },
         "horizontalOverflow": false,
@@ -14216,7 +13987,7 @@
         {
           "signature": "button",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -14244,7 +14015,7 @@
         {
           "signature": "button.modal-btn.modal-btn-primary",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "13px",
             "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -14252,11 +14023,11 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 1,
+          "count": 2,
           "sample": "Select None"
         },
         {
-          "signature": "button.modal-btn.modal-btn-primary",
+          "signature": "button.modal-btn.modal-btn-secondary",
           "style": {
             "font-size": "13px",
             "font-weight": "500",
@@ -14266,41 +14037,13 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 1,
-          "sample": "play_arrowRun (0 groups)"
-        },
-        {
-          "signature": "button.modal-btn.modal-btn-secondary",
-          "style": {
-            "font-size": "12.8px",
-            "font-weight": "500",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
+          "count": 2,
           "sample": "Select All"
-        },
-        {
-          "signature": "button.modal-btn.modal-btn-secondary",
-          "style": {
-            "font-size": "13px",
-            "font-weight": "500",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "Cancel"
         },
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -14314,9 +14057,9 @@
         {
           "signature": "div",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "400",
-            "line-height": "20.4px",
+            "line-height": "19.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -14328,9 +14071,9 @@
         {
           "signature": "div",
           "style": {
-            "font-size": "16px",
+            "font-size": "13px",
             "font-weight": "600",
-            "line-height": "24px",
+            "line-height": "19.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -14356,9 +14099,9 @@
         {
           "signature": "h2.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -14384,9 +14127,9 @@
         {
           "signature": "span.enabled.task-status-pill",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "10px",
             "font-weight": "400",
-            "line-height": "20.4px",
+            "line-height": "15px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -14438,11 +14181,11 @@
           "sample": "close"
         },
         {
-          "signature": "span.material-icons",
+          "signature": "span.material-icons.task-status-icon",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -14454,9 +14197,9 @@
         {
           "signature": "span.running.task-status-pill",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "10px",
             "font-weight": "400",
-            "line-height": "20.4px",
+            "line-height": "15px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -14470,7 +14213,7 @@
     "history-checkpoint-name": {
       "status": "rendered",
       "file": "src/components/HistoryToolbar.tsx",
-      "label": "History \u2192 name checkpoint",
+      "label": "History → name checkpoint",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
@@ -14478,10 +14221,10 @@
       "elementCount": 20,
       "fontSizeHistogram": {
         "16px": 8,
-        "13.6px": 5,
-        "24px": 4,
-        "11.2px": 2,
-        "14.4px": 1
+        "13px": 6,
+        "18px": 3,
+        "11px": 2,
+        "14px": 1
       },
       "geometry": {
         "container": null,
@@ -14498,7 +14241,7 @@
         {
           "signature": "button.cancel.checkpoint-name-btn",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -14512,7 +14255,7 @@
         {
           "signature": "button.checkpoint-name-btn.confirm",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -14526,7 +14269,7 @@
         {
           "signature": "button.history-btn",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -14540,7 +14283,7 @@
         {
           "signature": "button.history-btn.save-point-btn",
           "style": {
-            "font-size": "13.6px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -14568,7 +14311,7 @@
         {
           "signature": "input.checkpoint-name-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -14582,7 +14325,7 @@
         {
           "signature": "span.history-count",
           "style": {
-            "font-size": "11.2px",
+            "font-size": "11px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -14596,9 +14339,9 @@
         {
           "signature": "span.history-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -14610,9 +14353,9 @@
         {
           "signature": "span.material-icons.save-point-icon",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -14624,9 +14367,9 @@
         {
           "signature": "span.material-icons.unsaved-indicator",
           "style": {
-            "font-size": "24px",
+            "font-size": "14px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "14px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -14640,53 +14383,51 @@
     "tag-import": {
       "status": "rendered",
       "file": "src/components/settings/TagEngineSection.tsx",
-      "label": "Tag engine \u2192 import",
+      "label": "Tag engine → import",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 45,
       "fontSizeHistogram": {
-        "16px": 19,
+        "16px": 21,
         "18px": 7,
-        "14px": 2,
-        "13px": 9,
-        "24px": 2,
+        "13px": 13,
         "15px": 1,
         "11px": 2,
-        "13.3333px": 3
+        "14px": 1
       },
       "geometry": {
         "container": {
-          "w": 697.81,
-          "h": 514.07
+          "w": 700,
+          "h": 504.19
         },
         "header": {
-          "w": 695.82,
-          "h": 64.8
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 695.82,
-          "h": 381.49
+          "w": 698,
+          "h": 387.19
         },
         "footer": {
-          "w": 695.82,
-          "h": 65.79
+          "w": 698,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 3,
-            "min": 32.9,
-            "max": 35.89
+            "min": 33,
+            "max": 36
           },
           ".modal-form-group": {
             "n": 1,
-            "min": 306.23,
-            "max": 306.23
+            "min": 307.19,
+            "max": 307.19
           }
         },
         "horizontalOverflow": false,
@@ -14725,7 +14466,7 @@
         {
           "signature": "button.delete-group-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -14767,7 +14508,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -14781,9 +14522,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -14809,7 +14550,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -14817,21 +14558,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 1,
-          "sample": ""
-        },
-        {
-          "signature": "input",
-          "style": {
-            "font-size": "14px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
+          "count": 2,
           "sample": ""
         },
         {
@@ -14865,9 +14592,9 @@
         {
           "signature": "span.expand-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -14907,6 +14634,20 @@
         {
           "signature": "span.material-icons",
           "style": {
+            "font-size": "16px",
+            "font-weight": "400",
+            "line-height": "16px",
+            "font-family": "\"Material Icons\"",
+            "letter-spacing": "normal",
+            "text-transform": "none",
+            "font-style": "normal"
+          },
+          "count": 1,
+          "sample": "delete"
+        },
+        {
+          "signature": "span.material-icons",
+          "style": {
             "font-size": "18px",
             "font-weight": "400",
             "line-height": "18px",
@@ -14917,20 +14658,6 @@
           },
           "count": 6,
           "sample": "search"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "delete"
         },
         {
           "signature": "span.tag-count",
@@ -14965,27 +14692,25 @@
     "tag-create-group": {
       "status": "rendered",
       "file": "src/components/settings/TagEngineSection.tsx",
-      "label": "Tag engine \u2192 create group",
+      "label": "Tag engine → create group",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 43,
       "fontSizeHistogram": {
-        "16px": 20,
-        "18px": 5,
-        "14px": 2,
-        "13px": 9,
-        "24px": 3,
+        "16px": 22,
+        "18px": 6,
+        "13px": 12,
         "15px": 1,
         "11px": 1,
-        "13.3333px": 2
+        "14px": 1
       },
       "geometry": {
         "container": null,
         "header": {
           "w": 350,
-          "h": 65
+          "h": 49
         },
         "body": {
           "w": 350,
@@ -15033,7 +14758,7 @@
         {
           "signature": "button.delete-group-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -15047,7 +14772,7 @@
         {
           "signature": "button.modal-close",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -15061,9 +14786,9 @@
         {
           "signature": "h3",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -15097,21 +14822,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 2,
-          "sample": ""
-        },
-        {
-          "signature": "input",
-          "style": {
-            "font-size": "14px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
+          "count": 3,
           "sample": ""
         },
         {
@@ -15131,9 +14842,9 @@
         {
           "signature": "span.expand-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -15159,6 +14870,20 @@
         {
           "signature": "span.material-icons",
           "style": {
+            "font-size": "16px",
+            "font-weight": "400",
+            "line-height": "16px",
+            "font-family": "\"Material Icons\"",
+            "letter-spacing": "normal",
+            "text-transform": "none",
+            "font-style": "normal"
+          },
+          "count": 1,
+          "sample": "delete"
+        },
+        {
+          "signature": "span.material-icons",
+          "style": {
             "font-size": "18px",
             "font-weight": "400",
             "line-height": "18px",
@@ -15167,22 +14892,8 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 4,
+          "count": 5,
           "sample": "search"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 2,
-          "sample": "delete"
         },
         {
           "signature": "span.tag-count",
@@ -15203,54 +14914,52 @@
     "norm-rule-editor": {
       "status": "rendered",
       "file": "src/components/settings/NormalizationEngineSection.tsx",
-      "label": "Normalization \u2192 rule editor",
+      "label": "Normalization → rule editor",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 127,
       "fontSizeHistogram": {
-        "16px": 47,
-        "24px": 12,
+        "16px": 56,
+        "18px": 5,
         "15px": 2,
-        "13px": 44,
+        "13px": 54,
         "20px": 4,
         "10px": 4,
-        "11px": 2,
-        "13.3333px": 10,
-        "18px": 2
+        "11px": 2
       },
       "geometry": {
         "container": {
-          "w": 548.97,
-          "h": 637.56
+          "w": 550,
+          "h": 631.75
         },
         "header": {
-          "w": 546.98,
-          "h": 64.88
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 546.98,
-          "h": 504.8
+          "w": 548,
+          "h": 514.75
         },
         "footer": {
-          "w": 546.98,
-          "h": 65.88
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.94,
-          "h": 31.94
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.94,
-            "max": 32.94
+            "min": 33,
+            "max": 33
           },
           ".modal-form-group": {
             "n": 6,
-            "min": 63.07,
-            "max": 81.04
+            "min": 63.19,
+            "max": 81.19
           }
         },
         "horizontalOverflow": false,
@@ -15275,7 +14984,7 @@
         {
           "signature": "button.danger.norm-engine-btn-icon",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -15289,7 +14998,7 @@
         {
           "signature": "button.danger.norm-engine-btn-icon.small",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -15331,7 +15040,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -15373,7 +15082,7 @@
         {
           "signature": "button.norm-engine-btn-icon",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -15387,7 +15096,7 @@
         {
           "signature": "button.norm-engine-btn-icon.small",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -15429,9 +15138,9 @@
         {
           "signature": "h2.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -15471,20 +15180,6 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 5,
-          "sample": ""
-        },
-        {
-          "signature": "input",
-          "style": {
             "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
@@ -15493,7 +15188,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 4,
+          "count": 9,
           "sample": ""
         },
         {
@@ -15611,9 +15306,9 @@
         {
           "signature": "span.expanded.material-icons.norm-engine-expand",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -15633,8 +15328,8 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 3,
-          "sample": "edit"
+          "count": 11,
+          "sample": "download"
         },
         {
           "signature": "span.material-icons",
@@ -15647,29 +15342,15 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 1,
-          "sample": "close"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 9,
-          "sample": "download"
+          "count": 2,
+          "sample": "science"
         },
         {
           "signature": "span.material-icons.norm-engine-expand",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -15681,9 +15362,9 @@
         {
           "signature": "span.material-icons.norm-engine-icon",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -15781,54 +15462,52 @@
     "norm-group-editor": {
       "status": "rendered",
       "file": "src/components/settings/NormalizationEngineSection.tsx",
-      "label": "Normalization \u2192 group editor",
+      "label": "Normalization → group editor",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 71,
       "fontSizeHistogram": {
-        "16px": 28,
-        "24px": 12,
+        "16px": 37,
+        "18px": 5,
         "15px": 2,
-        "13px": 14,
+        "13px": 18,
         "20px": 4,
         "10px": 4,
-        "11px": 1,
-        "13.3333px": 4,
-        "18px": 2
+        "11px": 1
       },
       "geometry": {
         "container": {
-          "w": 398.75,
-          "h": 355.26
+          "w": 400,
+          "h": 340.38
         },
         "header": {
-          "w": 396.75,
-          "h": 64.8
+          "w": 398,
+          "h": 49
         },
         "body": {
-          "w": 396.75,
-          "h": 222.68
+          "w": 398,
+          "h": 223.38
         },
         "footer": {
-          "w": 396.75,
-          "h": 65.79
+          "w": 398,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.9,
-            "max": 32.9
+            "min": 33,
+            "max": 33
           },
           ".modal-form-group": {
             "n": 2,
-            "min": 62.99,
-            "max": 103.86
+            "min": 63.19,
+            "max": 104.19
           }
         },
         "horizontalOverflow": false,
@@ -15839,7 +15518,7 @@
         {
           "signature": "button.danger.norm-engine-btn-icon",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -15881,7 +15560,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -15909,7 +15588,7 @@
         {
           "signature": "button.norm-engine-btn-icon",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -15937,9 +15616,9 @@
         {
           "signature": "h2.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -15979,20 +15658,6 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": ""
-        },
-        {
-          "signature": "input",
-          "style": {
             "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
@@ -16001,7 +15666,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 1,
+          "count": 2,
           "sample": ""
         },
         {
@@ -16035,6 +15700,20 @@
         {
           "signature": "span.material-icons",
           "style": {
+            "font-size": "16px",
+            "font-weight": "400",
+            "line-height": "16px",
+            "font-family": "\"Material Icons\"",
+            "letter-spacing": "normal",
+            "text-transform": "none",
+            "font-style": "normal"
+          },
+          "count": 8,
+          "sample": "download"
+        },
+        {
+          "signature": "span.material-icons",
+          "style": {
             "font-size": "18px",
             "font-weight": "400",
             "line-height": "18px",
@@ -16043,29 +15722,15 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 1,
-          "sample": "close"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 9,
-          "sample": "download"
+          "count": 2,
+          "sample": "science"
         },
         {
           "signature": "span.material-icons.norm-engine-expand",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -16077,9 +15742,9 @@
         {
           "signature": "span.material-icons.norm-engine-icon",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -16163,54 +15828,52 @@
     "norm-import": {
       "status": "rendered",
       "file": "src/components/settings/NormalizationEngineSection.tsx",
-      "label": "Normalization \u2192 import",
+      "label": "Normalization → import",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 73,
       "fontSizeHistogram": {
-        "16px": 27,
-        "24px": 12,
+        "16px": 36,
+        "18px": 6,
         "15px": 2,
-        "13px": 14,
+        "13px": 19,
         "20px": 4,
         "10px": 4,
-        "11px": 2,
-        "13.3333px": 5,
-        "18px": 3
+        "11px": 2
       },
       "geometry": {
         "container": {
-          "w": 698.69,
-          "h": 490.77
+          "w": 700,
+          "h": 480.19
         },
         "header": {
-          "w": 696.7,
-          "h": 64.88
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 696.7,
-          "h": 358.02
+          "w": 698,
+          "h": 363.19
         },
         "footer": {
-          "w": 696.7,
-          "h": 65.88
+          "w": 698,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.94,
-          "h": 31.94
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 3,
-            "min": 32.94,
-            "max": 35.93
+            "min": 33,
+            "max": 36
           },
           ".modal-form-group": {
             "n": 1,
-            "min": 282.66,
-            "max": 282.66
+            "min": 283.19,
+            "max": 283.19
           }
         },
         "horizontalOverflow": false,
@@ -16221,7 +15884,7 @@
         {
           "signature": "button.danger.norm-engine-btn-icon",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -16263,7 +15926,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -16291,7 +15954,7 @@
         {
           "signature": "button.norm-engine-btn-icon",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -16319,9 +15982,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -16361,7 +16024,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -16431,6 +16094,20 @@
         {
           "signature": "span.material-icons",
           "style": {
+            "font-size": "16px",
+            "font-weight": "400",
+            "line-height": "16px",
+            "font-family": "\"Material Icons\"",
+            "letter-spacing": "normal",
+            "text-transform": "none",
+            "font-style": "normal"
+          },
+          "count": 8,
+          "sample": "download"
+        },
+        {
+          "signature": "span.material-icons",
+          "style": {
             "font-size": "18px",
             "font-weight": "400",
             "line-height": "18px",
@@ -16439,29 +16116,15 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 2,
-          "sample": "close"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 9,
-          "sample": "download"
+          "count": 3,
+          "sample": "science"
         },
         {
           "signature": "span.material-icons.norm-engine-expand",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -16473,9 +16136,9 @@
         {
           "signature": "span.material-icons.norm-engine-icon",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -16559,49 +16222,47 @@
     "norm-apply": {
       "status": "rendered",
       "file": "src/components/settings/NormalizationEngineSection.tsx",
-      "label": "Normalization \u2192 apply to channels",
+      "label": "Normalization → apply to channels",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 111,
       "fontSizeHistogram": {
-        "16px": 31,
-        "24px": 12,
+        "16px": 40,
+        "18px": 6,
         "15px": 2,
-        "13px": 37,
+        "13px": 51,
         "20px": 4,
         "10px": 4,
-        "11px": 4,
-        "13.3333px": 14,
-        "18px": 3
+        "11px": 4
       },
       "geometry": {
         "container": {
-          "w": 698.69,
-          "h": 466.62
+          "w": 700,
+          "h": 432
         },
         "header": {
-          "w": 696.69,
-          "h": 64.88
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 696.69,
-          "h": 333.87
+          "w": 698,
+          "h": 315
         },
         "footer": {
-          "w": 696.69,
-          "h": 65.88
+          "w": 698,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.94,
-          "h": 31.94
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.94,
-            "max": 32.94
+            "min": 33,
+            "max": 33
           }
         },
         "horizontalOverflow": false,
@@ -16612,7 +16273,7 @@
         {
           "signature": "button.danger.norm-engine-btn-icon",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -16654,7 +16315,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -16668,7 +16329,7 @@
         {
           "signature": "button.norm-engine-apply-trace-toggle",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -16696,7 +16357,7 @@
         {
           "signature": "button.norm-engine-btn-icon",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -16724,9 +16385,9 @@
         {
           "signature": "h2.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -16766,7 +16427,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -16780,7 +16441,7 @@
         {
           "signature": "option",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -16822,7 +16483,7 @@
         {
           "signature": "select",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -16844,8 +16505,8 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 2,
-          "sample": "chevron_right"
+          "count": 10,
+          "sample": "download"
         },
         {
           "signature": "span.material-icons",
@@ -16858,29 +16519,15 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 2,
-          "sample": "close"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 9,
-          "sample": "download"
+          "count": 3,
+          "sample": "science"
         },
         {
           "signature": "span.material-icons.norm-engine-expand",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -16892,9 +16539,9 @@
         {
           "signature": "span.material-icons.norm-engine-icon",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -16943,7 +16590,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "\u2014"
+          "sample": "—"
         },
         {
           "signature": "span.norm-engine-apply-rule-count",
@@ -17048,35 +16695,33 @@
     "norm-apply-confirm": {
       "status": "rendered",
       "file": "src/components/settings/NormalizationEngineSection.tsx",
-      "label": "Normalization \u2192 apply confirm (alertdialog)",
+      "label": "Normalization → apply confirm (alertdialog)",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 127,
       "fontSizeHistogram": {
-        "16px": 41,
-        "24px": 12,
+        "16px": 51,
+        "18px": 7,
         "15px": 2,
-        "13px": 40,
+        "13px": 55,
         "20px": 4,
         "10px": 4,
-        "11px": 4,
-        "13.3333px": 15,
-        "18px": 5
+        "11px": 4
       },
       "geometry": {
         "container": {
           "w": 700,
-          "h": 467.5
+          "h": 432
         },
         "header": {
           "w": 698,
-          "h": 65
+          "h": 49
         },
         "body": {
           "w": 698,
-          "h": 334.5
+          "h": 315
         },
         "footer": {
           "w": 698,
@@ -17089,7 +16734,7 @@
         "rowHeights": {
           ".modal-btn": {
             "n": 4,
-            "min": 32.9,
+            "min": 33,
             "max": 33
           }
         },
@@ -17101,7 +16746,7 @@
         {
           "signature": "button.danger.norm-engine-btn-icon",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -17143,7 +16788,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -17157,7 +16802,7 @@
         {
           "signature": "button.norm-engine-apply-trace-toggle",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -17185,7 +16830,7 @@
         {
           "signature": "button.norm-engine-btn-icon",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -17213,9 +16858,9 @@
         {
           "signature": "h2.modal-title",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -17255,7 +16900,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -17269,7 +16914,7 @@
         {
           "signature": "option",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -17353,7 +16998,7 @@
         {
           "signature": "select",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -17375,8 +17020,8 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 2,
-          "sample": "chevron_right"
+          "count": 10,
+          "sample": "download"
         },
         {
           "signature": "span.material-icons",
@@ -17389,29 +17034,15 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 3,
-          "sample": "close"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 9,
-          "sample": "download"
+          "count": 4,
+          "sample": "science"
         },
         {
           "signature": "span.material-icons.norm-engine-expand",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -17423,9 +17054,9 @@
         {
           "signature": "span.material-icons.norm-engine-icon",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -17474,7 +17105,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "\u2014"
+          "sample": "—"
         },
         {
           "signature": "span.norm-engine-apply-rule-count",
@@ -17593,45 +17224,43 @@
     "pending-merge-bulk": {
       "status": "rendered",
       "file": "src/components/tabs/PendingMergesPage.tsx",
-      "label": "Pending merges \u2192 bulk confirm",
+      "label": "Pending merges → bulk confirm",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 48,
+      "elementCount": 49,
       "fontSizeHistogram": {
-        "16px": 23,
+        "16px": 25,
         "15px": 1,
-        "13px": 14,
+        "13px": 16,
         "18px": 2,
-        "13.3333px": 2,
         "10px": 3,
-        "11px": 2,
-        "24px": 1
+        "11px": 2
       },
       "geometry": {
         "container": {
-          "w": 397.48,
-          "h": 290.16
+          "w": 400,
+          "h": 277
         },
         "header": {
-          "w": 395.49,
-          "h": 63.6
+          "w": 398,
+          "h": 49
         },
         "body": {
-          "w": 395.49,
-          "h": 158.99
+          "w": 398,
+          "h": 160
         },
         "footer": {
-          "w": 395.49,
-          "h": 65.58
+          "w": 398,
+          "h": 66
         },
         "closeBtn": null,
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.79,
-            "max": 32.79
+            "min": 33,
+            "max": 33
           }
         },
         "horizontalOverflow": false,
@@ -17712,7 +17341,7 @@
         {
           "signature": "button.modal-close",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -17740,9 +17369,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -17754,7 +17383,7 @@
         {
           "signature": "input.pending-merges-select",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -17832,22 +17461,8 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 1,
+          "count": 2,
           "sample": "refresh"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "close"
         },
         {
           "signature": "span.pending-merges-candidate-group",
@@ -17861,7 +17476,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "United Kingdom \u2014 Entertainment"
+          "sample": "United Kingdom — Entertainment"
         },
         {
           "signature": "span.pending-merges-candidate-id",
@@ -17938,19 +17553,18 @@
     "user-profile": {
       "status": "rendered",
       "file": "src/components/UserMenu.tsx",
-      "label": "User menu \u2192 profile",
+      "label": "User menu → profile",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 28,
       "fontSizeHistogram": {
-        "16px": 12,
-        "14px": 10,
-        "24px": 3,
-        "18px": 1,
-        "13.3333px": 1,
-        "12px": 1
+        "16px": 13,
+        "13px": 11,
+        "20px": 1,
+        "18px": 2,
+        "11px": 1
       },
       "geometry": {
         "container": null,
@@ -17967,7 +17581,7 @@
         {
           "signature": "button.user-menu-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -17981,7 +17595,7 @@
         {
           "signature": "button.user-modal-btn.user-modal-btn-primary",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -17995,7 +17609,7 @@
         {
           "signature": "button.user-modal-btn.user-modal-btn-secondary",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -18009,7 +17623,7 @@
         {
           "signature": "button.user-modal-close",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -18023,9 +17637,9 @@
         {
           "signature": "h3",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "27px",
+            "line-height": "24px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -18037,7 +17651,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -18051,9 +17665,9 @@
         {
           "signature": "label",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "500",
-            "line-height": "21px",
+            "line-height": "19.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -18065,9 +17679,9 @@
         {
           "signature": "p.user-modal-hint",
           "style": {
-            "font-size": "12px",
+            "font-size": "11px",
             "font-weight": "400",
-            "line-height": "18px",
+            "line-height": "16.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -18079,9 +17693,9 @@
         {
           "signature": "span.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -18093,9 +17707,9 @@
         {
           "signature": "span.material-icons.user-menu-arrow",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -18107,9 +17721,9 @@
         {
           "signature": "span.material-icons.user-menu-icon",
           "style": {
-            "font-size": "24px",
+            "font-size": "20px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "20px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -18121,7 +17735,7 @@
         {
           "signature": "span.user-menu-name",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -18137,19 +17751,18 @@
     "user-password": {
       "status": "rendered",
       "file": "src/components/UserMenu.tsx",
-      "label": "User menu \u2192 change password",
+      "label": "User menu → change password",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 28,
       "fontSizeHistogram": {
-        "16px": 12,
-        "14px": 10,
-        "24px": 3,
-        "18px": 1,
-        "13.3333px": 1,
-        "12px": 1
+        "16px": 13,
+        "13px": 11,
+        "20px": 1,
+        "18px": 2,
+        "11px": 1
       },
       "geometry": {
         "container": null,
@@ -18166,7 +17779,7 @@
         {
           "signature": "button.user-menu-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -18180,7 +17793,7 @@
         {
           "signature": "button.user-modal-btn.user-modal-btn-primary",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -18194,7 +17807,7 @@
         {
           "signature": "button.user-modal-btn.user-modal-btn-secondary",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "500",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -18208,7 +17821,7 @@
         {
           "signature": "button.user-modal-close",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -18222,9 +17835,9 @@
         {
           "signature": "h3",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "27px",
+            "line-height": "24px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -18236,7 +17849,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -18250,9 +17863,9 @@
         {
           "signature": "label",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "500",
-            "line-height": "21px",
+            "line-height": "19.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -18264,9 +17877,9 @@
         {
           "signature": "p.user-modal-hint",
           "style": {
-            "font-size": "12px",
+            "font-size": "11px",
             "font-weight": "400",
-            "line-height": "18px",
+            "line-height": "16.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -18278,9 +17891,9 @@
         {
           "signature": "span.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -18292,9 +17905,9 @@
         {
           "signature": "span.material-icons.user-menu-arrow",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -18306,9 +17919,9 @@
         {
           "signature": "span.material-icons.user-menu-icon",
           "style": {
-            "font-size": "24px",
+            "font-size": "20px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "20px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -18320,7 +17933,7 @@
         {
           "signature": "span.user-menu-name",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -18336,47 +17949,46 @@
     "settings-plex-token": {
       "status": "rendered",
       "file": "src/components/tabs/SettingsTab.tsx",
-      "label": "Settings \u2192 Plex token help",
+      "label": "Settings → Plex token help",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 153,
       "fontSizeHistogram": {
-        "16px": 60,
-        "18px": 11,
+        "16px": 61,
+        "18px": 10,
         "15px": 4,
         "10px": 4,
         "11px": 25,
-        "13.3333px": 5,
-        "13px": 44
+        "13px": 49
       },
       "geometry": {
         "container": {
-          "w": 546.53,
-          "h": 669.62
+          "w": 550,
+          "h": 657.88
         },
         "header": {
-          "w": 544.54,
-          "h": 64.59
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 544.54,
-          "h": 537.46
+          "w": 548,
+          "h": 540.88
         },
         "footer": {
-          "w": 544.54,
-          "h": 65.58
+          "w": 548,
+          "h": 66
         },
         "closeBtn": {
-          "w": 31.8,
-          "h": 31.8
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 1,
-            "min": 32.79,
-            "max": 32.79
+            "min": 33,
+            "max": 33
           }
         },
         "horizontalOverflow": false,
@@ -18471,7 +18083,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -18513,9 +18125,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -18541,20 +18153,6 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 3,
-          "sample": ""
-        },
-        {
-          "signature": "input",
-          "style": {
             "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
@@ -18563,7 +18161,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 3,
+          "count": 6,
           "sample": ""
         },
         {
@@ -18620,7 +18218,7 @@
             "font-style": "normal"
           },
           "count": 5,
-          "sample": "Open Plex Web in your browser \u2014 typically http://<your-plex-"
+          "sample": "Open Plex Web in your browser — typically http://<your-plex-"
         },
         {
           "signature": "p",
@@ -18648,7 +18246,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Important: use the server-local token from the steps above \u2014"
+          "sample": "Important: use the server-local token from the steps above —"
         },
         {
           "signature": "p.plex-token-ref-link",
@@ -18779,7 +18377,7 @@
         {
           "signature": "textarea.settings-text-input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -18795,45 +18393,42 @@
     "settings-probe-results": {
       "status": "rendered",
       "file": "src/components/tabs/SettingsTab.tsx",
-      "label": "Settings \u2192 probe results",
+      "label": "Settings → probe results",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 208,
       "fontSizeHistogram": {
-        "16px": 82,
+        "16px": 83,
         "18px": 23,
-        "15px": 9,
+        "15px": 10,
         "11px": 28,
-        "13px": 50,
-        "14px": 7,
-        "24px": 1,
+        "13px": 55,
+        "14px": 3,
         "12px": 5,
-        "15.2px": 1,
-        "10px": 1,
-        "13.3333px": 1
+        "10px": 1
       },
       "geometry": {
         "container": {
-          "w": 697.81,
-          "h": 236.76
+          "w": 700,
+          "h": 221.5
         },
         "header": {
-          "w": 695.82,
-          "h": 64.8
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 695.82,
-          "h": 102.18
+          "w": 698,
+          "h": 102.5
         },
         "footer": {
-          "w": 695.82,
-          "h": 67.79
+          "w": 698,
+          "h": 68
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {},
         "horizontalOverflow": false,
@@ -18900,7 +18495,7 @@
         {
           "signature": "button.custom-select-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -18928,7 +18523,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -19054,9 +18649,9 @@
         {
           "signature": "h2.failed",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -19064,20 +18659,6 @@
           },
           "count": 1,
           "sample": "Failed Streams (1)"
-        },
-        {
-          "signature": "h3",
-          "style": {
-            "font-size": "15.2px",
-            "font-weight": "600",
-            "line-height": "19.76px",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "Struck Out Streams"
         },
         {
           "signature": "h3",
@@ -19090,7 +18671,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 9,
+          "count": 10,
           "sample": "Stream Probing"
         },
         {
@@ -19180,7 +18761,7 @@
         {
           "signature": "span.custom-select-value",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -19258,22 +18839,8 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 20,
+          "count": 21,
           "sample": "speed"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "check_circle"
         },
         {
           "signature": "span.micro-label",
@@ -19322,42 +18889,39 @@
     "settings-reorder": {
       "status": "rendered",
       "file": "src/components/tabs/SettingsTab.tsx",
-      "label": "Settings \u2192 reorder",
+      "label": "Settings → reorder",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 223,
       "fontSizeHistogram": {
-        "16px": 83,
+        "16px": 84,
         "18px": 23,
-        "15px": 9,
+        "15px": 10,
         "11px": 31,
-        "13px": 56,
-        "14px": 6,
-        "24px": 1,
+        "13px": 61,
+        "14px": 2,
         "12px": 11,
-        "15.2px": 1,
-        "10px": 1,
-        "13.3333px": 1
+        "10px": 1
       },
       "geometry": {
         "container": {
-          "w": 897.19,
-          "h": 330.53
+          "w": 900,
+          "h": 315.56
         },
         "header": {
-          "w": 895.19,
-          "h": 64.8
+          "w": 898,
+          "h": 49
         },
         "body": {
-          "w": 895.19,
-          "h": 191.96
+          "w": 898,
+          "h": 192.56
         },
         "footer": null,
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {},
         "horizontalOverflow": false,
@@ -19410,7 +18974,7 @@
         {
           "signature": "button.custom-select-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -19438,7 +19002,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -19550,9 +19114,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -19560,20 +19124,6 @@
           },
           "count": 1,
           "sample": "Reordered Channels (1)"
-        },
-        {
-          "signature": "h3",
-          "style": {
-            "font-size": "15.2px",
-            "font-weight": "600",
-            "line-height": "19.76px",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "Struck Out Streams"
         },
         {
           "signature": "h3",
@@ -19586,7 +19136,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 9,
+          "count": 10,
           "sample": "Stream Probing"
         },
         {
@@ -19699,7 +19249,7 @@
             "font-style": "normal"
           },
           "count": 2,
-          "sample": "Priority: Resolution \u2192 Bitrate"
+          "sample": "Priority: Resolution → Bitrate"
         },
         {
           "signature": "span.custom-select-arrow.material-icons",
@@ -19718,7 +19268,7 @@
         {
           "signature": "span.custom-select-value",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -19782,22 +19332,8 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 20,
+          "count": 21,
           "sample": "speed"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "check_circle"
         },
         {
           "signature": "span.micro-label",
@@ -19846,57 +19382,54 @@
     "channels-pane-renumber-all": {
       "status": "rendered",
       "file": "src/components/ChannelsPane.tsx",
-      "label": "Channels pane \u2192 renumber all groups",
+      "label": "Channels pane → renumber all groups",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 127,
       "fontSizeHistogram": {
-        "16px": 44,
+        "16px": 45,
         "10px": 9,
         "14px": 1,
-        "13px": 27,
-        "13.3333px": 9,
+        "13px": 37,
         "18px": 13,
-        "24px": 1,
         "11px": 11,
-        "14.4px": 1,
         "9.6px": 1,
         "11.2px": 4,
         "19.2px": 6
       },
       "geometry": {
         "container": {
-          "w": 548.28,
-          "h": 510.09
+          "w": 550,
+          "h": 500.19
         },
         "header": {
-          "w": 546.29,
-          "h": 64.8
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 546.29,
-          "h": 374.51
+          "w": 548,
+          "h": 380.19
         },
         "footer": {
-          "w": 546.29,
-          "h": 68.78
+          "w": 548,
+          "h": 69
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-btn": {
             "n": 2,
-            "min": 32.9,
-            "max": 35.89
+            "min": 33,
+            "max": 36
           },
           ".modal-form-group": {
             "n": 1,
-            "min": 62.99,
-            "max": 62.99
+            "min": 63.19,
+            "max": 63.19
           }
         },
         "horizontalOverflow": false,
@@ -19935,7 +19468,7 @@
         {
           "signature": "button.expand-collapse-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -19949,7 +19482,7 @@
         {
           "signature": "button.filter-active.filter-settings-button",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -19986,12 +19519,12 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "3 groups selected\u25bc"
+          "sample": "3 groups selected▼"
         },
         {
           "signature": "button.group-menu-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -20014,7 +19547,7 @@
             "font-style": "normal"
           },
           "count": 4,
-          "sample": "\u25b6\ufe0eUncategorized \u2013 Channels without a specific group"
+          "sample": "▶︎Uncategorized – Channels without a specific group"
         },
         {
           "signature": "button.missing-streams-alert",
@@ -20061,7 +19594,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -20075,7 +19608,7 @@
         {
           "signature": "button.pane-toolbar-menu-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -20103,9 +19636,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -20113,20 +19646,6 @@
           },
           "count": 1,
           "sample": "format_list_numberedRenumber All Groups"
-        },
-        {
-          "signature": "input",
-          "style": {
-            "font-size": "13.3333px",
-            "font-weight": "400",
-            "line-height": "normal",
-            "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": ""
         },
         {
           "signature": "input",
@@ -20139,7 +19658,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 1,
+          "count": 2,
           "sample": ""
         },
         {
@@ -20159,7 +19678,7 @@
         {
           "signature": "input.search-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -20308,7 +19827,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "\u25bc"
+          "sample": "▼"
         },
         {
           "signature": "span.group-count",
@@ -20350,7 +19869,7 @@
             "font-style": "normal"
           },
           "count": 4,
-          "sample": "Uncategorized \u2013 Channels without a specific group"
+          "sample": "Uncategorized – Channels without a specific group"
         },
         {
           "signature": "span.group-range",
@@ -20378,7 +19897,7 @@
             "font-style": "italic"
           },
           "count": 1,
-          "sample": "\u2013 Channels without a specific group"
+          "sample": "– Channels without a specific group"
         },
         {
           "signature": "span.group-toggle",
@@ -20392,7 +19911,7 @@
             "font-style": "normal"
           },
           "count": 4,
-          "sample": "\u25b6\ufe0e"
+          "sample": "▶︎"
         },
         {
           "signature": "span.material-icons",
@@ -20419,7 +19938,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 12,
+          "count": 13,
           "sample": "more_vert"
         },
         {
@@ -20435,20 +19954,6 @@
           },
           "count": 3,
           "sample": "drag_indicator"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "format_list_numbered"
         },
         {
           "signature": "span.pane-item-count",
@@ -20490,7 +19995,7 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "United Kingdom \u2014 Entertainment"
+          "sample": "United Kingdom — Entertainment"
         },
         {
           "signature": "span.renumber-all-group-range",
@@ -20504,7 +20009,7 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "1\u20131"
+          "sample": "1–1"
         },
         {
           "signature": "strong",
@@ -20525,28 +20030,25 @@
     "streams-bulk-create": {
       "status": "rendered",
       "file": "src/components/StreamsPane.tsx",
-      "label": "Streams pane \u2192 bulk create channels",
+      "label": "Streams pane → bulk create channels",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 75,
       "fontSizeHistogram": {
-        "16px": 33,
-        "10px": 2,
-        "14.4px": 4,
-        "13.3333px": 4,
-        "18px": 10,
-        "13px": 14,
-        "14px": 4,
+        "16px": 34,
+        "10px": 5,
+        "13px": 23,
+        "18px": 9,
         "11px": 1,
-        "12.8px": 3
+        "15px": 3
       },
       "geometry": {
         "container": null,
         "header": {
           "w": 498,
-          "h": 65
+          "h": 49
         },
         "body": {
           "w": 498,
@@ -20597,7 +20099,7 @@
         {
           "signature": "button.custom-select-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -20611,7 +20113,7 @@
         {
           "signature": "button.expand-collapse-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -20625,7 +20127,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -20667,9 +20169,9 @@
         {
           "signature": "h3",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -20681,7 +20183,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -20709,7 +20211,7 @@
         {
           "signature": "input.search-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -20807,9 +20309,9 @@
         {
           "signature": "span.collapsible-summary",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "10px",
             "font-weight": "400",
-            "line-height": "19.2px",
+            "line-height": "15px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -20821,9 +20323,9 @@
         {
           "signature": "span.collapsible-title",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "15px",
             "font-weight": "500",
-            "line-height": "21.6px",
+            "line-height": "22.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -20849,7 +20351,7 @@
         {
           "signature": "span.custom-select-value",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -20872,7 +20374,7 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "\u25b6\ufe0e"
+          "sample": "▶︎"
         },
         {
           "signature": "span.expand-icon.material-icons",
@@ -20963,33 +20465,29 @@
     "streams-bulk-create-conflict": {
       "status": "rendered",
       "file": "src/components/StreamsPane.tsx",
-      "label": "Streams pane \u2192 bulk create conflict",
+      "label": "Streams pane → bulk create conflict",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
       "elementCount": 108,
       "fontSizeHistogram": {
-        "16px": 44,
-        "10px": 2,
-        "14.4px": 4,
-        "13.3333px": 10,
-        "18px": 11,
-        "13px": 23,
-        "14px": 7,
+        "16px": 46,
+        "10px": 5,
+        "13px": 41,
+        "18px": 9,
         "11px": 1,
-        "12.8px": 3,
-        "15px": 3
+        "15px": 6
       },
       "geometry": {
         "container": null,
         "header": {
           "w": 498,
-          "h": 65
+          "h": 49
         },
         "body": {
           "w": 498,
-          "h": 583
+          "h": 599
         },
         "footer": {
           "w": 498,
@@ -21014,7 +20512,7 @@
         {
           "signature": "button.add-to-end.conflict-option-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21056,7 +20554,7 @@
         {
           "signature": "button.conflict-option-btn.insert-at-end",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21070,7 +20568,7 @@
         {
           "signature": "button.conflict-option-btn.push-down",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21084,7 +20582,7 @@
         {
           "signature": "button.custom-select-trigger",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21098,7 +20596,7 @@
         {
           "signature": "button.expand-collapse-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21126,7 +20624,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21182,9 +20680,9 @@
         {
           "signature": "h3",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -21196,7 +20694,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21224,7 +20722,7 @@
         {
           "signature": "input.search-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21322,23 +20820,23 @@
         {
           "signature": "span.collapsible-summary",
           "style": {
-            "font-size": "12.8px",
+            "font-size": "10px",
             "font-weight": "400",
-            "line-height": "19.2px",
+            "line-height": "15px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "\"United Kingdom \u2014 Entertainment\""
+          "sample": "\"United Kingdom — Entertainment\""
         },
         {
           "signature": "span.collapsible-title",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "15px",
             "font-weight": "500",
-            "line-height": "21.6px",
+            "line-height": "22.5px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -21364,7 +20862,7 @@
         {
           "signature": "span.custom-select-value",
           "style": {
-            "font-size": "14px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21387,7 +20885,7 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "\u25b6\ufe0e"
+          "sample": "▶︎"
         },
         {
           "signature": "span.expand-icon.material-icons",
@@ -21534,39 +21032,37 @@
     "cp-rule-builder-modal": {
       "status": "rendered",
       "file": "src/components/channelPipeline/ChannelPipelineTab.tsx",
-      "label": "Pipeline tab \u2192 rule builder modal shell",
+      "label": "Pipeline tab → rule builder modal shell",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 194,
+      "elementCount": 197,
       "fontSizeHistogram": {
-        "16px": 67,
-        "13px": 46,
-        "18px": 17,
-        "13.3333px": 22,
+        "16px": 68,
+        "13px": 71,
+        "18px": 19,
         "20px": 1,
-        "24px": 6,
+        "24px": 3,
         "15px": 5,
         "11px": 10,
         "64px": 1,
-        "10px": 18,
-        "14.4px": 1
+        "10px": 19
       },
       "geometry": {
         "container": {
-          "w": 698.7,
-          "h": 283.97
+          "w": 700,
+          "h": 268.5
         },
         "header": {
-          "w": 696.7,
-          "h": 64.88
+          "w": 698,
+          "h": 49
         },
         "body": null,
         "footer": null,
         "closeBtn": {
-          "w": 31.94,
-          "h": 31.94
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {},
         "horizontalOverflow": false,
@@ -21577,7 +21073,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21591,7 +21087,7 @@
         {
           "signature": "button.action-btn.action-btn-revert",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21605,7 +21101,7 @@
         {
           "signature": "button.action-btn.danger",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21675,7 +21171,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21689,7 +21185,7 @@
         {
           "signature": "button.overflow-menu-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21726,7 +21222,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Run-on-refresh is disabled \u2014 the channel pipeline will not f"
+          "sample": "Run-on-refresh is disabled — the channel pipeline will not f"
         },
         {
           "signature": "div.rule-description",
@@ -21759,9 +21255,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -21787,7 +21283,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21801,7 +21297,7 @@
         {
           "signature": "input.search-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -21899,9 +21395,9 @@
         {
           "signature": "span.circuit-breaker-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -21922,14 +21418,14 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "Event sync \u2014 Premier League"
+          "sample": "Event sync — Premier League"
         },
         {
           "signature": "span.event-sync-exclusion-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -22061,7 +21557,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 15,
+          "count": 16,
           "sample": "add"
         },
         {
@@ -22077,20 +21573,6 @@
           },
           "count": 1,
           "sample": "more_vert"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "history_toggle_off"
         },
         {
           "signature": "span.material-icons",
@@ -22265,41 +21747,39 @@
     "cp-delete-confirm": {
       "status": "rendered",
       "file": "src/components/channelPipeline/ChannelPipelineTab.tsx",
-      "label": "Pipeline tab \u2192 delete rule confirm",
+      "label": "Pipeline tab → delete rule confirm",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 186,
+      "elementCount": 189,
       "fontSizeHistogram": {
-        "16px": 69,
-        "13px": 40,
-        "18px": 14,
-        "13.3333px": 21,
+        "16px": 70,
+        "13px": 64,
+        "18px": 16,
         "20px": 1,
-        "24px": 6,
+        "24px": 3,
         "15px": 5,
         "11px": 10,
         "64px": 1,
-        "10px": 18,
-        "14.4px": 1
+        "10px": 19
       },
       "geometry": {
         "container": {
-          "w": 398.75,
-          "h": 213.72
+          "w": 400,
+          "h": 207
         },
         "header": {
-          "w": 396.76,
-          "h": 56.21
+          "w": 398,
+          "h": 49
         },
         "body": {
-          "w": 396.76,
-          "h": 87.73
+          "w": 398,
+          "h": 88
         },
         "footer": {
-          "w": 396.76,
-          "h": 67.79
+          "w": 398,
+          "h": 68
         },
         "closeBtn": null,
         "rowHeights": {},
@@ -22311,7 +21791,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -22325,7 +21805,7 @@
         {
           "signature": "button.action-btn.action-btn-revert",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -22339,7 +21819,7 @@
         {
           "signature": "button.action-btn.danger",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -22423,7 +21903,7 @@
         {
           "signature": "button.overflow-menu-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -22446,7 +21926,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Run-on-refresh is disabled \u2014 the channel pipeline will not f"
+          "sample": "Run-on-refresh is disabled — the channel pipeline will not f"
         },
         {
           "signature": "div.rule-description",
@@ -22479,9 +21959,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -22507,7 +21987,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -22521,7 +22001,7 @@
         {
           "signature": "input.search-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -22619,9 +22099,9 @@
         {
           "signature": "span.circuit-breaker-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -22642,14 +22122,14 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "Event sync \u2014 Premier League"
+          "sample": "Event sync — Premier League"
         },
         {
           "signature": "span.event-sync-exclusion-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -22781,7 +22261,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 12,
+          "count": 13,
           "sample": "add"
         },
         {
@@ -22797,20 +22277,6 @@
           },
           "count": 1,
           "sample": "more_vert"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "history_toggle_off"
         },
         {
           "signature": "span.material-icons",
@@ -22985,51 +22451,49 @@
     "cp-import-dialog": {
       "status": "rendered",
       "file": "src/components/channelPipeline/ChannelPipelineTab.tsx",
-      "label": "Pipeline tab \u2192 import rules",
+      "label": "Pipeline tab → import rules",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 190,
+      "elementCount": 193,
       "fontSizeHistogram": {
-        "16px": 69,
-        "13px": 42,
-        "18px": 15,
-        "13.3333px": 22,
+        "16px": 70,
+        "13px": 67,
+        "18px": 17,
         "20px": 1,
-        "24px": 6,
+        "24px": 3,
         "15px": 5,
         "11px": 10,
         "64px": 1,
-        "10px": 18,
-        "14.4px": 1
+        "10px": 19
       },
       "geometry": {
         "container": {
-          "w": 548.97,
-          "h": 383.47
+          "w": 550,
+          "h": 368.19
         },
         "header": {
-          "w": 546.97,
-          "h": 64.88
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 546.97,
-          "h": 248.72
+          "w": 548,
+          "h": 249.19
         },
         "footer": {
-          "w": 546.97,
-          "h": 67.87
+          "w": 548,
+          "h": 68
         },
         "closeBtn": {
-          "w": 31.94,
-          "h": 31.94
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {
           ".modal-form-group": {
             "n": 1,
-            "min": 208.8,
-            "max": 208.8
+            "min": 209.19,
+            "max": 209.19
           }
         },
         "horizontalOverflow": false,
@@ -23040,7 +22504,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -23054,7 +22518,7 @@
         {
           "signature": "button.action-btn.action-btn-revert",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -23068,7 +22532,7 @@
         {
           "signature": "button.action-btn.danger",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -23138,7 +22602,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -23152,7 +22616,7 @@
         {
           "signature": "button.overflow-menu-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -23175,7 +22639,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Run-on-refresh is disabled \u2014 the channel pipeline will not f"
+          "sample": "Run-on-refresh is disabled — the channel pipeline will not f"
         },
         {
           "signature": "div.rule-description",
@@ -23208,9 +22672,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -23236,7 +22700,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -23250,7 +22714,7 @@
         {
           "signature": "input.search-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -23348,9 +22812,9 @@
         {
           "signature": "span.circuit-breaker-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -23371,14 +22835,14 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "Event sync \u2014 Premier League"
+          "sample": "Event sync — Premier League"
         },
         {
           "signature": "span.event-sync-exclusion-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -23510,7 +22974,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 13,
+          "count": 14,
           "sample": "add"
         },
         {
@@ -23526,20 +22990,6 @@
           },
           "count": 1,
           "sample": "more_vert"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "history_toggle_off"
         },
         {
           "signature": "span.material-icons",
@@ -23728,45 +23178,43 @@
     "cp-export-dialog": {
       "status": "rendered",
       "file": "src/components/channelPipeline/ChannelPipelineTab.tsx",
-      "label": "Pipeline tab \u2192 export rules",
+      "label": "Pipeline tab → export rules",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 189,
+      "elementCount": 192,
       "fontSizeHistogram": {
-        "16px": 68,
-        "13px": 41,
-        "18px": 16,
-        "13.3333px": 22,
+        "16px": 69,
+        "13px": 66,
+        "18px": 18,
         "20px": 1,
-        "24px": 6,
+        "24px": 3,
         "15px": 5,
         "11px": 10,
         "64px": 1,
-        "10px": 18,
-        "14.4px": 1
+        "10px": 19
       },
       "geometry": {
         "container": {
-          "w": 548.28,
-          "h": 469.53
+          "w": 550,
+          "h": 455
         },
         "header": {
-          "w": 546.29,
-          "h": 64.8
+          "w": 548,
+          "h": 49
         },
         "body": {
-          "w": 546.29,
-          "h": 334.95
+          "w": 548,
+          "h": 336
         },
         "footer": {
-          "w": 546.29,
-          "h": 67.79
+          "w": 548,
+          "h": 68
         },
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {},
         "horizontalOverflow": false,
@@ -23777,7 +23225,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -23791,7 +23239,7 @@
         {
           "signature": "button.action-btn.action-btn-revert",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -23805,7 +23253,7 @@
         {
           "signature": "button.action-btn.danger",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -23875,7 +23323,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -23889,7 +23337,7 @@
         {
           "signature": "button.overflow-menu-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -23912,7 +23360,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Run-on-refresh is disabled \u2014 the channel pipeline will not f"
+          "sample": "Run-on-refresh is disabled — the channel pipeline will not f"
         },
         {
           "signature": "div.rule-description",
@@ -23945,9 +23393,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -23973,7 +23421,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -23987,7 +23435,7 @@
         {
           "signature": "input.search-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -24071,9 +23519,9 @@
         {
           "signature": "span.circuit-breaker-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -24094,14 +23542,14 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "Event sync \u2014 Premier League"
+          "sample": "Event sync — Premier League"
         },
         {
           "signature": "span.event-sync-exclusion-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -24233,7 +23681,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 14,
+          "count": 15,
           "sample": "add"
         },
         {
@@ -24249,20 +23697,6 @@
           },
           "count": 1,
           "sample": "more_vert"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "history_toggle_off"
         },
         {
           "signature": "span.material-icons",
@@ -24451,42 +23885,40 @@
     "cp-execution-details": {
       "status": "rendered",
       "file": "src/components/channelPipeline/ChannelPipelineTab.tsx",
-      "label": "Pipeline tab \u2192 execution details",
+      "label": "Pipeline tab → execution details",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 206,
+      "elementCount": 209,
       "fontSizeHistogram": {
-        "16px": 86,
-        "13px": 39,
-        "18px": 15,
-        "13.3333px": 22,
+        "16px": 87,
+        "13px": 64,
+        "18px": 17,
         "20px": 1,
-        "24px": 6,
+        "24px": 3,
         "15px": 6,
         "11px": 10,
         "64px": 1,
-        "10px": 19,
-        "14.4px": 1
+        "10px": 20
       },
       "geometry": {
         "container": {
-          "w": 697.81,
-          "h": 467.53
+          "w": 700,
+          "h": 453
         },
         "header": {
-          "w": 695.82,
-          "h": 64.8
+          "w": 698,
+          "h": 49
         },
         "body": {
-          "w": 695.82,
-          "h": 400.74
+          "w": 698,
+          "h": 402
         },
         "footer": null,
         "closeBtn": {
-          "w": 31.9,
-          "h": 31.9
+          "w": 32,
+          "h": 32
         },
         "rowHeights": {},
         "horizontalOverflow": false,
@@ -24497,7 +23929,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -24511,7 +23943,7 @@
         {
           "signature": "button.action-btn.action-btn-revert",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -24525,7 +23957,7 @@
         {
           "signature": "button.action-btn.danger",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -24595,7 +24027,7 @@
         {
           "signature": "button.modal-close-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -24609,7 +24041,7 @@
         {
           "signature": "button.overflow-menu-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -24632,7 +24064,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Run-on-refresh is disabled \u2014 the channel pipeline will not f"
+          "sample": "Run-on-refresh is disabled — the channel pipeline will not f"
         },
         {
           "signature": "div.log-empty",
@@ -24679,9 +24111,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -24707,7 +24139,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -24721,7 +24153,7 @@
         {
           "signature": "input.search-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -24819,9 +24251,9 @@
         {
           "signature": "span.circuit-breaker-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -24856,14 +24288,14 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "Event sync \u2014 Premier League"
+          "sample": "Event sync — Premier League"
         },
         {
           "signature": "span.event-sync-exclusion-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -24995,7 +24427,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 13,
+          "count": 14,
           "sample": "add"
         },
         {
@@ -25011,20 +24443,6 @@
           },
           "count": 1,
           "sample": "more_vert"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "history_toggle_off"
         },
         {
           "signature": "span.material-icons",
@@ -25199,41 +24617,39 @@
     "cp-event-sync-run-confirm": {
       "status": "rendered",
       "file": "src/components/channelPipeline/ChannelPipelineTab.tsx",
-      "label": "Pipeline tab \u2192 event-sync run confirm",
+      "label": "Pipeline tab → event-sync run confirm",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 190,
+      "elementCount": 193,
       "fontSizeHistogram": {
-        "16px": 73,
-        "13px": 40,
-        "18px": 14,
-        "13.3333px": 21,
+        "16px": 74,
+        "13px": 64,
+        "18px": 16,
         "20px": 1,
-        "24px": 6,
+        "24px": 3,
         "15px": 5,
         "11px": 10,
         "64px": 1,
-        "10px": 18,
-        "14.4px": 1
+        "10px": 19
       },
       "geometry": {
         "container": {
-          "w": 398.75,
-          "h": 381.2
+          "w": 400,
+          "h": 375
         },
         "header": {
-          "w": 396.76,
-          "h": 56.21
+          "w": 398,
+          "h": 49
         },
         "body": {
-          "w": 396.76,
-          "h": 255.2
+          "w": 398,
+          "h": 256
         },
         "footer": {
-          "w": 396.76,
-          "h": 67.79
+          "w": 398,
+          "h": 68
         },
         "closeBtn": null,
         "rowHeights": {},
@@ -25245,7 +24661,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -25259,7 +24675,7 @@
         {
           "signature": "button.action-btn.action-btn-revert",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -25273,7 +24689,7 @@
         {
           "signature": "button.action-btn.danger",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -25343,7 +24759,7 @@
         {
           "signature": "button.overflow-menu-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -25366,7 +24782,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Run-on-refresh is disabled \u2014 the channel pipeline will not f"
+          "sample": "Run-on-refresh is disabled — the channel pipeline will not f"
         },
         {
           "signature": "div.rule-description",
@@ -25399,9 +24815,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -25427,7 +24843,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -25441,7 +24857,7 @@
         {
           "signature": "input.search-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -25478,7 +24894,7 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "Running \"Event sync \u2014 Premier League\" will attach streams to"
+          "sample": "Running \"Event sync — Premier League\" will attach streams to"
         },
         {
           "signature": "p.form-hint",
@@ -25539,9 +24955,9 @@
         {
           "signature": "span.circuit-breaker-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -25562,14 +24978,14 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "Event sync \u2014 Premier League"
+          "sample": "Event sync — Premier League"
         },
         {
           "signature": "span.event-sync-exclusion-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -25701,7 +25117,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 12,
+          "count": 13,
           "sample": "add"
         },
         {
@@ -25717,20 +25133,6 @@
           },
           "count": 1,
           "sample": "more_vert"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "history_toggle_off"
         },
         {
           "signature": "span.material-icons",
@@ -25919,41 +25321,39 @@
     "cp-rollback-confirm": {
       "status": "rendered",
       "file": "src/components/channelPipeline/ChannelPipelineTab.tsx",
-      "label": "Pipeline tab \u2192 rollback confirm",
+      "label": "Pipeline tab → rollback confirm",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 189,
+      "elementCount": 192,
       "fontSizeHistogram": {
-        "16px": 70,
-        "13px": 42,
-        "18px": 14,
-        "13.3333px": 21,
+        "16px": 71,
+        "13px": 66,
+        "18px": 16,
         "20px": 1,
-        "24px": 6,
+        "24px": 3,
         "15px": 5,
         "11px": 10,
         "64px": 1,
-        "10px": 18,
-        "14.4px": 1
+        "10px": 19
       },
       "geometry": {
         "container": {
-          "w": 398.75,
-          "h": 300.45
+          "w": 400,
+          "h": 294
         },
         "header": {
-          "w": 396.76,
-          "h": 56.21
+          "w": 398,
+          "h": 49
         },
         "body": {
-          "w": 396.76,
-          "h": 174.45
+          "w": 398,
+          "h": 175
         },
         "footer": {
-          "w": 396.76,
-          "h": 67.79
+          "w": 398,
+          "h": 68
         },
         "closeBtn": null,
         "rowHeights": {},
@@ -25965,7 +25365,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -25979,7 +25379,7 @@
         {
           "signature": "button.action-btn.action-btn-revert",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -25993,7 +25393,7 @@
         {
           "signature": "button.action-btn.danger",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -26077,7 +25477,7 @@
         {
           "signature": "button.overflow-menu-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -26100,7 +25500,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Run-on-refresh is disabled \u2014 the channel pipeline will not f"
+          "sample": "Run-on-refresh is disabled — the channel pipeline will not f"
         },
         {
           "signature": "div.rule-description",
@@ -26133,9 +25533,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -26161,7 +25561,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -26175,7 +25575,7 @@
         {
           "signature": "input.search-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -26287,9 +25687,9 @@
         {
           "signature": "span.circuit-breaker-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -26310,14 +25710,14 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "Event sync \u2014 Premier League"
+          "sample": "Event sync — Premier League"
         },
         {
           "signature": "span.event-sync-exclusion-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -26449,7 +25849,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 12,
+          "count": 13,
           "sample": "add"
         },
         {
@@ -26465,20 +25865,6 @@
           },
           "count": 1,
           "sample": "more_vert"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "history_toggle_off"
         },
         {
           "signature": "span.material-icons",
@@ -26667,41 +26053,39 @@
     "cp-revert-confirm": {
       "status": "rendered",
       "file": "src/components/channelPipeline/ChannelPipelineTab.tsx",
-      "label": "Pipeline tab \u2192 undo this run confirm",
+      "label": "Pipeline tab → undo this run confirm",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 193,
+      "elementCount": 196,
       "fontSizeHistogram": {
-        "16px": 69,
-        "13px": 46,
-        "18px": 14,
-        "13.3333px": 21,
+        "16px": 70,
+        "13px": 70,
+        "18px": 17,
         "20px": 1,
-        "24px": 7,
+        "24px": 3,
         "15px": 5,
         "11px": 10,
         "64px": 1,
-        "10px": 18,
-        "14.4px": 1
+        "10px": 19
       },
       "geometry": {
         "container": {
-          "w": 398.75,
-          "h": 398.14
+          "w": 400,
+          "h": 392
         },
         "header": {
-          "w": 396.76,
-          "h": 56.21
+          "w": 398,
+          "h": 49
         },
         "body": {
-          "w": 396.76,
-          "h": 272.15
+          "w": 398,
+          "h": 273
         },
         "footer": {
-          "w": 396.76,
-          "h": 67.79
+          "w": 398,
+          "h": 68
         },
         "closeBtn": null,
         "rowHeights": {},
@@ -26713,7 +26097,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -26727,7 +26111,7 @@
         {
           "signature": "button.action-btn.action-btn-revert",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -26741,7 +26125,7 @@
         {
           "signature": "button.action-btn.danger",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -26825,7 +26209,7 @@
         {
           "signature": "button.overflow-menu-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -26848,7 +26232,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Run-on-refresh is disabled \u2014 the channel pipeline will not f"
+          "sample": "Run-on-refresh is disabled — the channel pipeline will not f"
         },
         {
           "signature": "div.rule-description",
@@ -26881,9 +26265,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -26909,7 +26293,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -26923,7 +26307,7 @@
         {
           "signature": "input.search-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -26974,7 +26358,7 @@
             "font-style": "normal"
           },
           "count": 2,
-          "sample": "Any changes made since that snapshot \u2014 manual edits, automat"
+          "sample": "Any changes made since that snapshot — manual edits, automat"
         },
         {
           "signature": "span.badge.badge-info.badge-sm.rule-kind-badge",
@@ -27021,9 +26405,9 @@
         {
           "signature": "span.circuit-breaker-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -27044,14 +26428,14 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "Event sync \u2014 Premier League"
+          "sample": "Event sync — Premier League"
         },
         {
           "signature": "span.event-sync-exclusion-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -27183,7 +26567,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 12,
+          "count": 13,
           "sample": "add"
         },
         {
@@ -27203,20 +26587,6 @@
         {
           "signature": "span.material-icons",
           "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "history_toggle_off"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
             "font-size": "64px",
             "font-weight": "400",
             "line-height": "64px",
@@ -27231,9 +26601,9 @@
         {
           "signature": "span.material-icons.revert-warning-icon",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -27401,41 +26771,39 @@
     "cp-revert-result": {
       "status": "rendered",
       "file": "src/components/channelPipeline/ChannelPipelineTab.tsx",
-      "label": "Pipeline tab \u2192 revert complete summary",
+      "label": "Pipeline tab → revert complete summary",
       "via": "host",
       "error": null,
       "unstubbedCalls": [],
       "consoleErrors": [],
-      "elementCount": 191,
+      "elementCount": 194,
       "fontSizeHistogram": {
-        "16px": 75,
-        "13px": 39,
-        "18px": 14,
-        "13.3333px": 21,
+        "16px": 76,
+        "13px": 63,
+        "18px": 16,
         "20px": 1,
-        "24px": 6,
+        "24px": 3,
         "15px": 5,
         "11px": 10,
         "64px": 1,
-        "10px": 18,
-        "14.4px": 1
+        "10px": 19
       },
       "geometry": {
         "container": {
-          "w": 395.02,
-          "h": 256.16
+          "w": 400,
+          "h": 252
         },
         "header": {
-          "w": 393.05,
-          "h": 55.69
+          "w": 398,
+          "h": 49
         },
         "body": {
-          "w": 393.05,
-          "h": 131.34
+          "w": 398,
+          "h": 133
         },
         "footer": {
-          "w": 393.05,
-          "h": 67.15
+          "w": 398,
+          "h": 68
         },
         "closeBtn": null,
         "rowHeights": {},
@@ -27447,7 +26815,7 @@
         {
           "signature": "button.action-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -27461,7 +26829,7 @@
         {
           "signature": "button.action-btn.action-btn-revert",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -27475,7 +26843,7 @@
         {
           "signature": "button.action-btn.danger",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -27545,7 +26913,7 @@
         {
           "signature": "button.overflow-menu-btn",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -27568,7 +26936,7 @@
             "font-style": "normal"
           },
           "count": 1,
-          "sample": "Run-on-refresh is disabled \u2014 the channel pipeline will not f"
+          "sample": "Run-on-refresh is disabled — the channel pipeline will not f"
         },
         {
           "signature": "div.rule-description",
@@ -27601,9 +26969,9 @@
         {
           "signature": "h2",
           "style": {
-            "font-size": "18px",
+            "font-size": "16px",
             "font-weight": "600",
-            "line-height": "23.4px",
+            "line-height": "20.8px",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -27629,7 +26997,7 @@
         {
           "signature": "input",
           "style": {
-            "font-size": "13.3333px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -27643,7 +27011,7 @@
         {
           "signature": "input.search-input",
           "style": {
-            "font-size": "14.4px",
+            "font-size": "13px",
             "font-weight": "400",
             "line-height": "normal",
             "font-family": "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Noto Color Emoji\"",
@@ -27741,9 +27109,9 @@
         {
           "signature": "span.circuit-breaker-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -27778,14 +27146,14 @@
             "font-style": "normal"
           },
           "count": 3,
-          "sample": "Event sync \u2014 Premier League"
+          "sample": "Event sync — Premier League"
         },
         {
           "signature": "span.event-sync-exclusion-icon.material-icons",
           "style": {
-            "font-size": "24px",
+            "font-size": "18px",
             "font-weight": "400",
-            "line-height": "24px",
+            "line-height": "18px",
             "font-family": "\"Material Icons\"",
             "letter-spacing": "normal",
             "text-transform": "none",
@@ -27917,7 +27285,7 @@
             "text-transform": "none",
             "font-style": "normal"
           },
-          "count": 12,
+          "count": 13,
           "sample": "add"
         },
         {
@@ -27933,20 +27301,6 @@
           },
           "count": 1,
           "sample": "more_vert"
-        },
-        {
-          "signature": "span.material-icons",
-          "style": {
-            "font-size": "24px",
-            "font-weight": "400",
-            "line-height": "24px",
-            "font-family": "\"Material Icons\"",
-            "letter-spacing": "normal",
-            "text-transform": "none",
-            "font-style": "normal"
-          },
-          "count": 1,
-          "sample": "history_toggle_off"
         },
         {
           "signature": "span.material-icons",

--- a/scripts/measure-modal-typography.mjs
+++ b/scripts/measure-modal-typography.mjs
@@ -42,6 +42,27 @@
  * (`tag.class.class`). Element-by-element records would balloon the artefact
  * and churn on list length; signatures are what a CSS change actually moves,
  * and they diff cleanly: "`.modal-title` was 17.6px/600, now 15px/600".
+ *
+ * WHY EVERY CAPTURE IS ANIMATION-FROZEN
+ * ------------------------------------
+ * `ModalBase.css` opens every dialog with `modal-container-slide-in`: 0.2s,
+ * `translateY(-20px) scale(0.98)` -> `translateY(0) scale(1)`. A capture taken
+ * while that is still running multiplies EVERY box in the dialog by a
+ * run-dependent scale factor, so the geometry arm reports phantom movement in
+ * both directions on any change at all. Measured on bead
+ * `enhancedchannelmanager-iotbh`: in a single unfrozen run the 32px close
+ * button reported seven distinct sizes across the 81 dialogs (31.6, 31.74,
+ * 31.8, 31.85, 31.9, 31.99 and 32.0), and a change that could only shrink type
+ * by 0.33px moved 214 of 281 boxes by 1-11px.
+ *
+ * So this script freezes animations and transitions before it measures, on
+ * every dialog, with no flag to turn it off: there is no question this
+ * instrument answers that wants a mid-flight box. `.modal-container` declares
+ * no `transform` of its own, so suppressing the animation leaves it at exactly
+ * the resting state the keyframe was travelling to. TYPOGRAPHY rows were never
+ * affected, because `font-size`/`weight`/`family` are not scaled by a transform.
+ * Comparisons this instrument produced before the freeze therefore remain valid
+ * on the typography arm; only the geometry arm was untrustworthy.
  */
 import { spawn } from 'node:child_process'
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs'
@@ -107,6 +128,49 @@ async function waitForServer(url, timeoutMs = 30_000) {
     await new Promise((r) => setTimeout(r, 250))
   }
   throw new Error(`harness preview server did not come up at ${url}`)
+}
+
+/**
+ * Suppress every animation and transition, so a box is measured at rest.
+ *
+ * Same override, and the same `!important` reasoning, as `FREEZE_ANIMATION` in
+ * `e2e/contrast-aa.spec.ts`: the harness's route chunk stylesheets land in
+ * <head> after this tag, so ordinary specificity would let them win. It is
+ * repeated here rather than imported because that constant lives inside a
+ * Playwright TypeScript spec that this plain-ESM script cannot load.
+ */
+const FREEZE_ANIMATION = `
+*, *::before, *::after {
+  transition: none !important;
+  animation: none !important;
+}`
+
+/**
+ * Freeze, then wait for the page to actually be at rest before measuring.
+ *
+ * The style tag alone is enough for the slide-in, because dropping `animation`
+ * reverts `.modal-container` to its declared (untransformed) style
+ * immediately. The two extra steps cover the rest: `getAnimations()` catches
+ * anything script-driven that the stylesheet override cannot stop (the Web
+ * Animations API ignores CSS `animation: none`), and the double
+ * `requestAnimationFrame` lets the resulting style change reach layout, so
+ * `getBoundingClientRect` reads the post-freeze box rather than the one being
+ * left behind.
+ */
+async function freezeAndSettle(page) {
+  await page.addStyleTag({ content: FREEZE_ANIMATION })
+  await page.evaluate(async () => {
+    for (const animation of document.getAnimations()) {
+      try {
+        animation.finish()
+      } catch {
+        /* an infinite animation cannot be finished; cancelling is enough */
+        animation.cancel()
+      }
+    }
+    await new Promise((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+  })
 }
 
 /**
@@ -298,6 +362,7 @@ async function main() {
         continue
       }
 
+      await freezeAndSettle(page)
       const measured = await page.evaluate(COLLECT)
       results[entry.id] = {
         status: harnessStatus.status,
@@ -317,6 +382,9 @@ async function main() {
       capturedAt: new Date().toISOString(),
       viewport: VIEWPORT,
       theme: 'dark (app default)',
+      // Absent on any capture predating bead `enhancedchannelmanager-iotbh`,
+      // which is exactly how you tell whether a file's geometry can be trusted.
+      animationsFrozen: true,
       counts: {
         filesMatchingDialogMarkers: meta.discoveredFiles.length,
         cataloguedDialogs: meta.catalog.length,


### PR DESCRIPTION
Beads: `enhancedchannelmanager-pbkwo`, `enhancedchannelmanager-iotbh`, `enhancedchannelmanager-j5m9v`.

This is the instrument layer that roughly 18 downstream CSS beads will be verified against. A wrong oracle here does not fail loudly — it silently certifies bad work as good, or reports phantom regressions that waste engineer cycles.

## `pbkwo` — measure contrast on the compositor, not with a regex

`computedTextContrast` grepped numbers out of a colour string, so Chrome's `color(srgb 0.96 0.96 0.96 / 0.94)` serialisation of `color-mix()` would read 0-1 floats as 0-255 channels, turning a near-white surface into a near-black one. Replaced with the canvas paint-and-read core already used by `contrast-aa`, which never parses a colour at all — the engine that painted the page resolves the syntax and does the alpha maths.

A/B over the same DOM: 132 measurements, 42 moved, all by 0.01-0.15, and **none because of `color-mix`** — every chain these selectors walk is plain `rgb()`/`rgba()` today. The bug was genuinely latent; what moved was 8-bit compositor precision. No verdict changed.

Two further defects found and fixed while in there: a detached node measured as black-on-black (`getComputedStyle` off-document returns an empty declaration), and both tests flipped `data-theme` and measured immediately with no freeze — the same mistake that previously put a wrong entry into `contrast-aa`'s allowlist.

Also closes a hole where a gradient in the ancestor chain was detected and then discarded. Demonstrated rather than argued: injecting a gradient onto `.operator-dashboard-card`, the test **passed** reporting 15.96 against a `#f5f5f5` backdrop while the painted surface was `#111111` — true ratio 1.08 against a 4.5 floor, wrong by roughly 15x. It now refuses to measure, matching `contrast-aa`.

## `iotbh` — freeze animations before the harness measures

`measure-modal-typography.mjs` captured each dialog while `modal-container-slide-in` was still running, so every box was multiplied by a run-dependent scale factor. One unfrozen run reported the same 32px close button at **seven distinct sizes** across 81 dialogs.

After: `32x32` in all 62 dialogs, both runs. Two consecutive frozen runs on an unchanged tree move **0 of 411** geometry rows. Typography rows were never affected by the transform, so prior typography comparisons remain valid.

## `j5m9v` — review and refresh the stale baseline

The bead reported 33 unreviewed signature changes. The real number was **998**, stale since `cd880ddb` rather than the assumed commit.

Reviewed rather than recaptured, which was the entire point of the bead: off-scale count fell 877/3980 to 54/3988, only 16 changes are on-scale-to-on-scale judgement calls (all in two ratified families), and 13 pre-existing off-scale pairs are carried forward rather than silently ratified as new. **Zero pairs are off-scale in the new baseline that were not already off-scale in the old one**, and there are zero on-to-off transitions. `--diff` now reports 0.

## Verification

Reviewed twice. The reviewer rederived every quantitative claim above from the raw artifacts rather than trusting the commit messages — 998, 877/3980 to 54/3988, 13 carried forward, 16 judgement calls — and all reproduced exactly.

Gates: eslint 0, tsc 0, vitest 198 files / 2689 tests, `measure-modal-typography.mjs --diff` 0 changes on a full rebuild, both contrast specs pass at `--workers=2`.

`test:css-guards` and `contrast-aa` were **not** run: roughly 10 minutes and they need a live backend serving the tree under test. Stating that rather than reporting them green.

`operator-shell.spec.ts` runs 62 passed / 3 failed. Those three are pre-existing on `dev`, proven by stashing, and tracked as `enhancedchannelmanager-rnzu0`.

## Follow-ups filed, not included

`enhancedchannelmanager-23skw` carries the deferred hygiene items: no geometry arm on `--diff`, the canvas model duplicated across two spec files with only prose holding parity, silent ratio rounding, plus two found in review — `::before`/`::after` gradients still bypass single-argument `getComputedStyle`, and the failure message's locator uses `tagName` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)