### PR TITLE
v0.18.1-0132: Track dispatcharr:latest literally, and rebuild the documentation environment on 0.29.0

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -145,7 +145,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.1-0127",
+    version="0.18.1-0132",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -103,7 +103,7 @@ BACKUP_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.1-0127"
+APP_VERSION = "0.18.1-0132"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/docs/testing/dbas-test-env.md
+++ b/docs/testing/dbas-test-env.md
@@ -20,24 +20,50 @@ the EPG download wait, the `is_active` workaround, `/api/accounts/users/me/`),
 which are exactly the behaviors Phase 2 has to *validate*. A mock that re-states
 our assumptions can never falsify them.
 
-This environment provides a **live, pinned** Dispatcharr to test against, so the
+This environment provides a **live** Dispatcharr to test against, so the
 round-trip can be exercised for real before the importers
 (`.10`/`.11`/`.14`/`.15`/`.18`/`l1p4p`) ship.
 
-## Version pin
+## Version policy — this environment tracks `latest`
+
+**PO decision, bead `enhancedchannelmanager-xvuk1`:** `tests/dbas-test-env/`
+tracks `dispatcharr:latest` **literally**. There is no pinned version and no
+bump procedure, because there is nothing to bump.
 
 | What | Value | Source |
 |------|-------|--------|
-| Pinned image | `dispatcharr/dispatcharr:0.26.0` | operator's live instance |
+| Image | `ghcr.io/dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-latest}` | all three compose files in `tests/dbas-test-env/` |
+| Registry | `ghcr.io` | the registry the operator's production Dispatcharr pulls from, so the test env and production resolve the same artifact |
 | Behavioral floor in ECM code | `0.23.0+` | `config.py` throttle; `auth/providers/dispatcharr.py` users/me |
-| Version-detect endpoint | `GET /api/core/version/` | spike `tsfv0` |
-| 0.26.0 digest (2026-06-07) | `sha256:9275b0c1f5319a84b412af6839a1364ef25b61d8d6ff0d2130a6c2b2504a8b07` | Docker Hub |
+| Version-detect endpoint | `GET /api/core/version/` | spike `tsfv0` — **read it, every run** |
+| Override (opt-in) | `DISPATCHARR_VERSION=<old>` | only to deliberately reproduce an old finding |
 
-ECM encodes a 0.23.0+ **floor**; 0.26.0 is the **target**. The
-`validate-version-behaviors.py` probe re-checks the 0.23.0-era behaviors against
-0.26.0. They may have shifted across 0.24–0.26. **Bump procedure:** when the
-operator upgrades, change `DISPATCHARR_VERSION` in
-`tests/dbas-test-env/.env`, re-run the validator, refresh the digest comment.
+ECM encodes a 0.23.0+ **floor**; whatever `latest` currently resolves to is the
+**target**. The invariant that replaces the old pin:
+
+> **No live default anywhere in `tests/dbas-test-env/` — or in this document —
+> pins a Dispatcharr version. The default is always `latest`, and anything that
+> needs to know the version READS it from the running instance's version
+> endpoint and records what it saw.**
+
+Three consequences worth stating plainly:
+
+- **`:latest` is only as fresh as your last pull.** `docker compose up` reuses a
+  locally-cached `latest`; run `docker compose ... pull` when you mean to be
+  current, then re-read every version endpoint.
+- **`docker compose` auto-loads `.env` from that directory for every compose
+  file in it.** A stray `DISPATCHARR_VERSION` in a local `.env` pins all three
+  stacks, not just the one you are running. `.env.example` ships it commented
+  out for exactly this reason.
+- **A result that cannot name its platform is not a result.** Quote the version
+  you read alongside any finding. `validate-version-behaviors.py` hard-fails
+  rather than reporting probe results it cannot attribute, and
+  `capture-snapshot.sh` stamps the version it read into the snapshot manifest
+  (or the literal word `unknown` — never a guess).
+
+As of 2026-08-20, `latest` was Dispatcharr **0.29.0** (image `3621ebe3`, digest
+`sha256:df768adc…`, identical on docker.io and ghcr.io). That is a recorded
+observation, not a pin — re-read it rather than trusting this line.
 
 ## Topology: why modular, not all-in-one
 
@@ -101,17 +127,20 @@ Standing up postgres+redis+celery per PR is too slow for the per-PR gate. The
 fast path is a **faithful Dispatcharr fake** for unit/integration runs. The
 hard rule (acceptance criterion #3):
 
-> A CI fake **must be validated against the live/pinned instance**. A fake that
-> just re-encodes our assumptions is worth nothing. It's the same trap as the
+> A CI fake **must be validated against the live instance**, and the recorded
+> shapes must name the version they were captured from. A fake that just
+> re-encodes our assumptions is worth nothing. It's the same trap as the
 > current mocks.
 
 ### Validation approach (specified; full fake to be built in a follow-up)
 
 1. **Ground truth = the live probe.** `validate-version-behaviors.py` runs
-   against the pinned 0.26.0 stack and records, for each behavior ECM depends
-   on, the **real response shape**: version-detect payload, `users/me` (+ the
-   `/api/accounts/me/` fallback), login-throttle 429, and the M3U-refresh /
-   EPG-import / streams / logos list shapes.
+   against the live stack, **reads the running version and stamps it on the
+   report**, and records, for each behavior ECM depends on, the **real response
+   shape**: version-detect payload, `users/me` (+ the `/api/accounts/me/`
+   fallback), login-throttle 429, and the M3U-refresh / EPG-import / streams /
+   logos list shapes. It exits non-zero if it cannot read the version, so a
+   shape can never be recorded without an attributable platform.
 2. **Contract test pins the fake to ground truth.** The CI fake (successor to
    `mock_dispatcharr.py`) gets a **contract test** that asserts its responses
    match the recorded live shapes for those same endpoints. The contract
@@ -119,11 +148,13 @@ hard rule (acceptance criterion #3):
 3. **Two-tier gate:**
    - **Per-PR (fast):** importer tests run against the validated fake.
    - **Nightly / pre-merge-to-`dev` (slow, full):** the same importer round-trip
-     runs against the **live pinned stack** from this directory. Drift between
-     the two tiers fails the slow gate and flags the fake as stale.
-4. **Re-validate on version bump.** The contract fixtures are re-captured and
-   the fake updated whenever `DISPATCHARR_VERSION` changes: the fake is never
-   allowed to drift silently from the pinned reality.
+     runs against the **live stack** from this directory. Drift between the two
+     tiers fails the slow gate and flags the fake as stale.
+4. **Re-validate on every platform move.** Because the tag floats, nothing
+   announces a bump — the contract fixtures are re-captured and the fake updated
+   whenever a `pull` brings down a new image, and each fixture set records the
+   version it was captured from. The fake is never allowed to drift silently
+   from live reality.
 
 This keeps the per-PR loop fast **and** keeps the fake honest: the fake's
 correctness is *derived from* the live instance, never *assumed*.
@@ -196,7 +227,8 @@ prerequisite; none of this could be live-validated at authoring time):
       env names, `entrypoint.celery.sh` path, modular env vars, snapshot tables).
       Those are still **authored-not-live-validated**: close
       `tests/dbas-test-env/README.md` → "First-bring-up validation checklist"
-      against a live 0.26.0 BEFORE trusting the two-stack.
+      against a live instance BEFORE trusting the two-stack, recording the
+      version that instance reported.
 - [ ] **Bring up `docker-compose.dbas-sync-test.yml`** (`-p dbas-sync-testenv`)
       and confirm A (9601) + B (9602) both reach `healthy`, with B reachable from
       A at `http://dispatcharr-b-web:9191` (the `SyncTarget.base_url` analogue).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.1-0127",
+  "version": "0.18.1-0132",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tests/dbas-test-env/.env.example
+++ b/tests/dbas-test-env/.env.example
@@ -2,8 +2,13 @@
 # All defaults are chosen to avoid colliding with the production ECM stack
 # (6100/6143/6101) and the operator's live Dispatcharr (9191/5432).
 
-# Pinned Dispatcharr version (operator's live instance). Bump on operator upgrade.
-DISPATCHARR_VERSION=0.26.0
+# Dispatcharr version. LEAVE THIS UNSET — every compose file in this directory
+# defaults to `ghcr.io/dispatcharr/dispatcharr:latest` and tracking `latest` is
+# a PO decision (bead enhancedchannelmanager-xvuk1). Uncomment ONLY to
+# deliberately reproduce an old finding, and remember that `docker compose`
+# auto-loads `.env` from this directory for EVERY compose file here — a stray
+# value pins the A/B sync stack and the XC provider too, not just this one.
+# DISPATCHARR_VERSION=0.28.2
 
 # Host ports (deliberately off the ECM/live ranges).
 DBAS_TEST_HTTP_PORT=9591

