### PR TITLE
fix: adopt concurrent channel-group creation safely

### DIFF
--- a/backend/dbas/importers/groups_profiles.py
+++ b/backend/dbas/importers/groups_profiles.py
@@ -265,6 +265,24 @@ def _existing_by_name(existing_rows: list) -> dict[str, dict]:
     return index
 
 
+def _existing_by_raw_name(existing_rows: list) -> dict[str, dict]:
+    """Index rows by exact raw name, omitting any ambiguous duplicate."""
+    index: dict[str, dict] = {}
+    ambiguous: set[str] = set()
+    for row in existing_rows or []:
+        if not isinstance(row, dict):
+            continue
+        name = row.get("name")
+        if not isinstance(name, str) or name in ambiguous:
+            continue
+        if name in index:
+            index.pop(name)
+            ambiguous.add(name)
+            continue
+        index[name] = row
+    return index
+
+
 def _failure_reason_for(exc: Exception) -> FailureReason:
     """Classify a create failure into a restore-contract FailureReason.
 
@@ -416,14 +434,20 @@ async def _import_category(
         )
         existing = []
     existing_by_name = _existing_by_name(existing)
+    existing_by_raw_name = _existing_by_raw_name(existing)
 
     for archive_row in archive_rows:
         label = _row_label(archive_row)
         source_id = archive_row.get("id")
 
         # Collision: a row with the same name already on the destination.
-        name_key = _norm_name(archive_row.get("name"))
-        existing_row = existing_by_name.get(name_key) if name_key else None
+        raw_name = archive_row.get("name")
+        name_key = _norm_name(raw_name)
+        existing_row = (
+            existing_by_raw_name.get(raw_name) if isinstance(raw_name, str) else None
+        )
+        if existing_row is None and name_key:
+            existing_row = existing_by_name.get(name_key)
         if existing_row is not None:
             _skip(cat, config.name_match_skip_reason, label, source_id, is_dry_run)
             existing_id = existing_row.get("id")
@@ -508,10 +532,8 @@ async def _import_category(
                 ]
                 raced_row = raced_candidates[0] if len(raced_candidates) == 1 else None
                 if raced_row is not None:
-                    refreshed_by_name = _existing_by_name(refreshed)
-                    existing_by_name.update(refreshed_by_name)
-                    if name_key:
-                        existing_by_name[name_key] = raced_row
+                    existing_by_name = _existing_by_name(refreshed)
+                    existing_by_raw_name = _existing_by_raw_name(refreshed)
                     _skip(
                         cat,
                         config.name_match_skip_reason,

--- a/backend/dbas/importers/groups_profiles.py
+++ b/backend/dbas/importers/groups_profiles.py
@@ -277,6 +277,17 @@ def _failure_reason_for(exc: Exception) -> FailureReason:
     return FailureReason.UPSTREAM_API_ERROR
 
 
+def _is_channel_group_name_create_race(config: CategoryConfig, exc: Exception) -> bool:
+    """Recognize the observed Dispatcharr channel-group uniqueness response."""
+    text = str(exc).lower()
+    return (
+        config.entity_type == EntityType.CHANNEL_GROUP
+        and "channel group creation failed: 400 -" in text
+        and '"name"' in text
+        and "channel group with this name already exists." in text
+    )
+
+
 def _sanitize_failure(exc: Exception, noun: str) -> str:
     """Produce a sanitized, operator-facing failure message (no raw traces)."""
     return (str(exc) or "").strip() or f"Upstream rejected the {noun} creation request."
@@ -346,7 +357,9 @@ async def _import_category(
     * FK remap — any ``remappable_fk_fields`` are rewritten through the remap;
       unresolvable -> ``DEPENDENCY_UNRESOLVED`` (never a stale id upstream).
     * Dry-run — reports ``would_create`` / ``would_skip``; no creates, no ledger.
-    * Failure taxonomy — a uniqueness race is ``CONFLICT``; other errors are
+    * Failure taxonomy — the observed channel-group name-uniqueness race is
+      re-listed and adopted if the row is now present. Any race without a row to
+      adopt remains a fatal ``CONFLICT``; other errors are
       ``UPSTREAM_API_ERROR``.
 
     Args:
@@ -471,6 +484,47 @@ async def _import_category(
             else:
                 created = await getattr(client, config.creator)(payload)
         except Exception as exc:
+            if _is_channel_group_name_create_race(config, exc):
+                try:
+                    refreshed_by_name = _existing_by_name(
+                        await getattr(client, config.getter)()
+                    )
+                except Exception as relist_exc:
+                    logger.warning(
+                        "[%s] Could not re-list %ss after create conflict: %s",
+                        config.log_prefix,
+                        noun,
+                        relist_exc,
+                    )
+                    refreshed_by_name = {}
+
+                raced_row = refreshed_by_name.get(name_key) if name_key else None
+                if raced_row is not None:
+                    existing_by_name.update(refreshed_by_name)
+                    _skip(
+                        cat,
+                        config.name_match_skip_reason,
+                        label,
+                        source_id,
+                        is_dry_run,
+                    )
+                    destination_id = raced_row.get("id")
+                    if source_id is not None and destination_id is not None:
+                        remap.add(
+                            config.entity_type,
+                            int(source_id),
+                            int(destination_id),
+                        )
+                    logger.info(
+                        "[%s] %s '%s' appeared after a create conflict "
+                        "(dest id=%s); adopted, nothing created.",
+                        config.log_prefix,
+                        noun,
+                        label,
+                        destination_id,
+                    )
+                    continue
+
             reason = _failure_reason_for(exc)
             cat.failed += 1
             cat.failure_details.append(

--- a/backend/dbas/importers/groups_profiles.py
+++ b/backend/dbas/importers/groups_profiles.py
@@ -283,6 +283,34 @@ def _existing_by_raw_name(existing_rows: list) -> dict[str, dict]:
     return index
 
 
+def _channel_group_write_name(value) -> str | None:
+    """Apply Dispatcharr's channel-group serializer name normalization."""
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
+def _channel_groups_by_write_name(
+    existing_rows: list,
+) -> tuple[dict[str, dict], set[str]]:
+    """Index unique serializer-normalized names and retain ambiguous keys."""
+    index: dict[str, dict] = {}
+    ambiguous: set[str] = set()
+    for row in existing_rows or []:
+        if not isinstance(row, dict):
+            continue
+        name = _channel_group_write_name(row.get("name"))
+        if name is None or name in ambiguous:
+            continue
+        if name in index:
+            index.pop(name)
+            ambiguous.add(name)
+            continue
+        index[name] = row
+    return index, ambiguous
+
+
 def _failure_reason_for(exc: Exception) -> FailureReason:
     """Classify a create failure into a restore-contract FailureReason.
 
@@ -376,9 +404,10 @@ async def _import_category(
       unresolvable -> ``DEPENDENCY_UNRESOLVED`` (never a stale id upstream).
     * Dry-run — reports ``would_create`` / ``would_skip``; no creates, no ledger.
     * Failure taxonomy — the observed channel-group name-uniqueness race is
-      re-listed and adopted if exactly one row has the submitted raw name. Any
-      race without an unambiguous owner remains a fatal ``CONFLICT``; other
-      errors are ``UPSTREAM_API_ERROR``.
+      re-listed and adopted if exactly one row has the submitted name after
+      Dispatcharr's whitespace trimming. Case is preserved. Any race without an
+      unambiguous owner remains a fatal ``CONFLICT``; other errors are
+      ``UPSTREAM_API_ERROR``.
 
     Args:
         config: The per-category configuration (entity type, client methods,
@@ -435,6 +464,11 @@ async def _import_category(
         existing = []
     existing_by_name = _existing_by_name(existing)
     existing_by_raw_name = _existing_by_raw_name(existing)
+    channel_groups_by_write_name, ambiguous_channel_group_write_names = (
+        _channel_groups_by_write_name(existing)
+        if config.entity_type == EntityType.CHANNEL_GROUP
+        else ({}, set())
+    )
 
     for archive_row in archive_rows:
         label = _row_label(archive_row)
@@ -443,10 +477,16 @@ async def _import_category(
         # Collision: a row with the same name already on the destination.
         raw_name = archive_row.get("name")
         name_key = _norm_name(raw_name)
-        existing_row = (
-            existing_by_raw_name.get(raw_name) if isinstance(raw_name, str) else None
-        )
-        if existing_row is None and name_key:
+        write_name = _channel_group_write_name(raw_name)
+        write_name_is_ambiguous = write_name in ambiguous_channel_group_write_names
+        existing_row = channel_groups_by_write_name.get(write_name)
+        if (
+            existing_row is None
+            and not write_name_is_ambiguous
+            and isinstance(raw_name, str)
+        ):
+            existing_row = existing_by_raw_name.get(raw_name)
+        if existing_row is None and not write_name_is_ambiguous and name_key:
             existing_row = existing_by_name.get(name_key)
         if existing_row is not None:
             _skip(cat, config.name_match_skip_reason, label, source_id, is_dry_run)
@@ -520,20 +560,24 @@ async def _import_category(
                     )
                     refreshed = []
 
-                # Dispatcharr 0.29.0 stores ChannelGroup.name in a plain unique
-                # TextField and its serializer performs no canonicalization.
-                # The conflict therefore belongs only to the exact submitted
-                # value; case/whitespace variants may legally coexist.
-                attempted_name = payload.get("name")
+                # Dispatcharr 0.29.0's DRF CharField trims whitespace before
+                # unique validation and persistence. PostgreSQL uniqueness is
+                # case-sensitive, so preserve case when identifying the owner.
+                attempted_name = _channel_group_write_name(payload.get("name"))
                 raced_candidates = [
                     row
                     for row in refreshed or []
-                    if isinstance(row, dict) and row.get("name") == attempted_name
+                    if isinstance(row, dict)
+                    and _channel_group_write_name(row.get("name")) == attempted_name
                 ]
                 raced_row = raced_candidates[0] if len(raced_candidates) == 1 else None
                 if raced_row is not None:
                     existing_by_name = _existing_by_name(refreshed)
                     existing_by_raw_name = _existing_by_raw_name(refreshed)
+                    (
+                        channel_groups_by_write_name,
+                        ambiguous_channel_group_write_names,
+                    ) = _channel_groups_by_write_name(refreshed)
                     _skip(
                         cat,
                         config.name_match_skip_reason,

--- a/backend/dbas/importers/groups_profiles.py
+++ b/backend/dbas/importers/groups_profiles.py
@@ -358,9 +358,9 @@ async def _import_category(
       unresolvable -> ``DEPENDENCY_UNRESOLVED`` (never a stale id upstream).
     * Dry-run — reports ``would_create`` / ``would_skip``; no creates, no ledger.
     * Failure taxonomy — the observed channel-group name-uniqueness race is
-      re-listed and adopted if the row is now present. Any race without a row to
-      adopt remains a fatal ``CONFLICT``; other errors are
-      ``UPSTREAM_API_ERROR``.
+      re-listed and adopted if exactly one row has the submitted raw name. Any
+      race without an unambiguous owner remains a fatal ``CONFLICT``; other
+      errors are ``UPSTREAM_API_ERROR``.
 
     Args:
         config: The per-category configuration (entity type, client methods,
@@ -486,9 +486,7 @@ async def _import_category(
         except Exception as exc:
             if _is_channel_group_name_create_race(config, exc):
                 try:
-                    refreshed_by_name = _existing_by_name(
-                        await getattr(client, config.getter)()
-                    )
+                    refreshed = await getattr(client, config.getter)()
                 except Exception as relist_exc:
                     logger.warning(
                         "[%s] Could not re-list %ss after create conflict: %s",
@@ -496,11 +494,24 @@ async def _import_category(
                         noun,
                         relist_exc,
                     )
-                    refreshed_by_name = {}
+                    refreshed = []
 
-                raced_row = refreshed_by_name.get(name_key) if name_key else None
+                # Dispatcharr 0.29.0 stores ChannelGroup.name in a plain unique
+                # TextField and its serializer performs no canonicalization.
+                # The conflict therefore belongs only to the exact submitted
+                # value; case/whitespace variants may legally coexist.
+                attempted_name = payload.get("name")
+                raced_candidates = [
+                    row
+                    for row in refreshed or []
+                    if isinstance(row, dict) and row.get("name") == attempted_name
+                ]
+                raced_row = raced_candidates[0] if len(raced_candidates) == 1 else None
                 if raced_row is not None:
+                    refreshed_by_name = _existing_by_name(refreshed)
                     existing_by_name.update(refreshed_by_name)
+                    if name_key:
+                        existing_by_name[name_key] = raced_row
                     _skip(
                         cat,
                         config.name_match_skip_reason,

--- a/backend/tests/dbas/test_groups_profiles_importer.py
+++ b/backend/tests/dbas/test_groups_profiles_importer.py
@@ -403,12 +403,12 @@ async def test_channel_group_create_race_adopts_ingested_groups_and_follow_up_is
     """A destination ingest can create groups after the importer's first list.
 
     The observed Dispatcharr 0.29.0 uniqueness response must trigger a re-list,
