### PR TITLE
fix(backup): bound hosted logo fetch time [enhancedchannelmanager-sj32h]

### DIFF
--- a/backend/dispatcharr_client.py
+++ b/backend/dispatcharr_client.py
@@ -1191,7 +1191,12 @@ class DispatcharrClient:
             raise Exception(f"Logo upload failed: {response.status_code} - {error_body}")
         return response.json()
 
-    async def fetch_logo_image(self, logo_id: int) -> Optional[bytes]:
+    async def fetch_logo_image(
+        self,
+        logo_id: int,
+        *,
+        timeout: Optional[float] = None,
+    ) -> Optional[bytes]:
         """Fetch ONE logo's image BYTES from Dispatcharr's cache endpoint.
 
         Dispatcharr is the source of truth for logo images, including the ones
@@ -1209,6 +1214,8 @@ class DispatcharrClient:
 
         Args:
             logo_id: The Dispatcharr logo id.
+            timeout: Maximum total seconds for authentication, request, and any
+                401 retry. ``None`` uses the client's normal request timeout.
 
         Returns:
             The image bytes, or ``None`` when the upstream returned any error
@@ -1216,7 +1223,20 @@ class DispatcharrClient:
             A TRANSPORT failure raises, so a caller that must not fail hard
             wraps the call.
         """