--- a/tests/dbas-test-env/README.md
+++ b/tests/dbas-test-env/README.md
@@ -548,3 +548,390 @@ docker volume rm ecm-xdmru-config
 docker compose -p dbas-sync-testenv -f docker-compose.dbas-sync-test.yml down -v
 docker image rm ecm-xdmru:<sha>     # optional
 ```
+
+---
+
+# HANDOVER — the documentation environment (bead `enhancedchannelmanager-gk4d0`)
+
+**BUILT 2026-08-20.** Everything below is live and disposable. This section is
+the contract between the QA engineer who built the environment and the
+technical writer who will screenshot it — it is not a user guide, and it does
+not tell you what to write.
+
+The whole point of the build is that the writer can document the **Xtream
+Codes** path against a **real XC server**, not a hand-rolled fake. Dispatcharr
+implements the XC *server* side itself (`xc_player_api` / `xc_panel_api` /
+`get.php` / `xmltv.php`, routed in `dispatcharr/urls.py`), so a third
+Dispatcharr — **P** — loaded with a lineup and re-serving it over XC produces
+genuine XC fields. Instance **A** subscribes to P as an `account_type = XC`
+account, and every XC value ECM renders (expiry, connection counts, category
+list) came out of that real implementation.
+
+```
+  provider-northwind (nginx: playlist.m3u, local.m3u, epg.xml, local-epg.xml, 59 logos)
+        |                                        |
+        |  STANDARD M3U                          |  STANDARD M3U (local.m3u only)
+        v                                        v
+   Dispatcharr P  ---- XTREAM CODES ---->   Dispatcharr A  <---- reads ----  ECM
+   (the provider)                           (the operator's                  (ecm-docenv)
+                                             instance)                          |
+                                                                                | cross-instance sync
+                                                                                v
+                                                                          Dispatcharr B
+                                                                          (destination, EMPTY)
+```
+
+## NO REAL CREDENTIALS ANYWHERE
+
+Every credential in this environment is synthetic and chosen to read as fake in
+a screenshot (`northwind-demo` / `not-a-real-password`, `ecmtest-a` /
+`ecmtestpass-a`, and so on). The provider, the channel names and the listings
+are all invented. Keep it that way: per bead
+`enhancedchannelmanager-wfz8z`, a live `mcp_api_key` was once found rendered
+inside a committed image, invisible to gitleaks, detect-secrets and GitHub
+secret scanning alike — **byte scanners cannot see pixels.** If you need a new
+credential for a screenshot, invent one that is obviously fake; never paste a
+real one in "just to see how it looks".
+
+## URLs, ports, containers, credentials
+
+| What | Host URL | In-cluster address | Container | Credentials |
+|---|---|---|---|---|
+| **ECM** (under test) | `http://127.0.0.1:6400` | — | `ecm-docenv` | `ecm-demo-admin` / `Docs-Demo-Not-Real-2026!` |
+| **Dispatcharr A** — source | `http://127.0.0.1:9601` | `http://dispatcharr-a-web:9191` | `dbas-sync-testenv-dispatcharr-a-web-1` | `ecmtest-a` / `ecmtestpass-a` |
+| **Dispatcharr B** — sync destination | `http://127.0.0.1:9602` | `http://dispatcharr-b-web:9191` | `dbas-sync-testenv-dispatcharr-b-web-1` | `ecmtest-b` / `ecmtestpass-b` |
+| **Dispatcharr P** — XC provider | `http://127.0.0.1:9603` | `http://dispatcharr-p-web:9191` | `dbas-xc-provider-dispatcharr-p-web-1` | admin `ecmtest-p` / `ecmtestpass-p` |
+| **P's XC account** (what A subscribes with) | — | — | — | `northwind-demo` / `not-a-real-password` |
+| **provider-northwind** (nginx origin) | *no host port* | `http://provider-northwind/` | `dbas-xc-provider-provider-northwind-1` | none |
+
+Postgres ports, if you ever need them: A `5446`, B `5447`, P `5448`. All three
+Dispatcharr instances run **0.28.2**.
+
+ECM's own config volume is `ecm-docenv-config`; the image is
+`ecm-docenv:dd77d587`. The nginx document root is a **generated** fixture at
+`/home/lecaptainc/ecm-docenv-fixture` (see "Regenerating the fixture" below) —
+it is deliberately outside the repo and is not committed.
+
+### The XC values ECM will render
+
+Read back from A after its first XC refresh, harvested from P's real XC API:
+
+```
+status "Active" | exp_date 2026-11-18 (90 days from first auth)
+active_cons "0" | max_connections "4" | allowed_output_formats ["ts","mp4"]
+```
+
+`max_connections` is 4 because P's `northwind-demo` user has `stream_limit = 4`
+— change the user on P if you want a different number in the shot.
+
+## What is on instance A, by name and count
+
+**59 channels / 59 streams / 10 channel groups** (9 populated + Dispatcharr's
+always-present `Default Group`, which holds 0 channels). Every channel has a
+logo and a `tvg_id`, and **all 59 are linked to EPG data**.
+
+### Channel groups and numbering
+
+| Group | Channels | Numbers | Comes from |
+|---|---|---|---|
+| Northwind News | 8 | 100–107 | XC account |
+| Northwind Sports | 10 | 200–209 | XC account |
+| Northwind Movies | 9 | 300–308 | XC account |
+| Northwind Kids | 6 | 400–405 | XC account |
+| Northwind Documentary | 7 | 500–506 | XC account |
+| Northwind Entertainment | 8 | 600–607 | XC account |
+| Northwind Music | 5 | 700–704 | XC account |
+| Northwind Local | 3 | 800–802 | Standard M3U account |
+| Northwind Regional | 3 | 850–852 | Standard M3U account |
+
+### The full channel list (safe to caption verbatim)
+
+```
+News           100 Meridian News · 101 Meridian News HD · 102 Capitol Report
+               103 Global Wire · 104 Beacon Business · 105 Continental 24
+               106 Harbour Weather · 107 The Briefing
+Sports         200 Summit Sports 1 · 201 Summit Sports 2 · 202 Summit Sports HD
+               203 Velodrome TV · 204 Gridiron Network · 205 Pitchside FC
+               206 Court Vision · 207 Outdoor Pursuits · 208 Paddock Live · 209 Ringside
+Movies         300 Silverline Cinema · 301 Silverline Classics · 302 Silverline Action
+               303 Nightscreen Thrillers · 304 Matinee Family · 305 Indie Reel
+               306 Westward Westerns · 307 Orbit Sci-Fi · 308 Silverline 4K
+Kids           400 Sprout Junction · 401 Cartoon Cove · 402 Little Explorers
+               403 Storybook TV · 404 Puzzle Pals · 405 Dino Dash
+Documentary    500 Terra Discovery · 501 Wild Frontier · 502 History Vault
+               503 Deep Ocean · 504 Cosmos Files · 505 Engineering Marvels · 506 Culture Trail
+Entertainment  600 Primetime Plus · 601 Sitcom Central · 602 Reality Row
+               603 Talk of the Town · 604 Stage & Screen · 605 Retro Rewind
+               606 Lifestyle Loft · 607 Comedy Corner
+Music          700 Amp Rock · 701 Cadence Classical · 702 Groove Lounge
+               703 Chart Pulse · 704 Bayou Country
+Local          800 Harbour City TV · 801 Lakeside Local · 802 Riverbend Community
+Regional       850 Northern Counties · 851 Coastal Region One · 852 Valley Public
+```
+
+### Everything else on A
+
+| Thing | Count | Names / ids |
+|---|---|---|
+| M3U accounts | 3 | id 6 **`Northwind IPTV (Xtream Codes)`** (`account_type = XC`, `server_url http://dispatcharr-p-web:9191`, user `northwind-demo`, 53 streams); id 7 `Northwind Local Affiliates (Standard M3U)` (`STD`, 6 streams); id 1 `custom` (Dispatcharr's locked built-in) |
+| EPG sources | 2 | id 2 `Northwind IPTV EPG (Xtream Codes)` — 2,937 programmes / 53 channels; id 3 `Northwind Local XMLTV` — 421 programmes / 6 channels |
+| Channel profiles | 2 | id 2 `Living Room` (all 59 channels); id 3 `Kids & Family` (6 channels — the Kids group only) |
+| Stream profiles | 6 | 5 Dispatcharr built-ins + id 8 `Northwind Direct (ffmpeg)`, which references the custom user agent |
+| User agents | 4 | 3 built-ins (TiviMate, VLC, Chrome) + id 22 `Northwind Set-Top Box` (`NorthwindSTB/2.4 (Linux; documentation-environment)`) |
+| Logos | 60 | 59 remote-URL logos from the provider feed, **plus id 61 `Meridian News (hosted on Dispatcharr)`** |
+| Server groups | 0 | — |
+| Dispatcharr users | 1 | `ecmtest-a` |
+
+**The Dispatcharr-hosted logo** is id 61, bound to channel **100 Meridian
+News**. Its bytes live in **A's own** `/data/logos/meridian-news-hosted.png`
+(md5 `3ba03ea3c50f92ec7a8873e7f5b751b9`) — not in ECM's `/config/uploads/logos/`,
+which is empty and must stay that way. That distinction is the whole point of
+bead `cfxml`; if you re-upload a logo, upload it through **A's** Logo Manager.
+
+## What is on instance P (you will rarely need to open it)
+
+53 channels / 53 streams / 8 groups (7 populated + `Default Group`), all with
+logos and all linked to EPG. One STD M3U account `Northwind Origin Feed`
+reading the nginx `playlist.m3u`, one EPG source `Northwind XMLTV` (3,608
+programmes), one custom user agent `Northwind Fixture Agent`, and two users:
+the admin `ecmtest-p` and the XC-facing `northwind-demo`.
+
+P exists only to be a believable provider. The writer's screenshots are of ECM
+and, where the guide needs them, of A and B.
+
+## Instance B — the sync destination, currently EMPTY
+
+B is reset and holds the fresh-0.28.2 baseline, **which is not zero of
+everything** — record these as "empty" when captioning:
+
+```
+0 channels · 0 streams · 0 channel groups · 0 channel profiles · 0 logos
+0 EPG sources · 0 server groups
+3 user agents (ids 1-3: TiviMate, VLC, Chrome)
+5 stream profiles (ids 1-5: ffmpeg, streamlink, Proxy, Redirect, VLC)
+1 M3U account (id 1, `custom`, Dispatcharr's locked built-in)
+1 user (`ecmtest-b`)
+```
+
+Those id ranges matter: an artifact that lands on B with an id **outside** 1-3
+(user agents) or 1-5 (stream profiles) is one the sync created, not one that
+was already there.
+
+**No sync target exists in ECM.** That is deliberate — creating it is part of
+the workflow you are documenting, so you get to walk and shoot that path
+yourself. Point it at `http://dispatcharr-b-web:9191` with B's credentials.
+
+### Resetting B between screenshot runs
+
+You will want a clean destination more than once. From `tests/dbas-test-env`:
+
+```bash
+DISPATCHARR_VERSION=0.28.2 docker compose -p dbas-sync-testenv \
+  -f docker-compose.dbas-sync-test.yml \
+  rm -sf dispatcharr-b-web dispatcharr-b-celery dispatcharr-b-db dispatcharr-b-redis
+docker volume rm dbas-sync-testenv_dbas-sync-b-data dbas-sync-testenv_dbas-sync-b-pg
+DISPATCHARR_VERSION=0.28.2 docker compose -p dbas-sync-testenv \
+  -f docker-compose.dbas-sync-test.yml up -d \
+  dispatcharr-b-db dispatcharr-b-redis dispatcharr-b-web dispatcharr-b-celery
+
+# wait for health, then RE-CREATE THE SUPERUSER — the volume took it with it:
+until curl -fsS http://127.0.0.1:9602/api/core/version/ >/dev/null; do sleep 5; done
+docker exec dbas-sync-testenv-dispatcharr-b-web-1 sh -c '
+  cd /app && export DJANGO_SECRET_KEY="$(tr -d "\r\n" < /data/jwt)" && \
+  DJANGO_SUPERUSER_USERNAME=ecmtest-b \
+  DJANGO_SUPERUSER_PASSWORD=ecmtestpass-b \
+  DJANGO_SUPERUSER_EMAIL=ecmtest-b@example.invalid \
+  python manage.py createsuperuser --noinput'
+```
+
+**`DISPATCHARR_VERSION=0.28.2` is not optional.** The compose file's default is
+`0.26.0`; omit the variable and B silently comes back a minor version behind A,
+which is a different (out-of-scope) test matrix. This bit the build — B came up
+0.26.0 on the first reset and had to be torn down again. Confirm with
+`curl -s http://127.0.0.1:9602/api/core/version/` every time.
+
+After a reset, ECM's existing sync target still points at B correctly, but B's
+JWT changed — the next run re-authenticates on its own.
+
+## Traps — read before you spend an hour on one of these
+
+**1. B throttles `/api/accounts/token/` to roughly 3 requests per minute.**
+Pace anything that authenticates against B, and cache the token rather than
+re-authenticating per request. A self-inflicted `429` surfaces as
+`partial_failed_rolled_back` and has been misread as a code failure twice. One
+operation at a time; never reset B while a run is in flight.
+
+**2. A fresh Dispatcharr can import an entire playlist as ONE stream.** This
+cost real time during the build. Dispatcharr caches its settings groups in
+Redis, and on a first boot the `stream_settings` group can be cached **before**
+the migration writes it — so `m3u_hash_key` reads as `""` instead of `"url"`,
+`"".split(",")` yields `[""]`, the per-stream hash payload is the empty dict,
+and every stream in the playlist hashes to `sha256("{}")` =
+`44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` and
+deduplicates down to a single row. P imported **1 of 53 streams** this way and
+reported `status: success`. If a refresh reports far fewer streams than the
+playlist has, check for that hash before suspecting the playlist:
+
+```bash
+# the DB says one thing...
+docker exec dbas-xc-provider-dispatcharr-p-db-1 psql -U dispatch -d dispatcharr \
+  -tAc "select value from core_coresettings where key='stream_settings';"
+# ...and the cache says another. Bust it:
+docker exec dbas-xc-provider-dispatcharr-p-redis-1 \
+  redis-cli DEL ':1:coresettings:group:stream_settings'
+```
+Then delete the collapsed stream(s) and refresh again. A and P are both correct
+right now; this only bites a freshly created instance.
+
+**3. XC-imported channels do not carry the origin's `tvg-id`.** P's XC API
+publishes `epg_channel_id` as the **channel number** (`"100"`, `"101"`, …), not
+`meridian-news.northwind.example`. So on A, the 53 XC channels have
+`tvg_id = "100"`-style ids and match **P's XC XMLTV**
+(`http://dispatcharr-p-web:9191/xmltv.php?username=…&password=…`), which is
+exactly what EPG source id 2 points at. The 6 Standard-M3U channels keep the
+real slug ids and match `local-epg.xml`. Do not "fix" A by pointing the XC
+lineup at `http://provider-northwind/epg.xml` — nothing will match.
+
+**4. Dispatcharr returns `403`, not `404`, for an API path that does not
+exist.** `/api/m3u/accounts/6/refresh/` and
+`/api/channels/channels/from-stream/bulk` (no trailing slash) both answer 403
+and look like a permissions problem. The real routes are
+`/api/m3u/refresh/<account_id>/` and
+`/api/channels/channels/from-stream/bulk/`. When a Dispatcharr call 403s,
+check the path before checking the token.
+
+**5. Bulk channel-profile membership is `PATCH`, not `POST`.**
+`/api/channels/profiles/<id>/channels/bulk-update/` answers 405 to a POST.
+
+**6. `createsuperuser` needs `DJANGO_SECRET_KEY` exported.** A bare `manage.py`
+fails with "SECRET_KEY must not be empty"; the entrypoint derives it from
+`/data/jwt`. The reset recipe above already does this.
+
+**7. ECM's first-run setup rejects `.invalid` email addresses.** `EmailStr`
+refuses reserved TLDs, so `admin@example.invalid` 422s. Use `example.com`.
+
+**8. ECM caches Dispatcharr's channel-group list in-process.** If stream rows
+render empty under group headers that show non-zero counts, the cache was
+populated when A had no groups. `docker restart ecm-docenv` clears it.
+
+**9. "Create channels from this group" is a silent no-op on a COLLAPSED group.**
+Expand the group first. The bulk-create modal renders in a portal — search the
+whole page for it, not just the Channels pane.
+
+**10. Dispatcharr's bulk channel creation is asynchronous.** The POST returns a
+`task_id` immediately; poll `/api/channels/channels/` until the count settles
+rather than reading the response as the result.
+
+## Regenerating the fixture
+
+The nginx document root is generated, not committed (1.7 MB, mostly logos). The
+**generator** is committed as `northwind-fixture.py` and reproduces the
+playlists and all 59 logos byte for byte:
+
+```bash
+python3 tests/dbas-test-env/northwind-fixture.py /home/lecaptainc/ecm-docenv-fixture
+```
+
+The two XMLTV files are anchored to **today in UTC** and cover 3 days, so the
+listings go stale. When they do, re-run the generator and re-import all three
+EPG sources (P id 1; A ids 2 and 3) — the channel ids are stable, so existing
+EPG links survive:
+
+```bash
+# with a Dispatcharr access token in $TOK
+curl -s -X POST -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' \
+  -d '{"id":1}' http://127.0.0.1:9603/api/epg/import/
+```
+
+Changing the lineup itself (adding channels, renaming groups) means re-running
+the generator **and** re-refreshing P's M3U account, then A's — the counts in
+this handover would then be wrong, so update them here too.
+
+## Bringing the environment back up from cold
+
+If the host reboots, or containers with `RestartPolicy=no` get stopped:
+
+```bash
+cd tests/dbas-test-env
+
+# A and B (pin the version — see trap 1):
+DISPATCHARR_VERSION=0.28.2 docker compose -p dbas-sync-testenv \
+  -f docker-compose.dbas-sync-test.yml up -d
+
+# P and the nginx origin (joins A/B's network, so bring A/B up FIRST):
+NORTHWIND_FIXTURE_DIR=/home/lecaptainc/ecm-docenv-fixture \
+  docker compose -p dbas-xc-provider -f docker-compose.xc-provider.yml up -d
+
+# ECM:
+docker start ecm-docenv
+until curl -fsS http://127.0.0.1:6400/api/health/ready >/dev/null; do sleep 3; done
+```
+
+All persistent state is in named volumes, so nothing needs rebuilding.
+
+## Tearing the whole thing down
+
+```bash
+docker rm -f ecm-docenv
+docker volume rm ecm-docenv-config
+docker image rm ecm-docenv:dd77d587                      # optional
+
+cd tests/dbas-test-env
+docker compose -p dbas-xc-provider  -f docker-compose.xc-provider.yml  down -v
+docker compose -p dbas-sync-testenv -f docker-compose.dbas-sync-test.yml down -v
+
+rm -rf /home/lecaptainc/ecm-docenv-fixture               # the generated fixture
+```
+
+Tear down the `dbas-xc-provider` project **before** `dbas-sync-testenv`: P and
+nginx attach to `dbas-sync-testenv_default` as an external network, and Docker
+will refuse to remove a network that still has endpoints on it.
+
+**Never touch `ecm-ecm-1`, `ecm-ecm-mcp-1`, or the `dispatcharr` container.**
+Those are the operator's production stack. `ecm-ecm-1` and `ecm-ecm-mcp-1` are
+currently STOPPED and must stay stopped; production `dispatcharr` is running on
+its own network (`dispatcharr-green_default`) and is not part of this
+environment.
+
+## What was verified when this was built, and how
+
+Recorded so a later reader can tell a checked claim from an assumed one.
+
+| Claim | How it was checked |
+|---|---|
+| ECM runs `origin/dev` `dd77d587` | **Not** `/api/version` (that is baked-in build metadata and has misled three engineers). All **244** non-test `backend/**.py` files were sha256'd inside the container against `git show dd77d587:<path>`: **244 OK, 0 mismatched, 0 absent.** |
+| …and that checksum harness can actually fail | Two known-bad runs. Compared against an older revision (29 differing files) → **29 MISMATCH**. Then a byte was appended to `/app/main.py` in the live container → **exactly 1 MISMATCH**, restored → back to 244/244. (A first attempt to use the parent commit `b867538a` as the known-bad was **vacuous** — `dd77d587` is its merge commit, so 0 files differ and the check had no signal. Vacuous known-bads are the failure this table exists to prevent.) |
+| A's account really is XC | Read `account_type` from **A's Postgres directly** (`select account_type from m3u_m3uaccount`) → `XC`, not from a serializer that could be defaulting. Cross-checked in ECM's own UI: the M3U Manager renders the badge **`XtreamCodes`** on account 6 and **`Standard M3U`** on account 7. |
+| P is a genuine XC server | `player_api.php` with correct credentials returns a real `user_info` (auth 1, Active, exp_date, active_cons, max_connections); with a wrong password and with no credentials it returns **HTTP 401** `{"error":"Unauthorized"}`. Both poles from the same endpoint. `get_live_categories` → 7, `get_live_streams` → 53, `xmltv.php` → 200/776 KB, `get.php` → 200/13.7 KB. |
+| The A→B sync path works with an XC account in the mix | **Dry-run preview only** — no writes to B. Wrong password → `success=False`, `SYNC_DESTINATION_UNREADABLE`. Correct password → `success=True`, *"would create 78, update 0, skip 9, 0 conflict(s) across 9 categories"*. B re-read afterwards: still **0 channels / 0 streams / 0 groups / 0 logos / 0 EPG sources.** The temporary sync target and all 6 resulting notifications were then deleted, so ECM has no sync history for you to work around. (ECM's own scheduled tasks — the M3U Change Monitor in particular — keep producing routine notifications; those are normal, not leftovers. Clear them before a notifications screenshot with `DELETE /api/notifications?read_only=false`.) |
+| The Dispatcharr client used to build all this could report failure | Smoke-tested before use: known-good returns real JSON and exits 0; a nonexistent path and an unreachable host both exit **1** loudly. It never degrades an error into "0 rows". |
+| nginx is serving what we think | Real files return 200 with non-zero sizes; a bogus path returns **404** — checked again after the fixture was relocated. |
+| Playwright is pointed at a live app | Navigating to a dead port errors before any real page was read. The Channel Manager then rendered **"59 channels"** and all 9 Northwind groups. |
+| The committed generator matches the live fixture | `playlist.m3u`, `local.m3u` and all **59** logos compare byte-identical; the two XMLTV files match on the same UTC day. |
+| Production is untouched | `ecm-ecm-1` and `ecm-ecm-mcp-1` still `Exited`, with `FinishedAt` timestamps predating this session and no `StartedAt` since. Production `dispatcharr` still `Up`, unchanged, on `dispatcharr-green_default` — a different network from `dbas-sync-testenv_default`. |
+
+### What this environment does NOT cover
+
+- **No apply-mode sync has been run.** Only a dry-run preview. The first real
+  A→B apply will be the writer's, which is the intent — but it means the apply
+  path has not been exercised *with an XC account on A* by anyone yet. The
+  preview says it plans 78 creates across 9 categories; if the apply disagrees,
+  that is new information, not a known-good regression.
+- **The channel→logo binding does not cross the sync** (bead
+  `enhancedchannelmanager-xgbjm`, still open). Logo records and bytes land on B,
+  but every synced channel there shows `logo_id null` and B's Logo Manager reads
+  `UNUSED`. Do not write the guide as though it works.
+- **VOD and Series are empty.** P serves `get_vod_streams` / `get_series` as
+  empty lists, so ECM's VOD surfaces have nothing to show. Populating them was
+  out of scope.
+- **No stream actually plays.** The `.ts` URLs in the fixture are 404s — nginx
+  serves no `/stream/` directory. Everything about lineup management,
+  EPG, profiles and sync is real; anything that requires a live video
+  transport (probing, bitrate, playback) is not.
+- **ECM's first-run walkthrough has already been completed here.** The admin
+  account exists and the Dispatcharr connection is set. If you need to shoot
+  Getting Started from a genuinely blank ECM, do it against a throwaway second
+  container rather than resetting this one:
+  `docker rm -f ecm-docenv && docker volume rm ecm-docenv-config` then re-run
+  the `docker run` from "Bringing the environment back up" with a fresh volume —
+  but you will then have to re-create the admin and re-point it at A.

--- a/tests/dbas-test-env/README.md
+++ b/tests/dbas-test-env/README.md
@@ -1,6 +1,6 @@
 # DBAS round-trip test environment
 
-A pinned, **throwaway** Dispatcharr instance + production-shaped seed tooling so
+A **throwaway** Dispatcharr instance on `latest` + production-shaped seed tooling so
 the ECM ↔ Dispatcharr DBAS round-trip success signal (epic
 `enhancedchannelmanager-0i2vt`) can be tested against a **live** Dispatcharr
 instead of mocks.
@@ -58,8 +58,16 @@ docker-compose.yml/.mcp.yml) or the operator's live Dispatcharr.
   that is baked-in build metadata and has misled three engineers on this work.
   Checksum the deployed files instead (see the HANDOVER verification table).
 
-`docker-compose.dbas-test.yml` — the single-instance stack — still defaults to
-`0.26.0` and was **out of scope** for `xvuk1`. Treat its default as stale.
+This covers **all three** compose files in this directory —
+`docker-compose.dbas-test.yml` (single instance),
+`docker-compose.dbas-sync-test.yml` (A + B) and
+`docker-compose.xc-provider.yml` (P). None of them carries a hand-maintained
+version pin any more; do not reinstate one.
+
+`.env.example` no longer sets `DISPATCHARR_VERSION` either. Note that
+`docker compose` auto-loads `.env` from this directory for **every** compose
+file here, so a stray value in a local `.env` pins the sync stack and the XC
+provider too — not just the file you think you are running.
 
 ---
 
@@ -67,20 +75,24 @@ docker-compose.yml/.mcp.yml) or the operator's live Dispatcharr.
 
 ```bash
 cd tests/dbas-test-env
-cp .env.example .env            # optional: customize version/ports/creds
+cp .env.example .env            # optional: customize ports/creds (NOT the version)
+docker compose -p dbas-testenv -f docker-compose.dbas-test.yml pull   # if you mean to be current
 
 docker compose -p dbas-testenv -f docker-compose.dbas-test.yml up -d
 # wait for the web healthcheck (GET /api/core/version/) to go healthy:
 docker compose -p dbas-testenv -f docker-compose.dbas-test.yml ps
 ```
 