-    normalized-name adoption, and remap population. A complete follow-up import
+    exact-name adoption, and remap population. A complete follow-up import
     then adopts the same rows from its initial list without another create.
     """
     ingested_groups = [
-        {"id": 701, "name": "NORTHWIND LOCAL"},
-        {"id": 702, "name": " Northwind Regional "},
+        {"id": 701, "name": "Northwind Local"},
+        {"id": 702, "name": "Northwind Regional"},
     ]
     destination_groups = []
     client = _client()
@@ -466,6 +466,94 @@ async def test_channel_group_create_race_adopts_ingested_groups_and_follow_up_is
     assert follow_up_remap.resolve(EntityType.CHANNEL_GROUP, 11) == 701
     assert follow_up_remap.resolve(EntityType.CHANNEL_GROUP, 12) == 702
     assert client.create_channel_group.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_channel_group_create_race_adopts_exact_conflicting_case_variant():
+    """Dispatcharr's unique TextField compares the submitted raw name.
+
+    A differently-cased row can coexist and cannot own the create conflict.
+    """
+    destination_groups = []
+    client = _client()
+    client.get_channel_groups = AsyncMock(
+        side_effect=lambda: [dict(row) for row in destination_groups]
+    )
+
+    async def _create_races_with_case_variant(name):
+        destination_groups.extend(
+            [
+                {"id": 100, "name": "sports"},
+                {"id": 200, "name": name},
+            ]
+        )
+        raise RuntimeError(
+            'Channel group creation failed: 400 - '
+            '{"name":["channel group with this name already exists."]}'
+        )
+
+    client.create_channel_group = AsyncMock(side_effect=_create_races_with_case_variant)
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channel_groups(
+        archive_rows=[{"id": 5, "name": "Sports"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = report.category(EntityType.CHANNEL_GROUP)
+    assert cat.failed == 0
+    assert cat.skipped == 1
+    assert remap.resolve(EntityType.CHANNEL_GROUP, 5) == 200
+    assert len(ledger.entries) == 0
+    assert client.get_channel_groups.await_count == 2
+    client.create_channel_group.assert_awaited_once_with("Sports")
+
+
+@pytest.mark.asyncio
+async def test_channel_group_create_race_remains_fatal_when_exact_owner_is_ambiguous():
+    """Multiple exact rows cannot be attributed safely, even if upstream forbids them."""
+    client = _client()
+    client.get_channel_groups = AsyncMock(
+        side_effect=[
+            [],
+            [
+                {"id": 100, "name": "Sports"},
+                {"id": 200, "name": "Sports"},
+            ],
+        ]
+    )
+    client.create_channel_group = AsyncMock(
+        side_effect=RuntimeError(
+            'Channel group creation failed: 400 - '
+            '{"name":["channel group with this name already exists."]}'
+        )
+    )
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channel_groups(
+        archive_rows=[{"id": 5, "name": "Sports"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = report.category(EntityType.CHANNEL_GROUP)
+    assert cat.failed == 1
+    assert cat.failure_details[0].reason == FailureReason.CONFLICT
+    assert remap.resolve(EntityType.CHANNEL_GROUP, 5) is None
+    assert len(ledger.entries) == 0
+    assert client.get_channel_groups.await_count == 2
+    client.create_channel_group.assert_awaited_once_with("Sports")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/dbas/test_groups_profiles_importer.py
+++ b/backend/tests/dbas/test_groups_profiles_importer.py
@@ -399,6 +399,104 @@ async def test_create_conflict_recorded_as_failure_conflict(fn, etype, creator, 
 
 
 @pytest.mark.asyncio
+async def test_channel_group_create_race_adopts_ingested_groups_and_follow_up_is_idempotent():
+    """A destination ingest can create groups after the importer's first list.
+
+    The observed Dispatcharr 0.29.0 uniqueness response must trigger a re-list,
+    normalized-name adoption, and remap population. A complete follow-up import
+    then adopts the same rows from its initial list without another create.
+    """
+    ingested_groups = [
+        {"id": 701, "name": "NORTHWIND LOCAL"},
+        {"id": 702, "name": " Northwind Regional "},
+    ]
+    destination_groups = []
+    client = _client()
+    client.get_channel_groups = AsyncMock(
+        side_effect=lambda: [dict(row) for row in destination_groups]
+    )
+
+    async def _create_races_with_ingest(name):
+        destination_groups.extend(ingested_groups)
+        raise RuntimeError(
+            'Channel group creation failed: 400 - '
+            '{"name":["channel group with this name already exists."]}'
+        )
+
+    client.create_channel_group = AsyncMock(side_effect=_create_races_with_ingest)
+    archive_rows = [
+        {"id": 11, "name": "Northwind Local"},
+        {"id": 12, "name": "Northwind Regional"},
+    ]
+
+    first_report = _report()
+    first_remap = _remap()
+    await import_channel_groups(
+        archive_rows=archive_rows,
+        client=client,
+        selected=True,
+        report=first_report,
+        ledger=_ledger(),
+        remap=first_remap,
+    )
+
+    first = first_report.category(EntityType.CHANNEL_GROUP)
+    assert first.failed == 0
+    assert first.created == 0
+    assert first.skipped == 2
+    assert first_remap.resolve(EntityType.CHANNEL_GROUP, 11) == 701
+    assert first_remap.resolve(EntityType.CHANNEL_GROUP, 12) == 702
+    client.create_channel_group.assert_awaited_once_with("Northwind Local")
+
+    follow_up_report = _report()
+    follow_up_remap = _remap()
+    await import_channel_groups(
+        archive_rows=archive_rows,
+        client=client,
+        selected=True,
+        report=follow_up_report,
+        ledger=_ledger(),
+        remap=follow_up_remap,
+    )
+
+    follow_up = follow_up_report.category(EntityType.CHANNEL_GROUP)
+    assert follow_up.failed == 0
+    assert follow_up.created == 0
+    assert follow_up.skipped == 2
+    assert follow_up_remap.resolve(EntityType.CHANNEL_GROUP, 11) == 701
+    assert follow_up_remap.resolve(EntityType.CHANNEL_GROUP, 12) == 702
+    assert client.create_channel_group.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_channel_group_create_race_remains_fatal_when_relist_cannot_find_group():
+    """The uniqueness response is not a non-fatal result without a row to adopt."""
+    client = _client()
+    client.create_channel_group = AsyncMock(
+        side_effect=RuntimeError(
+            'Channel group creation failed: 400 - '
+            '{"name":["channel group with this name already exists."]}'
+        )
+    )
+    report = _report()
+    remap = _remap()
+
+    await import_channel_groups(
+        archive_rows=[{"id": 5, "name": "Sports"}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=_ledger(),
+        remap=remap,
+    )
+
+    cat = report.category(EntityType.CHANNEL_GROUP)
+    assert cat.failed == 1
+    assert cat.failure_details[0].reason == FailureReason.CONFLICT
+    assert remap.resolve(EntityType.CHANNEL_GROUP, 5) is None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("fn, etype, creator, existing_kw", _CATEGORIES)
 async def test_create_upstream_error_recorded_as_failure(fn, etype, creator, existing_kw):
     """A non-conflict create error is failed UPSTREAM_API_ERROR."""

--- a/backend/tests/dbas/test_groups_profiles_importer.py
+++ b/backend/tests/dbas/test_groups_profiles_importer.py
@@ -516,6 +516,78 @@ async def test_channel_group_create_race_adopts_exact_conflicting_case_variant()
 
 
 @pytest.mark.asyncio
+async def test_channel_group_create_race_preserves_exact_case_matches_in_batch_and_follow_up():
+    """A raced exact adoption must not replace another raw name's cache entry."""
+    destination_groups = []
+    client = _client()
+    client.get_channel_groups = AsyncMock(
+        side_effect=lambda: [dict(row) for row in destination_groups]
+    )
+
+    async def _create_races_with_case_variants(name):
+        destination_groups.extend(
+            [
+                {"id": 100, "name": "sports"},
+                {"id": 200, "name": name},
+            ]
+        )
+        raise RuntimeError(
+            'Channel group creation failed: 400 - '
+            '{"name":["channel group with this name already exists."]}'
+        )
+
+    client.create_channel_group = AsyncMock(side_effect=_create_races_with_case_variants)
+    archive_rows = [
+        {"id": 11, "name": "Sports"},
+        {"id": 12, "name": "sports"},
+    ]
+
+    first_report = _report()
+    first_ledger = _ledger()
+    first_remap = _remap()
+    await import_channel_groups(
+        archive_rows=archive_rows,
+        client=client,
+        selected=True,
+        report=first_report,
+        ledger=first_ledger,
+        remap=first_remap,
+    )
+
+    first = first_report.category(EntityType.CHANNEL_GROUP)
+    assert first.failed == 0
+    assert first.created == 0
+    assert first.skipped == 2
+    assert first_remap.resolve(EntityType.CHANNEL_GROUP, 11) == 200
+    assert first_remap.resolve(EntityType.CHANNEL_GROUP, 12) == 100
+    assert len(first_ledger.entries) == 0
+    assert client.get_channel_groups.await_count == 2
+    client.create_channel_group.assert_awaited_once_with("Sports")
+
+    follow_up_report = _report()
+    follow_up_ledger = _ledger()
+    follow_up_remap = _remap()
+    await import_channel_groups(
+        archive_rows=archive_rows,
+        client=client,
+        selected=True,
+        report=follow_up_report,
+        ledger=follow_up_ledger,
+        remap=follow_up_remap,
+    )
+
+    follow_up = follow_up_report.category(EntityType.CHANNEL_GROUP)
+    assert follow_up.failed == 0
+    assert follow_up.created == 0
+    assert follow_up.skipped == 2
+    assert follow_up_remap.resolve(EntityType.CHANNEL_GROUP, 11) == 200
+    assert follow_up_remap.resolve(EntityType.CHANNEL_GROUP, 12) == 100
+    assert len(follow_up_ledger.entries) == 0
+    assert client.get_channel_groups.await_count == 3
+    assert client.create_channel_group.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_channel_group_create_race_remains_fatal_when_exact_owner_is_ambiguous():
     """Multiple exact rows cannot be attributed safely, even if upstream forbids them."""
     client = _client()

