### PR TITLE
fix: fail archive restore on unreadable destination

### DIFF
--- a/backend/dbas/destination_read.py
+++ b/backend/dbas/destination_read.py
@@ -14,6 +14,18 @@ from security.ssrf import SSRFError
 # that cannot be read. Importers read this category again as part of their plan.
 _DESTINATION_PROBE = "get_channel_groups"
 _DESTINATION_READ_PREFIX = "get_"
+_DESTINATION_MUTATION_PREFIXES = (
+    "bulk_delete_",
+    "create_",
+    "patch_",
+    "refresh_",
+    "update_",
+    "upload_",
+)
+
+
+class DestinationUnreadableError(RuntimeError):
+    """Raised when an importer tries to mutate after a failed destination read."""
 
 
 def _describe_destination_error(exc: BaseException) -> str:
@@ -66,13 +78,39 @@ def mark_destination_unread(report: RestoreReport, reason: str) -> None:
 class ReadObservingClient:
     """Transparent client proxy that records every failed destination read."""
 
-    def __init__(self, inner, report: RestoreReport) -> None:
+    def __init__(
+        self,
+        inner,
+        report: RestoreReport,
+        *,
+        reject_mutations: bool = False,
+    ) -> None:
         object.__setattr__(self, "_inner", inner)
         object.__setattr__(self, "_report", report)
+        object.__setattr__(self, "_reject_mutations", reject_mutations)
 
     def __getattr__(self, name: str):
         attr = getattr(self._inner, name)