-## Validate the pinned version's behaviors
+## Validate the running version's behaviors
 
 This is the ground-truth probe — confirms the 0.23.0-era behaviors ECM encodes
-still hold at the pinned version, and records the response shapes the CI fake
-must reproduce:
+still hold on whatever `latest` currently resolves to, and records the response
+shapes the CI fake must reproduce. **Read and record the version first**; the
+probe's result is meaningless without it:
 
 ```bash
+curl -s http://localhost:9591/api/core/version/     # record this with the result
+
 DBAS_TEST_BASE_URL=http://localhost:9591 \
 DBAS_TEST_ADMIN_USER=ecmtest DBAS_TEST_ADMIN_PASS=ecmtestpass \
 python3 validate-version-behaviors.py
@@ -112,24 +124,27 @@ docker compose -p dbas-testenv -f docker-compose.dbas-test.yml down -v
 
 ---
 
-## First-bring-up validation checklist (do this once per version bump)
+## First-bring-up validation checklist (do this on every platform move)
 
-The compose env vars and the edge-supplement endpoint/field names are
-**best-effort against the pinned 0.26.0 schema** and must be confirmed on first
-real bring-up. None of this could be live-verified at authoring time (no
+Because this stack tracks `latest`, "once per version bump" is not a thing you
+get told about — re-run this checklist whenever `docker compose pull` brings
+something new down, and record the version it ran against. The compose env vars
+and the edge-supplement endpoint/field names were **best-effort against the
+0.26.0 schema** this file used to pin and must be confirmed against the running
+image. None of this could be live-verified at authoring time (no
 Dispatcharr reachable from the authoring sandbox).
 
 - [ ] **Seed-admin env names.** Confirm `DISPATCHARR_SUPERUSER_USERNAME` /
       `DISPATCHARR_SUPERUSER_PASSWORD` actually create the first admin on the
-      pinned image. If not, do the first-run wizard once, then capture a
+      running image. If not, do the first-run wizard once, then capture a
       snapshot so the admin is baked into the seed.
-- [ ] **`entrypoint.celery.sh` path** exists in the pinned image
+- [ ] **`entrypoint.celery.sh` path** exists in the running image
       (`/app/docker/entrypoint.celery.sh`).
 - [ ] **`validate-version-behaviors.py` runs clean** — any WARN is a drift
       finding to route to the importer authors.
 - [ ] **Edge-supplement endpoints** (`/api/channels/groups/`,
       `/api/channels/streams/`, `/api/accounts/users/`) and the privilege
-      fields (`is_superuser`/`is_staff`/`user_level`) match the pinned schema.
+      fields (`is_superuser`/`is_staff`/`user_level`) match the running schema.
 - [ ] **Snapshot table names** in `capture-snapshot.sh` manifest query reflect
       the real schema (the row-count query is schema-introspecting, so it's
       tolerant, but eyeball the manifest).
@@ -1037,7 +1052,7 @@ row below was re-run on the **2026-08-20 0.29.0 rebuild** — this is not the
 | Claim | How it was checked |
 |---|---|
 | Every node is on `0.29.0` | `GET /api/core/version/` on A (`:9601`), B (`:9602`) and P (`:9603`) each returned `{"version":"0.29.0"}`. The image behind all three is `ghcr.io/dispatcharr/dispatcharr:latest` = `3621ebe3`, digest `sha256:df768adc…`, and `docker pull` confirmed docker.io and ghcr.io agree on that digest. |
-| The compose default really is `latest`, and the override really works | `docker compose config` resolves `ghcr.io/dispatcharr/dispatcharr:latest` with no variable set, and `ghcr.io/dispatcharr/dispatcharr:0.28.2` with `DISPATCHARR_VERSION=0.28.2` — both poles, both files. Then proven live: B was reset with **no flag** and came back `0.29.0`, which is exactly the failure the old `0.26.0` default caused. |
+| The compose default really is `latest`, and the override really works | `docker compose config` resolves `ghcr.io/dispatcharr/dispatcharr:latest` with no variable set, and `ghcr.io/dispatcharr/dispatcharr:0.28.2` with `DISPATCHARR_VERSION=0.28.2` — both poles, all three files. Then proven live: B was reset with **no flag** and came back `0.29.0`, which is exactly the failure the old `0.26.0` default caused. |
 | ECM runs `origin/dev` `dd77d587` | **Not** `/api/version` (baked-in build metadata; it has misled three engineers). Two passes, both `sha256sum` inside the container against `git show dd77d587:<path>`: **243 non-test `backend/**.py` → 243 OK / 0 MISMATCH / 0 ABSENT**, and **all 698 `backend/**.py` including tests → 698 OK / 0 MISMATCH / 0 ABSENT**, with **0** `.py` files in `/app` that are not in the ref. (The retired build's "244" counted `backend/test_dispatcharr_api.py`, a top-level test file this filter excludes: 243 + 1 = 244, reconciled.) |
 | …and that checksum harness can actually fail | Two known-bad runs, exit status captured directly rather than through a pipe. (1) Compared against `b0e0a5ad`, 30 first-parent commits back → **48 MISMATCH**, harness exit 1. (2) A byte appended to `/app/main.py` in the live container → **exactly 1 MISMATCH** on `main.py`, harness exit 1; restored → **243 OK**, exit 0. (A previous attempt to use the parent commit `b867538a` as the known-bad was **vacuous** — `dd77d587` is its merge commit, so 0 files differ. Vacuous known-bads are the failure this table exists to prevent.) |
 | The Dispatcharr client used to build all this could report failure | Smoke-tested against four poles before use: known-good returns real JSON; a nonexistent path, an unreachable host, and a wrong password each raise loudly. It never degrades an error into "0 rows". |
@@ -1156,5 +1171,7 @@ the writer receives is unspent.
 - **Playwright was not exercised on this rebuild**, so unlike the first build
   there is no rendered-browser evidence in the table above. The ECM API was
   proven live (count 59) but nothing rendered a page.
-- **`docker-compose.dbas-test.yml`, the single-instance stack, still defaults to
-  `0.26.0`.** It was out of scope for `xvuk1` and nothing here validates it.
+- **`docker-compose.dbas-test.yml`, the single-instance stack, now defaults to
+  `latest` too** (PO decision, same bead), but it was **not stood up** on this
+  platform — only its resolved config was checked. Its first bring-up on 0.29.0
+  is unvalidated; run the first-bring-up checklist above.

--- a/tests/dbas-test-env/README.md
+++ b/tests/dbas-test-env/README.md
@@ -58,11 +58,31 @@ docker-compose.yml/.mcp.yml) or the operator's live Dispatcharr.
   that is baked-in build metadata and has misled three engineers on this work.
   Checksum the deployed files instead (see the HANDOVER verification table).
 
-This covers **all three** compose files in this directory —
-`docker-compose.dbas-test.yml` (single instance),
-`docker-compose.dbas-sync-test.yml` (A + B) and
-`docker-compose.xc-provider.yml` (P). None of them carries a hand-maintained
-version pin any more; do not reinstate one.
+State it as an invariant, not a file list — the compose files were three
+examples of the property, not the whole of it:
+
+> **No live default anywhere in `tests/dbas-test-env/` (or the docs describing
+> it) pins a Dispatcharr version. The default is always `latest`, and anything
+> that needs to know the version READS it from the running instance's version
+> endpoint and records what it saw.**
+
+What that covers today, all swept 2026-08-20:
+
+| Where | Was | Now |
+|---|---|---|
+| `docker-compose.dbas-test.yml` | `:${DISPATCHARR_VERSION:-0.26.0}` (x2) | `ghcr.io/…:${DISPATCHARR_VERSION:-latest}` |
+| `docker-compose.dbas-sync-test.yml` | `:${DISPATCHARR_VERSION:-0.26.0}` (x2) | same |
+| `docker-compose.xc-provider.yml` | `:${DISPATCHARR_VERSION:-0.28.2}` (x2) | same |
+| `.env.example` | `DISPATCHARR_VERSION=0.26.0` | commented out — and note `docker compose` auto-loads `.env` here for **every** compose file, so a stray value pins all three stacks |
+| `validate-version-behaviors.py` | `EXPECTED_VERSION = os.environ.get(…, "0.26.0")`, asserted | reads the version, stamps it on the report, and **hard-fails** if it cannot |
+| `capture-snapshot.sh` | stamped `version pin: ${DISPATCHARR_VERSION:-0.26.0}` into every manifest | stamps the version it actually read, or the literal `unknown (…)` — never a guess |
+| `seed/edge_supplement.py` | prose asserting a "pinned 0.26.0 schema" | prose pointing at the running schema |
+| `docs/testing/dbas-test-env.md` | a "Version pin" table + bump procedure | a version-policy section carrying this invariant |
+
+Remaining mentions of `0.26.0` / `0.28.2` in this directory are **history or
+opt-in override examples** — a past validation run, the retired default being
+described as retired, or a commented-out `DISPATCHARR_VERSION=0.28.2` showing
+how to reproduce an old finding. None of them is a live default.
 
 `.env.example` no longer sets `DISPATCHARR_VERSION` either. Note that
 `docker compose` auto-loads `.env` from this directory for **every** compose
@@ -91,12 +111,21 @@ shapes the CI fake must reproduce. **Read and record the version first**; the
 probe's result is meaningless without it:
 
 ```bash
-curl -s http://localhost:9591/api/core/version/     # record this with the result
-
 DBAS_TEST_BASE_URL=http://localhost:9591 \
 DBAS_TEST_ADMIN_USER=ecmtest DBAS_TEST_ADMIN_PASS=ecmtestpass \
 python3 validate-version-behaviors.py
 ```
+
+The probe reads `GET /api/core/version/` itself, prints
+`[summary] VALIDATED AGAINST DISPATCHARR <version> at <url>`, and **exits 2
+without reporting any shape** if it cannot read a version — so a recorded
+response shape can never be attributed to the wrong platform. Quote that
+summary line with any result.
+
+To assert a version deliberately (only when reproducing an old finding), set
+the opt-in `DBAS_EXPECT_VERSION`; a mismatch is a loud `WARN`, not a silent
+pass. It is unset by default, which is what keeps the probe from carrying a
+pin.
 
 ## Seed production-shaped data + edge cases
 

--- a/tests/dbas-test-env/README.md
+++ b/tests/dbas-test-env/README.md
@@ -33,6 +33,36 @@ docker-compose.yml/.mcp.yml) or the operator's live Dispatcharr.
 
 ---
 
+## Version policy — the test env tracks `dispatcharr:latest`
+
+**PO decision, bead `enhancedchannelmanager-xvuk1`:** this directory tracks
+`dispatcharr:latest` **literally**. Not a pinned version bumped by hand.
+
+- `docker-compose.dbas-sync-test.yml` (A + B) and `docker-compose.xc-provider.yml`
+  (P) both default to `ghcr.io/dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-latest}`.
+  `ghcr.io` is the registry the operator's production Dispatcharr pulls from, so
+  the test env and production resolve the same artifact.
+- **Latest is the default so nobody has to remember a flag.** The old
+  `DISPATCHARR_VERSION=0.28.2` instructions are gone; do not reinstate them.
+- **To reproduce an old finding deliberately**, pass the override:
+  `DISPATCHARR_VERSION=0.28.2 docker compose ... up -d`.
+- `:latest` is only as fresh as your last pull — `docker compose ... pull` first
+  when you mean to be current.
+- **Every validation run reads and reports the version it actually ran against**,
+  from `GET /api/core/version/` on each node. Tracking a floating tag means the
+  platform can move mid-flight: it did on 2026-08-20, when `latest` went from
+  `0.28.2` (image `1f55137b`) to `0.29.0` (image `3621ebe3`,
+  digest `sha256:df768adc…`, identical on docker.io and ghcr.io). **A run that
+  cannot name its Dispatcharr is not a result.**
+- **Do not read `/api/version`'s `git_commit` as proof of what is running** —
+  that is baked-in build metadata and has misled three engineers on this work.
+  Checksum the deployed files instead (see the HANDOVER verification table).
+
+`docker-compose.dbas-test.yml` — the single-instance stack — still defaults to
+`0.26.0` and was **out of scope** for `xvuk1`. Treat its default as stale.
+
+---
+
 ## Bring it up
 
 ```bash
@@ -274,16 +304,18 @@ production ECM is never repointed.
 
 ```bash
 cd tests/dbas-test-env
-DISPATCHARR_VERSION=0.28.2 docker compose -p dbas-sync-testenv \
+docker compose -p dbas-sync-testenv \
   -f docker-compose.dbas-sync-test.yml up -d
 # A = http://127.0.0.1:9601 (in-cluster: dispatcharr-a-web:9191)
 # B = http://127.0.0.1:9602 (in-cluster: dispatcharr-b-web:9191)
 ```
 
-> **GOTCHA (0.28.2, still true):** `DISPATCHARR_SUPERUSER_*` in the compose file
-> is **not honored**. Both instances come up showing the first-run "Create your
+> **GOTCHA (0.28.2 and 0.29.0 — re-confirmed 2026-08-20):**
+> `DISPATCHARR_SUPERUSER_*` in the compose file is **not honored**, on the
+> modular stack too. Both instances come up showing the first-run "Create your
 > Super User Account" wizard at `/login`. Complete it in the browser on each —
-> that is the intended UI-driven path and it takes ten seconds.
+> that is the intended UI-driven path and it takes ten seconds — or run
+> `createsuperuser` non-interactively (see the `DJANGO_SECRET_KEY` gotcha).
 
 ### 2. A fake provider both instances can reach
 
@@ -551,9 +583,27 @@ docker image rm ecm-xdmru:<sha>     # optional
 
 ---
 
-# HANDOVER — the documentation environment (bead `enhancedchannelmanager-gk4d0`)
+# HANDOVER — the documentation environment (beads `gk4d0`, `xvuk1`)
 
-**BUILT 2026-08-20.** Everything below is live and disposable. This section is
+**BUILT 2026-08-20. REBUILT FROM SCRATCH 2026-08-20 on Dispatcharr 0.29.0**
+(bead `enhancedchannelmanager-xvuk1`) — the first build was on 0.28.2, which
+`latest` has moved past. Every count, id and md5 below was re-measured on the
+rebuild; where the two builds differ it is called out.
+
+**THE PLATFORM THIS WAS BUILT AND MEASURED ON:**
+
+| Node | `GET /api/core/version/` | Image |
+|---|---|---|
+| Dispatcharr A (source) | `0.29.0` | `ghcr.io/dispatcharr/dispatcharr:latest` = `3621ebe3` |
+| Dispatcharr B (destination) | `0.29.0` | same |
+| Dispatcharr P (XC provider) | `0.29.0` | same |
+| ECM (`ecm-docenv`) | `origin/dev` `dd77d587` | `ecm-docenv:dd77d587` |
+
+`latest` resolved to digest `sha256:df768adc…`, identical on docker.io and
+ghcr.io. Read the version endpoint again yourself before you shoot anything —
+the tag floats, and a screenshot that cannot name its platform is not evidence.
+
+Everything below is live and disposable. This section is
 the contract between the QA engineer who built the environment and the
 technical writer who will screenshot it — it is not a user guide, and it does
 not tell you what to write.
@@ -605,10 +655,12 @@ real one in "just to see how it looks".
 | **provider-northwind** (nginx origin) | *no host port* | `http://provider-northwind/` | `dbas-xc-provider-provider-northwind-1` | none |
 
 Postgres ports, if you ever need them: A `5446`, B `5447`, P `5448`. All three
-Dispatcharr instances run **0.28.2**.
+Dispatcharr instances run **0.29.0** (see the table at the top of this section).
 
 ECM's own config volume is `ecm-docenv-config`; the image is
-`ecm-docenv:dd77d587`. The nginx document root is a **generated** fixture at
+`ecm-docenv:dd77d587`. ECM's first-run setup is already complete and it is
+already pointed at A (`http://dispatcharr-a-web:9191`, password auth,
+`ecmtest-a`). The nginx document root is a **generated** fixture at
 `/home/lecaptainc/ecm-docenv-fixture` (see "Regenerating the fixture" below) —
 it is deliberately outside the repo and is not committed.
 
@@ -620,6 +672,12 @@ Read back from A after its first XC refresh, harvested from P's real XC API:
 status "Active" | exp_date 2026-11-18 (90 days from first auth)
 active_cons "0" | max_connections "4" | allowed_output_formats ["ts","mp4"]
 ```
+
+Re-measured on 0.29.0: `player_api.php` with the right credentials returns
+exactly that; `get_live_categories` → 7, `get_live_streams` → 53,
+`get_vod_streams` / `get_series` → `[]`, `xmltv.php` → 200 / ~756 KB,
+`get.php?type=m3u_plus` → 200 / ~13.7 KB. A wrong password and no credentials
+both return **HTTP 401** `{"error":"Unauthorized"}`.
 
 `max_connections` is 4 because P's `northwind-demo` user has `stream_limit = 4`
 — change the user on P if you want a different number in the shot.
@@ -671,51 +729,76 @@ Regional       850 Northern Counties · 851 Coastal Region One · 852 Valley Pub
 
 ### Everything else on A
 
+> **The ids below are from the 2026-08-20 0.29.0 rebuild and are LOWER than
+> the ones the first build recorded** (the first build created and deleted
+> objects on the way, so its ids had gaps). If a doc or bead quotes M3U account
+> `6`, EPG source `2` or logo `61`, it is quoting the retired 0.28.2 build.
+
 | Thing | Count | Names / ids |
 |---|---|---|
-| M3U accounts | 3 | id 6 **`Northwind IPTV (Xtream Codes)`** (`account_type = XC`, `server_url http://dispatcharr-p-web:9191`, user `northwind-demo`, 53 streams); id 7 `Northwind Local Affiliates (Standard M3U)` (`STD`, 6 streams); id 1 `custom` (Dispatcharr's locked built-in) |
-| EPG sources | 2 | id 2 `Northwind IPTV EPG (Xtream Codes)` — 2,937 programmes / 53 channels; id 3 `Northwind Local XMLTV` — 421 programmes / 6 channels |
-| Channel profiles | 2 | id 2 `Living Room` (all 59 channels); id 3 `Kids & Family` (6 channels — the Kids group only) |
-| Stream profiles | 6 | 5 Dispatcharr built-ins + id 8 `Northwind Direct (ffmpeg)`, which references the custom user agent |
-| User agents | 4 | 3 built-ins (TiviMate, VLC, Chrome) + id 22 `Northwind Set-Top Box` (`NorthwindSTB/2.4 (Linux; documentation-environment)`) |
-| Logos | 60 | 59 remote-URL logos from the provider feed, **plus id 61 `Meridian News (hosted on Dispatcharr)`** |
+| M3U accounts | 3 | id 2 **`Northwind IPTV (Xtream Codes)`** (`account_type = XC`, `server_url http://dispatcharr-p-web:9191`, user `northwind-demo`, 53 streams); id 3 `Northwind Local Affiliates (Standard M3U)` (`STD`, 6 streams); id 1 `custom` (Dispatcharr's locked built-in) |
+| EPG sources | 2 | id 1 `Northwind IPTV EPG (Xtream Codes)` — 2,884 programmes / 53 channels; id 2 `Northwind Local XMLTV` — 421 programmes / 6 channels |
+| Channel profiles | 2 | id 1 `Living Room` (all 59 channels); id 2 `Kids & Family` (6 channels — the Kids group only) |
+| Stream profiles | 6 | 5 Dispatcharr built-ins (ids 1-5) + id 6 `Northwind Direct (ffmpeg)`, which references the custom user agent |
+| User agents | 4 | 3 built-ins (ids 1-3: TiviMate, VLC, Chrome) + id 4 `Northwind Set-Top Box` (`NorthwindSTB/2.4 (Linux; documentation-environment)`) |
+| Logos | 60 | 59 remote-URL logos from the provider feed, **plus id 60 `Meridian News (hosted on Dispatcharr)`** |
+| Channel groups | 10 | id 1 `Default Group` (0 channels) + ids 2-10 in lineup order: News, Sports, Movies, Kids, Documentary, Entertainment, Music, Local, Regional |
 | Server groups | 0 | — |
+| Output profiles | 2 | ids 1-2, `Media Server (AC3 Audio)` and `Web Player (AAC Audio)` — Dispatcharr built-ins on 0.28.2 **and** 0.29.0. The first build never recorded these; they are not new |
 | Dispatcharr users | 1 | `ecmtest-a` |
 
-**The Dispatcharr-hosted logo** is id 61, bound to channel **100 Meridian
+The XC EPG programme count moves with the clock: the fixture XMLTV covers 3 days
+from 00:00 UTC, and P's `xmltv.php` re-serves only the window it still holds, so
+2,884 today is not a contradiction of the 2,937 the first build saw.
+
+**The Dispatcharr-hosted logo** is id 60, bound to channel **100 Meridian
 News**. Its bytes live in **A's own** `/data/logos/meridian-news-hosted.png`
-(md5 `3ba03ea3c50f92ec7a8873e7f5b751b9`) — not in ECM's `/config/uploads/logos/`,
-which is empty and must stay that way. That distinction is the whole point of
-bead `cfxml`; if you re-upload a logo, upload it through **A's** Logo Manager.
+(md5 `f7e3278711ad164d1fd9c1e6324d81bc`, 7,180 bytes — the fixture's
+`logos/meridian-news.png` uploaded verbatim; the retired build's copy was a
+re-encode, md5 `3ba03ea3…`) — not in ECM's `/config/uploads/logos/`, which is
+empty and must stay that way. That distinction is the whole point of bead
+`cfxml`; if you re-upload a logo, upload it through **A's** Logo Manager.
 
 ## What is on instance P (you will rarely need to open it)
 
 53 channels / 53 streams / 8 groups (7 populated + `Default Group`), all with
-logos and all linked to EPG. One STD M3U account `Northwind Origin Feed`
-reading the nginx `playlist.m3u`, one EPG source `Northwind XMLTV` (3,608
-programmes), one custom user agent `Northwind Fixture Agent`, and two users:
-the admin `ecmtest-p` and the XC-facing `northwind-demo`.
+logos and all linked to EPG, numbered exactly as A numbers them (100-107,
+200-209, 300-308, 400-405, 500-506, 600-607, 700-704). One STD M3U account
+id 2 `Northwind Origin Feed` reading the nginx `playlist.m3u`, one EPG source
+id 1 `Northwind XMLTV` (3,608 programmes / 53 channels), one custom user agent
+id 4 `Northwind Fixture Agent`, and two users: the admin `ecmtest-p` (id 1) and
+the XC-facing `northwind-demo` (id 2, `stream_limit = 4`, `user_level = 1`,
+`custom_properties.xc_password`).
 
 P exists only to be a believable provider. The writer's screenshots are of ECM
 and, where the guide needs them, of A and B.
 
 ## Instance B — the sync destination, currently EMPTY
 
-B is reset and holds the fresh-0.28.2 baseline, **which is not zero of
-everything** — record these as "empty" when captioning:
+B was reset **after** the 0.29.0 fidelity measurement below and holds the
+fresh-0.29.0 baseline, **which is not zero of everything** — record these as
+"empty" when captioning. Every number here was read straight out of B's
+Postgres, not from an API:
 
 ```
 0 channels · 0 streams · 0 channel groups · 0 channel profiles · 0 logos
-0 EPG sources · 0 server groups
+0 EPG sources · 0 server groups · 0 EPG programmes
 3 user agents (ids 1-3: TiviMate, VLC, Chrome)
 5 stream profiles (ids 1-5: ffmpeg, streamlink, Proxy, Redirect, VLC)
+2 output profiles (ids 1-2: Media Server (AC3 Audio), Web Player (AAC Audio))
 1 M3U account (id 1, `custom`, Dispatcharr's locked built-in)
 1 user (`ecmtest-b`)
 ```
 
 Those id ranges matter: an artifact that lands on B with an id **outside** 1-3
-(user agents) or 1-5 (stream profiles) is one the sync created, not one that
-was already there.
+(user agents), 1-5 (stream profiles) or 1 (M3U accounts) is one the sync
+created, not one that was already there. Note `Default Group` is **not**
+present on a fresh instance — it appears the moment something creates an M3U
+account, so its arrival on B is a sync side effect, not a pre-existing row.
+
+**The destination is unspent.** The one apply-mode run recorded below was
+followed by a full container+volume reset, so nothing on B has been written by
+a sync.
 
 **No sync target exists in ECM.** That is deliberate — creating it is part of
 the workflow you are documenting, so you get to walk and shoot that path
@@ -726,11 +809,11 @@ yourself. Point it at `http://dispatcharr-b-web:9191` with B's credentials.
 You will want a clean destination more than once. From `tests/dbas-test-env`:
 
 ```bash
-DISPATCHARR_VERSION=0.28.2 docker compose -p dbas-sync-testenv \
+docker compose -p dbas-sync-testenv \
   -f docker-compose.dbas-sync-test.yml \
   rm -sf dispatcharr-b-web dispatcharr-b-celery dispatcharr-b-db dispatcharr-b-redis
 docker volume rm dbas-sync-testenv_dbas-sync-b-data dbas-sync-testenv_dbas-sync-b-pg
-DISPATCHARR_VERSION=0.28.2 docker compose -p dbas-sync-testenv \
+docker compose -p dbas-sync-testenv \
   -f docker-compose.dbas-sync-test.yml up -d \
   dispatcharr-b-db dispatcharr-b-redis dispatcharr-b-web dispatcharr-b-celery
 
@@ -744,11 +827,13 @@ docker exec dbas-sync-testenv-dispatcharr-b-web-1 sh -c '
   python manage.py createsuperuser --noinput'
 ```
 
-**`DISPATCHARR_VERSION=0.28.2` is not optional.** The compose file's default is
-`0.26.0`; omit the variable and B silently comes back a minor version behind A,
-which is a different (out-of-scope) test matrix. This bit the build — B came up
-0.26.0 on the first reset and had to be torn down again. Confirm with
-`curl -s http://127.0.0.1:9602/api/core/version/` every time.
+**Pass no version flag.** The compose default is `latest`, which is what A and
+P are running, so a bare reset brings B back on the same platform they are on.
+Confirm it anyway — `curl -s http://127.0.0.1:9602/api/core/version/` — and
+record the answer with whatever you measured. (This used to read
+"`DISPATCHARR_VERSION=0.28.2` is not optional", because the old default was
+`0.26.0` and a reset silently came back a minor version behind A. That default
+is gone; the instruction is now the opposite one.)
 
 After a reset, ECM's existing sync target still points at B correctly, but B's
 JWT changed — the next run re-authenticates on its own.
@@ -756,13 +841,26 @@ JWT changed — the next run re-authenticates on its own.
 ## Traps — read before you spend an hour on one of these
 
 **1. B throttles `/api/accounts/token/` to roughly 3 requests per minute.**
+**Re-measured on 0.29.0, 2026-08-20 — it carried over, do not assume it stays
+that way.** Sequential token POSTs: requests 1-3 returned `200`, request 4
+returned `429` `{"detail":"Request was throttled. Expected available in 57
+seconds."}`. 0.29.0 ships a NEW `apps/accounts/throttling.py`, so this is a
+re-implementation that happens to land on the same rate — re-measure it after
+every platform move rather than quoting this paragraph.
+
 Pace anything that authenticates against B, and cache the token rather than
 re-authenticating per request. A self-inflicted `429` surfaces as
 `partial_failed_rolled_back` and has been misread as a code failure twice. One
-operation at a time; never reset B while a run is in flight.
+operation at a time; never reset B while a run is in flight. The same throttle
+is live on A and P — a script that re-authenticates per process (rather than
+caching the token to disk) will trip it against P during a fixture rebuild.
 
-**2. A fresh Dispatcharr can import an entire playlist as ONE stream.** This
-cost real time during the build. Dispatcharr caches its settings groups in
+**2. A fresh Dispatcharr can import an entire playlist as ONE stream.**
+**Still live on 0.29.0 — confirmed 2026-08-20 on ALL THREE fresh instances.**
+Immediately after first boot, A, B and P each had `m3u_hash_key: "url"` in
+Postgres and `m3u_hash_key: ""` in the Redis cache. Bust the cache on every
+fresh instance **before the first M3U refresh**; it is a required build step,
+not a rescue. This cost real time during the first build. Dispatcharr caches its settings groups in
 Redis, and on a first boot the `stream_settings` group can be cached **before**
 the migration writes it — so `m3u_hash_key` reads as `""` instead of `"url"`,
 `"".split(",")` yields `[""]`, the per-stream hash payload is the empty dict,
@@ -788,12 +886,13 @@ publishes `epg_channel_id` as the **channel number** (`"100"`, `"101"`, …), no
 `meridian-news.northwind.example`. So on A, the 53 XC channels have
 `tvg_id = "100"`-style ids and match **P's XC XMLTV**
 (`http://dispatcharr-p-web:9191/xmltv.php?username=…&password=…`), which is
-exactly what EPG source id 2 points at. The 6 Standard-M3U channels keep the
+exactly what EPG source id 1 points at (id 2 on the retired 0.28.2 build).
+**Re-confirmed on 0.29.0.** The 6 Standard-M3U channels keep the
 real slug ids and match `local-epg.xml`. Do not "fix" A by pointing the XC
 lineup at `http://provider-northwind/epg.xml` — nothing will match.
 
 **4. Dispatcharr returns `403`, not `404`, for an API path that does not
-exist.** `/api/m3u/accounts/6/refresh/` and
+exist.** `/api/m3u/accounts/2/refresh/` and
 `/api/channels/channels/from-stream/bulk` (no trailing slash) both answer 403
 and look like a permissions problem. The real routes are
 `/api/m3u/refresh/<account_id>/` and
@@ -821,6 +920,18 @@ whole page for it, not just the Channels pane.
 **10. Dispatcharr's bulk channel creation is asynchronous.** The POST returns a
 `task_id` immediately; poll `/api/channels/channels/` until the count settles
 rather than reading the response as the result.
+
+**11. SCREENSHOT HAZARD — Dispatcharr's sidebar renders the host's REAL PUBLIC
+IP.** A previous capture of B included it. Nothing in CI can catch this: a byte
+scanner cannot see pixels (bead `enhancedchannelmanager-wfz8z`, where a live
+`mcp_api_key` was found inside a committed image, invisible to gitleaks,
+detect-secrets and GitHub secret scanning alike). **Suppress or crop it on
+EVERY capture of B and of P**, and check A too. Crop the sidebar out, or blank
+the element in devtools before the shot — do not rely on noticing it later.
+
+**12. `/api/version`'s `git_commit` is baked-in build metadata, not what is
+running.** It has misled three engineers on this work. Prove the deployed tree
+by checksum instead — see the verification table at the end of this section.
 
 ## Regenerating the fixture
 
@@ -854,8 +965,8 @@ If the host reboots, or containers with `RestartPolicy=no` get stopped:
 ```bash
 cd tests/dbas-test-env
 
-# A and B (pin the version — see trap 1):
-DISPATCHARR_VERSION=0.28.2 docker compose -p dbas-sync-testenv \
+# A and B (no version flag — the compose default is `latest`):
+docker compose -p dbas-sync-testenv \
   -f docker-compose.dbas-sync-test.yml up -d
 
 # P and the nginx origin (joins A/B's network, so bring A/B up FIRST):
@@ -868,6 +979,30 @@ until curl -fsS http://127.0.0.1:6400/api/health/ready >/dev/null; do sleep 3; d
 ```
 
 All persistent state is in named volumes, so nothing needs rebuilding.
+
+**A bare `up -d` reuses the locally-cached `latest`.** That is deliberate — it
+keeps a cold restart from silently moving the platform under a screenshot run in
+progress. When you *do* mean to be current, pull first and then re-read every
+version endpoint:
+
+```bash
+docker compose -p dbas-sync-testenv -f docker-compose.dbas-sync-test.yml pull
+NORTHWIND_FIXTURE_DIR=/home/lecaptainc/ecm-docenv-fixture \
+  docker compose -p dbas-xc-provider -f docker-compose.xc-provider.yml pull
+for port in 9601 9602 9603; do curl -s "http://127.0.0.1:$port/api/core/version/"; echo; done
+```
+
+If ECM's container is gone rather than merely stopped, this is the run line it
+was created with:
+
+```bash
+docker run -d --name ecm-docenv \
+  --network dbas-sync-testenv_default \
+  -p 127.0.0.1:6400:6400 \
+  -e ECM_PORT=6400 -e ECM_HTTPS_PORT=6443 -e CONFIG_DIR=/config -e PUID=1000 -e PGID=1000 \
+  -v ecm-docenv-config:/config \
+  ecm-docenv:dd77d587
+```
 
 ## Tearing the whole thing down
 
@@ -895,39 +1030,122 @@ environment.
 
 ## What was verified when this was built, and how
 
-Recorded so a later reader can tell a checked claim from an assumed one.
+Recorded so a later reader can tell a checked claim from an assumed one. Every
+row below was re-run on the **2026-08-20 0.29.0 rebuild** — this is not the
+0.28.2 table carried forward.
 
 | Claim | How it was checked |
 |---|---|
-| ECM runs `origin/dev` `dd77d587` | **Not** `/api/version` (that is baked-in build metadata and has misled three engineers). All **244** non-test `backend/**.py` files were sha256'd inside the container against `git show dd77d587:<path>`: **244 OK, 0 mismatched, 0 absent.** |
-| …and that checksum harness can actually fail | Two known-bad runs. Compared against an older revision (29 differing files) → **29 MISMATCH**. Then a byte was appended to `/app/main.py` in the live container → **exactly 1 MISMATCH**, restored → back to 244/244. (A first attempt to use the parent commit `b867538a` as the known-bad was **vacuous** — `dd77d587` is its merge commit, so 0 files differ and the check had no signal. Vacuous known-bads are the failure this table exists to prevent.) |
-| A's account really is XC | Read `account_type` from **A's Postgres directly** (`select account_type from m3u_m3uaccount`) → `XC`, not from a serializer that could be defaulting. Cross-checked in ECM's own UI: the M3U Manager renders the badge **`XtreamCodes`** on account 6 and **`Standard M3U`** on account 7. |
-| P is a genuine XC server | `player_api.php` with correct credentials returns a real `user_info` (auth 1, Active, exp_date, active_cons, max_connections); with a wrong password and with no credentials it returns **HTTP 401** `{"error":"Unauthorized"}`. Both poles from the same endpoint. `get_live_categories` → 7, `get_live_streams` → 53, `xmltv.php` → 200/776 KB, `get.php` → 200/13.7 KB. |
-| The A→B sync path works with an XC account in the mix | **Dry-run preview only** — no writes to B. Wrong password → `success=False`, `SYNC_DESTINATION_UNREADABLE`. Correct password → `success=True`, *"would create 78, update 0, skip 9, 0 conflict(s) across 9 categories"*. B re-read afterwards: still **0 channels / 0 streams / 0 groups / 0 logos / 0 EPG sources.** The temporary sync target and all 6 resulting notifications were then deleted, so ECM has no sync history for you to work around. (ECM's own scheduled tasks — the M3U Change Monitor in particular — keep producing routine notifications; those are normal, not leftovers. Clear them before a notifications screenshot with `DELETE /api/notifications?read_only=false`.) |
-| The Dispatcharr client used to build all this could report failure | Smoke-tested before use: known-good returns real JSON and exits 0; a nonexistent path and an unreachable host both exit **1** loudly. It never degrades an error into "0 rows". |
-| nginx is serving what we think | Real files return 200 with non-zero sizes; a bogus path returns **404** — checked again after the fixture was relocated. |
-| Playwright is pointed at a live app | Navigating to a dead port errors before any real page was read. The Channel Manager then rendered **"59 channels"** and all 9 Northwind groups. |
-| The committed generator matches the live fixture | `playlist.m3u`, `local.m3u` and all **59** logos compare byte-identical; the two XMLTV files match on the same UTC day. |
-| Production is untouched | `ecm-ecm-1` and `ecm-ecm-mcp-1` still `Exited`, with `FinishedAt` timestamps predating this session and no `StartedAt` since. Production `dispatcharr` still `Up`, unchanged, on `dispatcharr-green_default` — a different network from `dbas-sync-testenv_default`. |
+| Every node is on `0.29.0` | `GET /api/core/version/` on A (`:9601`), B (`:9602`) and P (`:9603`) each returned `{"version":"0.29.0"}`. The image behind all three is `ghcr.io/dispatcharr/dispatcharr:latest` = `3621ebe3`, digest `sha256:df768adc…`, and `docker pull` confirmed docker.io and ghcr.io agree on that digest. |
+| The compose default really is `latest`, and the override really works | `docker compose config` resolves `ghcr.io/dispatcharr/dispatcharr:latest` with no variable set, and `ghcr.io/dispatcharr/dispatcharr:0.28.2` with `DISPATCHARR_VERSION=0.28.2` — both poles, both files. Then proven live: B was reset with **no flag** and came back `0.29.0`, which is exactly the failure the old `0.26.0` default caused. |
+| ECM runs `origin/dev` `dd77d587` | **Not** `/api/version` (baked-in build metadata; it has misled three engineers). Two passes, both `sha256sum` inside the container against `git show dd77d587:<path>`: **243 non-test `backend/**.py` → 243 OK / 0 MISMATCH / 0 ABSENT**, and **all 698 `backend/**.py` including tests → 698 OK / 0 MISMATCH / 0 ABSENT**, with **0** `.py` files in `/app` that are not in the ref. (The retired build's "244" counted `backend/test_dispatcharr_api.py`, a top-level test file this filter excludes: 243 + 1 = 244, reconciled.) |
+| …and that checksum harness can actually fail | Two known-bad runs, exit status captured directly rather than through a pipe. (1) Compared against `b0e0a5ad`, 30 first-parent commits back → **48 MISMATCH**, harness exit 1. (2) A byte appended to `/app/main.py` in the live container → **exactly 1 MISMATCH** on `main.py`, harness exit 1; restored → **243 OK**, exit 0. (A previous attempt to use the parent commit `b867538a` as the known-bad was **vacuous** — `dd77d587` is its merge commit, so 0 files differ. Vacuous known-bads are the failure this table exists to prevent.) |
+| The Dispatcharr client used to build all this could report failure | Smoke-tested against four poles before use: known-good returns real JSON; a nonexistent path, an unreachable host, and a wrong password each raise loudly. It never degrades an error into "0 rows". |
+| The DB reader could report failure | The counters below come from `psql` against A's and B's Postgres directly, no API in the path. A bogus table name produces `ERROR: relation ... does not exist` in the cell, not `0`. Its B column went from all-zero to non-zero across the apply and back to all-zero after the reset, so it is not structurally stuck. |
+| A's account really is XC | Read `account_type` from **A's Postgres directly** (`select id, name, account_type from m3u_m3uaccount`) → id 2 `XC`, id 3 `STD`, id 1 `STD` — not from a serializer that could be defaulting. |
+| **The XC server side survived the 0.29.0 bump** | `dispatcharr/urls.py` still routes `player_api.php` → `xc_player_api`, `panel_api.php` → `xc_panel_api`, `get.php` → `xc_get`, `xmltv.php` → `xc_xmltv`, all still defined in `apps/output/views.py`. The module changed between versions but the surface the provider design depends on did not move, and 0.29.0 *added* XC coverage (`apps/output/tests/test_xc_series_info.py`, `test_xc_vod_info.py`). Then proven live, both poles: `player_api.php` with the right credentials returns a real `user_info` (auth 1, Active, `exp_date` 2026-11-18, `active_cons` 0, `max_connections` 4); a wrong password and no credentials each return **HTTP 401** `{"error":"Unauthorized"}`. `get_live_categories` → 7, `get_live_streams` → 53, `xmltv.php` → 200 / 755,706 bytes, `get.php?type=m3u_plus` → 200 / 13,719 bytes. |
+| nginx is serving what we think | From inside P: `playlist.m3u` 200/12,587, `local.m3u` 200/1,499, `epg.xml` 200/1,089,386, a logo 200/7,180 — and a bogus path **404**. Both poles. |
+| The committed generator reproduces the fixture | `northwind-fixture.py` was re-run into a wiped directory and produced 53 + 6 channels and **59** logos, the same lineup the handover captions. |
+| ECM is actually talking to A | `/api/health/ready` reports `dispatcharr: reachable (HTTP 200)`; `GET /api/channels` returns **count 59**. Login was proven both poles: correct password 200, wrong password **401**. |
+| Production is untouched | `ecm-ecm-1` and `ecm-ecm-mcp-1` are still `exited`, `FinishedAt 2026-08-20T03:12`, with no `StartedAt` after it. Production `dispatcharr` is still `Up` on `dispatcharr-green_default` — a different network from `dbas-sync-testenv_default` — on image id `1f55137b`, which it has held since `03:13`. |
+
+### The 0.29.0 replica-fidelity measurement (epic `enhancedchannelmanager-f5a5j`)
+
+Epic `f5a5j` was diagnosed on 0.28.2 and explicitly requires re-confirmation
+before any member is treated as diagnosed. **This is that re-confirmation, taken
+on 0.29.0.** One apply-mode run, `A → B`, sync target `sync_logos: true`,
+`confirm_apply: true`, `cloud_credential_version: 1`. What the run reported:
+
+```
+outcome success | 146 items | created 134 | updated 0 | failed 0 | skipped 12 | 3.7s
+
+category            created  updated  skipped  failed
+user_agent                1        0        3       0   (3x already_exists_identical)
+m3u_account               2        0        1       0   (custom, already_exists_identical)
+epg_source                2        0        0       0
+channel_group             7        0        3       0   (3x already_exists_name_match)
+channel_profile           2        0        0       0
+stream_profile            1        0        5       0   (5x already_exists_identical)
+channel                  59        0        0       0
+stream                   59        0        0       0
+logo                      1        0        0       0
+```
+
+Both databases read directly afterwards (`psql`, no API in the path):
+
+```
+                          A      B
+channels                 59     59
+streams                  59     59
+groups                   10     10
+channel profiles          2      2
+EPG sources               2      2
+channels with an EPG link 59      6
+channels with a logo     59      0
+logos present at all     60      1
+```
+
+EPG source `url`, both sides:
+
+```
+A  1 | Northwind IPTV EPG (Xtream Codes) | http://dispatcharr-p-web:9191/xmltv.php?username=northwind-demo&password=not-a-real-password
+A  2 | Northwind Local XMLTV             | http://provider-northwind/local-epg.xml
+B  1 | Northwind IPTV EPG (Xtream Codes) | <EMPTY>
+B  2 | Northwind Local XMLTV             | http://provider-northwind/local-epg.xml
+```
+
+**The 0.28.2 finding reproduces exactly on 0.29.0**: the credential-bearing XC
+URL is stripped to empty on the destination while the credential-free one
+crosses intact. B's EPG source 1 is left in `status = error`, *"No URL provided
+and no valid local file exists"*.
+
+What else the direct read showed, all of it measured, none of it fixed here:
+
+- **Channel → logo binding does not cross** (bead `xgbjm`, still open). 59
+  channels on A carry a `logo_id`; **0** on B.
+- **Only 1 of A's 60 logo records landed on B** — the Dispatcharr-hosted one.
+  A's other 59 are remote-URL logos and no record was created for them. The
+  retired 0.28.2 note said "logo records and bytes land on B"; on this run they
+  did not. Treat that older sentence as superseded, not as a regression claim —
+  the two runs differed in `sync_logos` and are not a controlled comparison.
+- **EPG programme data does not cross, and B's sources are not re-imported.**
+  B ends with 6 `epg_epgdata` rows and **0** `epg_programdata` rows. Its usable
+  source imported before any channel was linked, so it still reports *"No
+  channels mapped"*.
+- **Channel-profile membership *enablement* does not cross.** A: `Living Room`
+  59/59 enabled, `Kids & Family` **6**/59 enabled. B: `Living Room` 59/59,
+  `Kids & Family` **59**/59. Both profiles arrive with all 59 channels enabled,
+  so the destination's `Kids & Family` is not the profile the source has.
+- **Provider attribution does not cross.** All 59 streams on B hang off a
+  synthesized 4th M3U account, `ECM Custom Streams (DBAS restore)` (`STD`, empty
+  `server_url`) — not off the replicated XC account (id 2) or STD account
+  (id 3), both of which arrive but hold 0 streams.
+- **`Default Group` on B is a sync side effect.** A fresh instance has zero
+  channel groups; the group appears once an M3U account is created, and the run
+  then reports it as `already_exists_name_match`.
+
+**B was reset to empty immediately after this measurement** (container + volume
+destroyed, superuser re-created, `stream_settings` cache busted), the temporary
+sync target was deleted, and ECM's notifications were cleared. The destination
+the writer receives is unspent.
 
 ### What this environment does NOT cover
 