--- a/backend/tests/dbas/test_groups_profiles_importer.py
+++ b/backend/tests/dbas/test_groups_profiles_importer.py
@@ -516,6 +516,83 @@ async def test_channel_group_create_race_adopts_exact_conflicting_case_variant()
 
 
 @pytest.mark.asyncio
+async def test_channel_group_create_race_adopts_trimmed_case_preserving_owner():
+    """Dispatcharr trims a group name before unique validation and persistence."""
+    destination_groups = []
+    client = _client()
+    client.get_channel_groups = AsyncMock(
+        side_effect=lambda: [dict(row) for row in destination_groups]
+    )
+
+    async def _create_races_after_serializer_trim(name):
+        destination_groups.extend(
+            [
+                {"id": 100, "name": "sports"},
+                {"id": 200, "name": name.strip()},
+            ]
+        )
+        raise RuntimeError(
+            'Channel group creation failed: 400 - '
+            '{"name":["channel group with this name already exists."]}'
+        )
+
+    client.create_channel_group = AsyncMock(
+        side_effect=_create_races_after_serializer_trim
+    )
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channel_groups(
+        archive_rows=[{"id": 5, "name": "  Sports  "}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = report.category(EntityType.CHANNEL_GROUP)
+    assert cat.failed == 0
+    assert cat.created == 0
+    assert cat.skipped == 1
+    assert remap.resolve(EntityType.CHANNEL_GROUP, 5) == 200
+    assert len(ledger.entries) == 0
+    client.create_channel_group.assert_awaited_once_with("  Sports  ")
+
+
+@pytest.mark.asyncio
+async def test_channel_group_retry_keeps_trimmed_race_owner_with_case_variant():
+    """A retry adopts the same trimmed owner selected during race recovery."""
+    client = _client(
+        groups=[
+            {"id": 100, "name": "sports"},
+            {"id": 200, "name": "Sports"},
+        ]
+    )
+    report = _report()
+    ledger = _ledger()
+    remap = _remap()
+
+    await import_channel_groups(
+        archive_rows=[{"id": 5, "name": "  Sports  "}],
+        client=client,
+        selected=True,
+        report=report,
+        ledger=ledger,
+        remap=remap,
+    )
+
+    cat = report.category(EntityType.CHANNEL_GROUP)
+    assert cat.failed == 0
+    assert cat.created == 0
+    assert cat.skipped == 1
+    assert remap.resolve(EntityType.CHANNEL_GROUP, 5) == 200
+    assert len(ledger.entries) == 0
+    client.create_channel_group.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_channel_group_create_race_preserves_exact_case_matches_in_batch_and_follow_up():
     """A raced exact adoption must not replace another raw name's cache entry."""
     destination_groups = []
@@ -589,14 +666,14 @@ async def test_channel_group_create_race_preserves_exact_case_matches_in_batch_a
 
 @pytest.mark.asyncio
 async def test_channel_group_create_race_remains_fatal_when_exact_owner_is_ambiguous():
-    """Multiple exact rows cannot be attributed safely, even if upstream forbids them."""
+    """Multiple canonical rows cannot be attributed safely."""
     client = _client()
     client.get_channel_groups = AsyncMock(
         side_effect=[
             [],
             [
                 {"id": 100, "name": "Sports"},
-                {"id": 200, "name": "Sports"},
+                {"id": 200, "name": " Sports "},
             ],
         ]
     )


### PR DESCRIPTION
## Summary
- adopt a concurrently created channel group only when the Dispatcharr-normalized owner is unambiguous
- preserve case-sensitive identities while matching serializer-trimmed whitespace
- keep retries bounded and rollback ownership correct

## Tracking
- enhancedchannelmanager-5040e

## Verification
- frozen code and DBA reviews approved at a319e40d
- independent canonical backend gate passed with 92.22% coverage
- same-batch and retry-stability regressions included