-        if not name.startswith(_DESTINATION_READ_PREFIX) or not callable(attr):
+        if not callable(attr):
+            return attr
+
+        if self._reject_mutations and name.startswith(_DESTINATION_MUTATION_PREFIXES):
+
+            async def _guarded_mutation(*args, **kwargs):
+                reason = self._report.destination_unreadable
+                if reason is not None:
+                    raise DestinationUnreadableError(
+                        "refusing %s after destination read failure: %s"
+                        % (name, reason)
+                    )
+                result = attr(*args, **kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+                return result
+
+            return _guarded_mutation
+
+        if not name.startswith(_DESTINATION_READ_PREFIX):
             return attr
 
         async def _observed_read(*args, **kwargs):

--- a/backend/dbas/destination_read.py
+++ b/backend/dbas/destination_read.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import inspect
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Optional
 
 from httpx import HTTPStatusError, RequestError, TimeoutException
@@ -15,17 +17,62 @@ from security.ssrf import SSRFError
 _DESTINATION_PROBE = "get_channel_groups"
 _DESTINATION_READ_PREFIX = "get_"
 _DESTINATION_MUTATION_PREFIXES = (
-    "bulk_delete_",
+    "bulk_",
     "create_",
+    "delete_",
     "patch_",
     "refresh_",
+    "trigger_",
     "update_",
     "upload_",
 )
+_COMPENSATING_DELETE_PREFIXES = ("bulk_delete_", "delete_")
 
 
 class DestinationUnreadableError(RuntimeError):
     """Raised when an importer tries to mutate after a failed destination read."""
+
+
+class DestinationReadError(DestinationUnreadableError):
+    """Sanitized destination read failure safe for reports and logs."""
+
+    def __init__(
+        self,
+        operation: str,
+        *,
+        category: str,
+        diagnostic: str,
+        status_code: int | None = None,
+    ) -> None:
+        self.operation = operation
+        self.category = category
+        self.status_code = status_code
+        self.diagnostic = diagnostic
+        status = "" if status_code is None else ", status=%d" % status_code
+        super().__init__(
+            "destination read %s failed (category=%s%s): %s"
+            % (operation, category, status, diagnostic)
+        )
+
+
+def _destination_error_category(exc: BaseException) -> tuple[str, int | None]:
+    """Classify a destination failure without retaining its unsafe text."""
+    if isinstance(exc, SSRFError):
+        return "ssrf_policy", None
+    if isinstance(exc, HTTPStatusError):
+        status = exc.response.status_code
+        if status == 429:
+            return "rate_limit", status
+        if status in (401, 403):
+            return "authentication", status
+        if status >= 500:
+            return "server_error", status
+        return "http_error", status
+    if isinstance(exc, TimeoutException):
+        return "timeout", None
+    if isinstance(exc, RequestError):
+        return "network", None
+    return "unexpected", None
 
 
 def _describe_destination_error(exc: BaseException) -> str:
@@ -88,6 +135,20 @@ class ReadObservingClient:
         object.__setattr__(self, "_inner", inner)
         object.__setattr__(self, "_report", report)
         object.__setattr__(self, "_reject_mutations", reject_mutations)
+        object.__setattr__(
+            self,
+            "_compensation_active",
+            ContextVar("destination_compensation_active", default=False),
+        )
+
+    @contextmanager
+    def compensation(self):
+        """Allow rollback DELETEs in this task while forward writes stay blocked."""
+        token = self._compensation_active.set(True)
+        try:
+            yield self
+        finally:
+            self._compensation_active.reset(token)
 
     def __getattr__(self, name: str):
         attr = getattr(self._inner, name)
@@ -98,7 +159,11 @@ class ReadObservingClient:
 
             async def _guarded_mutation(*args, **kwargs):
                 reason = self._report.destination_unreadable
-                if reason is not None:
+                compensating_delete = (
+                    name.startswith(_COMPENSATING_DELETE_PREFIXES)
+                    and self._compensation_active.get()
+                )
+                if reason is not None and not compensating_delete:
                     raise DestinationUnreadableError(
                         "refusing %s after destination read failure: %s"
                         % (name, reason)
@@ -120,11 +185,18 @@ class ReadObservingClient:
                     result = await result
                 return result
             except Exception as exc:  # noqa: BLE001 - observe, never swallow
+                category, status_code = _destination_error_category(exc)
+                diagnostic = _describe_destination_error(exc)
                 mark_destination_unread(
                     self._report,
                     "%s could not be read - %s"
-                    % (name, _describe_destination_error(exc)),
+                    % (name, diagnostic),
                 )
-                raise
+                raise DestinationReadError(
+                    name,
+                    category=category,
+                    diagnostic=diagnostic,
+                    status_code=status_code,
+                ) from None
 
         return _observed_read

--- a/backend/dbas/destination_read.py
+++ b/backend/dbas/destination_read.py
@@ -1,0 +1,92 @@
+"""Shared fail-closed observation for reads from a restore destination."""
+from __future__ import annotations
+
+import inspect
+from typing import Optional
+
+from httpx import HTTPStatusError, RequestError, TimeoutException
+
+from dbas.restore_contracts import RestoreReport
+from security.ssrf import SSRFError
+
+
+# Cheap authenticated read used to distinguish an empty destination from one
+# that cannot be read. Importers read this category again as part of their plan.
+_DESTINATION_PROBE = "get_channel_groups"
+_DESTINATION_READ_PREFIX = "get_"
+
+
+def _describe_destination_error(exc: BaseException) -> str:
+    """Return an actionable diagnostic without exposing exception text or URLs."""
+    if isinstance(exc, SSRFError):
+        return "the destination is blocked by this instance's outbound SSRF policy"
+    if isinstance(exc, HTTPStatusError):
+        status = exc.response.status_code
+        if status == 429:
+            return (
+                "the destination rate-limited this request (HTTP 429) - this is "
+                "not a credential problem; wait for its limit window to clear "
+                "and retry"
+            )
+        if status in (401, 403):
+            return (
+                "authentication to the destination was rejected (HTTP %d) - "
+                "check the destination credentials configured on this instance"
+                % status
+            )
+        if status >= 500:
+            return "the destination returned a server error (HTTP %d)" % status
+        return "the destination returned HTTP %d" % status
+    if isinstance(exc, TimeoutException):
+        return "the destination did not respond in time (%s)" % type(exc).__name__
+    if isinstance(exc, RequestError):
+        return "the destination could not be reached (%s)" % type(exc).__name__
+    return "the destination could not be read (%s)" % type(exc).__name__
+
+
+async def destination_read_reason(client) -> Optional[str]:
+    """Probe the destination once; return a sanitized refusal reason on failure."""
+    probe = getattr(client, _DESTINATION_PROBE, None)
+    if probe is None:
+        return "the destination client has no authenticated readability check"
+    try:
+        await probe()
+    except Exception as exc:  # noqa: BLE001 - every failure class is a refusal
+        return _describe_destination_error(exc)
+    return None
+
+
+def mark_destination_unread(report: RestoreReport, reason: str) -> None:
+    """Record the first failed read and retain each failure as an operator note."""
+    if report.destination_unreadable is None:
+        report.destination_unreadable = reason
+    report.notes.append("destination not read: %s" % reason)
+
+
+class ReadObservingClient:
+    """Transparent client proxy that records every failed destination read."""
+
+    def __init__(self, inner, report: RestoreReport) -> None:
+        object.__setattr__(self, "_inner", inner)
+        object.__setattr__(self, "_report", report)
+
+    def __getattr__(self, name: str):
+        attr = getattr(self._inner, name)
+        if not name.startswith(_DESTINATION_READ_PREFIX) or not callable(attr):
+            return attr
+
+        async def _observed_read(*args, **kwargs):
+            try:
+                result = attr(*args, **kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+                return result
+            except Exception as exc:  # noqa: BLE001 - observe, never swallow
+                mark_destination_unread(
+                    self._report,
+                    "%s could not be read - %s"
+                    % (name, _describe_destination_error(exc)),
+                )
+                raise
+
+        return _observed_read

--- a/backend/dbas/importers/logos.py
+++ b/backend/dbas/importers/logos.py
@@ -391,6 +391,10 @@ def _sanitize_failure(exc: Exception | str) -> str:
     carries any path/url marker, replace it wholesale with a generic message
     rather than risk leaking a path or token into the report.
     """
+    from dbas.destination_read import DestinationReadError
+
+    if isinstance(exc, DestinationReadError):
+        return str(exc)
     text = (str(exc) or "").strip()
     lowered = text.lower()
     if not text or any(m in lowered for m in _PATH_LEAK_MARKERS):

--- a/backend/dbas/restore_orchestrator.py
+++ b/backend/dbas/restore_orchestrator.py
@@ -179,6 +179,7 @@ import json
 import logging
 import os
 import uuid
+from contextlib import nullcontext
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -455,53 +456,56 @@ async def run_rollback(
         A :class:`RollbackResult` with ``complete`` and the compensated/residue
         split.
     """
-    dispatch = _delete_dispatch(client)
     compensated: list[LedgerEntry] = []
     residue: list[LedgerEntry] = []
 
-    for entry in ledger.compensation_order():
-        deleter = dispatch.get(entry.entity_type)
-        if deleter is None:
-            logger.error(
-                "[DBAS-ROLLBACK] No compensator registered for entity_type=%s id=%s; "
-                "rollback INCOMPLETE for this entry — manual cleanup required.",
-                entry.entity_type.value,
-                entry.destination_id,
-            )
-            residue.append(entry)
-            continue
-        try:
-            await deleter(entry.destination_id)
-        except Exception as exc:  # noqa: BLE001 - classify by status, re-bucket below
-            if _is_already_gone(exc):
-                logger.info(
-                    "[DBAS-ROLLBACK] Compensating delete of %s id=%s returned 404 "
-                    "(already gone) — counted as success.",
+    compensation = getattr(type(client), "compensation", None)
+    scope = client.compensation() if compensation is not None else nullcontext()
+    with scope:
+        dispatch = _delete_dispatch(client)
+        for entry in ledger.compensation_order():
+            deleter = dispatch.get(entry.entity_type)
+            if deleter is None:
+                logger.error(
+                    "[DBAS-ROLLBACK] No compensator registered for entity_type=%s id=%s; "
+                    "rollback INCOMPLETE for this entry — manual cleanup required.",
                     entry.entity_type.value,
                     entry.destination_id,
                 )
-                entry.compensated = True
-                compensated.append(entry)
-                persist_ledger(ledger, ledger_dir=ledger_dir)
+                residue.append(entry)
                 continue
-            logger.error(
-                "[DBAS-ROLLBACK] Compensating delete of %s id=%s FAILED (status=%s); "
-                "rollback INCOMPLETE — manual cleanup required.",
+            try:
+                await deleter(entry.destination_id)
+            except Exception as exc:  # noqa: BLE001 - classify by status, re-bucket below
+                if _is_already_gone(exc):
+                    logger.info(
+                        "[DBAS-ROLLBACK] Compensating delete of %s id=%s returned 404 "
+                        "(already gone) — counted as success.",
+                        entry.entity_type.value,
+                        entry.destination_id,
+                    )
+                    entry.compensated = True
+                    compensated.append(entry)
+                    persist_ledger(ledger, ledger_dir=ledger_dir)
+                    continue
+                logger.error(
+                    "[DBAS-ROLLBACK] Compensating delete of %s id=%s FAILED (status=%s); "
+                    "rollback INCOMPLETE — manual cleanup required.",
+                    entry.entity_type.value,
+                    entry.destination_id,
+                    _status_code_of(exc),
+                )
+                residue.append(entry)
+                continue
+
+            entry.compensated = True
+            compensated.append(entry)
+            persist_ledger(ledger, ledger_dir=ledger_dir)
+            logger.info(
+                "[DBAS-ROLLBACK] Compensated %s id=%s.",
                 entry.entity_type.value,
                 entry.destination_id,
-                _status_code_of(exc),
             )
-            residue.append(entry)
-            continue
-
-        entry.compensated = True
-        compensated.append(entry)
-        persist_ledger(ledger, ledger_dir=ledger_dir)
-        logger.info(
-            "[DBAS-ROLLBACK] Compensated %s id=%s.",
-            entry.entity_type.value,
-            entry.destination_id,
-        )
 
     complete = not residue
     logger.warning(

--- a/backend/dbas/restore_orchestrator.py
+++ b/backend/dbas/restore_orchestrator.py
@@ -1863,6 +1863,7 @@ async def run_dry_run(
     *,
     plan: ImportPlan,
     client: DispatcharrClient,
+    report: RestoreReport | None = None,
     steps: list[ImporterStep] | None = None,
     ledger_dir: Path | None = None,
     max_entities_per_category: int = None,  # type: ignore[assignment]
@@ -1900,7 +1901,8 @@ async def run_dry_run(
         ``would_*`` counts, the ``logo_misses`` aggregate, and the
         ``epg_link_reattach`` / ``logo_reattach`` population splits.
     """
-    report = RestoreReport(is_dry_run=True)
+    if report is None:
+        report = RestoreReport(is_dry_run=True)
     ledger = RollbackLedger(restore_id=new_restore_id())
     from dbas.restore_contracts import IdRemapTable
 

--- a/backend/tasks/dbas_restore.py
+++ b/backend/tasks/dbas_restore.py
@@ -379,7 +379,7 @@ class DbasRestoreTask(TaskScheduler):
                 % unread_reason,
             )
         report = RestoreReport(is_dry_run=not is_apply)
-        client = ReadObservingClient(client, report)
+        client = ReadObservingClient(client, report, reject_mutations=True)
 
         try:
             if is_apply:

--- a/backend/tasks/dbas_restore.py
+++ b/backend/tasks/dbas_restore.py
@@ -337,6 +337,7 @@ class DbasRestoreTask(TaskScheduler):
         # Local imports keep the heavy backup router / orchestrator off this
         # module's import-time path (mirrors DbasBackupTask's deferred imports).
         from dispatcharr_client import get_client
+        from dbas.destination_read import ReadObservingClient, destination_read_reason
         from routers.backup import validate_artifact_manifest
         from dbas.restore_artifact import decode_artifact_to_plan
         from dbas.restore_orchestrator import run_dry_run, run_restore, new_restore_id
@@ -367,13 +368,26 @@ class DbasRestoreTask(TaskScheduler):
         is_apply = bool(self.confirm_apply)
         client = get_client()
 
+        # Every importer count is a claim about the destination. Prove it can be
+        # read before either preview or apply reaches the orchestrator, then keep
+        # observing every get_* call in case readability is lost mid-run.
+        unread_reason = await destination_read_reason(client)
+        if unread_reason is not None:
+            return self._fail(
+                started_at,
+                "Restore refused because the destination could not be read: %s"
+                % unread_reason,
+            )
+        report = RestoreReport(is_dry_run=not is_apply)
+        client = ReadObservingClient(client, report)
+
         try:
             if is_apply:
                 report = await run_restore(
                     plan=plan,
                     client=client,
                     steps=default_importer_steps(),
-                    report=RestoreReport(is_dry_run=False),
+                    report=report,
                     ledger=RollbackLedger(restore_id=new_restore_id()),
                     remap=plan.existing_remap or IdRemapTable(),
                     confirm_apply=True,
@@ -393,6 +407,7 @@ class DbasRestoreTask(TaskScheduler):
                 report = await run_dry_run(
                     plan=plan,
                     client=client,
+                    report=report,
                     channel_reattach_mode=self.channel_reattach_mode,
                 )
         except Exception as exc:  # noqa: BLE001 - any orchestration error is a sanitized failure
@@ -473,6 +488,8 @@ class DbasRestoreTask(TaskScheduler):
         """A dry-run always 'succeeds' (it produced a plan); an apply succeeds
         only on a clean SUCCESS outcome (never on a rolled-back/incomplete state)."""
         from dbas.restore_contracts import RestoreOutcome
+        if report.destination_unreadable is not None:
+            return False
 
         if not is_apply or report.is_dry_run:
             return True
@@ -799,6 +816,11 @@ class DbasRestoreTask(TaskScheduler):
 
     @staticmethod
     def _summary_message(report, is_apply: bool) -> str:
+        if report.destination_unreadable is not None:
+            return (
+                "Restore failed because the destination could not be read safely: %s"
+                % report.destination_unreadable
+            )
         if report.is_dry_run or not is_apply:
             total_create = sum(c.would_create for c in report.categories)
             total_update = sum(c.would_update for c in report.categories)

--- a/backend/tasks/dbas_sync_engine.py
+++ b/backend/tasks/dbas_sync_engine.py
@@ -110,24 +110,18 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import inspect
 import logging
 import posixpath
 import time
 from pathlib import Path
 from typing import Optional
 
-# EXCEPTION TYPES ONLY — this module opens no socket. The destination readback
-# gate below has to tell an operator whether B refused the credentials,
-# rate-limited the request, or could not be reached at all, and those arrive as
-# httpx exception classes raised by the SSRF-pinned client dbas_sync_client
-# built. Deliberately `from httpx import <errors>` rather than `import httpx`:
-# the name ``httpx`` never enters this namespace, so no client or request class
-# is reachable from here and the module's ONLY outbound path stays
-# make_remote_client's chokepointed transport.
-from httpx import HTTPStatusError, RequestError, TimeoutException  # ssrf-ok: error classes only, no I/O
-
 import journal
+from dbas.destination_read import (
+    ReadObservingClient as _ReadObservingClient,
+    destination_read_reason,
+    mark_destination_unread as _mark_destination_unread,
+)
 from dbas.channel_reattach import (
     reattach_channel_logos,
     reattach_epg_links,
@@ -175,7 +169,6 @@ from routers.backup import (
     _redact_credentials_deep,
     _url_carries_credentials,
 )
-from security.ssrf import SSRFError
 from tasks.dbas_sync_client import make_remote_client, sync_freshness_reason
 
 logger = logging.getLogger(__name__)
@@ -2301,171 +2294,6 @@ async def _apply_group_selection_only(
         sum(s.get("groups_enabled", 0) for s in summaries),
     )
     return []
-
-
-# ---------------------------------------------------------------------------
-# Destination readability (bead …-jqfxm) — the preview must have READ B.
-# ---------------------------------------------------------------------------
-
-# The probe endpoint. It must be an AUTHENTICATED read (an unauthenticated
-# liveness ping would answer "the box is up" to a question about credentials),
-# and it must be cheap — channel groups are a handful of rows even on a large
-# instance, and the plan reads them anyway a moment later.
-_DESTINATION_PROBE = "get_channel_groups"
-
-# Everything the destination is ASKED, as opposed to told. Only reads need
-# watching: a failed WRITE already lands in its category's ``failed`` counter
-# and drives the orchestrator's rollback, whereas a failed READ is swallowed by
-# every importer's ``except Exception: existing = []`` fallback and silently
-# becomes "the destination is empty".
-_DESTINATION_READ_PREFIX = "get_"
-
-
-def _describe_destination_error(exc: BaseException) -> str:
-    """Turn a destination-read exception into a sanitized operator sentence.
-
-    Credential hygiene (the same rule ``dispatcharr_client._request`` documents):
-    an httpx error's own text can embed the request URL, and that URL can carry a
-    token — so this NEVER interpolates ``str(exc)``. Only the HTTP status code
-    and the exception's CLASS name reach the message, which is plenty to tell an
-    operator whether to fix credentials, wait, or check the network.
-
-    The 401/403 vs 429 split is load-bearing: B's Dispatcharr rate-limits
-    ``/api/accounts/token/`` at 3/min per IP, so back-to-back cycles produce 429s
-    that have nothing to do with the credentials. Reporting one as the other
-    would send an operator to rotate perfectly good passwords (or to wait out a
-    limiter that will never clear a genuinely wrong password).
-    """
-    if isinstance(exc, SSRFError):
-        return (
-            "the destination is blocked by this instance's outbound SSRF policy"
-        )
-    if isinstance(exc, HTTPStatusError):
-        status = exc.response.status_code
-        if status == 429:
-            return (
-                "the destination rate-limited this request (HTTP 429) — this is "
-                "NOT a credential problem; wait for its limit window to clear "
-                "and retry"
-            )
-        if status in (401, 403):
-            return (
-                "authentication to the destination was rejected (HTTP %d) — "
-                "check the sync target's credentials on this instance" % status
-            )
-        if status >= 500:
-            return "the destination returned a server error (HTTP %d)" % status
-        return "the destination returned HTTP %d" % status
-    if isinstance(exc, TimeoutException):
-        return "the destination did not respond in time (%s)" % type(exc).__name__
-    if isinstance(exc, RequestError):
-        # Connection refused, DNS failure and a TLS handshake refusal all arrive
-        # here as some ConnectError flavour — the class name is the distinction
-        # an operator can act on without leaking the URL.
-        return "the destination could not be reached (%s)" % type(exc).__name__
-    return "the destination could not be read (%s)" % type(exc).__name__
-
-
-async def destination_read_reason(client) -> Optional[str]:
-    """Probe the destination ONCE and return why it is unreadable, or ``None``.
-
-    The fail-closed gate this bead exists for. Deliberately shaped like
-    :func:`sync_freshness_reason` — a reason string aborts, ``None`` proceeds —
-    because it is the same kind of gate: a precondition checked before any work,
-    whose failure must stop the cycle rather than colour a result afterwards.
-
-    Two things it buys beyond honesty:
-
-    * **Fail-fast.** Without it, an unauthenticated cycle runs all seven config
-      steps, each of which re-enters ``DispatcharrClient._login`` because no
-      access token was ever obtained — seven ``POST /api/accounts/token/`` in a
-      few seconds against an endpoint limited to 3/min. Live validation caught
-      exactly that: seven 401/429s in B's log for one preview. One probe, one
-      login attempt.
-    * **No plan.** A cycle that cannot read B never gathers or redacts A's
-      config, so an unreachable destination costs nothing.
-    """
-    probe = getattr(client, _DESTINATION_PROBE, None)
-    if probe is None:  # pragma: no cover - defensive; every client has it
-        return None
-    try:
-        await probe()
-    except Exception as exc:  # noqa: BLE001 - every failure class is a refusal
-        return _describe_destination_error(exc)
-    return None
-
-
-class _ReadObservingClient:
-    """Wrap the dest-B client so a FAILED destination read cannot go unnoticed.
-
-    :func:`destination_read_reason` proves the destination was readable when the
-    cycle started. It cannot prove every read the cycle then makes succeeded —
-    and each importer degrades its own failed read to ``existing = []``, which
-    the report renders as "would create N" (a statement about the SOURCE wearing
-    the destination's clothes). B restarting mid-cycle, one endpoint answering
-    500, or a token expiring against a rate-limited refresh all land there.
-
-    So the client handed to the orchestrator marks the REPORT the moment a read
-    raises. Nothing is suppressed or retried — the importers' own fallbacks
-    still run and the run still completes — but the report carries
-    ``destination_unreadable`` from that moment on, which is what stops a
-    preview built on a half-read destination from unlocking Apply.
-
-    IT MARKS THE REPORT DURING THE RUN, NOT AFTER IT (bead ``…-bj442``). This
-    used to collect the failures in a list that ``run_sync`` drained once
-    ``run_restore`` had returned — which is to say, after ``compute_outcome``
-    had already decided the run was a clean SUCCESS from counts that describe
-    the SOURCE. Stamping at the moment of the failed read is what lets the ONE
-    outcome decision see it, so the task result, the task-history
-    ``details.outcome`` row, the ``sync_outbound`` journal row and the persisted
-    ``sync_targets.last_outcome`` column all read the same verdict instead of
-    needing a second correction each.
-
-    A transparent proxy rather than a subclass: the client is constructed by
-    :func:`make_remote_client` (Fernet decrypt + SSRF-pinned transport) and must
-    not be rebuilt here, and every attribute other than the wrapped reads passes
-    straight through.
-    """
-
-    def __init__(self, inner, report: RestoreReport) -> None:
-        # Bypass __getattr__ for our own state (anything not set here routes to
-        # the wrapped client).
-        object.__setattr__(self, "_inner", inner)
-        object.__setattr__(self, "_report", report)
-
-    def __getattr__(self, name: str):
-        attr = getattr(self._inner, name)
-        if not name.startswith(_DESTINATION_READ_PREFIX) or not callable(attr):
-            return attr
-
-        async def _observed_read(*args, **kwargs):
-            try:
-                result = attr(*args, **kwargs)
-                if inspect.isawaitable(result):
-                    result = await result
-                return result
-            except Exception as exc:  # noqa: BLE001 - observe, never swallow
-                _mark_destination_unread(
-                    self._report,
-                    "%s could not be read — %s" % (
-                        name, _describe_destination_error(exc),
-                    ),
-                )
-                raise
-
-        return _observed_read
-
-
-def _mark_destination_unread(report: RestoreReport, reason: str) -> None:
-    """Stamp the "I never read the destination" marker and say so in the notes.
-
-    One writer so the marker and the operator-facing note can never disagree,
-    and so a second failure never overwrites the first (the first refusal is the
-    one that explains the rest).
-    """
-    if report.destination_unreadable is None:
-        report.destination_unreadable = reason
-    report.notes.append("destination not read: %s" % reason)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/dbas/test_restore_orchestrator.py
+++ b/backend/tests/dbas/test_restore_orchestrator.py
@@ -42,6 +42,7 @@ from dbas.restore_orchestrator import (
     run_restore,
     run_rollback,
 )
+from dbas.destination_read import DestinationReadError, ReadObservingClient
 
 _GOOD_MANIFEST = {"schema_version": 1}
 
@@ -270,6 +271,23 @@ async def test_rollback_404_counts_as_success(tmp_path):
     assert result.complete is True
     assert result.residue == []
     assert all(e.compensated for e in ledger.entries)
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_rollback_opens_explicit_delete_compensation_scope(tmp_path):
+    inner = _client()
+    inner.get_m3u_accounts.side_effect = _http_error(503)
+    report = _report()
+    client = ReadObservingClient(inner, report, reject_mutations=True)
+    with pytest.raises(DestinationReadError):
+        await client.get_m3u_accounts()
+    ledger = _ledger("explicit-compensation")
+    ledger.record_created(EntityType.M3U_ACCOUNT, 901, "prov")
+
+    result = await run_rollback(ledger=ledger, client=client, ledger_dir=tmp_path)
+
+    assert result.complete is True
+    inner.delete_m3u_account.assert_awaited_once_with(901)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/tasks/test_dbas_restore_destination_readable.py
+++ b/backend/tests/tasks/test_dbas_restore_destination_readable.py
@@ -1,0 +1,155 @@
+"""Archive restore must distinguish an empty destination from a failed read."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from dbas.destination_read import ReadObservingClient, destination_read_reason
+from dbas.restore_contracts import RestoreReport
+from tasks.dbas_restore import DbasRestoreTask
+from tests.tasks.test_dbas_restore_task import (
+    _apply_report,
+    _dry_run_report,
+    _make_task,
+    _write_artifact,
+)
+
+
+def _http_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request(
+        "GET",
+        "http://destination.invalid/api/channels/groups/?token=do-not-disclose",
+    )
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(
+        "request failed for token=do-not-disclose",
+        request=request,
+        response=response,
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_authenticated_probe_fails_closed():
+    reason = await destination_read_reason(object())
+
+    assert reason is not None
+    assert "authenticated readability check" in reason
+
+
+@pytest.mark.parametrize("confirm_apply", [False, True])
+@pytest.mark.asyncio
+async def test_unreadable_destination_is_refused_before_orchestration(
+    tmp_path, confirm_apply
+):
+    artifact = _write_artifact(tmp_path)
+    task = _make_task(artifact, confirm_apply=confirm_apply)
+    client = AsyncMock()
+    client.get_channel_groups.side_effect = _http_error(401)
+    dry_run = AsyncMock(return_value=_dry_run_report())
+    apply = AsyncMock(return_value=_apply_report())
+
+    with patch("dispatcharr_client.get_client", return_value=client), patch(
+        "dbas.restore_orchestrator.run_dry_run", dry_run
+    ), patch("dbas.restore_orchestrator.run_restore", apply):
+        result = await task.execute()
+
+    assert result.success is False
+    assert "authentication" in result.message.lower()
+    assert "401" in result.message
+    assert "do-not-disclose" not in result.message
+    client.get_channel_groups.assert_awaited_once_with()
+    dry_run.assert_not_awaited()
+    apply.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_genuinely_empty_destination_still_runs_the_restore_preview(tmp_path):
+    artifact = _write_artifact(tmp_path)
+    task = _make_task(artifact)
+    client = AsyncMock()
+    client.get_channel_groups.return_value = []
+    dry_run = AsyncMock(return_value=_dry_run_report())
+
+    with patch("dispatcharr_client.get_client", return_value=client), patch(
+        "dbas.restore_orchestrator.run_dry_run", dry_run
+    ):
+        result = await task.execute()
+
+    assert result.success is True
+    client.get_channel_groups.assert_awaited_once_with()
+    observed_client = dry_run.await_args.kwargs["client"]
+    report = dry_run.await_args.kwargs["report"]
+    assert isinstance(observed_client, ReadObservingClient)
+    assert report.destination_unreadable is None
+
+
+@pytest.mark.asyncio
+async def test_read_failure_after_gate_fails_the_preview_with_the_read_named(tmp_path):
+    artifact = _write_artifact(tmp_path)
+    task = _make_task(artifact)
+    client = AsyncMock()
+    client.get_channel_groups.return_value = []
+    client.get_m3u_accounts.side_effect = _http_error(503)
+
+    async def run_dry_run(*, client, report, **_kwargs):
+        try:
+            await client.get_m3u_accounts()
+        except httpx.HTTPStatusError:
+            pass  # Mirrors the importer fallback that currently uses existing = [].
+        return report
+
+    with patch("dispatcharr_client.get_client", return_value=client), patch(
+        "dbas.restore_orchestrator.run_dry_run", side_effect=run_dry_run
+    ):
+        result = await task.execute()
+
+    report = result.details["restore_report"]
+    assert result.success is False
+    assert "get_m3u_accounts" in report["destination_unreadable"]
+    assert "503" in result.message
+    assert "do-not-disclose" not in result.message
+
+
+_SWALLOWED_IMPORTER_READS = (
+    # m3u_accounts.py
+    "get_m3u_accounts",
+    # epg_sources.py
+    "get_epg_sources",
+    # groups_profiles.py (four category configurations)
+    "get_channel_groups",
+    "get_channel_profiles",
+    "get_stream_profiles",
+    "get_server_groups",
+    # settings_agents.py
+    "get_user_agents",
+    "get_dvr_rules",
+    "get_recordings",
+    "get_core_setting_id_map",
+    # channels.py
+    "get_channels",
+    "get_streams",
+    # logos.py
+    "get_all_logos_paginated",
+    # users.py
+    "get_users",
+)
+
+
+@pytest.mark.parametrize("method_name", _SWALLOWED_IMPORTER_READS)
+@pytest.mark.asyncio
+async def test_every_swallowed_importer_read_marks_the_destination_unreadable(
+    method_name
+):
+    inner = AsyncMock()
+    getattr(inner, method_name).side_effect = _http_error(503)
+    report = RestoreReport(is_dry_run=True)
+    client = ReadObservingClient(inner, report)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await getattr(client, method_name)()
+
+    assert method_name in report.destination_unreadable
+    assert "503" in report.destination_unreadable
+    assert "do-not-disclose" not in report.destination_unreadable

--- a/backend/tests/tasks/test_dbas_restore_destination_readable.py
+++ b/backend/tests/tasks/test_dbas_restore_destination_readable.py
@@ -1,17 +1,26 @@
 """Archive restore must distinguish an empty destination from a failed read."""
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 
 from dbas.destination_read import (
+    DestinationReadError,
     DestinationUnreadableError,
     ReadObservingClient,
     destination_read_reason,
 )
-from dbas.restore_contracts import RestoreReport
+from dbas.preflight import ImportPlan, PlanCategory
+from dbas.restore_contracts import (
+    EntityType,
+    IdRemapTable,
+    RestoreReport,
+    RollbackLedger,
+)
+from dbas.restore_orchestrator import default_importer_steps, run_restore
 from tasks.dbas_restore import DbasRestoreTask
 from tests.tasks.test_dbas_restore_task import (
     _apply_report,
@@ -25,6 +34,7 @@ def _http_error(status: int) -> httpx.HTTPStatusError:
     request = httpx.Request(
         "GET",
         "http://destination.invalid/api/channels/groups/?token=do-not-disclose",
+        headers={"Authorization": "Bearer header-secret-do-not-disclose"},
     )
     response = httpx.Response(status, request=request)
     return httpx.HTTPStatusError(
@@ -32,6 +42,14 @@ def _http_error(status: int) -> httpx.HTTPStatusError:
         request=request,
         response=response,
     )
+
+
+_LOG_SECRET_CORPUS = (
+    "destination.invalid",
+    "token=do-not-disclose",
+    "header-secret-do-not-disclose",
+    "request failed for token=do-not-disclose",
+)
 
 
 @pytest.mark.asyncio
@@ -100,7 +118,7 @@ async def test_read_failure_after_gate_fails_the_preview_with_the_read_named(tmp
     async def run_dry_run(*, client, report, **_kwargs):
         try:
             await client.get_m3u_accounts()
-        except httpx.HTTPStatusError:
+        except DestinationReadError:
             pass  # Mirrors the importer fallback that currently uses existing = [].
         with pytest.raises(DestinationUnreadableError):
             await client.create_m3u_account({"name": "must not be written"})
@@ -154,22 +172,25 @@ async def test_every_swallowed_importer_read_marks_the_destination_unreadable(
     report = RestoreReport(is_dry_run=True)
     client = ReadObservingClient(inner, report)
 
-    with pytest.raises(httpx.HTTPStatusError):
+    with pytest.raises(DestinationReadError) as read_failure:
         await getattr(client, method_name)()
 
+    assert read_failure.value.operation == method_name
+    assert read_failure.value.category == "server_error"
+    assert read_failure.value.status_code == 503
     assert method_name in report.destination_unreadable
     assert "503" in report.destination_unreadable
     assert "do-not-disclose" not in report.destination_unreadable
 
 
 @pytest.mark.asyncio
-async def test_failed_read_blocks_fallback_mutation_but_allows_rollback_delete():
+async def test_failed_read_blocks_forward_mutations_including_cleanup_delete():
     inner = AsyncMock()
     inner.get_m3u_accounts.side_effect = _http_error(503)
     report = RestoreReport(is_dry_run=False)
     client = ReadObservingClient(inner, report, reject_mutations=True)
 
-    with pytest.raises(httpx.HTTPStatusError):
+    with pytest.raises(DestinationReadError):
         await client.get_m3u_accounts()
 
     with pytest.raises(DestinationUnreadableError) as refused:
@@ -179,5 +200,119 @@ async def test_failed_read_blocks_fallback_mutation_but_allows_rollback_delete()
     assert "do-not-disclose" not in str(refused.value)
     inner.create_m3u_account.assert_not_awaited()
 
-    await client.delete_m3u_account(42)
+    with pytest.raises(DestinationUnreadableError):
+        await client.delete_m3u_account(42)
+    inner.delete_m3u_account.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_only_explicit_compensation_scope_allows_delete_after_failed_read():
+    inner = AsyncMock()
+    inner.get_m3u_accounts.side_effect = _http_error(503)
+    report = RestoreReport(is_dry_run=False)
+    client = ReadObservingClient(inner, report, reject_mutations=True)
+
+    with pytest.raises(DestinationReadError):
+        await client.get_m3u_accounts()
+
+    with client.compensation():
+        await client.delete_m3u_account(42)
+
     inner.delete_m3u_account.assert_awaited_once_with(42)
+    with pytest.raises(DestinationUnreadableError):
+        await client.delete_m3u_account(43)
+
+
+_REAL_IMPORTER_READ_MATRIX = (
+    (EntityType.M3U_ACCOUNT, "get_m3u_accounts", "create_m3u_account", {"id": 1, "name": "M3U"}),
+    (EntityType.EPG_SOURCE, "get_epg_sources", "create_epg_source", {"id": 2, "name": "EPG"}),
+    (EntityType.CHANNEL_GROUP, "get_channel_groups", "create_channel_group", {"id": 3, "name": "News"}),
+    (EntityType.USER_AGENT, "get_user_agents", "create_user_agent", {"id": 4, "name": "Agent"}),
+    (EntityType.DVR_RULE, "get_dvr_rules", "create_dvr_rule", {"id": 5, "name": "Rule"}),
+    (EntityType.CHANNEL, "get_channels", "create_channel", {"id": 6, "name": "Channel", "channel_number": 6}),
+    (
+        EntityType.LOGO,
+        "get_all_logos_paginated",
+        "create_logo",
+        {"id": 7, "name": "Logo", "url": "https://cdn.example.invalid/logo.png"},
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("entity_type", "getter", "mutation", "archive_row"),
+    _REAL_IMPORTER_READ_MATRIX,
+)
+@pytest.mark.asyncio
+async def test_real_importer_orchestrator_paths_fail_closed_and_log_safely(
+    tmp_path, caplog, entity_type, getter, mutation, archive_row
+):
+    """Each swallowed-read family runs through its production registry step."""
+    inner = AsyncMock()
+    getattr(inner, getter).side_effect = _http_error(503)
+    report = RestoreReport(is_dry_run=False)
+    client = ReadObservingClient(inner, report, reject_mutations=True)
+    plan = ImportPlan(
+        manifest={"schema_version": 1},
+        categories=[
+            PlanCategory(entity_type=entity_type, entities=[archive_row], selected=True)
+        ],
+    )
+    step = next(s for s in default_importer_steps() if s.entity_type == entity_type)
+
+    with caplog.at_level(logging.WARNING):
+        out = await run_restore(
+            plan=plan,
+            client=client,
+            steps=[step],
+            report=report,
+            ledger=RollbackLedger(restore_id="read-matrix-%s" % entity_type.value),
+            remap=IdRemapTable(),
+            confirm_apply=True,
+            ledger_dir=tmp_path,
+        )
+
+    assert getter in out.destination_unreadable
+    assert "HTTP 503" in out.destination_unreadable
+    getattr(inner, mutation).assert_not_awaited()
+    assert "category=server_error" in caplog.text
+    assert "status=503" in caplog.text
+    for secret in _LOG_SECRET_CORPUS:
+        assert secret not in caplog.text
+        assert secret not in "\n".join(out.notes)
+
+
+@pytest.mark.parametrize(
+    ("streams", "blocked_delete"),
+    (
+        ([{"id": 77, "name": "old placeholder", "url": None, "m3u_account": 42}], "delete_stream"),
+        ([], "delete_m3u_account"),
+    ),
+)
+@pytest.mark.asyncio
+async def test_post_rebind_read_failure_blocks_forward_cleanup_deletes(
+    streams, blocked_delete
+):
+    from dbas.custom_stream_fallback import CUSTOM_STREAM_ACCOUNT_NAME
+    from dbas.placeholder_rebind import rebind_placeholder_streams
+
+    inner = AsyncMock()
+    inner.get_streams.return_value = streams
+    inner.get_channels.return_value = []
+    inner.get_m3u_accounts.side_effect = _http_error(503)
+    report = RestoreReport(is_dry_run=False)
+    client = ReadObservingClient(inner, report, reject_mutations=True)
+    ledger = RollbackLedger(restore_id="post-rebind-read")
+    ledger.record_created(EntityType.M3U_ACCOUNT, 42, CUSTOM_STREAM_ACCOUNT_NAME)
+
+    await rebind_placeholder_streams(
+        client=client,
+        report=report,
+        ledger=ledger,
+        remap=IdRemapTable(),
+        archive_channels=[],
+        allow_fuzzy=True,
+    )
+
+    assert "get_m3u_accounts" in report.destination_unreadable
+    getattr(inner, blocked_delete).assert_not_awaited()

--- a/backend/tests/tasks/test_dbas_restore_destination_readable.py
+++ b/backend/tests/tasks/test_dbas_restore_destination_readable.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
-from dbas.destination_read import ReadObservingClient, destination_read_reason
+from dbas.destination_read import (
+    DestinationUnreadableError,
+    ReadObservingClient,
+    destination_read_reason,
+)
 from dbas.restore_contracts import RestoreReport
 from tasks.dbas_restore import DbasRestoreTask
 from tests.tasks.test_dbas_restore_task import (
@@ -98,6 +102,8 @@ async def test_read_failure_after_gate_fails_the_preview_with_the_read_named(tmp
             await client.get_m3u_accounts()
         except httpx.HTTPStatusError:
             pass  # Mirrors the importer fallback that currently uses existing = [].
+        with pytest.raises(DestinationUnreadableError):
+            await client.create_m3u_account({"name": "must not be written"})
         return report
 
     with patch("dispatcharr_client.get_client", return_value=client), patch(
@@ -110,6 +116,7 @@ async def test_read_failure_after_gate_fails_the_preview_with_the_read_named(tmp
     assert "get_m3u_accounts" in report["destination_unreadable"]
     assert "503" in result.message
     assert "do-not-disclose" not in result.message
+    client.create_m3u_account.assert_not_awaited()
 
 
 _SWALLOWED_IMPORTER_READS = (
@@ -153,3 +160,24 @@ async def test_every_swallowed_importer_read_marks_the_destination_unreadable(
     assert method_name in report.destination_unreadable
     assert "503" in report.destination_unreadable
     assert "do-not-disclose" not in report.destination_unreadable
+
+
+@pytest.mark.asyncio
+async def test_failed_read_blocks_fallback_mutation_but_allows_rollback_delete():
+    inner = AsyncMock()
+    inner.get_m3u_accounts.side_effect = _http_error(503)
+    report = RestoreReport(is_dry_run=False)
+    client = ReadObservingClient(inner, report, reject_mutations=True)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.get_m3u_accounts()
+
+    with pytest.raises(DestinationUnreadableError) as refused:
+        await client.create_m3u_account({"name": "would duplicate"})
+
+    assert "get_m3u_accounts" in str(refused.value)
+    assert "do-not-disclose" not in str(refused.value)
+    inner.create_m3u_account.assert_not_awaited()
+
+    await client.delete_m3u_account(42)
+    inner.delete_m3u_account.assert_awaited_once_with(42)


### PR DESCRIPTION
## Summary
- distinguish a genuinely empty destination from failed destination reads
- block archive-restore forward mutations after an observed read failure
- preserve explicit rollback compensation and redact destination secrets from diagnostics

## Tracking
- enhancedchannelmanager-06gax

## Verification
- frozen-scope acceptance approved at cef9cf2e
- independent canonical backend gate passed with 92.24% coverage
- dry-run, apply, rollback, and seven affected read families covered