-- **No apply-mode sync has been run.** Only a dry-run preview. The first real
-  A→B apply will be the writer's, which is the intent — but it means the apply
-  path has not been exercised *with an XC account on A* by anyone yet. The
-  preview says it plans 78 creates across 9 categories; if the apply disagrees,
-  that is new information, not a known-good regression.
-- **The channel→logo binding does not cross the sync** (bead
-  `enhancedchannelmanager-xgbjm`, still open). Logo records and bytes land on B,
-  but every synced channel there shows `logo_id null` and B's Logo Manager reads
-  `UNUSED`. Do not write the guide as though it works.
+- **The apply path has now been exercised once, by QA, and B was reset after.**
+  The writer's own apply will be the first one whose output is documented. The
+  numbers above are what to expect; a disagreement is new information.
 - **VOD and Series are empty.** P serves `get_vod_streams` / `get_series` as
   empty lists, so ECM's VOD surfaces have nothing to show. Populating them was
-  out of scope.
+  out of scope — note that 0.29.0 added real VOD/series work
+  (`apps/vod/image_proxy.py`, `vod_...0005_movie_is_adult`), so this is a bigger
+  gap on this platform than it was on 0.28.2.
 - **No stream actually plays.** The `.ts` URLs in the fixture are 404s — nginx