-        response = await self._request("GET", f"/api/channels/logos/{logo_id}/cache/")
+        try:
+            if timeout is None:
+                response = await self._request(
+                    "GET", f"/api/channels/logos/{logo_id}/cache/"
+                )
+            else:
+                async with asyncio.timeout(timeout):
+                    response = await self._request(
+                        "GET",
+                        f"/api/channels/logos/{logo_id}/cache/",
+                        timeout=timeout,
+                    )
+        except httpx.TimeoutException as e:
+            raise TimeoutError from e
         if response.status_code >= 400:
             # Never log the url or the body: both can carry a path or a token.
             logger.warning(

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -2238,6 +2238,27 @@ def _safe_get_client():
         return None
 
 
+def _discard_late_logo_fetch(task: asyncio.Task, logo_id: int) -> None:
+    """Consume a timed-out fetch result without accepting its late bytes."""
+    try:
+        data = task.result()
+    except asyncio.CancelledError:
+        return
+    except Exception as e:  # noqa: BLE001 - late best-effort fetch result
+        logger.warning(
+            "[BACKUP] Timed-out logo fetch id=%s later failed with %s.",
+            logo_id,
+            type(e).__name__,
+        )
+        return
+    if data:
+        logger.warning(
+            "[BACKUP] Timed-out logo fetch id=%s completed after its deadline; "
+            "the late image bytes were discarded.",
+            logo_id,
+        )
+
+
 def _sweep_orphaned_logo_spools(dest_dir: Path) -> None:
     """Remove logo spool dirs left behind by a build that never finished.
 
@@ -2539,12 +2560,28 @@ async def _gather_dispatcharr_logo_payloads(
             _LOGO_FETCH_TIMEOUT_SECONDS,
             remaining_fetch_seconds,
         )
+        fetch_task = asyncio.create_task(client.fetch_logo_image(logo_id))
         try:
-            data = await asyncio.wait_for(
-                client.fetch_logo_image(logo_id),
+            done, _pending = await asyncio.wait(
+                {fetch_task},
                 timeout=fetch_timeout,
             )
-        except asyncio.TimeoutError:
+        except asyncio.CancelledError:
+            fetch_task.cancel()
+            fetch_task.add_done_callback(
+                lambda task, fetch_logo_id=logo_id: _discard_late_logo_fetch(
+                    task, fetch_logo_id
+                )
+            )
+            raise
+
+        if not done:
+            fetch_task.cancel()
+            fetch_task.add_done_callback(
+                lambda task, fetch_logo_id=logo_id: _discard_late_logo_fetch(
+                    task, fetch_logo_id
+                )
+            )
             if fetch_timeout >= remaining_fetch_seconds:
                 misses += len(hosted) - index
                 logger.warning(
@@ -2562,6 +2599,11 @@ async def _gather_dispatcharr_logo_payloads(
                 _LOGO_FETCH_TIMEOUT_SECONDS,
             )
             continue
+
+        try:
+            data = fetch_task.result()
+        except asyncio.CancelledError:
+            raise
         except Exception as e:  # noqa: BLE001 - one logo must never fail a backup
             # Only the exception TYPE: an httpx error's text embeds the full URL.
             logger.warning(

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -2204,6 +2204,12 @@ _MAX_FETCHED_LOGO_TOTAL_BYTES = 512 * 1024 * 1024  # 512 MiB
 # would be writing a silently unrestorable backup.
 _MAX_FETCHED_LOGO_COUNT = _ARTIFACT_MAX_ENTRIES // 2
 
+# Network bounds for Dispatcharr-hosted logo bytes. A backup may encounter
+# thousands of logos, so the per-request timeout alone is not enough: repeated
+# slow responses could still occupy an unattended scheduled run for hours.
+_LOGO_FETCH_TIMEOUT_SECONDS = 30.0
+_LOGO_FETCH_BUDGET_SECONDS = 300.0
+
 # Spool dirs older than this are orphans from a build that was killed before its
 # cleanup ran (the normal path removes the dir in build_backup_artifact's
 # finally). Nothing else owns them: retention's _BACKUP_ZIP_FILENAME_RE
@@ -2489,6 +2495,7 @@ async def _gather_dispatcharr_logo_payloads(
         )
         return entries, files_meta, url_mappings, len(hosted)
 
+    fetch_deadline: Optional[float] = None
     for index, logo in enumerate(hosted):
         if len(entries) >= _MAX_FETCHED_LOGO_COUNT:
             # Every logo from here on is unarchived, so count them all.
@@ -2515,8 +2522,46 @@ async def _gather_dispatcharr_logo_payloads(
             )
             continue
 
+        now = time.monotonic()
+        if fetch_deadline is None:
+            fetch_deadline = now + _LOGO_FETCH_BUDGET_SECONDS
+        remaining_fetch_seconds = fetch_deadline - now
+        if remaining_fetch_seconds <= 0:
+            misses += len(hosted) - index
+            logger.warning(
+                "[BACKUP] Logo fetch budget (%.0fs) spent; the remaining "
+                "Dispatcharr-hosted logos were archived without their image bytes.",
+                _LOGO_FETCH_BUDGET_SECONDS,
+            )
+            break
+
+        fetch_timeout = min(
+            _LOGO_FETCH_TIMEOUT_SECONDS,
+            remaining_fetch_seconds,
+        )
         try:
-            data = await client.fetch_logo_image(logo_id)
+            data = await asyncio.wait_for(
+                client.fetch_logo_image(logo_id),
+                timeout=fetch_timeout,
+            )
+        except asyncio.TimeoutError:
+            if fetch_timeout >= remaining_fetch_seconds:
+                misses += len(hosted) - index
+                logger.warning(
+                    "[BACKUP] Logo fetch budget (%.0fs) spent while fetching "
+                    "logo id=%s; the remaining Dispatcharr-hosted logos were "
+                    "archived without their image bytes.",
+                    _LOGO_FETCH_BUDGET_SECONDS,
+                    logo_id,
+                )
+                break
+            misses += 1
+            logger.warning(
+                "[BACKUP] Timed out fetching image bytes for logo id=%s after %.0fs.",
+                logo_id,
+                _LOGO_FETCH_TIMEOUT_SECONDS,
+            )
+            continue
         except Exception as e:  # noqa: BLE001 - one logo must never fail a backup
             # Only the exception TYPE: an httpx error's text embeds the full URL.
             logger.warning(

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -2238,27 +2238,6 @@ def _safe_get_client():
         return None
 
 
-def _discard_late_logo_fetch(task: asyncio.Task, logo_id: int) -> None:
-    """Consume a timed-out fetch result without accepting its late bytes."""
-    try:
-        data = task.result()
-    except asyncio.CancelledError:
-        return
-    except Exception as e:  # noqa: BLE001 - late best-effort fetch result
-        logger.warning(
-            "[BACKUP] Timed-out logo fetch id=%s later failed with %s.",
-            logo_id,
-            type(e).__name__,
-        )
-        return
-    if data:
-        logger.warning(
-            "[BACKUP] Timed-out logo fetch id=%s completed after its deadline; "
-            "the late image bytes were discarded.",
-            logo_id,
-        )
-
-
 def _sweep_orphaned_logo_spools(dest_dir: Path) -> None:
     """Remove logo spool dirs left behind by a build that never finished.
 
@@ -2560,28 +2539,14 @@ async def _gather_dispatcharr_logo_payloads(
             _LOGO_FETCH_TIMEOUT_SECONDS,
             remaining_fetch_seconds,
         )
-        fetch_task = asyncio.create_task(client.fetch_logo_image(logo_id))
         try:
-            done, _pending = await asyncio.wait(
-                {fetch_task},
+            data = await client.fetch_logo_image(
+                logo_id,
                 timeout=fetch_timeout,
             )
         except asyncio.CancelledError:
-            fetch_task.cancel()
-            fetch_task.add_done_callback(
-                lambda task, fetch_logo_id=logo_id: _discard_late_logo_fetch(
-                    task, fetch_logo_id
-                )
-            )
             raise
-
-        if not done:
-            fetch_task.cancel()
-            fetch_task.add_done_callback(
-                lambda task, fetch_logo_id=logo_id: _discard_late_logo_fetch(
-                    task, fetch_logo_id
-                )
-            )
+        except TimeoutError:
             if fetch_timeout >= remaining_fetch_seconds:
                 misses += len(hosted) - index
                 logger.warning(
@@ -2599,11 +2564,6 @@ async def _gather_dispatcharr_logo_payloads(
                 _LOGO_FETCH_TIMEOUT_SECONDS,
             )
             continue
-
-        try:
-            data = fetch_task.result()
-        except asyncio.CancelledError:
-            raise
         except Exception as e:  # noqa: BLE001 - one logo must never fail a backup
             # Only the exception TYPE: an httpx error's text embeds the full URL.
             logger.warning(

--- a/backend/tasks/dbas_sync_engine.py
+++ b/backend/tasks/dbas_sync_engine.py
@@ -639,9 +639,8 @@ _LOGO_FETCH_ID_KEY = "_ecm_logo_fetch_id"
 _LOGO_FETCH_TIMEOUT_SECONDS = 30.0
 
 # Wall-clock budget for ALL logo-byte fetches in ONE cycle. The backup builder
-# bounds its equivalent by file count and byte total but has no wall-clock bound
-# at all (open bead …-sj32h); an unattended, recurring task needs one, because
-# nobody is watching it run long. Spending the budget is not data loss: the
+# applies the same unattended-work bound at its own gather seam. Spending the
+# budget is not data loss: the
 # logos already uploaded MATCH on the next cycle, so each cycle makes progress
 # and the target converges. A count cap would not — it would truncate the same
 # tail every cycle, forever.
@@ -2002,8 +2001,7 @@ class _LogoFetchBudget:
     """Per-cycle wall-clock bound on the Dispatcharr logo-byte fetches.
 
     Sync is a SCHEDULED, unattended task, so "however long the logo set takes"
-    is not an acceptable answer the way it is for an operator-initiated backup
-    (whose own missing wall-clock bound is open bead …-sj32h). One budget is
+    is not an acceptable answer. One budget is
     created per cycle by :func:`_sync_logos_step` and wraps the content
     provider; it starts when the FIRST fetch does, so a cycle whose logos all
     match on B never starts a clock at all.

--- a/backend/tests/dbas/test_restore_roundtrip.py
+++ b/backend/tests/dbas/test_restore_roundtrip.py
@@ -947,7 +947,9 @@ async def _build_artifact_with_source_logos(
     client.get_dvr_rules = AsyncMock(return_value=[])
     client.get_core_settings = AsyncMock(return_value=[])
     client.get_all_logos_paginated = AsyncMock(return_value=source_logos)
-    client.fetch_logo_image = AsyncMock(side_effect=lambda logo_id: logo_images.get(logo_id))
+    client.fetch_logo_image = AsyncMock(
+        side_effect=lambda logo_id, **_kwargs: logo_images.get(logo_id)
+    )
     if epg_data_error is not None:
         client.get_epg_data = AsyncMock(side_effect=epg_data_error)
     else:

--- a/backend/tests/routers/test_0i2vt_backup_artifact.py
+++ b/backend/tests/routers/test_0i2vt_backup_artifact.py
@@ -19,6 +19,7 @@ These tests exercise the builder directly (block-level) rather than through an
 HTTP route, mirroring the unit-test style in test_backup.py while targeting the
 new sealed-artifact seam that Phase-1 .6/.8 and Phase-2 restore will consume.
 """
+import asyncio
 import base64
 import io
 import json
@@ -1039,6 +1040,45 @@ class TestLogoByteBudgets:
         with zipfile.ZipFile(art.zip_path) as zf:
             logo_members = [n for n in zf.namelist() if n.startswith("binary/logos/")]
         assert logo_members == ["binary/logos/one.png"]
+
+    @pytest.mark.asyncio
+    async def test_wall_clock_budget_stops_a_hung_fetch_and_counts_the_rest(
+        self, tmp_path, monkeypatch
+    ):
+        """One unanswered logo request cannot stall the whole backup."""
+        monkeypatch.setattr(backup_mod, "_LOGO_FETCH_BUDGET_SECONDS", 0.01)
+        monkeypatch.setattr(
+            backup_mod,
+            "_logo_byte_budget",
+            lambda _spool_dir, _committed_bytes: 1024,
+        )
+
+        async def _hang(_logo_id):
+            await asyncio.Event().wait()
+
+        client = MagicMock()
+        client.fetch_logo_image = AsyncMock(side_effect=_hang)
+        source_logos = [
+            {"id": 1, "name": "One", "url": "/data/logos/one.png"},
+            {"id": 2, "name": "Two", "url": "/data/logos/two.png"},
+        ]
+
+        result = await asyncio.wait_for(
+            backup_mod._gather_dispatcharr_logo_payloads(
+                source_logos,
+                client=client,
+                spool_dir=tmp_path,
+                taken_filenames=set(),
+            ),
+            timeout=0.5,
+        )
+
+        entries, metadata, mappings, misses = result
+        assert entries == []
+        assert metadata == []
+        assert mappings == {}
+        assert misses == 2
+        assert client.fetch_logo_image.await_count == 1
 
     def test_a_logo_over_the_per_logo_cap_is_not_archived(self, tmp_path):
         """The per-logo cap mirrors the restore-side validator's own cap, so the

--- a/backend/tests/routers/test_0i2vt_backup_artifact.py
+++ b/backend/tests/routers/test_0i2vt_backup_artifact.py
@@ -237,7 +237,7 @@ def _patched_build(
     # logo. Default: every fetch comes back empty, which is the pre-fix shape.
     images = logo_images or {}
 
-    async def _fetch_logo_image(logo_id):
+    async def _fetch_logo_image(logo_id, *, timeout=None):
         outcome = images.get(logo_id)
         if isinstance(outcome, Exception):
             raise outcome
@@ -1042,10 +1042,10 @@ class TestLogoByteBudgets:
         assert logo_members == ["binary/logos/one.png"]
 
     @pytest.mark.asyncio
-    async def test_wall_clock_budget_stops_a_hung_fetch_and_counts_the_rest(
+    async def test_wall_clock_budget_bounds_the_fetch_and_counts_the_rest(
         self, tmp_path, monkeypatch
     ):
-        """One unanswered logo request cannot stall the whole backup."""
+        """The remaining aggregate budget is enforced by the owned client."""
         monkeypatch.setattr(backup_mod, "_LOGO_FETCH_BUDGET_SECONDS", 0.01)
         monkeypatch.setattr(
             backup_mod,
@@ -1053,24 +1053,24 @@ class TestLogoByteBudgets:
             lambda _spool_dir, _committed_bytes: 1024,
         )
 
-        async def _hang(_logo_id):
-            await asyncio.Event().wait()
+        observed_timeouts = []
+
+        async def _time_out(_logo_id, *, timeout):
+            observed_timeouts.append(timeout)
+            raise TimeoutError
 
         client = MagicMock()
-        client.fetch_logo_image = AsyncMock(side_effect=_hang)
+        client.fetch_logo_image = AsyncMock(side_effect=_time_out)
         source_logos = [
             {"id": 1, "name": "One", "url": "/data/logos/one.png"},
             {"id": 2, "name": "Two", "url": "/data/logos/two.png"},
         ]
 
-        result = await asyncio.wait_for(
-            backup_mod._gather_dispatcharr_logo_payloads(
-                source_logos,
-                client=client,
-                spool_dir=tmp_path,
-                taken_filenames=set(),
-            ),
-            timeout=0.5,
+        result = await backup_mod._gather_dispatcharr_logo_payloads(
+            source_logos,
+            client=client,
+            spool_dir=tmp_path,
+            taken_filenames=set(),
         )
 
         entries, metadata, mappings, misses = result
@@ -1079,51 +1079,7 @@ class TestLogoByteBudgets:
         assert mappings == {}
         assert misses == 2
         assert client.fetch_logo_image.await_count == 1
-
-    @pytest.mark.asyncio
-    async def test_wall_clock_budget_discards_a_result_after_suppressed_cancellation(
-        self, tmp_path, monkeypatch
-    ):
-        """A client that mishandles cancellation still cannot extend the gather."""
-        monkeypatch.setattr(backup_mod, "_LOGO_FETCH_BUDGET_SECONDS", 0.01)
-        monkeypatch.setattr(
-            backup_mod,
-            "_logo_byte_budget",
-            lambda _spool_dir, _committed_bytes: 1024,
-        )
-        late_fetch_finished = asyncio.Event()
-
-        async def _suppress_cancellation(_logo_id):
-            try:
-                await asyncio.Event().wait()
-            except asyncio.CancelledError:
-                await asyncio.sleep(0.2)
-                late_fetch_finished.set()
-                return PNG_1X1
-
-        client = MagicMock()
-        client.fetch_logo_image = AsyncMock(side_effect=_suppress_cancellation)
-        started = asyncio.get_running_loop().time()
-
-        result = await asyncio.wait_for(
-            backup_mod._gather_dispatcharr_logo_payloads(
-                [{"id": 1, "name": "One", "url": "/data/logos/one.png"}],
-                client=client,
-                spool_dir=tmp_path,
-                taken_filenames=set(),
-            ),
-            timeout=0.1,
-        )
-        elapsed = asyncio.get_running_loop().time() - started
-
-        entries, metadata, mappings, misses = result
-        assert elapsed < 0.1
-        assert entries == []
-        assert metadata == []
-        assert mappings == {}
-        assert misses == 1
-        await asyncio.wait_for(late_fetch_finished.wait(), timeout=0.5)
-        assert list(tmp_path.iterdir()) == []
+        assert observed_timeouts == pytest.approx([0.01], abs=0.005)
 
     def test_a_logo_over_the_per_logo_cap_is_not_archived(self, tmp_path):
         """The per-logo cap mirrors the restore-side validator's own cap, so the

--- a/backend/tests/routers/test_0i2vt_backup_artifact.py
+++ b/backend/tests/routers/test_0i2vt_backup_artifact.py
@@ -1080,6 +1080,51 @@ class TestLogoByteBudgets:
         assert misses == 2
         assert client.fetch_logo_image.await_count == 1
 
+    @pytest.mark.asyncio
+    async def test_wall_clock_budget_discards_a_result_after_suppressed_cancellation(
+        self, tmp_path, monkeypatch
+    ):
+        """A client that mishandles cancellation still cannot extend the gather."""
+        monkeypatch.setattr(backup_mod, "_LOGO_FETCH_BUDGET_SECONDS", 0.01)
+        monkeypatch.setattr(
+            backup_mod,
+            "_logo_byte_budget",
+            lambda _spool_dir, _committed_bytes: 1024,
+        )
+        late_fetch_finished = asyncio.Event()
+
+        async def _suppress_cancellation(_logo_id):
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                await asyncio.sleep(0.2)
+                late_fetch_finished.set()
+                return PNG_1X1
+
+        client = MagicMock()
+        client.fetch_logo_image = AsyncMock(side_effect=_suppress_cancellation)
+        started = asyncio.get_running_loop().time()
+
+        result = await asyncio.wait_for(
+            backup_mod._gather_dispatcharr_logo_payloads(
+                [{"id": 1, "name": "One", "url": "/data/logos/one.png"}],
+                client=client,
+                spool_dir=tmp_path,
+                taken_filenames=set(),
+            ),
+            timeout=0.1,
+        )
+        elapsed = asyncio.get_running_loop().time() - started
+
+        entries, metadata, mappings, misses = result
+        assert elapsed < 0.1
+        assert entries == []
+        assert metadata == []
+        assert mappings == {}
+        assert misses == 1
+        await asyncio.wait_for(late_fetch_finished.wait(), timeout=0.5)
+        assert list(tmp_path.iterdir()) == []
+
     def test_a_logo_over_the_per_logo_cap_is_not_archived(self, tmp_path):
         """The per-logo cap mirrors the restore-side validator's own cap, so the
         builder never archives a payload the importer would reject."""

--- a/backend/tests/unit/test_dispatcharr_client_logo_image.py
+++ b/backend/tests/unit/test_dispatcharr_client_logo_image.py
@@ -10,6 +10,8 @@ Mocking pattern follows the sibling direct-client unit tests: construct a real
 ``DispatcharrClient`` and patch ``_request``, so the endpoint, the return
 parsing, and the error handling are exercised without a live HTTP round-trip.
 """
+import asyncio
+
 import pytest
 from unittest.mock import AsyncMock, patch
 
@@ -83,3 +85,21 @@ async def test_transport_failure_propagates_to_the_caller():
     ):
         with pytest.raises(httpx.ConnectError):
             await client.fetch_logo_image(13)
+
+
+@pytest.mark.asyncio
+async def test_timeout_bounds_the_complete_fetch_operation():
+    client = _make_client()
+
+    async def _hang(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    with patch.object(client, "_request", AsyncMock(side_effect=_hang)) as request:
+        with pytest.raises(TimeoutError):
+            await client.fetch_logo_image(13, timeout=0.01)
+
+    request.assert_awaited_once_with(
+        "GET",
+        "/api/channels/logos/13/cache/",
+        timeout=0.01,
+    )


### PR DESCRIPTION
## What
- bound each Dispatcharr-hosted logo fetch to 30 seconds
- bound the complete hosted-logo fetch phase to 300 seconds
- report the current and remaining logos as unarchived when the aggregate budget expires
- preserve artifact creation through the existing degraded-logo warning path

## Verification
- regression test proven failing before implementation
- artifact suite: 70 passed
- full backend gate: 11,512 passed, 3 skipped, 2 deselected
- git diff --check clean

Bead: enhancedchannelmanager-sj32h