-  serves no `/stream/` directory. Everything about lineup management,
-  EPG, profiles and sync is real; anything that requires a live video
-  transport (probing, bitrate, playback) is not.
+  serves no `/stream/` directory. Everything about lineup management, EPG,
+  profiles and sync is real; anything that requires a live video transport
+  (probing, bitrate, playback) is not.
+- **No screenshots were taken on this rebuild.** Re-shooting the guide is bead
+  `enhancedchannelmanager-x4eoi`, which resumes after this. Read trap 11 before
+  the first capture.
 - **ECM's first-run walkthrough has already been completed here.** The admin
   account exists and the Dispatcharr connection is set. If you need to shoot
   Getting Started from a genuinely blank ECM, do it against a throwaway second
@@ -935,3 +1153,8 @@ Recorded so a later reader can tell a checked claim from an assumed one.
   `docker rm -f ecm-docenv && docker volume rm ecm-docenv-config` then re-run
   the `docker run` from "Bringing the environment back up" with a fresh volume —
   but you will then have to re-create the admin and re-point it at A.
+- **Playwright was not exercised on this rebuild**, so unlike the first build
+  there is no rendered-browser evidence in the table above. The ECM API was
+  proven live (count 59) but nothing rendered a page.
+- **`docker-compose.dbas-test.yml`, the single-instance stack, still defaults to
+  `0.26.0`.** It was out of scope for `xvuk1` and nothing here validates it.

--- a/tests/dbas-test-env/capture-snapshot.sh
+++ b/tests/dbas-test-env/capture-snapshot.sh
@@ -31,6 +31,12 @@
 # Output: tests/dbas-test-env/seed/dispatcharr-seed.sql.gz
 #         tests/dbas-test-env/seed/SNAPSHOT_MANIFEST.txt  (row counts + meta)
 #
+# The manifest stamps the Dispatcharr version READ from the running instance
+# (GET /api/core/version/, via DBAS_SNAPSHOT_BASE_URL / DBAS_TEST_BASE_URL, else
+# http://localhost:${DBAS_TEST_HTTP_PORT:-9591}). This directory tracks
+# `dispatcharr:latest`, so there is nothing to pin; if the endpoint cannot be
+# read the manifest says "unknown" rather than stamping a guess.
+#
 # NOTE: the .sql.gz snapshot is intentionally NOT committed (see seed/.gitignore)
 # — it is large and machine-local. The MANIFEST and the loader scripts ARE the
 # committed, reviewable artifacts. Regenerate the snapshot on demand.
@@ -63,6 +69,35 @@ dump_via_testenv_container() {
     pg_dump -U dispatch -d dispatcharr --no-owner --no-privileges --clean --if-exists
 }
 
+# Read the Dispatcharr version from the RUNNING instance. This directory tracks
+# `dispatcharr:latest` (PO decision, bead enhancedchannelmanager-xvuk1), so there
+# is no version to hardcode — a stamped guess would mislabel every snapshot.
+# Prints the version, or the literal string "unknown (could not read <url>)" so
+# that "did not run" stays distinguishable from a real value. Never invents one.
+read_dispatcharr_version() {
+  local url="${DBAS_SNAPSHOT_BASE_URL:-${DBAS_TEST_BASE_URL:-http://localhost:${DBAS_TEST_HTTP_PORT:-9591}}}"
+  url="${url%/}/api/core/version/"
+  local body version
+  if ! body="$(curl -fsS --max-time 10 "${url}" 2>/dev/null)"; then
+    echo "unknown (could not read ${url})"
+    return 0
+  fi
+  version="$(printf '%s' "${body}" \
+    | python3 -c 'import json,sys
+try:
+    p = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+v = p.get("version") if isinstance(p, dict) else (p if isinstance(p, str) else None)
+if not isinstance(v, str) or not v.strip():
+    sys.exit(1)
+print(v.strip())' 2>/dev/null)" || {
+    echo "unknown (no version field at ${url})"
+    return 0
+  }
+  printf '%s\n' "${version}"
+}
+
 echo "[capture] mode=${MODE} -> ${OUT}"
 case "${MODE}" in
   live)     dump_via_psql_env       | gzip -9 > "${OUT}" ;;
@@ -71,11 +106,13 @@ case "${MODE}" in
 esac
 
 # Build a reviewable manifest (row counts of the round-trip-relevant tables).
-# Table names below are best-effort; adjust to the pinned schema on first run.
+# Table names below are best-effort; adjust to the running schema on first run.
+DISPATCHARR_VERSION_READ="$(read_dispatcharr_version)"
+echo "[capture] dispatcharr version (read from the instance): ${DISPATCHARR_VERSION_READ}"
 {
   echo "# Dispatcharr DBAS seed snapshot manifest"
   echo "# captured: $(date -u +%Y-%m-%dT%H:%M:%SZ)  mode=${MODE}"
-  echo "# dispatcharr version pin: ${DISPATCHARR_VERSION:-0.26.0}"
+  echo "# dispatcharr version (READ from the running instance, not a pin): ${DISPATCHARR_VERSION_READ}"
   echo "# file: $(basename "${OUT}")  size: $(du -h "${OUT}" | cut -f1)"
   echo "#"
   echo "# Row counts (the categories the round-trip must reproduce):"

--- a/tests/dbas-test-env/docker-compose.dbas-sync-test.yml
+++ b/tests/dbas-test-env/docker-compose.dbas-sync-test.yml
@@ -25,11 +25,26 @@
 # fully-isolated stacks. A = the sync SOURCE, B = the sync DESTINATION (managed
 # replica). One-way only (A -> B); B never writes back to A (ADR-013 S3).
 #
-# Version pin — same as the single-instance stack
-# -----------------------------------------------
-# Both instances pin Dispatcharr ${DISPATCHARR_VERSION:-0.26.0} (the operator's
-# live version). Mixed-version A/B sync is a SEPARATE matrix dimension and is out
-# of scope for this scaffold — A and B are the SAME version here.
+# Version — TRACKS `latest` LITERALLY (PO decision, bead
+# enhancedchannelmanager-xvuk1)
+# -----------------------------------------------------------------------------
+# Both instances run `ghcr.io/dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-latest}`.
+# `latest` is the DEFAULT so nobody has to remember a flag, and ghcr.io is the
+# registry the operator's production Dispatcharr actually pulls from, so the test
+# env and production resolve the same artifact.
+#
+#   * To deliberately reproduce an OLD finding, pass the override explicitly:
+#       DISPATCHARR_VERSION=0.28.2 docker compose -p dbas-sync-testenv ... up -d
+#   * `:latest` is only as fresh as your last pull. `docker compose up` reuses a
+#     locally-cached `latest`; run `docker compose ... pull` first when you mean
+#     to be current.
+#   * BECAUSE the tag floats, every validation run MUST read and report the
+#     version it actually ran against:
+#       curl -s http://127.0.0.1:9601/api/core/version/
+#     A run that cannot name its Dispatcharr is not a result.
+#
+# Mixed-version A/B sync is a SEPARATE matrix dimension and is out of scope for
+# this scaffold — A and B are the SAME version here.
 #
 # Isolation contract (NON-NEGOTIABLE — must never touch ecm-ecm-1 OR the single-
 # instance dbas-testenv stack)
@@ -49,13 +64,13 @@
 name: dbas-sync-testenv
 
 x-dispatcharr-web: &dispatcharr-web-base
-  image: dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-0.26.0}
+  image: ghcr.io/dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-latest}
   restart: "no"
   extra_hosts:
     - "host.docker.internal:host-gateway"
 
 x-dispatcharr-celery: &dispatcharr-celery-base
-  image: dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-0.26.0}
+  image: ghcr.io/dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-latest}
   restart: "no"
   entrypoint: ["/app/docker/entrypoint.celery.sh"]
   extra_hosts:

--- a/tests/dbas-test-env/docker-compose.dbas-test.yml
+++ b/tests/dbas-test-env/docker-compose.dbas-test.yml
@@ -1,5 +1,5 @@
 # =============================================================================
-# DBAS round-trip test stack — a pinned, throwaway Dispatcharr instance
+# DBAS round-trip test stack — a throwaway Dispatcharr instance on `latest`
 # =============================================================================
 #
 # Purpose
@@ -18,25 +18,34 @@
 # resources (no networks, no volumes, no ports, no project name) with the
 # production stack or the live ecm-ecm-1 container.
 #
-# Version pin
-# -----------
-# Pinned to Dispatcharr 0.26.0 — the operator's live instance version
-# (GET /api/core/version/ -> 0.26.0; spike enhancedchannelmanager-tsfv0).
+# Version — TRACKS `latest` LITERALLY (PO decision, bead
+# enhancedchannelmanager-xvuk1)
+# -----------------------------------------------------------------------------
+# Runs `ghcr.io/dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-latest}` — the
+# same default as docker-compose.dbas-sync-test.yml (A + B) and
+# docker-compose.xc-provider.yml (P), so everything under tests/dbas-test-env/
+# resolves the same artifact. ghcr.io is the registry the operator's production
+# Dispatcharr pulls from. There is NO hand-maintained version pin here any more;
+# do not reinstate one.
+#
+#   * `latest` is the DEFAULT so nobody has to remember a flag.
+#   * To deliberately reproduce an OLD finding, pass the override explicitly:
+#       DISPATCHARR_VERSION=0.28.2 docker compose -p dbas-testenv ... up -d
+#   * `:latest` is only as fresh as your last pull. `docker compose up` reuses a
+#     locally-cached `latest`; run `docker compose ... pull` first when you mean
+#     to be current.
+#   * BECAUSE the tag floats, every validation run MUST read and report the
+#     version it actually ran against:
+#       curl -s http://127.0.0.1:9591/api/core/version/
+#     A run that cannot name its Dispatcharr is not a result. Do NOT read
+#     /api/version's git_commit as proof of what is running — that is baked-in
+#     build metadata and has misled three engineers on this work.
+#
 # The ECM code encodes a 0.23.0+ behavioral FLOOR (config.py login throttle;
 # auth/providers/dispatcharr.py /api/accounts/users/me/ with /api/accounts/me/
-# fallback); 0.26.0 is the validation TARGET. Re-validate the 0.23.0-era
-# behaviors against 0.26.0 — they may have changed across 0.24–0.26.
-#
-# Bump procedure: when the operator upgrades, change DISPATCHARR_VERSION in
-# .env (or override at the command line) and re-run the validation suite. The
-# digest pin in the comment below should be refreshed at the same time for an
-# immutable-tag guarantee.
-#
-# Image: dispatcharr/dispatcharr (Docker Hub) — mirror of
-#        ghcr.io/dispatcharr/dispatcharr.
-#   0.26.0 digest (2026-06-07):
-#   sha256:9275b0c1f5319a84b412af6839a1364ef25b61d8d6ff0d2130a6c2b2504a8b07
-#   For an immutable pin in CI, replace the tag with @<digest>.
+# fallback). Whatever `latest` resolves to is the validation TARGET; re-run
+# validate-version-behaviors.py after any platform move and record the version
+# the run reported.
 #
 # Isolation contract (NON-NEGOTIABLE — must never touch ecm-ecm-1)
 # ----------------------------------------------------------------
@@ -58,7 +67,7 @@ services:
   # talks to. Exposed on host 9591 (NOT the operator's 9191).
   # ---------------------------------------------------------------------------
   dispatcharr-web:
-    image: dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-0.26.0}
+    image: ghcr.io/dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-latest}
     restart: "no"
     ports:
       - "${DBAS_TEST_HTTP_PORT:-9591}:9191"
@@ -103,7 +112,7 @@ services:
   # validated — the whole point of this stack.
   # ---------------------------------------------------------------------------
   dispatcharr-celery:
-    image: dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-0.26.0}
+    image: ghcr.io/dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-latest}
     restart: "no"
     depends_on:
       dispatcharr-db:

--- a/tests/dbas-test-env/docker-compose.xc-provider.yml
+++ b/tests/dbas-test-env/docker-compose.xc-provider.yml
@@ -30,6 +30,26 @@
 #     A/B stack up FIRST — this file does not create that network.
 #   * Everything is throwaway. Tear down with `-v`.
 #
+# Version — TRACKS `latest` LITERALLY (PO decision, bead
+# enhancedchannelmanager-xvuk1)
+# -----------------------------------------------------------------------------
+# P runs `ghcr.io/dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-latest}`, the
+# same default as the A/B stack, so A, B and P are the same artifact unless you
+# deliberately override. ghcr.io is the registry production pulls from.
+#
+#   * Override only to reproduce an old finding:
+#       DISPATCHARR_VERSION=0.28.2 docker compose -p dbas-xc-provider ... up -d
+#   * `:latest` is only as fresh as your last pull — `docker compose ... pull`
+#     first when you mean to be current.
+#   * Every validation run MUST read and report the version it ran against:
+#       curl -s http://127.0.0.1:9603/api/core/version/
+#
+# P depends on Dispatcharr implementing the XC SERVER side. Re-confirm that on
+# any platform bump before assuming the provider design survives:
+#   docker run --rm --entrypoint sh ghcr.io/dispatcharr/dispatcharr:latest -c \
+#     'grep -c xc_player_api /app/dispatcharr/urls.py /app/apps/output/views.py'
+# Confirmed present on 0.29.0 (bead enhancedchannelmanager-xvuk1).
+#
 # The nginx document root is a GENERATED fixture — build it first with
 #   python3 northwind-fixture.py <dir>
 # and point NORTHWIND_FIXTURE_DIR at it (see the README HANDOVER section).
@@ -56,7 +76,7 @@ services:
   # Dispatcharr P — the Xtream Codes provider.
   # ---------------------------------------------------------------------------
   dispatcharr-p-web:
-    image: dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-0.28.2}
+    image: ghcr.io/dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-latest}
     restart: "no"
     ports:
       - "${DBAS_XC_P_HTTP_PORT:-9603}:9191"
@@ -91,7 +111,7 @@ services:
       start_period: 60s
 
   dispatcharr-p-celery:
-    image: dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-0.28.2}
+    image: ghcr.io/dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-latest}
     restart: "no"
     entrypoint: ["/app/docker/entrypoint.celery.sh"]
     depends_on:

--- a/tests/dbas-test-env/docker-compose.xc-provider.yml
+++ b/tests/dbas-test-env/docker-compose.xc-provider.yml
@@ -1,0 +1,155 @@
+# =============================================================================
+# DOCUMENTATION tier — Dispatcharr "P", an XTREAM CODES provider for instance A
+# =============================================================================
+#
+# Purpose
+# -------
+# The user guide needs screenshots of ECM managing an Xtream Codes M3U account
+# whose fields (expiry, active/max connections, category list) are REAL. Rather
+# than hand-rolling a fake XC server, this stands up a third Dispatcharr — "P" —
+# and uses Dispatcharr's OWN XC server implementation (`xc_player_api` /
+# `xc_panel_api` / `get.php` / `xmltv.php`, wired in `dispatcharr/urls.py`).
+# P ingests a plain M3U + XMLTV from the `provider-northwind` nginx service and
+# then re-serves that lineup over XC. Instance A subscribes to P as an
+# `account_type = XC` account, so every XC field ECM renders was produced by a
+# genuine XC implementation.
+#
+#   provider-northwind (nginx, static M3U/XMLTV/logos)
+#        -> P  (Dispatcharr, ingests as STANDARD, re-serves as XC)
+#             -> A (Dispatcharr, subscribes as XC)   [docker-compose.dbas-sync-test.yml]
+#                  -> B (Dispatcharr, sync destination)
+#
+# Isolation contract (NON-NEGOTIABLE)
+# -----------------------------------
+#   * Project name:  -p dbas-xc-provider
+#   * Host ports: P web 9603, P pg 5448 — clear of ECM (6100/6143/6101/6300),
+#     the operator's live Dispatcharr (9191), the single-instance stack
+#     (9591/5436) and the A/B sync stack (9601/5446, 9602/5447).
+#   * Joins the EXISTING `dbas-sync-testenv_default` network as an external
+#     network so A can reach P at `http://dispatcharr-p-web:9191`. Bring the
+#     A/B stack up FIRST — this file does not create that network.
+#   * Everything is throwaway. Tear down with `-v`.
+#
+# The nginx document root is a GENERATED fixture — build it first with
+#   python3 northwind-fixture.py <dir>
+# and point NORTHWIND_FIXTURE_DIR at it (see the README HANDOVER section).
+# =============================================================================
+
+name: dbas-xc-provider
+
+services:
+  # ---------------------------------------------------------------------------
+  # The static origin: playlist.m3u, epg.xml and 53 channel logos over plain
+  # HTTP. Reachable from P (and from A) as `http://provider-northwind/`.
+  # ---------------------------------------------------------------------------
+  provider-northwind:
+    image: nginx:alpine
+    restart: "no"
+    volumes:
+      - ${NORTHWIND_FIXTURE_DIR:?set NORTHWIND_FIXTURE_DIR to the generated fixture dir}:/usr/share/nginx/html:ro
+    networks:
+      default:
+        aliases:
+          - provider-northwind
+
+  # ---------------------------------------------------------------------------
+  # Dispatcharr P — the Xtream Codes provider.
+  # ---------------------------------------------------------------------------
+  dispatcharr-p-web:
+    image: dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-0.28.2}
+    restart: "no"
+    ports:
+      - "${DBAS_XC_P_HTTP_PORT:-9603}:9191"
+    depends_on:
+      dispatcharr-p-db:
+        condition: service_healthy
+      dispatcharr-p-redis:
+        condition: service_healthy
+    volumes:
+      - dbas-xc-p-data:/data
+    environment:
+      - DISPATCHARR_ENV=modular
+      - POSTGRES_HOST=dispatcharr-p-db
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=dispatcharr
+      - POSTGRES_USER=dispatch
+      - POSTGRES_PASSWORD=secret
+      - REDIS_HOST=dispatcharr-p-redis
+      - REDIS_PORT=6379
+      - DISPATCHARR_LOG_LEVEL=info
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      default:
+        aliases:
+          - dispatcharr-p-web
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9191/api/core/version/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+
+  dispatcharr-p-celery:
+    image: dispatcharr/dispatcharr:${DISPATCHARR_VERSION:-0.28.2}
+    restart: "no"
+    entrypoint: ["/app/docker/entrypoint.celery.sh"]
+    depends_on:
+      dispatcharr-p-db:
+        condition: service_healthy
+      dispatcharr-p-redis:
+        condition: service_healthy
+      dispatcharr-p-web:
+        condition: service_started
+    volumes:
+      - dbas-xc-p-data:/data
+    environment:
+      - DISPATCHARR_ENV=modular
+      - DISPATCHARR_PORT=9191
+      - POSTGRES_HOST=dispatcharr-p-db
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=dispatcharr
+      - POSTGRES_USER=dispatch
+      - POSTGRES_PASSWORD=secret
+      - REDIS_HOST=dispatcharr-p-redis
+      - REDIS_PORT=6379
+      - DISPATCHARR_LOG_LEVEL=info
+      - DJANGO_SETTINGS_MODULE=dispatcharr.settings
+      - PYTHONUNBUFFERED=1
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  dispatcharr-p-db:
+    image: postgres:17
+    restart: "no"
+    ports:
+      - "${DBAS_XC_P_PG_PORT:-5448}:5432"
+    environment:
+      - POSTGRES_DB=dispatcharr
+      - POSTGRES_USER=dispatch
+      - POSTGRES_PASSWORD=secret
+    volumes:
+      - dbas-xc-p-pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dispatch -d dispatcharr"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  dispatcharr-p-redis:
+    image: redis:7
+    restart: "no"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+networks:
+  default:
+    name: dbas-sync-testenv_default
+    external: true
+
+volumes:
+  dbas-xc-p-data:
+  dbas-xc-p-pg:

--- a/tests/dbas-test-env/northwind-fixture.py
+++ b/tests/dbas-test-env/northwind-fixture.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Generate the "Northwind IPTV" documentation fixture served by nginx.
+
+Everything produced here is FICTIONAL — invented provider, invented channel
+names, invented listings, and credentials that read as fake on sight. Nothing
+in this fixture is, or resembles, a real provider or a real credential. See
+bead `enhancedchannelmanager-wfz8z`: screenshots taken against this environment
+may end up committed, and byte scanners cannot see pixels.
+
+Outputs, into the directory given as argv[1]:
+
+    playlist.m3u    53 channels in 7 group-titles  -> ingested by Dispatcharr P,
+                                                      which re-serves them as XC
+    epg.xml         XMLTV for those 53, 3 days
+    local.m3u        6 channels in 2 group-titles  -> a STANDARD M3U account on
+                                                      instance A, so the M3U
+                                                      Manager shows both account
+                                                      types side by side
+    local-epg.xml   XMLTV for those 6, 3 days
+    logos/*.png     one 320x320 logo per channel
+
+Deterministic: the RNG is seeded, so re-running reproduces the same playlists
+and logos byte for byte. The XMLTV files are anchored to "today" in UTC, so
+they move with the calendar — regenerate them when the listings go stale and
+re-import the EPG sources.
+
+Usage:
+    python3 northwind-fixture.py /home/lecaptainc/ecm-docenv-fixture
+
+Requires Pillow. Point NORTHWIND_FIXTURE_DIR at the output directory when
+bringing up docker-compose.xc-provider.yml.
+"""
+import datetime as dt
+import os
+import random
+import sys
+
+from PIL import Image, ImageDraw, ImageFont
+
+# --- the provider lineup, ingested by P and re-served over Xtream Codes -------
+LINEUP = [
+    ("Northwind News", [
+        "Meridian News", "Meridian News HD", "Capitol Report", "Global Wire",
+        "Beacon Business", "Continental 24", "Harbour Weather", "The Briefing",
+    ]),
+    ("Northwind Sports", [
+        "Summit Sports 1", "Summit Sports 2", "Summit Sports HD", "Velodrome TV",
+        "Gridiron Network", "Pitchside FC", "Court Vision", "Outdoor Pursuits",
+        "Paddock Live", "Ringside",
+    ]),
+    ("Northwind Movies", [
+        "Silverline Cinema", "Silverline Classics", "Silverline Action",
+        "Nightscreen Thrillers", "Matinee Family", "Indie Reel",
+        "Westward Westerns", "Orbit Sci-Fi", "Silverline 4K",
+    ]),
+    ("Northwind Kids", [
+        "Sprout Junction", "Cartoon Cove", "Little Explorers",
+        "Storybook TV", "Puzzle Pals", "Dino Dash",
+    ]),
+    ("Northwind Documentary", [
+        "Terra Discovery", "Wild Frontier", "History Vault", "Deep Ocean",
+        "Cosmos Files", "Engineering Marvels", "Culture Trail",
+    ]),
+    ("Northwind Entertainment", [
+        "Primetime Plus", "Sitcom Central", "Reality Row", "Talk of the Town",
+        "Stage & Screen", "Retro Rewind", "Lifestyle Loft", "Comedy Corner",
+    ]),
+    ("Northwind Music", [
+        "Amp Rock", "Cadence Classical", "Groove Lounge", "Chart Pulse",
+        "Bayou Country",
+    ]),
+]
+
+# --- the small local lineup, a STANDARD M3U account on instance A ------------
+LOCAL_LINEUP = [
+    ("Northwind Local", ["Harbour City TV", "Lakeside Local", "Riverbend Community"]),
+    ("Northwind Regional", ["Northern Counties", "Coastal Region One", "Valley Public"]),
+]
+
+PALETTE = [
+    ("#1f3a5f", "#e8f0fa"), ("#7a2f2f", "#fbeaea"), ("#2f5f3a", "#e9f7ee"),
+    ("#5a3f7a", "#f2eafb"), ("#7a5a1f", "#fbf3e2"), ("#1f5f5f", "#e6f6f6"),
+    ("#4a4a52", "#eeeef2"),
+]
+LOCAL_PALETTE = [("#31465a", "#eaf1f7"), ("#4a5a2f", "#f0f5e6")]
+
+PROGRAMMES = {
+    "Northwind News": ["Morning Briefing", "World at One", "Market Watch",
+                       "The Evening Report", "Newsline Tonight", "Weather Now",
+                       "Correspondents' Round Table", "Headlines"],
+    "Northwind Sports": ["Match of the Day", "League Round-Up", "Live: Regional Final",
+                         "Transfer Desk", "Classic Encounters", "Training Ground",
+                         "Sports Tonight", "Highlights Hour"],
+    "Northwind Movies": ["Feature Presentation: The Long Road", "Late Night Double Bill",
+                         "Classic Matinee: Harbour Lights", "Director's Cut",
+                         "Feature: Northern Skies", "Feature: The Quiet Signal"],
+    "Northwind Kids": ["Sprout Stories", "Cartoon Carnival", "Adventure Club",
+                       "Sing-Along Hour", "Puzzle Time", "Bedtime Tales"],
+    "Northwind Documentary": ["Life in the Canopy", "Ancient Engineering",
+                              "Beneath the Waves", "Voyagers", "The Long Winter",
+                              "Cities of Stone"],
+    "Northwind Entertainment": ["Primetime Live", "Sitcom Block", "The Talk",
+                                "Reality Check", "Retro Hour", "Late Show"],
+    "Northwind Music": ["Rock Block", "Concert Hall", "Late Lounge",
+                        "The Countdown", "Acoustic Sessions"],
+    "Northwind Local": ["Local News at Six", "Council Report", "Community Notice Board",
+                        "Town Hall", "Local Sport Round-Up", "Afternoon Movie"],
+    "Northwind Regional": ["Regional Weather", "Around the Counties", "Farming Today",
+                           "Regional Assembly", "Coast Report", "Late Local"],
+}
+
+DEJAVU_BOLD = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+DEJAVU = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+
+
+def slugify(name):
+    return "".join(
+        c.lower() if c.isalnum() else "-" for c in name
+    ).strip("-").replace("--", "-")
+
+
+def _font(path, size):
+    try:
+        return ImageFont.truetype(path, size)
+    except OSError:
+        return ImageFont.load_default()
+
+
+def make_logo(path, text, fg, bg, footer):
+    img = Image.new("RGBA", (320, 320), bg)
+    d = ImageDraw.Draw(img)
+    d.rounded_rectangle([12, 12, 307, 307], radius=36, outline=fg, width=8)
+    d.rectangle([12, 210, 307, 260], fill=fg)
+    initials = "".join(w[0] for w in text.split() if w[0].isalnum())[:3].upper()
+    d.text((160, 130), initials, font=_font(DEJAVU_BOLD, 108), fill=fg, anchor="mm")
+    d.text((160, 235), footer, font=_font(DEJAVU, 26 if len(footer) > 5 else 24),
+           fill=bg, anchor="mm")
+    img.save(path, "PNG")
+
+
+def build(out, lineup, palette, footer, m3u_name, xml_name, generator, days=3):
+    """Write one playlist + its XMLTV + its logos. Returns (channels, programmes)."""
+    base_day = dt.datetime.now(dt.timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0)
+    m3u = ["#EXTM3U"]
+    xml = ['<?xml version="1.0" encoding="UTF-8"?>',
+           f'<tv generator-info-name="{generator}">']
+    programmes = []
+    count = 0
+
+    for gi, (group, channels) in enumerate(lineup):
+        fg, bg = palette[gi % len(palette)]
+        for name in channels:
+            count += 1
+            slug = slugify(name)
+            tvg_id = f"{slug}.northwind.example"
+            logo_rel = f"logos/{slug}.png"
+            make_logo(os.path.join(out, logo_rel), name, fg, bg, footer)
+            logo_url = f"http://provider-northwind/{logo_rel}"
+
+            m3u.append(
+                f'#EXTINF:-1 tvg-id="{tvg_id}" tvg-name="{name}" '
+                f'tvg-logo="{logo_url}" group-title="{group}",{name}')
+            m3u.append(f"http://provider-northwind/stream/{slug}.ts")
+            xml.append(f'  <channel id="{tvg_id}">'
+                       f'<display-name>{name}</display-name>'
+                       f'<icon src="{logo_url}" /></channel>')
+
+            titles = PROGRAMMES[group]
+            for day in range(days):
+                cursor = base_day + dt.timedelta(days=day)
+                end_of_day = cursor + dt.timedelta(days=1)
+                idx = 0
+                while cursor < end_of_day:
+                    mins = random.choice([30, 30, 60, 60, 60, 90, 120])
+                    stop = min(cursor + dt.timedelta(minutes=mins), end_of_day)
+                    title = titles[idx % len(titles)]
+                    idx += 1
+                    programmes.append(
+                        f'  <programme start="{cursor.strftime("%Y%m%d%H%M%S")} +0000" '
+                        f'stop="{stop.strftime("%Y%m%d%H%M%S")} +0000" '
+                        f'channel="{tvg_id}">'
+                        f'<title lang="en">{title}</title>'
+                        f'<desc lang="en">{title} on {name}. '
+                        f'Fictional listing for documentation.</desc>'
+                        f'<category lang="en">{group.replace("Northwind ", "")}</category>'
+                        f'</programme>')
+                    cursor = stop
+
+    xml.extend(programmes)
+    xml.append("</tv>")
+    with open(os.path.join(out, m3u_name), "w") as fh:
+        fh.write("\n".join(m3u) + "\n")
+    with open(os.path.join(out, xml_name), "w") as fh:
+        fh.write("\n".join(xml) + "\n")
+    return count, len(programmes)
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(f"usage: {sys.argv[0]} <output-dir>")
+    out = sys.argv[1]
+    os.makedirs(os.path.join(out, "logos"), exist_ok=True)
+
+    random.seed(20260820)
+    n1, p1 = build(out, LINEUP, PALETTE, "NORTHWIND",
+                   "playlist.m3u", "epg.xml", "northwind-fixture")
+    random.seed(9021)
+    n2, p2 = build(out, LOCAL_LINEUP, LOCAL_PALETTE, "LOCAL",
+                   "local.m3u", "local-epg.xml", "northwind-local-fixture")
+
+    print(f"playlist.m3u : {n1} channels in {len(LINEUP)} groups, "
+          f"epg.xml {p1} programmes")
+    print(f"local.m3u    : {n2} channels in {len(LOCAL_LINEUP)} groups, "
+          f"local-epg.xml {p2} programmes")
+    print(f"logos/       : {n1 + n2} PNGs")
+    print(f"written to   : {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/dbas-test-env/seed/edge_supplement.py
+++ b/tests/dbas-test-env/seed/edge_supplement.py
@@ -37,8 +37,12 @@ Usage:
 
 This script is idempotent-ish: it tags everything it creates with an
 "[ECM-EDGE]" marker so a re-run can find/skip existing edge objects. It is
-written defensively — endpoints/fields are best-effort against the pinned
-0.26.0 schema and MUST be validated on first real bring-up (see README).
+written defensively — endpoints/fields are best-effort and MUST be validated
+against the RUNNING schema on every platform move (see README). There is no
+version to check them against here: `tests/dbas-test-env/` tracks
+`dispatcharr:latest` (PO decision, bead enhancedchannelmanager-xvuk1), so read
+the version from `GET /api/core/version/` and record it with whatever you
+find. These fields were last shaped against the 0.26.0 schema.
 """
 from __future__ import annotations
 
@@ -54,7 +58,7 @@ PASS = os.environ.get("DBAS_TEST_ADMIN_PASS", "ecmtestpass")
 MARKER = "[ECM-EDGE]"
 
 # Field-length probe for MAX-LENGTH case. Dispatcharr names are typically
-# varchar(255); we go right to the edge. Adjust if the pinned schema differs.
+# varchar(255); we go right to the edge. Adjust if the running schema differs.
 MAX_NAME = (MARKER + " ") + ("X" * (255 - len(MARKER) - 1))
 
 UNICODE_NAMES = [
@@ -112,7 +116,7 @@ def create_foreign_admin(token: str) -> None:
         print("[edge] +foreign admin (D11 lockout guard) created")
     else:
         print(f"[edge] ! foreign admin not created ({status}): {payload} "
-              "-- verify /api/accounts/users/ path + privilege fields on pinned schema")
+              "-- verify /api/accounts/users/ path + privilege fields on the running schema")
 
 
 def main() -> int:
@@ -133,7 +137,7 @@ def main() -> int:
     if dup_group:
         # Two streams with the SAME name in the same group => the .14 4-tier
         # matcher must disambiguate. (Stream-create path/fields vary by version;
-        # validate against pinned 0.26.0 — see README.)
+        # validate against the RUNNING instance, not a pin — see README.)
         for i in (1, 2):
             status, payload = _req("POST", "/api/channels/streams/", token, {
                 "name": f"{MARKER} Duplicate Stream",
@@ -145,7 +149,8 @@ def main() -> int:
     # 5. Foreign-admin lockout guard (D11)
     create_foreign_admin(token)
 
-    print("[edge] supplement complete (validate field/endpoint names vs pinned schema)")
+    print("[edge] supplement complete (validate field/endpoint names vs the "
+          "RUNNING schema — read GET /api/core/version/ and record it)")
     return 0
 
 

--- a/tests/dbas-test-env/validate-version-behaviors.py
+++ b/tests/dbas-test-env/validate-version-behaviors.py
@@ -1,17 +1,26 @@
 #!/usr/bin/env python3
 """
 validate-version-behaviors.py — re-validate the 0.23.0-era behaviors ECM
-encodes, against the pinned LIVE Dispatcharr (default 0.26.0).
+encodes, against whatever Dispatcharr is actually running.
 
 This is the "don't let the fake re-encode our assumptions" guard (acceptance
 criterion #3) applied to the LIVE instance: it probes the real, running stack
-and reports whether each version-specific behavior ECM depends on still holds
-at the pinned version. The output is the GROUND TRUTH that any CI fake
+and reports whether each version-specific behavior ECM depends on still holds.
+The output is the GROUND TRUTH that any CI fake
 (backend/tests/fixtures/mock_dispatcharr.py and its successor) must be
 diffed against.
 
+THIS SCRIPT DOES NOT KNOW WHAT VERSION IT SHOULD SEE, AND MUST NOT.
+`tests/dbas-test-env/` tracks `dispatcharr:latest` literally (PO decision, bead
+enhancedchannelmanager-xvuk1), so the platform moves without announcing itself.
+The version is READ from `GET /api/core/version/` and stamped on every line of
+the report; if it cannot be read, the run is a hard failure rather than a
+result, because a result that cannot name its platform is not a result. It used
+to default `EXPECTED_VERSION` to `0.26.0`, which meant a run against a newer
+instance either failed or — worse — passed for the wrong reason.
+
 Behaviors checked (from bead zqtjj / spike tsfv0):
-  1. Version-detect endpoint   GET /api/core/version/        -> reports 0.26.0
+  1. Version-detect endpoint   GET /api/core/version/        -> RECORD the value
   2. Current-user endpoint     GET /api/accounts/users/me/   (0.23.0+); record
                                whether /api/accounts/me/ also answers (fallback)
   3. Login throttle            >3 logins/min/IP -> 429 (0.23.0+ shared throttle)
@@ -28,10 +37,16 @@ Usage:
   DBAS_TEST_ADMIN_USER=ecmtest DBAS_TEST_ADMIN_PASS=ecmtestpass \
   python3 validate-version-behaviors.py
 
-Exit code 0 if all probes ran (PASS/INFO recorded); non-zero only on a hard
-failure (instance unreachable). Behavior DRIFT from expectations is reported as
-WARN, not a hard failure — drift is a finding for the importer authors, not a
-crash.
+Optional, and OFF by default: set DBAS_EXPECT_VERSION to assert a specific
+version — only useful when you are deliberately reproducing an old finding with
+`DISPATCHARR_VERSION=<old>`. Leaving it unset is the normal case and is what
+keeps this script from carrying a pin.
+
+Exit codes:
+  0  all probes ran (PASS/INFO recorded)
+  2  hard failure — instance unreachable, or its version could not be read
+Behavior DRIFT from expectations is reported as WARN, not a hard failure —
+drift is a finding for the importer authors, not a crash.
 """
 from __future__ import annotations
 
@@ -45,7 +60,11 @@ import urllib.error
 BASE = os.environ.get("DBAS_TEST_BASE_URL", "http://localhost:9591").rstrip("/")
 USER = os.environ.get("DBAS_TEST_ADMIN_USER", "ecmtest")
 PASS = os.environ.get("DBAS_TEST_ADMIN_PASS", "ecmtestpass")
-EXPECTED_VERSION = os.environ.get("DISPATCHARR_VERSION", "0.26.0")
+# OPT-IN only. Unset by default — this script must never carry a version pin.
+EXPECT_VERSION = os.environ.get("DBAS_EXPECT_VERSION") or None
+
+# Filled in by probe 1 from the running instance. Never guessed, never defaulted.
+RUNNING_VERSION: str | None = None
 
 results: list[tuple[str, str, str]] = []  # (level, name, detail)
 
@@ -77,17 +96,58 @@ def call(method: str, path: str, token=None, body=None, raw_body=None):
         return None, str(e)
 
 
+def read_running_version(status, txt) -> str | None:
+    """Pull the version STRING out of /api/core/version/.
+
+    Returns None rather than a guess when the response is not a 200 carrying a
+    non-empty `version` field, so "could not read" is never mistaken for a
+    value. Tolerates a bare string body as well as the documented JSON object.
+    """
+    if status != 200:
+        return None
+    try:
+        payload = json.loads(txt)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if isinstance(payload, str):
+        return payload.strip() or None
+    if isinstance(payload, dict):
+        value = payload.get("version")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
 def main() -> int:
-    # 1. Version-detect
+    global RUNNING_VERSION
+
+    # 1. Version-detect. This is not an assertion — it is how every other line
+    #    of this report gets a platform to name.
     status, txt = call("GET", "/api/core/version/")
     if status is None:
         rec("FAIL", "reachability", f"instance unreachable at {BASE}: {txt}")
         return 2
-    if status == 200 and EXPECTED_VERSION in txt:
-        rec("PASS", "version-detect", f"/api/core/version/ -> {txt.strip()[:120]}")
-    else:
-        rec("WARN", "version-detect",
-            f"expected {EXPECTED_VERSION}, got status={status} body={txt[:120]}")
+
+    RUNNING_VERSION = read_running_version(status, txt)
+    if RUNNING_VERSION is None:
+        rec("FAIL", "version-detect",
+            f"could not read a version from /api/core/version/ "
+            f"(status={status} body={txt[:120]!r}). Refusing to report probe "
+            f"results that cannot name the platform they ran against.")
+        return 2
+
+    rec("PASS", "version-detect",
+        f"running Dispatcharr {RUNNING_VERSION} "
+        f"(/api/core/version/ -> {txt.strip()[:120]})")
+
+    if EXPECT_VERSION is not None:
+        if EXPECT_VERSION == RUNNING_VERSION:
+            rec("PASS", "version-expectation",
+                f"DBAS_EXPECT_VERSION={EXPECT_VERSION} matches the running instance")
+        else:
+            rec("WARN", "version-expectation",
+                f"DBAS_EXPECT_VERSION={EXPECT_VERSION} but the instance reports "
+                f"{RUNNING_VERSION} — you are not testing what you think you are")
 
     # Login (also primes throttle test)
     status, txt = call("POST", "/api/accounts/token/", body={"username": USER, "password": PASS})
@@ -97,7 +157,7 @@ def main() -> int:
         rec("PASS", "auth", "token obtained")
     else:
         rec("WARN", "auth", f"login status={status} body={txt[:120]} "
-                            "(seed-admin env may differ on pinned image)")
+                            f"(seed-admin env may differ on Dispatcharr {RUNNING_VERSION})")
 
     # 2. current-user endpoint + fallback
     if token:
@@ -116,7 +176,8 @@ def main() -> int:
         rec("PASS", "login-throttle", f"saw 429 in burst: {codes}")
     else:
         rec("WARN", "login-throttle",
-            f"no 429 in burst {codes} — throttle behavior may have changed at {EXPECTED_VERSION}")
+            f"no 429 in burst {codes} — throttle behavior may have changed "
+            f"in Dispatcharr {RUNNING_VERSION}")
 
     # 4/5/6: shape probes (read-only listing of what ECM polls; do not assert
     # success, just record the response SHAPE the fake must reproduce).
@@ -131,7 +192,10 @@ def main() -> int:
             rec("INFO", f"shape:{label}", f"status={s} body[:160]={t[:160]}")
 
     warns = sum(1 for lvl, _, _ in results if lvl == "WARN")
-    print(f"\n[summary] {len(results)} probes, {warns} WARN (drift findings for importer authors)")
+    print(f"\n[summary] VALIDATED AGAINST DISPATCHARR {RUNNING_VERSION} at {BASE}")
+    print(f"[summary] {len(results)} probes, {warns} WARN (drift findings for importer authors)")
+    print("[summary] Quote the version above with any result from this run — "
+          "tests/dbas-test-env/ tracks `latest`, so the platform moves.")
     print("[summary] Feed these shapes into the CI fake's contract test "
           "(see docs/testing/dbas-test-env.md 'CI fake validation').")
     return 0


### PR DESCRIPTION
Test-environment work only. No operator-visible behaviour changes, hence no CHANGELOG entry — `docs/shipping.md` §5 scopes that to user-facing changes, and the only production files touched here are the three version literals themselves.

## Why now

The PO set a standing rule: **we always work against `dispatcharr:latest`.** The test environments were pinned, and `latest` had moved a minor version ahead of everything this project has ever validated.

Shipping this ahead of the documentation work it was built for, because the latest-tracking compose files exist **only on this branch** — an engineer on a `dev`-based branch followed the handover, reset the destination, and got `0.26.0` back. Merging puts the rule on `dev` so every subsequent branch inherits it instead of each hitting the same trap.

## What changed

**A real Xtream Codes provider chain.** Dispatcharr implements the XC *server* side itself (`xc_player_api`), so a third instance serves a genuine XC feed rather than a hand-rolled fake — ECM's UI renders real XC fields because a real XC implementation produces them. Confirmed by reading the ORM, not a serializer: `account_type=XC`, with a live `user_info` block (`status Active`, `exp_date 2026-11-18`, `max_connections 4`). The provider returns `401` on a wrong password, so it genuinely authenticates. Fixture generator committed; reproduces the playlists and all 59 logos byte-identically.

**All three compose files now track `ghcr.io/dispatcharr/dispatcharr:latest`**, the registry production actually uses. The `0.26.0` and `0.28.2` defaults are gone. Override still works for deliberately reproducing an old finding.

**A `.env.example` landmine removed.** It set `DISPATCHARR_VERSION=0.26.0`, and the README's own recipe says `cp .env.example .env` — which Compose auto-loads for *every* file in the directory. Following the documented setup would have silently re-pinned all three stacks.

**No live default pins a version anywhere.** Stated as an invariant rather than a file list: anything needing the version now **reads it from the running instance and records what it saw**. A floating tag never announces a bump, so a result that cannot name its platform is not a result.

`validate-version-behaviors.py` was the sharp one — its check was `EXPECTED_VERSION in txt`, a **substring match over the whole response body**. A body merely containing the string satisfied it. It now parses the field and hard-fails `exit 2` if it cannot read one, proven across eight response shapes including "version string present only in an unrelated field."

## Environment rebuilt on 0.29.0

All three Dispatcharrs report `0.29.0`. ECM verified by checksumming **all 698 backend Python files** against `git show`, with the harness proven able to fail (planted byte → exactly one mismatch). The XC server surface survived the minor bump — 0.29.0 *added* XC tests.

## Findings recorded, not fixed

The rebuild re-took the replica-fidelity measurement on 0.29.0 and it reproduces exactly, plus two new defects — channel-profile membership arriving fully enabled, and provider attribution not crossing. Those are epic `enhancedchannelmanager-f5a5j`, on their own branch.

Bead `enhancedchannelmanager-xvuk1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
