### PR TITLE
fix: harden legacy restore admission

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1071,6 +1071,14 @@ def _sanitize_settings_data(data: dict) -> dict:
     return data
 
 
+def prepare_settings_data(data: dict) -> dict:
+    """Apply the compatibility migrations used by the settings-file loader."""
+    prepared = dict(data)
+    prepared = _migrate_normalization_settings(prepared)
+    prepared = _migrate_dispatcharr_api_key(prepared)
+    return _sanitize_settings_data(prepared)
+
+
 def load_settings() -> DispatcharrSettings:
     """Load settings from file or return defaults."""
     global _cached_settings
@@ -1084,14 +1092,7 @@ def load_settings() -> DispatcharrSettings:
     if CONFIG_FILE.exists():
         try:
             data = json.loads(CONFIG_FILE.read_text())
-            # Apply migrations
-            data = _migrate_normalization_settings(data)
-            # bd-jmi1c (GH #273) — rename legacy ``api_key`` to
-            # ``dispatcharr_api_key``. Must run before _sanitize so the WARN
-            # log fires on the actual legacy value, not on a sanitized "".
-            data = _migrate_dispatcharr_api_key(data)
-            # Sanitize nulls to prevent Pydantic validation failures
-            data = _sanitize_settings_data(data)
+            data = prepare_settings_data(data)
             # KNOWN RESIDUAL (bead ...-04c0u.10): this read-parse-assign takes
             # NO lock, so a load that started before a concurrent save can
             # assign a pre-save value into the cache afterwards and leave it

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -22,7 +22,7 @@ import time
 import zipfile
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import BinaryIO, Optional
 from urllib.parse import parse_qsl, unquote, urlsplit, urlunsplit
 
 import yaml
@@ -49,6 +49,7 @@ from config import (
     CONFIG_FILE,
     DispatcharrSettings,
     get_settings,
+    prepare_settings_data,
     save_settings,
     clear_settings_cache,
 )
@@ -3226,7 +3227,55 @@ def validate_artifact_manifest(zf: zipfile.ZipFile) -> dict:
     return manifest
 
 
-def _validate_backup_zip(zf: zipfile.ZipFile) -> dict:
+class _ValidatedLegacyBackup(dict):
+    """Validated metadata plus retained, private member inodes for installation."""
+
+    def __init__(self, manifest: dict):
+        super().__init__(manifest)
+        self._workspace = Path(tempfile.mkdtemp(prefix="ecm-legacy-restore-"))
+        os.chmod(self._workspace, stat.S_IRWXU)
+        self._files: dict[str, BinaryIO] = {}
+        self.staged_paths: dict[str, Path] = {}
+        self.staged_inodes: dict[str, int] = {}
+
+    def stage(self, zf: zipfile.ZipFile, name: str) -> None:
+        path = self._workspace / ("member-%d" % len(self._files))
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600)
+        staged = os.fdopen(fd, "w+b")
+        try:
+            with zf.open(name) as member:
+                while chunk := member.read(_RESTORE_UPLOAD_CHUNK):
+                    staged.write(chunk)
+            staged.flush()
+            staged.seek(0)
+        except Exception:
+            staged.close()
+            raise
+        self._files[name] = staged
+        self.staged_paths[name] = path
+        self.staged_inodes[name] = os.fstat(staged.fileno()).st_ino
+
+    def file(self, name: str):
+        staged = self._files[name]
+        staged.seek(0)
+        return staged
+
+    def load_json(self, name: str):
+        duplicate = os.fdopen(os.dup(self.file(name).fileno()), "rb")
+        with duplicate, io.TextIOWrapper(duplicate, encoding="utf-8") as text_stream:
+            return json.load(text_stream)
+
+    def close(self) -> None:
+        for staged in self._files.values():
+            staged.close()
+        self._files.clear()
+        shutil.rmtree(self._workspace, ignore_errors=True)
+
+    def __del__(self):
+        self.close()
+
+
+def _validate_backup_zip(zf: zipfile.ZipFile) -> _ValidatedLegacyBackup:
     """Validate a backup zip file and return its manifest."""
     # Bound metadata before reading the legacy manifest. Only ECM's historical
     # SQLite/M3U members receive the documented 1000x compatibility ceiling;
@@ -3239,85 +3288,105 @@ def _validate_backup_zip(zf: zipfile.ZipFile) -> dict:
 
     # Parse manifest
     try:
-        manifest = json.loads(zf.read("ecm_backup.json"))
-    except (json.JSONDecodeError, KeyError) as e:
+        with zf.open("ecm_backup.json") as manifest_member, io.TextIOWrapper(
+            manifest_member, encoding="utf-8"
+        ) as manifest_stream:
+            manifest = json.load(manifest_stream)
+    except (json.JSONDecodeError, UnicodeDecodeError, KeyError) as e:
         raise HTTPException(status_code=400, detail="Invalid backup manifest: %s" % str(e))
 
     if not isinstance(manifest, dict) or "version" not in manifest:
         raise HTTPException(status_code=400, detail="Invalid backup manifest: missing version")
 
-    # Validate settings.json if present
-    if "settings.json" in zf.namelist():
-        try:
-            settings = json.loads(zf.read("settings.json"))
-            if not isinstance(settings, dict):
-                raise ValueError("settings must be an object")
-            DispatcharrSettings.model_validate(settings)
-        except (json.JSONDecodeError, UnicodeDecodeError, ValidationError, ValueError):
-            raise HTTPException(status_code=400, detail="Backup contains invalid settings.json")
-
-    # Validate journal.db if present. Bounds have already been checked above, so
-    # it is safe to stream the member into a private disposable file for SQLite.
-    if "journal.db" in zf.namelist():
-        _validate_legacy_journal_db(zf)
-
-    # Check for path traversal in zip entries
+    # Check path safety before materializing any member.
     for name in zf.namelist():
         if name.startswith("/") or ".." in name:
             raise HTTPException(status_code=400, detail="Backup contains unsafe file paths")
-        # Canonicalize and verify resolved path stays within CONFIG_DIR
         resolved = (CONFIG_DIR / name).resolve()
         if not str(resolved).startswith(str(CONFIG_DIR.resolve())):
             raise HTTPException(status_code=400, detail="Backup contains unsafe file paths")
 
-    return manifest
+    plan = _ValidatedLegacyBackup(manifest)
+    try:
+        restorable = {
+            name
+            for name in zf.namelist()
+            if name in {"settings.json", "journal.db"}
+            or any(name.startswith(directory + "/") for directory in LEGACY_RESTORE_DIRS)
+        }
+        for name in sorted(restorable):
+            if not name.endswith("/"):
+                plan.stage(zf, name)
+
+        # Validate settings using the same historical migrations and null
+        # sanitation as config.load_settings().
+        if "settings.json" in plan.staged_paths:
+            settings = plan.load_json("settings.json")
+            if not isinstance(settings, dict):
+                raise ValueError("settings must be an object")
+            DispatcharrSettings.model_validate(prepare_settings_data(settings))
+
+        if "journal.db" in plan.staged_paths:
+            _validate_legacy_journal_db(plan)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValidationError, ValueError):
+        plan.close()
+        raise HTTPException(status_code=400, detail="Backup contains invalid settings.json")
+    except Exception:
+        plan.close()
+        raise
+
+    return plan
 
 
-_LEGACY_JOURNAL_BASELINE_TABLES = frozenset({"journal_entries", "scheduled_tasks"})
+_LEGACY_JOURNAL_BASELINE_SCHEMA = {
+    "journal_entries": frozenset(
+        {"id", "timestamp", "category", "action_type", "entity_name", "description"}
+    ),
+    "scheduled_tasks": frozenset(
+        {"id", "task_id", "task_name", "enabled", "schedule_type"}
+    ),
+    "auto_creation_rules": frozenset(
+        {"id", "name", "enabled", "priority", "conditions", "actions"}
+    ),
+}
 
 
-def _validate_legacy_journal_db(zf: zipfile.ZipFile) -> None:
-    """Stream and validate a legacy journal without touching the live database."""
-    fd, tmp_name = tempfile.mkstemp(prefix="ecm-legacy-journal-", suffix=".db")
-    tmp_path = Path(tmp_name)
+def _validate_legacy_journal_db(plan: _ValidatedLegacyBackup) -> None:
+    """Validate the retained journal inode without touching the live database."""
+    staged = plan.file("journal.db")
+    tmp_path = plan.staged_paths["journal.db"]
     connection = None
     try:
-        try:
-            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:  # pragma: no cover - platform without fchmod
-            pass
-        with os.fdopen(fd, "wb") as out, zf.open("journal.db") as db_member:
-            while chunk := db_member.read(_RESTORE_UPLOAD_CHUNK):
-                out.write(chunk)
+        if not staged.read(16).startswith(b"SQLite format 3"):
+            raise HTTPException(
+                status_code=400,
+                detail="Backup contains invalid journal.db (not a SQLite database)",
+            )
+        staged.seek(0)
 
-        with tmp_path.open("rb") as candidate:
-            if not candidate.read(16).startswith(b"SQLite format 3"):
-                raise HTTPException(
-                    status_code=400,
-                    detail="Backup contains invalid journal.db (not a SQLite database)",
-                )
-
+        # The workspace is 0700 and the member is 0600. Confirm the pathname
+        # SQLite opens still names the retained descriptor's inode.
+        if os.fstat(staged.fileno()).st_ino != tmp_path.stat().st_ino:
+            raise HTTPException(status_code=400, detail="Backup contains invalid journal.db")
         connection = sqlite3.connect(f"{tmp_path.resolve().as_uri()}?mode=ro", uri=True)
-        rows = connection.execute(
-            "SELECT name FROM sqlite_master WHERE type = 'table'"
-        ).fetchall()
-        tables = {row[0] for row in rows}
-        if not _LEGACY_JOURNAL_BASELINE_TABLES.issubset(tables):
-            raise HTTPException(status_code=400, detail="Backup contains incompatible journal.db")
+        if connection.execute("PRAGMA quick_check").fetchall() != [("ok",)]:
+            raise HTTPException(status_code=400, detail="Backup contains invalid journal.db")
+
+        for table, required_columns in _LEGACY_JOURNAL_BASELINE_SCHEMA.items():
+            columns = {
+                row[1]
+                for row in connection.execute('PRAGMA table_info("%s")' % table).fetchall()
+            }
+            if not required_columns.issubset(columns):
+                raise HTTPException(status_code=400, detail="Backup contains incompatible journal.db")
     except HTTPException:
         raise
-    except (OSError, sqlite3.Error, zipfile.BadZipFile, RuntimeError) as exc:
+    except (OSError, sqlite3.Error, RuntimeError) as exc:
         logger.warning("[BACKUP] Refusing invalid legacy journal.db: %s", exc)
         raise HTTPException(status_code=400, detail="Backup contains invalid journal.db") from exc
     finally:
         if connection is not None:
             connection.close()
-        try:
-            tmp_path.unlink()
-        except FileNotFoundError:
-            pass
-        except OSError as exc:
-            logger.warning("[BACKUP] Failed to remove journal validation temp file: %s", exc)
 
 
 def _merge_settings_preserving_redacted(zip_settings_bytes: bytes) -> bytes:
@@ -3355,7 +3424,7 @@ def _merge_settings_preserving_redacted(zip_settings_bytes: bytes) -> bytes:
     if skipped:
         logger.info("[BACKUP] Preserved existing protected settings: %s", skipped)
     try:
-        validated = DispatcharrSettings.model_validate(merged)
+        validated = DispatcharrSettings.model_validate(prepare_settings_data(merged))
     except ValidationError as exc:
         raise HTTPException(status_code=400, detail="Backup contains invalid settings.json") from exc
     return json.dumps(validated.model_dump(mode="json"), indent=2).encode("utf-8")
@@ -3834,8 +3903,11 @@ def _restore_from_zip(zf: zipfile.ZipFile, manifest: dict) -> list[str]:
     # Finish settings validation and normalization before any database shutdown
     # or live write. The resulting bytes are the only settings bytes installed.
     restored_settings = None
-    if "settings.json" in zf.namelist():
-        restored_settings = _merge_settings_preserving_redacted(zf.read("settings.json"))
+    if "settings.json" in manifest.staged_paths:
+        settings = manifest.load_json("settings.json")
+        restored_settings = _merge_settings_preserving_redacted(
+            json.dumps(settings).encode("utf-8")
+        )
 
     # Capture existing alert_methods.config BEFORE we close/replace the DB so
     # we can merge real creds back where the restored ZIP has REDACTED.
@@ -3864,8 +3936,11 @@ def _restore_from_zip(zf: zipfile.ZipFile, manifest: dict) -> list[str]:
             logger.info("[BACKUP] Restored settings.json")
 
         # Restore journal.db
-        if "journal.db" in zf.namelist():
-            JOURNAL_DB_FILE.write_bytes(zf.read("journal.db"))
+        if "journal.db" in manifest.staged_paths:
+            with JOURNAL_DB_FILE.open("wb") as destination:
+                shutil.copyfileobj(
+                    manifest.file("journal.db"), destination, _RESTORE_UPLOAD_CHUNK
+                )
             restored.append("journal.db")
             logger.info("[BACKUP] Restored journal.db")
             # Merge any REDACTED alert_methods.config creds back from the
@@ -3887,7 +3962,9 @@ def _restore_from_zip(zf: zipfile.ZipFile, manifest: dict) -> list[str]:
             dir_path = CONFIG_DIR / dir_rel
             # Find files in this directory from the zip
             prefix = dir_rel + "/"
-            dir_files = [n for n in zf.namelist() if n.startswith(prefix) and not n.endswith("/")]
+            dir_files = [
+                name for name in manifest.staged_paths if name.startswith(prefix)
+            ]
 
             if dir_files:
                 # Clear existing directory
@@ -3898,7 +3975,10 @@ def _restore_from_zip(zf: zipfile.ZipFile, manifest: dict) -> list[str]:
                 for name in dir_files:
                     target = CONFIG_DIR / name
                     target.parent.mkdir(parents=True, exist_ok=True)
-                    target.write_bytes(zf.read(name))
+                    with target.open("wb") as destination:
+                        shutil.copyfileobj(
+                            manifest.file(name), destination, _RESTORE_UPLOAD_CHUNK
+                        )
                     restored.append(name)
                 _apply_restored_directory_modes(dir_rel, dir_path, dir_files)
                 logger.info("[BACKUP] Restored %d files to %s", len(dir_files), dir_rel)
@@ -3974,7 +4054,10 @@ async def restore_backup(file: UploadFile = File(...), _admin=RequireHumanAdminI
 
         with zf:
             manifest = _validate_backup_zip(zf)
-            restored = _restore_from_zip(zf, manifest)
+            try:
+                restored = _restore_from_zip(zf, manifest)
+            finally:
+                manifest.close()
     finally:
         try:
             tmp_path.unlink()
@@ -4140,7 +4223,10 @@ async def restore_backup_initial(
 
         with zf:
             manifest = _validate_backup_zip(zf)
-            restored = _restore_from_zip(zf, manifest)
+            try:
+                restored = _restore_from_zip(zf, manifest)
+            finally:
+                manifest.close()
     finally:
         try:
             tmp_path.unlink()
@@ -6437,14 +6523,18 @@ async def restore_saved_backup(req: RestoreSavedRequest, _admin=RequireHumanAdmi
 
     # Open + validate + restore via the SAME path the uploaded-ZIP restore uses.
     try:
-        buf = io.BytesIO(path.read_bytes())
-        zf = zipfile.ZipFile(buf, "r")
+        archive = path.open("rb")
+        zf = zipfile.ZipFile(archive, "r")
     except zipfile.BadZipFile:
+        archive.close()
         raise HTTPException(status_code=400, detail="Saved file is not a valid zip archive")
 
-    with zf:
+    with archive, zf:
         manifest = _validate_backup_zip(zf)
-        restored = _restore_from_zip(zf, manifest)
+        try:
+            restored = _restore_from_zip(zf, manifest)
+        finally:
+            manifest.close()
 
     logger.info("[BACKUP] Restore-from-saved complete, %d files restored", len(restored))
     return {

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -6882,6 +6882,9 @@ async def restore_saved_backup(req: RestoreSavedRequest, _admin=RequireHumanAdmi
     except zipfile.BadZipFile:
         archive.close()
         raise HTTPException(status_code=400, detail="Saved file is not a valid zip archive")
+    except BaseException:
+        archive.close()
+        raise
 
     with archive, zf:
         manifest = _validate_backup_zip(zf)

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -28,7 +28,7 @@ from urllib.parse import parse_qsl, unquote, urlsplit, urlunsplit
 import yaml
 from fastapi import APIRouter, Body, Depends, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import PlainTextResponse, StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -3249,16 +3249,17 @@ def _validate_backup_zip(zf: zipfile.ZipFile) -> dict:
     # Validate settings.json if present
     if "settings.json" in zf.namelist():
         try:
-            json.loads(zf.read("settings.json"))
-        except json.JSONDecodeError:
+            settings = json.loads(zf.read("settings.json"))
+            if not isinstance(settings, dict):
+                raise ValueError("settings must be an object")
+            DispatcharrSettings.model_validate(settings)
+        except (json.JSONDecodeError, UnicodeDecodeError, ValidationError, ValueError):
             raise HTTPException(status_code=400, detail="Backup contains invalid settings.json")
 
-    # Validate journal.db if present (check SQLite magic bytes)
+    # Validate journal.db if present. Bounds have already been checked above, so
+    # it is safe to stream the member into a private disposable file for SQLite.
     if "journal.db" in zf.namelist():
-        with zf.open("journal.db") as db_member:
-            db_header = db_member.read(16)
-        if not db_header.startswith(b"SQLite format 3"):
-            raise HTTPException(status_code=400, detail="Backup contains invalid journal.db (not a SQLite database)")
+        _validate_legacy_journal_db(zf)
 
     # Check for path traversal in zip entries
     for name in zf.namelist():
@@ -3272,22 +3273,67 @@ def _validate_backup_zip(zf: zipfile.ZipFile) -> dict:
     return manifest
 
 
+_LEGACY_JOURNAL_BASELINE_TABLES = frozenset({"journal_entries", "scheduled_tasks"})
+
+
+def _validate_legacy_journal_db(zf: zipfile.ZipFile) -> None:
+    """Stream and validate a legacy journal without touching the live database."""
+    fd, tmp_name = tempfile.mkstemp(prefix="ecm-legacy-journal-", suffix=".db")
+    tmp_path = Path(tmp_name)
+    connection = None
+    try:
+        try:
+            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:  # pragma: no cover - platform without fchmod
+            pass
+        with os.fdopen(fd, "wb") as out, zf.open("journal.db") as db_member:
+            while chunk := db_member.read(_RESTORE_UPLOAD_CHUNK):
+                out.write(chunk)
+
+        with tmp_path.open("rb") as candidate:
+            if not candidate.read(16).startswith(b"SQLite format 3"):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Backup contains invalid journal.db (not a SQLite database)",
+                )
+
+        connection = sqlite3.connect(f"{tmp_path.resolve().as_uri()}?mode=ro", uri=True)
+        rows = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ).fetchall()
+        tables = {row[0] for row in rows}
+        if not _LEGACY_JOURNAL_BASELINE_TABLES.issubset(tables):
+            raise HTTPException(status_code=400, detail="Backup contains incompatible journal.db")
+    except HTTPException:
+        raise
+    except (OSError, sqlite3.Error, zipfile.BadZipFile, RuntimeError) as exc:
+        logger.warning("[BACKUP] Refusing invalid legacy journal.db: %s", exc)
+        raise HTTPException(status_code=400, detail="Backup contains invalid journal.db") from exc
+    finally:
+        if connection is not None:
+            connection.close()
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning("[BACKUP] Failed to remove journal validation temp file: %s", exc)
+
+
 def _merge_settings_preserving_redacted(zip_settings_bytes: bytes) -> bytes:
     """Apply restored settings.json on top of existing settings, dropping
-    REDACTED sentinels so existing credentials are preserved.
+    REDACTED sentinels and the instance-bound MCP key.
 
     Mirrors the YAML restore semantics in _restore_settings (lines below) so
     a redacted ZIP behaves the same as a redacted YAML export. Backward-compat:
-    legacy non-redacted ZIPs have no sentinels, so every value is taken as-is.
+    Legacy non-redacted ZIP values remain restorable except for mcp_api_key.
     """
     try:
         zipped = json.loads(zip_settings_bytes)
-    except (json.JSONDecodeError, TypeError):
-        # Validator has already accepted this as JSON; if it's somehow not a
-        # dict, fall back to writing as-is rather than corrupting the file.
-        return zip_settings_bytes
+    except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as exc:
+        raise HTTPException(status_code=400, detail="Backup contains invalid settings.json") from exc
     if not isinstance(zipped, dict):
-        return zip_settings_bytes
+        raise HTTPException(status_code=400, detail="Backup contains invalid settings.json")
 
     if CONFIG_FILE.exists():
         try:
@@ -3302,13 +3348,17 @@ def _merge_settings_preserving_redacted(zip_settings_bytes: bytes) -> bytes:
     merged = dict(existing)
     skipped = []
     for key, value in zipped.items():
-        if value == REDACTED:
+        if key == "mcp_api_key" or value == REDACTED:
             skipped.append(key)
             continue
         merged[key] = value
     if skipped:
-        logger.info("[BACKUP] Preserved existing values for redacted settings: %s", skipped)
-    return json.dumps(merged, indent=2).encode("utf-8")
+        logger.info("[BACKUP] Preserved existing protected settings: %s", skipped)
+    try:
+        validated = DispatcharrSettings.model_validate(merged)
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail="Backup contains invalid settings.json") from exc
+    return json.dumps(validated.model_dump(mode="json"), indent=2).encode("utf-8")
 
 
 def _capture_existing_alert_method_configs() -> dict[int, dict]:
@@ -3781,6 +3831,12 @@ def _restore_from_zip(zf: zipfile.ZipFile, manifest: dict) -> list[str]:
     """Restore files from a validated backup zip."""
     restored = []
 
+    # Finish settings validation and normalization before any database shutdown
+    # or live write. The resulting bytes are the only settings bytes installed.
+    restored_settings = None
+    if "settings.json" in zf.namelist():
+        restored_settings = _merge_settings_preserving_redacted(zf.read("settings.json"))
+
     # Capture existing alert_methods.config BEFORE we close/replace the DB so
     # we can merge real creds back where the restored ZIP has REDACTED.
     prior_alert_configs = _capture_existing_alert_method_configs()
@@ -3802,8 +3858,8 @@ def _restore_from_zip(zf: zipfile.ZipFile, manifest: dict) -> list[str]:
     try:
         # Restore settings.json — drop REDACTED sentinels in favor of the
         # currently-on-disk value, mirroring YAML restore semantics.
-        if "settings.json" in zf.namelist():
-            CONFIG_FILE.write_bytes(_merge_settings_preserving_redacted(zf.read("settings.json")))
+        if restored_settings is not None:
+            CONFIG_FILE.write_bytes(restored_settings)
             restored.append("settings.json")
             logger.info("[BACKUP] Restored settings.json")
 

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -6836,10 +6836,10 @@ async def restore_saved_backup(req: RestoreSavedRequest, _admin=RequireHumanAdmi
     blob write path as POST /restore, so it carries the same admin-field-bypass
     risk. The shipped MCP ``restore_backup`` tool now receives a clean 403 here.
 
-    Takes ``{"filename": "ecm-backup-<ts>.zip"}``, validates it through the
-    strict regex + containment guard (zip-only allowlist), then restores from
-    the on-disk archive reusing the EXACT same validate + restore code path as
-    the uploaded-ZIP POST /restore (``_validate_backup_zip`` +
+    Takes ``{"filename": "ecm-backup-<ts>.zip"}``, selects it from the trusted
+    direct-child listing of BACKUPS_DIR, then restores from the retained file
+    descriptor reusing the EXACT same validate + restore code path as the
+    uploaded-ZIP POST /restore (``_validate_backup_zip`` +
     ``_restore_from_zip``). YAML artifacts are rejected — section-import is a
     different path (POST /restore-yaml), out of scope here (bd-0hjrk.5).
 
@@ -6847,26 +6847,37 @@ async def restore_saved_backup(req: RestoreSavedRequest, _admin=RequireHumanAdmi
     """
     logger.info("[BACKUP] Restore-from-saved requested, filename=%s", req.filename)
     filename = req.filename
-    # Two-layer guard, inlined (CodeQL py/path-injection, CWE-22/23/36/73/99 —
-    # the containment barrier is not tracked across a function-return boundary,
-    # so the barrier and the read_bytes sink must live in this same function).
-    # Layer 1 (defense in depth): strict zip-only regex allowlist (fullmatch so a
-    # trailing newline cannot pass the anchor).
+    # Keep the strict allowlist, then break request taint by selecting a Path
+    # originating from BACKUPS_DIR's trusted direct-child enumeration.
     if not _BACKUP_ZIP_FILENAME_RE.fullmatch(filename):
         raise HTTPException(status_code=400, detail="Invalid filename")
-    # Layer 2: canonicalize + verify containment under BACKUPS_DIR.
+
+    saved_backups = {}
     try:
-        safe_root = BACKUPS_DIR.resolve()
-        path = (BACKUPS_DIR / filename).resolve()
-        path.relative_to(safe_root)
-    except (ValueError, OSError):
-        raise HTTPException(status_code=400, detail="Invalid filename")
-    if not path.exists():
+        for entry in BACKUPS_DIR.iterdir():
+            saved_backups[entry.name] = entry
+    except OSError:
+        raise HTTPException(status_code=404, detail="Backup not found")
+    path = saved_backups.get(filename)
+    if path is None:
         raise HTTPException(status_code=404, detail="Backup not found")
 
-    # Open + validate + restore via the SAME path the uploaded-ZIP restore uses.
+    # O_NOFOLLOW and fstat bind type validation and restore to the same opened
+    # object. O_NONBLOCK prevents a planted FIFO from blocking this request.
     try:
-        archive = path.open("rb")
+        descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    except OSError:
+        raise HTTPException(status_code=404, detail="Backup not found")
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise HTTPException(status_code=404, detail="Backup not found")
+        archive = os.fdopen(descriptor, "rb")
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+    # Validate + restore via the SAME path the uploaded-ZIP restore uses.
+    try:
         zf = zipfile.ZipFile(archive, "r")
     except zipfile.BadZipFile:
         archive.close()

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -1662,6 +1662,15 @@ _ARTIFACT_MAX_ENTRY_RATIO = 100  # max decompressed:compressed per entry
 # bound everything below the floor.
 _ARTIFACT_RATIO_MIN_COMPRESSED = 1024  # 1 KiB
 
+# JSON control members are parsed in memory and therefore need limits far below
+# the generic 1 GiB data-member ceiling. A manifest is metadata, so 1 MiB is
+# ample even for thousands of hash entries. settings.json can contain sizable
+# operator-authored rule/tag configuration; 8 MiB preserves useful headroom
+# while bounding both validation and the unauthenticated first-run restore.
+_MAX_DBAS_MANIFEST_BYTES = 1 * 1024 * 1024
+_MAX_LEGACY_MANIFEST_BYTES = 1 * 1024 * 1024
+_MAX_LEGACY_SETTINGS_BYTES = 8 * 1024 * 1024
+
 # Legacy ZIPs produced by ECM can hold its SQLite database and uploaded M3U
 # files with a 292x--650x DEFLATE ratio. Keep the DBAS 100x policy unchanged,
 # but accept only those known legacy data members up to 1000x: the demonstrated
@@ -3179,6 +3188,46 @@ def _verify_artifact_member_integrity(zf: zipfile.ZipFile, manifest: dict) -> No
             raise HTTPException(status_code=400, detail="Backup integrity check failed")
 
 
+def _read_zip_member_bounded(
+    zf: zipfile.ZipFile,
+    name: str,
+    max_bytes: int,
+    *,
+    detail: str,
+) -> bytes:
+    """Read one small control member without an unbounded ``read()`` call."""
+    try:
+        info = zf.getinfo(name)
+    except KeyError:
+        raise HTTPException(status_code=400, detail=detail)
+    if info.file_size > max_bytes:
+        logger.warning(
+            "[BACKUP] Refusing restore: %s declares %d bytes (member cap %d)",
+            name,
+            info.file_size,
+            max_bytes,
+        )
+        raise HTTPException(status_code=400, detail=detail)
+
+    chunks: list[bytes] = []
+    total = 0
+    with zf.open(info) as member:
+        while True:
+            chunk = member.read(min(_RESTORE_UPLOAD_CHUNK, max_bytes + 1 - total))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > max_bytes:
+                logger.warning(
+                    "[BACKUP] Refusing restore: %s expanded beyond member cap %d",
+                    name,
+                    max_bytes,
+                )
+                raise HTTPException(status_code=400, detail=detail)
+    return b"".join(chunks)
+
+
 def validate_artifact_manifest(zf: zipfile.ZipFile) -> dict:
     """Validate a new-format DBAS artifact at the restore-ingest chokepoint.
 
@@ -3204,8 +3253,15 @@ def validate_artifact_manifest(zf: zipfile.ZipFile) -> dict:
         raise HTTPException(status_code=400, detail="Not a valid ECM backup artifact")
 
     try:
-        manifest = json.loads(zf.read(ARTIFACT_MANIFEST_NAME))
-    except (json.JSONDecodeError, KeyError) as e:
+        manifest = json.loads(
+            _read_zip_member_bounded(
+                zf,
+                ARTIFACT_MANIFEST_NAME,
+                _MAX_DBAS_MANIFEST_BYTES,
+                detail="Invalid backup manifest",
+            )
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError, KeyError) as e:
         logger.warning("[BACKUP] Refusing restore: unreadable artifact manifest: %s", e)
         raise HTTPException(status_code=400, detail="Invalid backup manifest")
 
@@ -3260,10 +3316,19 @@ class _ValidatedLegacyBackup(dict):
         staged.seek(0)
         return staged
 
-    def load_json(self, name: str):
-        duplicate = os.fdopen(os.dup(self.file(name).fileno()), "rb")
-        with duplicate, io.TextIOWrapper(duplicate, encoding="utf-8") as text_stream:
-            return json.load(text_stream)
+    def load_json(self, name: str, max_bytes: int):
+        staged = self.file(name)
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            chunk = staged.read(min(_RESTORE_UPLOAD_CHUNK, max_bytes + 1 - total))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > max_bytes:
+                raise ValueError("staged JSON member exceeds its limit")
+        return json.loads(b"".join(chunks))
 
     def close(self) -> None:
         for staged in self._files.values():
@@ -3288,10 +3353,14 @@ def _validate_backup_zip(zf: zipfile.ZipFile) -> _ValidatedLegacyBackup:
 
     # Parse manifest
     try:
-        with zf.open("ecm_backup.json") as manifest_member, io.TextIOWrapper(
-            manifest_member, encoding="utf-8"
-        ) as manifest_stream:
-            manifest = json.load(manifest_stream)
+        manifest = json.loads(
+            _read_zip_member_bounded(
+                zf,
+                "ecm_backup.json",
+                _MAX_LEGACY_MANIFEST_BYTES,
+                detail="Invalid backup manifest",
+            )
+        )
     except (json.JSONDecodeError, UnicodeDecodeError, KeyError) as e:
         raise HTTPException(status_code=400, detail="Invalid backup manifest: %s" % str(e))
 
@@ -3314,6 +3383,16 @@ def _validate_backup_zip(zf: zipfile.ZipFile) -> _ValidatedLegacyBackup:
             if name in {"settings.json", "journal.db"}
             or any(name.startswith(directory + "/") for directory in LEGACY_RESTORE_DIRS)
         }
+        if "settings.json" in restorable:
+            info = zf.getinfo("settings.json")
+            if info.file_size > _MAX_LEGACY_SETTINGS_BYTES:
+                logger.warning(
+                    "[BACKUP] Refusing restore: settings.json declares %d bytes "
+                    "(member cap %d)",
+                    info.file_size,
+                    _MAX_LEGACY_SETTINGS_BYTES,
+                )
+                raise ValueError("settings member exceeds its limit")
         for name in sorted(restorable):
             if not name.endswith("/"):
                 plan.stage(zf, name)
@@ -3321,7 +3400,7 @@ def _validate_backup_zip(zf: zipfile.ZipFile) -> _ValidatedLegacyBackup:
         # Validate settings using the same historical migrations and null
         # sanitation as config.load_settings().
         if "settings.json" in plan.staged_paths:
-            settings = plan.load_json("settings.json")
+            settings = plan.load_json("settings.json", _MAX_LEGACY_SETTINGS_BYTES)
             if not isinstance(settings, dict):
                 raise ValueError("settings must be an object")
             DispatcharrSettings.model_validate(prepare_settings_data(settings))
@@ -3350,6 +3429,16 @@ _LEGACY_JOURNAL_BASELINE_SCHEMA = {
     ),
 }
 
+# Standard ZIP production now drops journal_entries because it is unbounded
+# audit history, not restorable configuration. Admission accepts either the
+# original historical profile above or this producer profile; both still
+# require the two configuration tables and their load-bearing columns.
+_CURRENT_REDACTED_JOURNAL_SCHEMA = {
+    table: columns
+    for table, columns in _LEGACY_JOURNAL_BASELINE_SCHEMA.items()
+    if table != "journal_entries"
+}
+
 
 def _validate_legacy_journal_db(plan: _ValidatedLegacyBackup) -> None:
     """Validate the retained journal inode without touching the live database."""
@@ -3372,13 +3461,34 @@ def _validate_legacy_journal_db(plan: _ValidatedLegacyBackup) -> None:
         if connection.execute("PRAGMA quick_check").fetchall() != [("ok",)]:
             raise HTTPException(status_code=400, detail="Backup contains invalid journal.db")
 
-        for table, required_columns in _LEGACY_JOURNAL_BASELINE_SCHEMA.items():
-            columns = {
-                row[1]
-                for row in connection.execute('PRAGMA table_info("%s")' % table).fetchall()
-            }
-            if not required_columns.issubset(columns):
-                raise HTTPException(status_code=400, detail="Backup contains incompatible journal.db")
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+
+        def matches(schema: dict[str, frozenset[str]]) -> bool:
+            return all(
+                required_columns.issubset(
+                    {
+                        row[1]
+                        for row in connection.execute(
+                            'PRAGMA table_info("%s")' % table
+                        ).fetchall()
+                    }
+                )
+                for table, required_columns in schema.items()
+            )
+
+        compatible = matches(_LEGACY_JOURNAL_BASELINE_SCHEMA) or (
+            "journal_entries" not in tables
+            and matches(_CURRENT_REDACTED_JOURNAL_SCHEMA)
+        )
+        if not compatible:
+            raise HTTPException(
+                status_code=400, detail="Backup contains incompatible journal.db"
+            )
     except HTTPException:
         raise
     except (OSError, sqlite3.Error, RuntimeError) as exc:
@@ -3430,18 +3540,21 @@ def _merge_settings_preserving_redacted(zip_settings_bytes: bytes) -> bytes:
     return json.dumps(validated.model_dump(mode="json"), indent=2).encode("utf-8")
 
 
-def _capture_existing_alert_method_configs() -> dict[int, dict]:
+def _capture_existing_alert_method_configs(
+    journal_path: Optional[Path] = None,
+) -> dict[int, dict]:
     """Read existing alert_methods rows directly from journal.db so we can
     re-merge non-redacted credential fields after the restored DB is written.
 
     Returns {id: parsed_config_dict}. Rows with malformed JSON or missing
     table are skipped silently — the caller treats absent ids as 'no merge'.
     """
-    if not JOURNAL_DB_FILE.exists():
+    journal_path = journal_path or JOURNAL_DB_FILE
+    if not journal_path.exists():
         return {}
     out: dict[int, dict] = {}
     try:
-        conn = sqlite3.connect(str(JOURNAL_DB_FILE))
+        conn = sqlite3.connect(str(journal_path))
     except sqlite3.Error as e:
         logger.warning("[BACKUP] Could not open journal.db for pre-restore capture: %s", e)
         return {}
@@ -3472,7 +3585,9 @@ def _capture_existing_alert_method_configs() -> dict[int, dict]:
     return out
 
 
-def _merge_alert_method_creds_after_restore(prior: dict[int, dict]) -> None:
+def _merge_alert_method_creds_after_restore(
+    prior: dict[int, dict], journal_path: Optional[Path] = None
+) -> None:
     """For each alert_methods row in the restored DB, restore non-redacted
     credential-class values from the prior snapshot when the restored value
     is the REDACTED sentinel. Match by row id.
@@ -3489,10 +3604,11 @@ def _merge_alert_method_creds_after_restore(prior: dict[int, dict]) -> None:
     Backward-compat: legacy non-redacted ZIPs carry no sentinel — every value
     survives the merge unchanged.
     """
-    if not JOURNAL_DB_FILE.exists():
+    journal_path = journal_path or JOURNAL_DB_FILE
+    if not journal_path.exists():
         return
     try:
-        conn = sqlite3.connect(str(JOURNAL_DB_FILE))
+        conn = sqlite3.connect(str(journal_path))
     except sqlite3.Error as e:
         logger.warning("[BACKUP] Could not open restored journal.db for cred merge: %s", e)
         return
@@ -3564,7 +3680,9 @@ FIRST_RUN_SETUP_NOTICE = (
 )
 
 
-def _capture_existing_auth_rows() -> dict[str, tuple[list[str], list[tuple]]]:
+def _capture_existing_auth_rows(
+    journal_path: Optional[Path] = None,
+) -> dict[str, tuple[list[str], list[tuple]]]:
     """Snapshot this instance's OWN account rows before journal.db is replaced.
 
     Returns ``{table: (column_names, rows)}`` for :data:`_AUTH_IDENTITY_TABLES`.
@@ -3582,11 +3700,12 @@ def _capture_existing_auth_rows() -> dict[str, tuple[list[str], list[tuple]]]:
     running first-run setup, and unlike the PRODUCER side (where an unrunnable
     scrub means a leak) nothing confidential turns on it.
     """
-    if not JOURNAL_DB_FILE.exists():
+    journal_path = journal_path or JOURNAL_DB_FILE
+    if not journal_path.exists():
         return {}
     out: dict[str, tuple[list[str], list[tuple]]] = {}
     try:
-        conn = sqlite3.connect(str(JOURNAL_DB_FILE))
+        conn = sqlite3.connect(str(journal_path))
     except sqlite3.Error as e:
         logger.warning("[BACKUP] Could not open journal.db to capture accounts: %s", e)
         return {}
@@ -3654,6 +3773,7 @@ def _create_missing_auth_table(cur, table: str) -> list[str]:
 
 def _reassert_auth_rows_after_restore(
     prior: dict[str, tuple[list[str], list[tuple]]],
+    journal_path: Optional[Path] = None,
 ) -> None:
     """Put this instance's own account rows back over the restored journal.db.
 
@@ -3682,10 +3802,11 @@ def _reassert_auth_rows_after_restore(
     """
     if not prior.get("users"):
         return
-    if not JOURNAL_DB_FILE.exists():
+    journal_path = journal_path or JOURNAL_DB_FILE
+    if not journal_path.exists():
         return
     try:
-        conn = sqlite3.connect(str(JOURNAL_DB_FILE))
+        conn = sqlite3.connect(str(journal_path))
     except sqlite3.Error as e:
         logger.warning(
             "[BACKUP] Could not open the restored journal.db to reinstate "
@@ -3770,7 +3891,7 @@ _REESTABLISH_ON_RESTORE: dict[str, str] = {
 _LAST_RESTORE_CONFIG_LOSSES: dict[str, int] = {}
 
 
-def _count_reestablish_rows() -> dict[str, int]:
+def _count_reestablish_rows(journal_path: Optional[Path] = None) -> dict[str, int]:
     """Row counts for :data:`_REESTABLISH_ON_RESTORE`, read off the live database.
 
     Used on BOTH sides of the file swap so the notice names only what this
@@ -3780,10 +3901,11 @@ def _count_reestablish_rows() -> dict[str, int]:
 
     Best-effort: a table that cannot be read is omitted rather than guessed at.
     """
-    if not JOURNAL_DB_FILE.exists():
+    journal_path = journal_path or JOURNAL_DB_FILE
+    if not journal_path.exists():
         return {}
     try:
-        conn = sqlite3.connect(str(JOURNAL_DB_FILE))
+        conn = sqlite3.connect(str(journal_path))
     except sqlite3.Error:
         return {}
     counts: dict[str, int] = {}
@@ -3896,15 +4018,222 @@ def _apply_restored_directory_modes(dir_rel: str, dir_path: Path, names: list[st
         )
 
 
+def _path_exists(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def _random_absent_sibling(path: Path, label: str) -> Path:
+    candidate = Path(tempfile.mkdtemp(prefix=f".{path.name}.{label}-", dir=path.parent))
+    candidate.rmdir()
+    return candidate
+
+
+def _fsync_directory_best_effort(path: Path) -> None:
+    descriptor = None
+    try:
+        descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+        os.fsync(descriptor)
+    except OSError as exc:
+        logger.warning("[BACKUP] Could not fsync restore directory %s: %s", path, exc)
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _stage_restore_file(
+    destination: Path,
+    *,
+    content: Optional[bytes] = None,
+    source: Optional[BinaryIO] = None,
+) -> Path:
+    """Fully write and fsync a file beside its destination before shutdown."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, raw_path = tempfile.mkstemp(
+        prefix=f".{destination.name}.restore-stage-", dir=destination.parent
+    )
+    staged = Path(raw_path)
+    try:
+        with os.fdopen(descriptor, "w+b") as output:
+            os.fchmod(output.fileno(), 0o600)
+            if content is not None:
+                output.write(content)
+            elif source is not None:
+                source.seek(0)
+                shutil.copyfileobj(source, output, _RESTORE_UPLOAD_CHUNK)
+            output.flush()
+            os.fsync(output.fileno())
+        _fsync_directory_best_effort(destination.parent)
+        return staged
+    except BaseException:
+        try:
+            staged.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _stage_restore_directory(
+    dir_rel: str,
+    names: list[str],
+    manifest: _ValidatedLegacyBackup,
+) -> Path:
+    """Materialize and fsync a complete tree beside the destination tree."""
+    destination = CONFIG_DIR / dir_rel
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staged = Path(
+        tempfile.mkdtemp(
+            prefix=f".{destination.name}.restore-stage-", dir=destination.parent
+        )
+    )
+    try:
+        for name in names:
+            relative = Path(name).relative_to(dir_rel)
+            target = staged / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with target.open("w+b") as output:
+                manifest.file(name).seek(0)
+                shutil.copyfileobj(
+                    manifest.file(name), output, _RESTORE_UPLOAD_CHUNK
+                )
+                output.flush()
+                os.fsync(output.fileno())
+
+        modes = _RESTORED_DIR_MODES.get(dir_rel)
+        if modes is not None:
+            dir_mode, file_mode = modes
+            for directory in [staged, *[p for p in staged.rglob("*") if p.is_dir()]]:
+                os.chmod(directory, dir_mode)
+            for file_path in (p for p in staged.rglob("*") if p.is_file()):
+                os.chmod(file_path, file_mode)
+
+        directories = [staged, *[p for p in staged.rglob("*") if p.is_dir()]]
+        for directory in reversed(directories):
+            _fsync_directory_best_effort(directory)
+        _fsync_directory_best_effort(destination.parent)
+        return staged
+    except BaseException:
+        shutil.rmtree(staged, ignore_errors=True)
+        raise
+
+
+def _remove_restore_path(path: Path) -> None:
+    if not _path_exists(path):
+        return
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+def _rollback_restore_swaps(records: list[dict]) -> None:
+    """Compensate completed same-filesystem swaps and verify prior inodes."""
+    errors: list[str] = []
+    for record in reversed(records):
+        target = record["target"]
+        backup = record["backup"]
+        discarded = None
+        try:
+            if record["installed"] and _path_exists(target):
+                discarded = _random_absent_sibling(target, "rollback-discard")
+                os.replace(target, discarded)
+            if backup is not None and _path_exists(backup):
+                os.replace(backup, target)
+
+            if record["identity"] is None:
+                if _path_exists(target):
+                    raise RuntimeError("target should be absent")
+            else:
+                current = os.lstat(target)
+                identity = (current.st_dev, current.st_ino, stat.S_IFMT(current.st_mode))
+                if identity != record["identity"]:
+                    raise RuntimeError("prior inode was not restored")
+        except BaseException as exc:
+            errors.append(f"{target}: {exc}")
+        finally:
+            if discarded is not None:
+                try:
+                    _remove_restore_path(discarded)
+                except OSError as exc:
+                    logger.warning(
+                        "[BACKUP] Could not remove failed restore artifact %s: %s",
+                        discarded,
+                        exc,
+                    )
+            _fsync_directory_best_effort(target.parent)
+    if errors:
+        raise RuntimeError("Restore rollback could not be verified: " + "; ".join(errors))
+
+
+def _swap_staged_restore(staged_items: list[tuple[Path, Path]]) -> list[dict]:
+    """Swap adjacent staged artifacts into place, compensating on any failure."""
+    records: list[dict] = []
+    try:
+        for target, staged in staged_items:
+            prior = os.lstat(target) if _path_exists(target) else None
+            backup = (
+                _random_absent_sibling(target, "restore-backup")
+                if prior is not None
+                else None
+            )
+            record = {
+                "target": target,
+                "backup": backup,
+                "identity": (
+                    (prior.st_dev, prior.st_ino, stat.S_IFMT(prior.st_mode))
+                    if prior is not None
+                    else None
+                ),
+                "installed": False,
+            }
+            records.append(record)
+            if backup is not None:
+                os.replace(target, backup)
+            os.replace(staged, target)
+            record["installed"] = True
+            _fsync_directory_best_effort(target.parent)
+        return records
+    except BaseException:
+        _rollback_restore_swaps(records)
+        raise
+
+
+def _discard_restore_backups(records: list[dict]) -> None:
+    for record in records:
+        backup = record["backup"]
+        if backup is not None:
+            try:
+                _remove_restore_path(backup)
+            except OSError as exc:
+                # The new state is already live and init_db succeeded. Once any
+                # prior backup has been deleted, cleanup is not rollback-safe;
+                # retain and report a residue rather than risk removing live data.
+                logger.warning(
+                    "[BACKUP] Could not remove prior restore artifact %s: %s",
+                    backup,
+                    exc,
+                )
+            _fsync_directory_best_effort(record["target"].parent)
+
+
 def _restore_from_zip(zf: zipfile.ZipFile, manifest: dict) -> list[str]:
-    """Restore files from a validated backup zip."""
-    restored = []
+    """Restore with destination-local atomic swaps and verified compensation.
+
+    This is not a cross-filesystem transaction. Each file/tree is staged beside
+    its own destination so its individual ``os.replace`` is atomic; if a later
+    swap or database initialization fails, prior inodes are renamed back and
+    verified before the old database is reinitialized.
+    """
+    restored: list[str] = []
+    staged_items: list[tuple[Path, Path]] = []
+    records: list[dict] = []
+    database_closed = False
+    failure_reinitialized = False
 
     # Finish settings validation and normalization before any database shutdown
     # or live write. The resulting bytes are the only settings bytes installed.
     restored_settings = None
     if "settings.json" in manifest.staged_paths:
-        settings = manifest.load_json("settings.json")
+        settings = manifest.load_json("settings.json", _MAX_LEGACY_SETTINGS_BYTES)
         restored_settings = _merge_settings_preserving_redacted(
             json.dumps(settings).encode("utf-8")
         )
@@ -3923,70 +4252,84 @@ def _restore_from_zip(zf: zipfile.ZipFile, manifest: dict) -> list[str]:
     _LAST_RESTORE_CONFIG_LOSSES.clear()
     prior_reestablish_counts = _count_reestablish_rows()
 
-    # Close database before replacing files
-    close_db()
-    logger.info("[BACKUP] Database closed for restore")
-
     try:
-        # Restore settings.json — drop REDACTED sentinels in favor of the
-        # currently-on-disk value, mirroring YAML restore semantics.
+        # Complete every potentially failing copy before closing SQLite or
+        # touching a live artifact. Every stage resides on its target filesystem.
         if restored_settings is not None:
-            CONFIG_FILE.write_bytes(restored_settings)
+            staged_items.append(
+                (CONFIG_FILE, _stage_restore_file(CONFIG_FILE, content=restored_settings))
+            )
             restored.append("settings.json")
-            logger.info("[BACKUP] Restored settings.json")
 
-        # Restore journal.db
         if "journal.db" in manifest.staged_paths:
-            with JOURNAL_DB_FILE.open("wb") as destination:
-                shutil.copyfileobj(
-                    manifest.file("journal.db"), destination, _RESTORE_UPLOAD_CHUNK
-                )
+            staged_journal = _stage_restore_file(
+                JOURNAL_DB_FILE, source=manifest.file("journal.db")
+            )
+            _merge_alert_method_creds_after_restore(
+                prior_alert_configs, staged_journal
+            )
+            _reassert_auth_rows_after_restore(prior_auth_rows, staged_journal)
+            with staged_journal.open("rb") as staged_db:
+                os.fsync(staged_db.fileno())
+            staged_items.append((JOURNAL_DB_FILE, staged_journal))
             restored.append("journal.db")
-            logger.info("[BACKUP] Restored journal.db")
-            # Merge any REDACTED alert_methods.config creds back from the
-            # pre-restore snapshot so existing rows aren't degraded.
-            _merge_alert_method_creds_after_restore(prior_alert_configs)
-            # Same for this instance's own accounts (bead …-gi4zn).
-            _reassert_auth_rows_after_restore(prior_auth_rows)
 
-        # Restore directories — clear existing before writing.
-        #
-        # The ``if dir_files:`` guard is load-bearing in BOTH directions, not a
-        # micro-optimization. A newly produced ZIP carries no ``tls/`` or
-        # ``m3u_uploads/`` member (BACKUP_DIRS), so without it every restore of a
-        # current artifact would rmtree the live TLS private key — the same data
-        # loss LEGACY_RESTORE_DIRS exists to prevent, arriving from the other
-        # side. Both halves are pinned by
-        # ``tests/routers/test_04c0u13_backup_confidentiality.py``.
         for dir_rel in LEGACY_RESTORE_DIRS:
             dir_path = CONFIG_DIR / dir_rel
-            # Find files in this directory from the zip
             prefix = dir_rel + "/"
             dir_files = [
                 name for name in manifest.staged_paths if name.startswith(prefix)
             ]
-
             if dir_files:
-                # Clear existing directory
-                if dir_path.exists():
-                    shutil.rmtree(dir_path)
-                dir_path.mkdir(parents=True, exist_ok=True)
+                staged_items.append(
+                    (dir_path, _stage_restore_directory(dir_rel, dir_files, manifest))
+                )
+                restored.extend(dir_files)
 
-                for name in dir_files:
-                    target = CONFIG_DIR / name
-                    target.parent.mkdir(parents=True, exist_ok=True)
-                    with target.open("wb") as destination:
-                        shutil.copyfileobj(
-                            manifest.file(name), destination, _RESTORE_UPLOAD_CHUNK
-                        )
-                    restored.append(name)
-                _apply_restored_directory_modes(dir_rel, dir_path, dir_files)
-                logger.info("[BACKUP] Restored %d files to %s", len(dir_files), dir_rel)
-
-    finally:
-        # Always reinitialize database
-        init_db()
+        close_db()
+        database_closed = True
+        logger.info("[BACKUP] Database closed for restore")
+        records = _swap_staged_restore(staged_items)
+        try:
+            init_db()
+        except BaseException:
+            # init_db may have opened connections or partially migrated the new
+            # journal. Close those before putting the prior inode back.
+            close_db()
+            rollback_records = records
+            records = []
+            _rollback_restore_swaps(rollback_records)
+            init_db()
+            failure_reinitialized = True
+            logger.info("[BACKUP] Prior database reinitialized after restore rollback")
+            raise
+        _discard_restore_backups(records)
+        records = []
         logger.info("[BACKUP] Database reinitialized after restore")
+    except BaseException:
+        # A staging failure occurs before close_db and has no live compensation.
+        # A swap failure compensates inside _swap_staged_restore, then the prior
+        # database still needs to be made available again.
+        if records:
+            _rollback_restore_swaps(records)
+            records = []
+        if database_closed and not failure_reinitialized:
+            try:
+                init_db()
+            except BaseException as init_exc:
+                raise RuntimeError(
+                    "Restore failed and the prior database could not be reinitialized"
+                ) from init_exc
+        raise
+    finally:
+        for _, staged in staged_items:
+            try:
+                _remove_restore_path(staged)
+            except OSError as exc:
+                logger.warning("[BACKUP] Could not remove restore stage %s: %s", staged, exc)
+
+    for name in restored:
+        logger.info("[BACKUP] Restored %s", name)
 
     # Compare the same live counts across the swap. init_db() has already run, so
     # every model-declared table the artifact dropped is back and empty — a table

--- a/backend/tests/routers/test_04c0u13_backup_confidentiality.py
+++ b/backend/tests/routers/test_04c0u13_backup_confidentiality.py
@@ -291,9 +291,11 @@ def _run_legacy_restore(zip_path, config_dir):
             patch.object(backup_mod, "_capture_existing_auth_rows", return_value={}),
             patch.object(backup_mod, "_count_reestablish_rows", return_value={}),
         ):
-            return backup_mod._restore_from_zip(
-                zf, {"version": "0.17.0", "files": zf.namelist()}
-            )
+            plan = backup_mod._validate_backup_zip(zf)
+            try:
+                return backup_mod._restore_from_zip(zf, plan)
+            finally:
+                plan.close()
 
 
 # --- policy mechanics ------------------------------------------------------

--- a/backend/tests/routers/test_0hjrk_backup_save_restore.py
+++ b/backend/tests/routers/test_0hjrk_backup_save_restore.py
@@ -22,6 +22,7 @@ Mocks at router module level per backend/CLAUDE.md
 """
 import io
 import json
+import os
 import zipfile
 
 import pytest
@@ -208,6 +209,67 @@ class TestRestoreSaved:
                 json={"filename": "ecm-backup-2099-12-31_235959.zip"},
             )
         assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_restore_saved_rejects_symlink(self, async_client, backups_dir, tmp_path):
+        """A valid-name symlink is not a saved regular-file archive."""
+        fname = "ecm-backup-2026-01-01_000000.zip"
+        outside = tmp_path / "outside.zip"
+        outside.write_bytes(_make_backup_zip())
+        (backups_dir / fname).symlink_to(outside)
+
+        with patch("routers.backup.BACKUPS_DIR", backups_dir), patch(
+            "routers.backup._restore_from_zip"
+        ) as mock_restore:
+            response = await async_client.post(
+                "/api/backup/restore-saved", json={"filename": fname}
+            )
+
+        assert response.status_code == 404
+        mock_restore.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_restore_saved_rejects_non_regular_entry(self, async_client, backups_dir):
+        """A direct child with a valid archive name must still be a regular file."""
+        fname = "ecm-backup-2026-01-01_000000.zip"
+        (backups_dir / fname).mkdir()
+
+        with patch("routers.backup.BACKUPS_DIR", backups_dir), patch(
+            "routers.backup._restore_from_zip"
+        ) as mock_restore:
+            response = await async_client.post(
+                "/api/backup/restore-saved", json={"filename": fname}
+            )
+
+        assert response.status_code == 404
+        mock_restore.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_restore_saved_does_not_follow_substituted_symlink(
+        self, async_client, backups_dir, tmp_path
+    ):
+        """A regular file replaced after enumeration cannot redirect the open."""
+        fname = "ecm-backup-2026-01-01_000000.zip"
+        selected = backups_dir / fname
+        selected.write_bytes(_make_backup_zip())
+        outside = tmp_path / "outside.zip"
+        outside.write_bytes(_make_backup_zip())
+        real_open = os.open
+
+        def substitute_then_open(path, flags, *args, **kwargs):
+            selected.unlink()
+            selected.symlink_to(outside)
+            return real_open(path, flags, *args, **kwargs)
+
+        with patch("routers.backup.BACKUPS_DIR", backups_dir), patch(
+            "routers.backup.os.open", side_effect=substitute_then_open
+        ), patch("routers.backup._restore_from_zip") as mock_restore:
+            response = await async_client.post(
+                "/api/backup/restore-saved", json={"filename": fname}
+            )
+
+        assert response.status_code == 404
+        mock_restore.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_restore_saved_rejects_yaml_artifact(self, async_client, backups_dir):

--- a/backend/tests/routers/test_0hjrk_backup_save_restore.py
+++ b/backend/tests/routers/test_0hjrk_backup_save_restore.py
@@ -27,13 +27,15 @@ import zipfile
 import pytest
 from unittest.mock import patch
 
+from .test_backup import _minimal_journal_db_bytes
+
 
 def _make_backup_zip() -> bytes:
     """Build a minimal valid ECM backup ZIP (manifest + settings + sqlite db)."""
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
         zf.writestr("settings.json", json.dumps({"url": "http://test:9191"}))
-        zf.writestr("journal.db", b"SQLite format 3\x00" + b"\x00" * 100)
+        zf.writestr("journal.db", _minimal_journal_db_bytes())
         zf.writestr(
             "ecm_backup.json",
             json.dumps(

--- a/backend/tests/routers/test_0hjrk_backup_save_restore.py
+++ b/backend/tests/routers/test_0hjrk_backup_save_restore.py
@@ -26,7 +26,7 @@ import os
 import zipfile
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from .test_backup import _minimal_journal_db_bytes
 
@@ -49,6 +49,25 @@ def _make_backup_zip() -> bytes:
         )
     buf.seek(0)
     return buf.getvalue()
+
+
+class _CloseCountingFile:
+    def __init__(self, file):
+        self.file = file
+        self.close_count = 0
+
+    def close(self):
+        self.close_count += 1
+        self.file.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def __getattr__(self, name):
+        return getattr(self.file, name)
 
 
 @pytest.fixture
@@ -167,6 +186,22 @@ class TestListSavedIncludesZip:
 # POST /api/backup/restore-saved — restore from on-disk zip
 # ---------------------------------------------------------------------------
 class TestRestoreSaved:
+    @staticmethod
+    def _track_archive_open(path):
+        real_fdopen = os.fdopen
+        opened = []
+        target = path.stat()
+
+        def fdopen(descriptor, mode):
+            opened_file = os.fstat(descriptor)
+            if (opened_file.st_dev, opened_file.st_ino) != (target.st_dev, target.st_ino):
+                return real_fdopen(descriptor, mode)
+            archive = _CloseCountingFile(real_fdopen(descriptor, mode))
+            opened.append(archive)
+            return archive
+
+        return opened, fdopen
+
     @pytest.mark.asyncio
     async def test_restore_saved_valid_filename(self, async_client, backups_dir, tmp_path):
         """A valid on-disk .zip is restored via the shared restore path; the
@@ -209,6 +244,71 @@ class TestRestoreSaved:
                 json={"filename": "ecm-backup-2099-12-31_235959.zip"},
             )
         assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_restore_saved_closes_archive_when_zip_open_raises_oserror(
+        self, async_client, backups_dir
+    ):
+        fname = "ecm-backup-2026-01-01_000000.zip"
+        path = backups_dir / fname
+        path.write_bytes(_make_backup_zip())
+        opened, fdopen = self._track_archive_open(path)
+
+        with patch("routers.backup.BACKUPS_DIR", backups_dir), patch(
+            "routers.backup.os.fdopen", side_effect=fdopen
+        ), patch("routers.backup.zipfile.ZipFile", side_effect=OSError("zip read failed")):
+            with pytest.raises(OSError, match="zip read failed"):
+                await async_client.post(
+                    "/api/backup/restore-saved", json={"filename": fname}
+                )
+
+        assert len(opened) == 1
+        assert opened[0].close_count == 1
+
+    @pytest.mark.asyncio
+    async def test_restore_saved_closes_archive_once_for_bad_zip(
+        self, async_client, backups_dir
+    ):
+        fname = "ecm-backup-2026-01-01_000000.zip"
+        path = backups_dir / fname
+        path.write_bytes(b"not a zip")
+        opened, fdopen = self._track_archive_open(path)
+
+        with patch("routers.backup.BACKUPS_DIR", backups_dir), patch(
+            "routers.backup.os.fdopen", side_effect=fdopen
+        ):
+            response = await async_client.post(
+                "/api/backup/restore-saved", json={"filename": fname}
+            )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Saved file is not a valid zip archive"
+        assert len(opened) == 1
+        assert opened[0].close_count == 1
+
+    @pytest.mark.asyncio
+    async def test_restore_saved_closes_archive_once_for_valid_zip(
+        self, async_client, backups_dir
+    ):
+        fname = "ecm-backup-2026-01-01_000000.zip"
+        path = backups_dir / fname
+        path.write_bytes(_make_backup_zip())
+        opened, fdopen = self._track_archive_open(path)
+        manifest = MagicMock()
+        manifest.get.side_effect = {"version": "test", "created_at": "today"}.get
+
+        with patch("routers.backup.BACKUPS_DIR", backups_dir), patch(
+            "routers.backup.os.fdopen", side_effect=fdopen
+        ), patch("routers.backup._validate_backup_zip", return_value=manifest), patch(
+            "routers.backup._restore_from_zip", return_value=[]
+        ):
+            response = await async_client.post(
+                "/api/backup/restore-saved", json={"filename": fname}
+            )
+
+        assert response.status_code == 200
+        assert len(opened) == 1
+        assert opened[0].close_count == 1
 
     @pytest.mark.asyncio
     async def test_restore_saved_rejects_symlink(self, async_client, backups_dir, tmp_path):

--- a/backend/tests/routers/test_6n76m_mcp_restore_gate.py
+++ b/backend/tests/routers/test_6n76m_mcp_restore_gate.py
@@ -32,6 +32,8 @@ from unittest.mock import patch
 
 from config import DispatcharrSettings
 
+from .test_backup import _minimal_journal_db_bytes
+
 
 MCP_KEY = "mcp-secret-key-6n76m"
 
@@ -62,7 +64,7 @@ def _make_backup_zip() -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
         zf.writestr("settings.json", json.dumps({"url": "http://attacker:9191"}))
-        zf.writestr("journal.db", b"SQLite format 3\x00" + b"\x00" * 100)
+        zf.writestr("journal.db", _minimal_journal_db_bytes())
         zf.writestr(
             "ecm_backup.json",
             json.dumps({

--- a/backend/tests/routers/test_9kwzp2_4_legacy_restore_admission.py
+++ b/backend/tests/routers/test_9kwzp2_4_legacy_restore_admission.py
@@ -13,12 +13,22 @@ import pytest
 from routers import backup as backup_mod
 
 
-def _sqlite_bytes(tmp_path: Path, tables: tuple[str, ...]) -> bytes:
+_BASELINE_SCHEMA = {
+    "journal_entries": ("timestamp", "category", "action_type", "entity_name", "description"),
+    "scheduled_tasks": ("task_id", "task_name", "enabled", "schedule_type"),
+    "auto_creation_rules": ("name", "enabled", "priority", "conditions", "actions"),
+}
+
+
+def _sqlite_bytes(tmp_path: Path, tables: tuple[str, ...], *, baseline_columns: bool = False) -> bytes:
     path = tmp_path / ("-".join(tables) + ".db")
     connection = sqlite3.connect(path)
     try:
         for table in tables:
-            connection.execute(f'CREATE TABLE "{table}" (id INTEGER PRIMARY KEY)')
+            columns = ["id INTEGER PRIMARY KEY"]
+            if baseline_columns:
+                columns.extend(f'"{name}" TEXT' for name in _BASELINE_SCHEMA.get(table, ()))
+            connection.execute(f'CREATE TABLE "{table}" ({", ".join(columns)})')
         connection.commit()
     finally:
         connection.close()
@@ -52,7 +62,7 @@ async def test_invalid_known_setting_is_rejected_before_close_or_live_write(
     journal_path.write_bytes(b"live journal sentinel")
     artifact = _legacy_zip(
         settings={"linked_m3u_accounts": "not-a-list"},
-        journal=_sqlite_bytes(tmp_path, ("journal_entries", "scheduled_tasks")),
+        journal=_sqlite_bytes(tmp_path, tuple(_BASELINE_SCHEMA), baseline_columns=True),
     )
 
     with (
@@ -103,6 +113,29 @@ def test_settings_merge_preserves_destination_mcp_key_and_drops_unknown_keys(tmp
     assert "obsolete_destination_key" not in restored
 
 
+def test_historical_nulls_and_legacy_api_key_use_loader_compatibility(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({"mcp_api_key": "destination-key"}))
+    archived = json.dumps(
+        {
+            "url": "http://restored:9191",
+            "user_timezone": None,
+            "stats_poll_interval": None,
+            "api_key": "legacy-dispatcharr-key",
+            "mcp_api_key": "artifact-key",
+        }
+    ).encode()
+
+    with patch.object(backup_mod, "CONFIG_FILE", settings_path):
+        restored = json.loads(backup_mod._merge_settings_preserving_redacted(archived))
+
+    assert restored["user_timezone"] == ""
+    assert restored["stats_poll_interval"] == 10
+    assert restored["dispatcharr_api_key"] == "legacy-dispatcharr-key"
+    assert restored["api_key"] == "legacy-dispatcharr-key"
+    assert restored["mcp_api_key"] == "destination-key"
+
+
 def test_schema_mismatched_sqlite_is_rejected_before_close_db(tmp_path):
     archive = tmp_path / "wrong-schema.zip"
     archive.write_bytes(
@@ -122,7 +155,7 @@ def test_legacy_baseline_schema_is_accepted_without_current_full_schema(tmp_path
     archive = tmp_path / "old-valid.zip"
     archive.write_bytes(
         _legacy_zip(
-            journal=_sqlite_bytes(tmp_path, ("journal_entries", "scheduled_tasks"))
+            journal=_sqlite_bytes(tmp_path, tuple(_BASELINE_SCHEMA), baseline_columns=True)
         )
     )
 
@@ -132,11 +165,47 @@ def test_legacy_baseline_schema_is_accepted_without_current_full_schema(tmp_path
     assert manifest["version"] == "0.15.0"
 
 
+def test_table_names_without_historical_columns_are_rejected(tmp_path):
+    archive = tmp_path / "unusable-schema.zip"
+    archive.write_bytes(_legacy_zip(journal=_sqlite_bytes(tmp_path, tuple(_BASELINE_SCHEMA))))
+
+    with zipfile.ZipFile(archive) as zf, pytest.raises(backup_mod.HTTPException) as exc:
+        backup_mod._validate_backup_zip(zf)
+
+    assert exc.value.detail == "Backup contains incompatible journal.db"
+
+
+def test_corrupt_sqlite_with_readable_schema_is_rejected(tmp_path):
+    path = tmp_path / "corrupt-source.db"
+    path.write_bytes(
+        _sqlite_bytes(tmp_path, tuple(_BASELINE_SCHEMA), baseline_columns=True)
+    )
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute("CREATE TABLE payloads (data BLOB)")
+        connection.executemany(
+            "INSERT INTO payloads VALUES (?)", [(b"x" * 3000,)] * 20
+        )
+        connection.commit()
+        page_size = connection.execute("PRAGMA page_size").fetchone()[0]
+    finally:
+        connection.close()
+    journal = bytearray(path.read_bytes())
+    journal[-page_size:] = b"\0" * page_size
+    archive = tmp_path / "corrupt.zip"
+    archive.write_bytes(_legacy_zip(journal=bytes(journal)))
+
+    with zipfile.ZipFile(archive) as zf, pytest.raises(backup_mod.HTTPException) as exc:
+        backup_mod._validate_backup_zip(zf)
+
+    assert exc.value.detail == "Backup contains invalid journal.db"
+
+
 def test_journal_validation_streams_to_private_temp_and_opens_read_only(tmp_path):
     archive = tmp_path / "valid.zip"
     archive.write_bytes(
         _legacy_zip(
-            journal=_sqlite_bytes(tmp_path, ("journal_entries", "scheduled_tasks"))
+            journal=_sqlite_bytes(tmp_path, tuple(_BASELINE_SCHEMA), baseline_columns=True)
         )
     )
     real_connect = sqlite3.connect
@@ -162,7 +231,37 @@ def test_journal_validation_streams_to_private_temp_and_opens_read_only(tmp_path
             patch.object(zf, "read", side_effect=reject_whole_journal_read),
             patch.object(backup_mod.sqlite3, "connect", side_effect=checked_connect),
         ):
-            backup_mod._validate_backup_zip(zf)
+            plan = backup_mod._validate_backup_zip(zf)
+            plan.close()
 
     assert observed_temp is not None
     assert not observed_temp.exists()
+
+
+def test_restore_installs_validated_journal_inode_after_path_substitution(tmp_path):
+    original = _sqlite_bytes(tmp_path, tuple(_BASELINE_SCHEMA), baseline_columns=True)
+    replacement = _sqlite_bytes(tmp_path, ("users",))
+    archive = tmp_path / "valid.zip"
+    archive.write_bytes(_legacy_zip(journal=original))
+    live = tmp_path / "live-journal.db"
+
+    with zipfile.ZipFile(archive) as zf:
+        plan = backup_mod._validate_backup_zip(zf)
+        staged_path = plan.staged_paths["journal.db"]
+        staged_path.unlink()
+        staged_path.write_bytes(replacement)
+        with (
+            patch.object(backup_mod, "JOURNAL_DB_FILE", live),
+            patch.object(backup_mod, "CONFIG_DIR", tmp_path),
+            patch.object(backup_mod, "close_db"),
+            patch.object(backup_mod, "init_db"),
+            patch.object(backup_mod, "clear_settings_cache"),
+            patch.object(backup_mod, "reset_client"),
+            patch.object(backup_mod, "_capture_existing_alert_method_configs", return_value={}),
+            patch.object(backup_mod, "_capture_existing_auth_rows", return_value={}),
+            patch.object(backup_mod, "_count_reestablish_rows", return_value={}),
+        ):
+            backup_mod._restore_from_zip(zf, plan)
+        plan.close()
+
+    assert live.read_bytes() == original

--- a/backend/tests/routers/test_9kwzp2_4_legacy_restore_admission.py
+++ b/backend/tests/routers/test_9kwzp2_4_legacy_restore_admission.py
@@ -1,12 +1,13 @@
 """Legacy ZIP settings and journal admission regressions (9kwzp.2, 9kwzp.4)."""
 
+import errno
 import io
 import json
 import sqlite3
 import stat
 import zipfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -265,3 +266,275 @@ def test_restore_installs_validated_journal_inode_after_path_substitution(tmp_pa
         plan.close()
 
     assert live.read_bytes() == original
+
+
+def test_current_standard_zip_producer_is_admitted_and_restored(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    source_settings = source / "settings.json"
+    source_settings.write_text(json.dumps({"url": "http://source:9191"}))
+    source_journal = source / "journal.db"
+    source_journal.write_bytes(
+        _sqlite_bytes(tmp_path, tuple(_BASELINE_SCHEMA), baseline_columns=True)
+    )
+    with sqlite3.connect(source_journal) as connection:
+        connection.execute(
+            "INSERT INTO scheduled_tasks "
+            "(task_id, task_name, enabled, schedule_type) VALUES (?, ?, ?, ?)",
+            ("backup", "Backup", "1", "manual"),
+        )
+        connection.commit()
+
+    engine = MagicMock()
+    engine.connect.side_effect = RuntimeError("checkpoint unavailable in fixture")
+    with (
+        patch.object(backup_mod, "CONFIG_DIR", source),
+        patch.object(backup_mod, "CONFIG_FILE", source_settings),
+        patch.object(backup_mod, "JOURNAL_DB_FILE", source_journal),
+        patch.object(backup_mod, "get_engine", return_value=engine),
+    ):
+        artifact = backup_mod._create_backup_zip().getvalue()
+
+    archive = tmp_path / "current-standard.zip"
+    archive.write_bytes(artifact)
+    extracted = tmp_path / "produced-journal.db"
+    with zipfile.ZipFile(archive) as zf:
+        extracted.write_bytes(zf.read("journal.db"))
+    with sqlite3.connect(extracted) as connection:
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    assert "journal_entries" not in tables
+    assert {"scheduled_tasks", "auto_creation_rules"}.issubset(tables)
+
+    destination = tmp_path / "destination"
+    destination.mkdir()
+    destination_settings = destination / "settings.json"
+    destination_journal = destination / "journal.db"
+    with zipfile.ZipFile(archive) as zf:
+        with patch.object(backup_mod, "CONFIG_DIR", destination):
+            plan = backup_mod._validate_backup_zip(zf)
+        try:
+            with (
+                patch.object(backup_mod, "CONFIG_DIR", destination),
+                patch.object(backup_mod, "CONFIG_FILE", destination_settings),
+                patch.object(backup_mod, "JOURNAL_DB_FILE", destination_journal),
+                patch.object(backup_mod, "close_db"),
+                patch.object(backup_mod, "init_db"),
+                patch.object(backup_mod, "clear_settings_cache"),
+                patch.object(backup_mod, "reset_client"),
+            ):
+                restored = backup_mod._restore_from_zip(zf, plan)
+        finally:
+            plan.close()
+
+    assert {"settings.json", "journal.db"}.issubset(restored)
+    with sqlite3.connect(destination_journal) as connection:
+        assert connection.execute(
+            "SELECT task_name FROM scheduled_tasks WHERE task_id='backup'"
+        ).fetchone() == ("Backup",)
+
+
+def _transactional_restore_fixture(tmp_path: Path):
+    live = tmp_path / "live"
+    live.mkdir()
+    settings = live / "settings.json"
+    settings.write_text(json.dumps({"url": "http://live:9191"}))
+    journal = live / "journal.db"
+    journal_bytes = _sqlite_bytes(
+        tmp_path, tuple(_BASELINE_SCHEMA), baseline_columns=True
+    )
+    journal.write_bytes(journal_bytes)
+    members = {
+        "uploads/logos/logo.png": b"new logo",
+        "tls/key.pem": b"new key",
+        "m3u_uploads/list.m3u": b"new playlist",
+    }
+    old = {}
+    for name, content in {
+        "uploads/logos/old.png": b"old logo",
+        "tls/old.pem": b"old key",
+        "m3u_uploads/old.m3u": b"old playlist",
+    }.items():
+        path = live / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        old[name] = content
+
+    archive = tmp_path / "transaction.zip"
+    archive.write_bytes(
+        _legacy_zip(
+            settings={"url": "http://restored:9191"},
+            journal=journal_bytes,
+        )
+    )
+    with zipfile.ZipFile(archive, "a") as zf:
+        for name, content in members.items():
+            zf.writestr(name, content)
+
+    return live, settings, journal, old, archive
+
+
+def _assert_prior_live_state(live, settings, journal, old, prior_journal):
+    assert json.loads(settings.read_text()) == {"url": "http://live:9191"}
+    assert journal.read_bytes() == prior_journal
+    for name, content in old.items():
+        assert (live / name).read_bytes() == content
+    assert not (live / "uploads/logos/logo.png").exists()
+    assert not (live / "tls/key.pem").exists()
+    assert not (live / "m3u_uploads/list.m3u").exists()
+
+
+@pytest.mark.parametrize(
+    "failed_target",
+    ["settings.json", "journal.db", "uploads/logos", "tls", "m3u_uploads"],
+)
+def test_restore_replace_failure_rolls_back_every_live_artifact(
+    tmp_path, failed_target
+):
+    live, settings, journal, old, archive = _transactional_restore_fixture(tmp_path)
+    prior_journal = journal.read_bytes()
+    real_replace = backup_mod.os.replace
+    failed = False
+
+    def fail_one_install(source, destination):
+        nonlocal failed
+        destination = Path(destination)
+        if not failed and destination == live / failed_target:
+            failed = True
+            raise PermissionError("injected replace failure")
+        return real_replace(source, destination)
+
+    with zipfile.ZipFile(archive) as zf:
+        with patch.object(backup_mod, "CONFIG_DIR", live):
+            plan = backup_mod._validate_backup_zip(zf)
+        try:
+            with (
+                patch.object(backup_mod, "CONFIG_DIR", live),
+                patch.object(backup_mod, "CONFIG_FILE", settings),
+                patch.object(backup_mod, "JOURNAL_DB_FILE", journal),
+                patch.object(backup_mod.os, "replace", side_effect=fail_one_install),
+                patch.object(backup_mod, "close_db") as close_db,
+                patch.object(backup_mod, "init_db") as init_db,
+                patch.object(backup_mod, "clear_settings_cache"),
+                patch.object(backup_mod, "reset_client"),
+                pytest.raises(PermissionError, match="injected replace failure"),
+            ):
+                backup_mod._restore_from_zip(zf, plan)
+        finally:
+            plan.close()
+
+    assert failed
+    close_db.assert_called_once()
+    init_db.assert_called_once()
+    _assert_prior_live_state(live, settings, journal, old, prior_journal)
+
+
+@pytest.mark.parametrize("failed_member", ["journal.db", "tls/key.pem"])
+def test_restore_staging_copy_failure_never_touches_live_state(tmp_path, failed_member):
+    live, settings, journal, old, archive = _transactional_restore_fixture(tmp_path)
+    prior_journal = journal.read_bytes()
+    real_copy = backup_mod.shutil.copyfileobj
+
+    def fail_selected_copy(source, destination, length=0):
+        staged_name = next(
+            name for name, handle in plan._files.items() if handle.fileno() == source.fileno()
+        )
+        if staged_name == failed_member:
+            raise OSError("injected copy failure")
+        return real_copy(source, destination, length)
+
+    with zipfile.ZipFile(archive) as zf:
+        with patch.object(backup_mod, "CONFIG_DIR", live):
+            plan = backup_mod._validate_backup_zip(zf)
+        try:
+            with (
+                patch.object(backup_mod, "CONFIG_DIR", live),
+                patch.object(backup_mod, "CONFIG_FILE", settings),
+                patch.object(backup_mod, "JOURNAL_DB_FILE", journal),
+                patch.object(backup_mod.shutil, "copyfileobj", side_effect=fail_selected_copy),
+                patch.object(backup_mod, "close_db") as close_db,
+                patch.object(backup_mod, "init_db") as init_db,
+                pytest.raises(OSError, match="injected copy failure"),
+            ):
+                backup_mod._restore_from_zip(zf, plan)
+        finally:
+            plan.close()
+
+    close_db.assert_not_called()
+    init_db.assert_not_called()
+    _assert_prior_live_state(live, settings, journal, old, prior_journal)
+
+
+def test_restore_init_failure_rolls_back_then_reinitializes_prior_database(tmp_path):
+    live, settings, journal, old, archive = _transactional_restore_fixture(tmp_path)
+    prior_journal = journal.read_bytes()
+
+    with zipfile.ZipFile(archive) as zf:
+        with patch.object(backup_mod, "CONFIG_DIR", live):
+            plan = backup_mod._validate_backup_zip(zf)
+        try:
+            with (
+                patch.object(backup_mod, "CONFIG_DIR", live),
+                patch.object(backup_mod, "CONFIG_FILE", settings),
+                patch.object(backup_mod, "JOURNAL_DB_FILE", journal),
+                patch.object(backup_mod, "close_db") as close_db,
+                patch.object(
+                    backup_mod,
+                    "init_db",
+                    side_effect=[RuntimeError("injected init failure"), None],
+                ) as init_db,
+                patch.object(backup_mod, "clear_settings_cache"),
+                patch.object(backup_mod, "reset_client"),
+                pytest.raises(RuntimeError, match="injected init failure"),
+            ):
+                backup_mod._restore_from_zip(zf, plan)
+        finally:
+            plan.close()
+
+    assert close_db.call_count == 2
+    assert init_db.call_count == 2
+    _assert_prior_live_state(live, settings, journal, old, prior_journal)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [OSError(errno.ENOSPC, "injected disk full"), KeyboardInterrupt()],
+)
+def test_restore_disk_full_or_interruption_compensates_live_state(tmp_path, failure):
+    live, settings, journal, old, archive = _transactional_restore_fixture(tmp_path)
+    prior_journal = journal.read_bytes()
+    real_replace = backup_mod.os.replace
+    failed = False
+
+    def interrupt_settings_install(source, destination):
+        nonlocal failed
+        if not failed and Path(destination) == settings:
+            failed = True
+            raise failure
+        return real_replace(source, destination)
+
+    with zipfile.ZipFile(archive) as zf:
+        with patch.object(backup_mod, "CONFIG_DIR", live):
+            plan = backup_mod._validate_backup_zip(zf)
+        try:
+            with (
+                patch.object(backup_mod, "CONFIG_DIR", live),
+                patch.object(backup_mod, "CONFIG_FILE", settings),
+                patch.object(backup_mod, "JOURNAL_DB_FILE", journal),
+                patch.object(
+                    backup_mod.os, "replace", side_effect=interrupt_settings_install
+                ),
+                patch.object(backup_mod, "close_db"),
+                patch.object(backup_mod, "init_db"),
+                pytest.raises(type(failure)),
+            ):
+                backup_mod._restore_from_zip(zf, plan)
+        finally:
+            plan.close()
+
+    assert failed
+    _assert_prior_live_state(live, settings, journal, old, prior_journal)

--- a/backend/tests/routers/test_9kwzp2_4_legacy_restore_admission.py
+++ b/backend/tests/routers/test_9kwzp2_4_legacy_restore_admission.py
@@ -1,0 +1,168 @@
+"""Legacy ZIP settings and journal admission regressions (9kwzp.2, 9kwzp.4)."""
+
+import io
+import json
+import sqlite3
+import stat
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from routers import backup as backup_mod
+
+
+def _sqlite_bytes(tmp_path: Path, tables: tuple[str, ...]) -> bytes:
+    path = tmp_path / ("-".join(tables) + ".db")
+    connection = sqlite3.connect(path)
+    try:
+        for table in tables:
+            connection.execute(f'CREATE TABLE "{table}" (id INTEGER PRIMARY KEY)')
+        connection.commit()
+    finally:
+        connection.close()
+    return path.read_bytes()
+
+
+def _legacy_zip(*, settings: object | None = None, journal: bytes | None = None) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        files = []
+        if settings is not None:
+            zf.writestr("settings.json", json.dumps(settings))
+            files.append("settings.json")
+        if journal is not None:
+            zf.writestr("journal.db", journal)
+            files.append("journal.db")
+        zf.writestr(
+            "ecm_backup.json",
+            json.dumps({"version": "0.15.0", "files": files}),
+        )
+    return buffer.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_invalid_known_setting_is_rejected_before_close_or_live_write(
+    async_client, tmp_path
+):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({"url": "http://live:9191"}))
+    journal_path = tmp_path / "journal.db"
+    journal_path.write_bytes(b"live journal sentinel")
+    artifact = _legacy_zip(
+        settings={"linked_m3u_accounts": "not-a-list"},
+        journal=_sqlite_bytes(tmp_path, ("journal_entries", "scheduled_tasks")),
+    )
+
+    with (
+        patch.object(backup_mod, "CONFIG_DIR", tmp_path),
+        patch.object(backup_mod, "CONFIG_FILE", settings_path),
+        patch.object(backup_mod, "JOURNAL_DB_FILE", journal_path),
+        patch.object(backup_mod, "close_db") as close_db,
+    ):
+        response = await async_client.post(
+            "/api/backup/restore",
+            files={"file": ("backup.zip", artifact, "application/zip")},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Backup contains invalid settings.json"
+    close_db.assert_not_called()
+    assert json.loads(settings_path.read_text()) == {"url": "http://live:9191"}
+    assert journal_path.read_bytes() == b"live journal sentinel"
+
+
+def test_settings_merge_preserves_destination_mcp_key_and_drops_unknown_keys(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "url": "http://live:9191",
+                "mcp_api_key": "destination-key",
+                "obsolete_destination_key": "drop-me",
+            }
+        )
+    )
+    archived = json.dumps(
+        {
+            "url": "http://restored:9191",
+            "mcp_api_key": "attacker-key",
+            "unknown_archive_key": "drop-me-too",
+            "max_auto_created_channels_per_run": -7,
+        }
+    ).encode()
+
+    with patch.object(backup_mod, "CONFIG_FILE", settings_path):
+        restored = json.loads(backup_mod._merge_settings_preserving_redacted(archived))
+
+    assert restored["url"] == "http://restored:9191"
+    assert restored["mcp_api_key"] == "destination-key"
+    assert restored["max_auto_created_channels_per_run"] == 0
+    assert "unknown_archive_key" not in restored
+    assert "obsolete_destination_key" not in restored
+
+
+def test_schema_mismatched_sqlite_is_rejected_before_close_db(tmp_path):
+    archive = tmp_path / "wrong-schema.zip"
+    archive.write_bytes(
+        _legacy_zip(journal=_sqlite_bytes(tmp_path, ("users",)))
+    )
+
+    with zipfile.ZipFile(archive) as zf, patch.object(backup_mod, "close_db") as close_db:
+        with pytest.raises(backup_mod.HTTPException) as exc:
+            backup_mod._validate_backup_zip(zf)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Backup contains incompatible journal.db"
+    close_db.assert_not_called()
+
+
+def test_legacy_baseline_schema_is_accepted_without_current_full_schema(tmp_path):
+    archive = tmp_path / "old-valid.zip"
+    archive.write_bytes(
+        _legacy_zip(
+            journal=_sqlite_bytes(tmp_path, ("journal_entries", "scheduled_tasks"))
+        )
+    )
+
+    with zipfile.ZipFile(archive) as zf:
+        manifest = backup_mod._validate_backup_zip(zf)
+
+    assert manifest["version"] == "0.15.0"
+
+
+def test_journal_validation_streams_to_private_temp_and_opens_read_only(tmp_path):
+    archive = tmp_path / "valid.zip"
+    archive.write_bytes(
+        _legacy_zip(
+            journal=_sqlite_bytes(tmp_path, ("journal_entries", "scheduled_tasks"))
+        )
+    )
+    real_connect = sqlite3.connect
+    observed_temp: Path | None = None
+
+    def checked_connect(database, *args, **kwargs):
+        nonlocal observed_temp
+        assert kwargs.get("uri") is True
+        assert str(database).endswith("?mode=ro")
+        observed_temp = Path(str(database).removeprefix("file:").removesuffix("?mode=ro"))
+        assert stat.S_IMODE(observed_temp.stat().st_mode) == 0o600
+        return real_connect(database, *args, **kwargs)
+
+    with zipfile.ZipFile(archive) as zf:
+        original_read = zf.read
+
+        def reject_whole_journal_read(name, *args, **kwargs):
+            if name == "journal.db":
+                raise AssertionError("journal.db was read wholesale")
+            return original_read(name, *args, **kwargs)
+
+        with (
+            patch.object(zf, "read", side_effect=reject_whole_journal_read),
+            patch.object(backup_mod.sqlite3, "connect", side_effect=checked_connect),
+        ):
+            backup_mod._validate_backup_zip(zf)
+
+    assert observed_temp is not None
+    assert not observed_temp.exists()

--- a/backend/tests/routers/test_9kwzp3_legacy_restore_bounds.py
+++ b/backend/tests/routers/test_9kwzp3_legacy_restore_bounds.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import sqlite3
 import zipfile
 from unittest.mock import AsyncMock, patch
 
@@ -10,16 +11,35 @@ from starlette.datastructures import UploadFile
 
 from routers import backup as backup_mod
 
+from .test_backup import _minimal_journal_db_bytes
 
-def _legacy_zip(*, journal: bytes = b"SQLite format 3\x00") -> bytes:
+
+def _legacy_zip(*, journal: bytes | None = None) -> bytes:
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr(
             "ecm_backup.json",
             json.dumps({"version": "1.0", "files": ["journal.db"]}),
         )
-        zf.writestr("journal.db", journal)
+        zf.writestr(
+            "journal.db",
+            journal if journal is not None else _minimal_journal_db_bytes(),
+        )
     return buffer.getvalue()
+
+
+def _compressible_journal_bytes(tmp_path) -> bytes:
+    path = tmp_path / "compressible-journal.db"
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute("CREATE TABLE journal_entries (id INTEGER PRIMARY KEY)")
+        connection.execute("CREATE TABLE scheduled_tasks (id INTEGER PRIMARY KEY)")
+        connection.execute("CREATE TABLE payloads (data BLOB)")
+        connection.execute("INSERT INTO payloads VALUES (zeroblob(?))", (1024 * 1024,))
+        connection.commit()
+    finally:
+        connection.close()
+    return path.read_bytes()
 
 
 @pytest.mark.asyncio
@@ -27,7 +47,7 @@ def _legacy_zip(*, journal: bytes = b"SQLite format 3\x00") -> bytes:
 async def test_legacy_restore_streams_through_upload_cap_and_cleans_partial_file(
     tmp_path, initial
 ):
-    payload = _legacy_zip(journal=b"SQLite format 3\x00" + b"x" * 512)
+    payload = _legacy_zip()
     settings = type("Settings", (), {"is_configured": lambda self: False})()
 
     with (
@@ -70,7 +90,11 @@ def test_legacy_validator_rejects_high_ratio_member_before_any_read(tmp_path):
 def test_legacy_validator_accepts_ecm_shaped_high_ratio_member(tmp_path, member_name):
     """Only legacy SQLite/M3U data may exceed the DBAS 100x ratio cap."""
     archive = tmp_path / "legacy-high-ratio.zip"
-    content = b"SQLite format 3\x00" + b"playlist-line-title-channel-name-operator-visible-metadata\n" * (1024 * 1024 // 57)
+    content = (
+        _compressible_journal_bytes(tmp_path)
+        if member_name == "journal.db"
+        else b"playlist-line-title-channel-name-operator-visible-metadata\n" * (1024 * 1024 // 57)
+    )
     with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("ecm_backup.json", json.dumps({"version": "1.0"}))
         zf.writestr(member_name, content)
@@ -130,11 +154,11 @@ def test_legacy_validator_enforces_declared_bounds_before_any_read(
     assert exc.value.detail == "Backup archive rejected"
 
 
-def test_legacy_validator_reads_only_sqlite_header_from_journal(tmp_path):
+def test_legacy_validator_streams_journal_in_bounded_chunks(tmp_path):
     archive = tmp_path / "backup.zip"
     with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_STORED) as zf:
         zf.writestr("ecm_backup.json", json.dumps({"version": "1.0"}))
-        zf.writestr("journal.db", b"SQLite format 3\x00" + b"x" * 4096)
+        zf.writestr("journal.db", _minimal_journal_db_bytes())
 
     with zipfile.ZipFile(archive) as zf:
         original_open = zf.open
@@ -163,4 +187,4 @@ def test_legacy_validator_reads_only_sqlite_header_from_journal(tmp_path):
             manifest = backup_mod._validate_backup_zip(zf)
 
     assert manifest["version"] == "1.0"
-    assert journal_reads == [16]
+    assert journal_reads == [backup_mod._RESTORE_UPLOAD_CHUNK] * 2

--- a/backend/tests/routers/test_9kwzp3_legacy_restore_bounds.py
+++ b/backend/tests/routers/test_9kwzp3_legacy_restore_bounds.py
@@ -3,6 +3,7 @@
 import io
 import json
 import sqlite3
+import stat
 import zipfile
 from unittest.mock import AsyncMock, patch
 
@@ -32,8 +33,18 @@ def _compressible_journal_bytes(tmp_path) -> bytes:
     path = tmp_path / "compressible-journal.db"
     connection = sqlite3.connect(path)
     try:
-        connection.execute("CREATE TABLE journal_entries (id INTEGER PRIMARY KEY)")
-        connection.execute("CREATE TABLE scheduled_tasks (id INTEGER PRIMARY KEY)")
+        connection.execute(
+            "CREATE TABLE journal_entries (id INTEGER PRIMARY KEY, timestamp TEXT, "
+            "category TEXT, action_type TEXT, entity_name TEXT, description TEXT)"
+        )
+        connection.execute(
+            "CREATE TABLE scheduled_tasks (id INTEGER PRIMARY KEY, task_id TEXT, "
+            "task_name TEXT, enabled INTEGER, schedule_type TEXT)"
+        )
+        connection.execute(
+            "CREATE TABLE auto_creation_rules (id INTEGER PRIMARY KEY, name TEXT, "
+            "enabled INTEGER, priority INTEGER, conditions TEXT, actions TEXT)"
+        )
         connection.execute("CREATE TABLE payloads (data BLOB)")
         connection.execute("INSERT INTO payloads VALUES (zeroblob(?))", (1024 * 1024,))
         connection.commit()
@@ -188,3 +199,68 @@ def test_legacy_validator_streams_journal_in_bounded_chunks(tmp_path):
 
     assert manifest["version"] == "1.0"
     assert journal_reads == [backup_mod._RESTORE_UPLOAD_CHUNK] * 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["restore", "restore-initial", "restore-saved"])
+async def test_legacy_restore_endpoints_never_whole_read_archive_or_payload_members(
+    async_client, tmp_path, endpoint
+):
+    artifact = _legacy_zip()
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    backups_dir = tmp_path / "backups"
+    backups_dir.mkdir()
+    filename = "ecm-backup-2026-01-01_000000.zip"
+    (backups_dir / filename).write_bytes(artifact)
+
+    def guarded_read(self, name, *args, **kwargs):
+        raise AssertionError(f"whole-member read: {name}")
+
+    saved_path = backups_dir / filename
+    real_path_read_bytes = type(saved_path).read_bytes
+
+    def guarded_path_read_bytes(self):
+        if self == saved_path:
+            raise AssertionError("whole saved archive read")
+        return real_path_read_bytes(self)
+
+    settings = type("Settings", (), {"is_configured": lambda self: False})()
+    with (
+        patch.object(zipfile.ZipFile, "read", guarded_read),
+        patch.object(type(saved_path), "read_bytes", guarded_path_read_bytes),
+        patch.object(backup_mod, "CONFIG_DIR", config_dir),
+        patch.object(backup_mod, "CONFIG_FILE", config_dir / "settings.json"),
+        patch.object(backup_mod, "JOURNAL_DB_FILE", config_dir / "journal.db"),
+        patch.object(backup_mod, "BACKUPS_DIR", backups_dir),
+        patch.object(backup_mod, "get_settings", return_value=settings),
+        patch.object(backup_mod, "_guard_initial_restore", new=AsyncMock()),
+        patch.object(backup_mod, "close_db"),
+        patch.object(backup_mod, "init_db"),
+        patch.object(backup_mod, "clear_settings_cache"),
+        patch.object(backup_mod, "reset_client"),
+    ):
+        if endpoint == "restore-saved":
+            response = await async_client.post(
+                "/api/backup/restore-saved", json={"filename": filename}
+            )
+        else:
+            response = await async_client.post(
+                f"/api/backup/{endpoint}",
+                files={"file": ("backup.zip", artifact, "application/zip")},
+            )
+
+    assert response.status_code == 200, response.text
+
+
+def test_validation_workspace_is_private_and_retains_staged_inode(tmp_path):
+    archive = tmp_path / "backup.zip"
+    archive.write_bytes(_legacy_zip())
+
+    with zipfile.ZipFile(archive) as zf:
+        plan = backup_mod._validate_backup_zip(zf)
+        staged = plan.staged_paths["journal.db"]
+        assert stat.S_IMODE(staged.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(staged.stat().st_mode) == 0o600
+        assert plan.staged_inodes["journal.db"] == staged.stat().st_ino
+        plan.close()

--- a/backend/tests/routers/test_9kwzp3_legacy_restore_bounds.py
+++ b/backend/tests/routers/test_9kwzp3_legacy_restore_bounds.py
@@ -264,3 +264,135 @@ def test_validation_workspace_is_private_and_retains_staged_inode(tmp_path):
         assert stat.S_IMODE(staged.stat().st_mode) == 0o600
         assert plan.staged_inodes["journal.db"] == staged.stat().st_ino
         plan.close()
+
+
+def test_dbas_manifest_cap_is_checked_from_zipinfo_before_open(tmp_path, monkeypatch):
+    archive = tmp_path / "oversized-manifest.zip"
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr(
+            "manifest.json",
+            json.dumps({"schema_version": 1, "padding": "x" * 128, "files": []}),
+        )
+    monkeypatch.setattr(backup_mod, "_MAX_DBAS_MANIFEST_BYTES", 64)
+
+    with zipfile.ZipFile(archive) as zf:
+        with patch.object(zf, "open", side_effect=AssertionError("member opened")):
+            with pytest.raises(backup_mod.HTTPException) as exc:
+                backup_mod.validate_artifact_manifest(zf)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid backup manifest"
+
+
+def test_dbas_manifest_parser_never_uses_unbounded_member_read(tmp_path):
+    archive = tmp_path / "manifest.zip"
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("manifest.json", json.dumps({"schema_version": 1, "files": []}))
+
+    with zipfile.ZipFile(archive) as zf:
+        original_open = zf.open
+        reads = []
+
+        def tracked_open(name, *args, **kwargs):
+            member = original_open(name, *args, **kwargs)
+            if getattr(name, "filename", name) != "manifest.json":
+                return member
+
+            class TrackedMember:
+                def __enter__(self):
+                    member.__enter__()
+                    return self
+
+                def __exit__(self, *exc):
+                    return member.__exit__(*exc)
+
+                def read(self, size=-1):
+                    reads.append(size)
+                    assert size >= 0
+                    return member.read(size)
+
+            return TrackedMember()
+
+        with patch.object(zf, "open", side_effect=tracked_open):
+            backup_mod.validate_artifact_manifest(zf)
+
+    assert reads
+
+
+@pytest.mark.asyncio
+async def test_initial_restore_rejects_oversized_settings_before_open_or_shutdown(
+    async_client, tmp_path, monkeypatch
+):
+    artifact = io.BytesIO()
+    with zipfile.ZipFile(artifact, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("ecm_backup.json", json.dumps({"version": "1.0"}))
+        zf.writestr("settings.json", json.dumps({"padding": "x" * 128}))
+    monkeypatch.setattr(backup_mod, "_MAX_LEGACY_SETTINGS_BYTES", 64)
+    settings = type("Settings", (), {"is_configured": lambda self: False})()
+    real_open = zipfile.ZipFile.open
+
+    def reject_settings_open(self, name, *args, **kwargs):
+        if name == "settings.json":
+            raise AssertionError("oversized settings member opened")
+        return real_open(self, name, *args, **kwargs)
+
+    with (
+        patch.object(backup_mod, "get_settings", return_value=settings),
+        patch.object(backup_mod, "_guard_initial_restore", new=AsyncMock()),
+        patch.object(zipfile.ZipFile, "open", reject_settings_open),
+        patch.object(backup_mod, "close_db") as close_db,
+    ):
+        response = await async_client.post(
+            "/api/backup/restore-initial",
+            files={"file": ("backup.zip", artifact.getvalue(), "application/zip")},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Backup contains invalid settings.json"
+    close_db.assert_not_called()
+
+
+def test_settings_cap_retains_multi_megabyte_operator_configuration(tmp_path):
+    archive = tmp_path / "large-settings.zip"
+    settings = json.dumps({"url": "http://test:9191"}).encode() + b" " * (2 * 1024 * 1024)
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("ecm_backup.json", json.dumps({"version": "1.0"}))
+        zf.writestr("settings.json", settings)
+
+    with zipfile.ZipFile(archive) as zf:
+        plan = backup_mod._validate_backup_zip(zf)
+        plan.close()
+
+
+def test_staged_settings_parser_never_uses_unbounded_read(tmp_path):
+    archive = tmp_path / "settings.zip"
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("ecm_backup.json", json.dumps({"version": "1.0"}))
+        zf.writestr("settings.json", json.dumps({"url": "http://test:9191"}))
+
+    with zipfile.ZipFile(archive) as zf:
+        plan = backup_mod._validate_backup_zip(zf)
+        original = plan._files["settings.json"]
+        reads = []
+
+        class TrackedStagedFile:
+            def read(self, size=-1):
+                reads.append(size)
+                assert size >= 0
+                return original.read(size)
+
+            def seek(self, *args):
+                return original.seek(*args)
+
+            def close(self):
+                return original.close()
+
+        plan._files["settings.json"] = TrackedStagedFile()
+        try:
+            assert plan.load_json(
+                "settings.json", backup_mod._MAX_LEGACY_SETTINGS_BYTES
+            )["url"] == "http://test:9191"
+        finally:
+            plan.close()
+
+    assert reads

--- a/backend/tests/routers/test_backup.py
+++ b/backend/tests/routers/test_backup.py
@@ -49,8 +49,20 @@ def _add_legacy_baseline_tables(path):
     """Add the tables present throughout the legacy ZIP backup era."""
     connection = sqlite3.connect(str(path))
     try:
-        connection.execute("CREATE TABLE IF NOT EXISTS journal_entries (id INTEGER PRIMARY KEY)")
-        connection.execute("CREATE TABLE IF NOT EXISTS scheduled_tasks (id INTEGER PRIMARY KEY)")
+        connection.execute(
+            "CREATE TABLE IF NOT EXISTS journal_entries "
+            "(id INTEGER PRIMARY KEY, timestamp TEXT, category TEXT, action_type TEXT, "
+            "entity_name TEXT, description TEXT)"
+        )
+        connection.execute(
+            "CREATE TABLE IF NOT EXISTS scheduled_tasks "
+            "(id INTEGER PRIMARY KEY, task_id TEXT, task_name TEXT, enabled INTEGER, schedule_type TEXT)"
+        )
+        connection.execute(
+            "CREATE TABLE IF NOT EXISTS auto_creation_rules "
+            "(id INTEGER PRIMARY KEY, name TEXT, enabled INTEGER, priority INTEGER, "
+            "conditions TEXT, actions TEXT)"
+        )
         connection.commit()
     finally:
         connection.close()
@@ -1816,10 +1828,9 @@ def _create_journal_db_with_alert_methods(path, rows):
     and the supplied rows. Each row is a dict with at least name, method_type,
     config (dict — will be JSON-encoded for storage)."""
     import sqlite3
+    _add_legacy_baseline_tables(path)
     conn = sqlite3.connect(str(path))
     try:
-        conn.execute("CREATE TABLE journal_entries (id INTEGER PRIMARY KEY)")
-        conn.execute("CREATE TABLE scheduled_tasks (id INTEGER PRIMARY KEY)")
         conn.execute(
             "CREATE TABLE alert_methods ("
             "id INTEGER PRIMARY KEY AUTOINCREMENT, "

--- a/backend/tests/routers/test_backup.py
+++ b/backend/tests/routers/test_backup.py
@@ -8,7 +8,9 @@ Mocks: get_settings(), get_engine(), close_db(), init_db(), clear_settings_cache
 import io
 import json
 import sqlite3
+import tempfile
 import zipfile
+from pathlib import Path
 
 import pytest
 import yaml
@@ -37,10 +39,28 @@ def _write_empty_journal_db(path):
     now (bead …-gi4zn, finding A-3), and a live instance always has a real
     database here, so the faithful fixture is the one that matches production.
 
-    ``_make_backup_zip`` below keeps the magic-byte stub on purpose: that is a
-    ZIP MEMBER, and ``_validate_backup_zip`` checks exactly those bytes.
+    ZIP restore fixtures use the minimal historical schema because admission
+    now verifies SQLite structure rather than trusting magic bytes.
     """
     sqlite3.connect(str(path)).close()
+
+
+def _add_legacy_baseline_tables(path):
+    """Add the tables present throughout the legacy ZIP backup era."""
+    connection = sqlite3.connect(str(path))
+    try:
+        connection.execute("CREATE TABLE IF NOT EXISTS journal_entries (id INTEGER PRIMARY KEY)")
+        connection.execute("CREATE TABLE IF NOT EXISTS scheduled_tasks (id INTEGER PRIMARY KEY)")
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _minimal_journal_db_bytes() -> bytes:
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "journal.db"
+        _add_legacy_baseline_tables(path)
+        return path.read_bytes()
 
 
 def _make_backup_zip(
@@ -62,8 +82,7 @@ def _make_backup_zip(
             files.append("settings.json")
 
         if include_db:
-            # SQLite magic bytes
-            content = db_content or (b"SQLite format 3\x00" + b"\x00" * 100)
+            content = db_content if db_content is not None else _minimal_journal_db_bytes()
             zf.writestr("journal.db", content)
             files.append("journal.db")
 
@@ -1799,6 +1818,8 @@ def _create_journal_db_with_alert_methods(path, rows):
     import sqlite3
     conn = sqlite3.connect(str(path))
     try:
+        conn.execute("CREATE TABLE journal_entries (id INTEGER PRIMARY KEY)")
+        conn.execute("CREATE TABLE scheduled_tasks (id INTEGER PRIMARY KEY)")
         conn.execute(
             "CREATE TABLE alert_methods ("
             "id INTEGER PRIMARY KEY AUTOINCREMENT, "
@@ -2005,7 +2026,8 @@ class TestZipRestoreRedactionAware:
     """ZIP restore must preserve existing creds when the ZIP contains the
     REDACTED sentinel — both for settings.json and for alert_methods.config.
 
-    Backward compat: a legacy ZIP with raw values must still restore as-is.
+    Backward compat: legacy raw credentials still restore, except mcp_api_key,
+    which always remains bound to the destination instance.
     """
 
     @pytest.mark.asyncio
@@ -2147,15 +2169,16 @@ class TestZipRestoreRedactionAware:
         assert by_id[2][1]["webhook_url"] == existing_webhook
 
     @pytest.mark.asyncio
-    async def test_zip_restore_legacy_non_redacted_still_works(
+    async def test_zip_restore_legacy_non_redacted_preserves_only_destination_mcp_key(
         self, async_client, tmp_path
     ):
         """Backward-compat smoke: a legacy ZIP with raw credential values
-        (no ***REDACTED*** sentinels) must restore values as-is."""
+        restores them as-is except for the destination's MCP bearer key."""
         settings_file = tmp_path / "settings.json"
         settings_file.write_text(json.dumps({
             "url": "http://existing:9191",
             "password": "should-be-overwritten",
+            "mcp_api_key": "destination-mcp-key",
         }))
         db_file = tmp_path / "journal.db"
 
@@ -2164,6 +2187,7 @@ class TestZipRestoreRedactionAware:
             "username": "restored_user",
             "password": "raw-restored-pass",
             "smtp_password": "raw-restored-smtp",
+            "mcp_api_key": "hostile-legacy-mcp-key",
         })
         backup = _make_backup_zip(settings_content=legacy_settings)
 
@@ -2181,8 +2205,10 @@ class TestZipRestoreRedactionAware:
 
         assert response.status_code == 200
         restored = json.loads(settings_file.read_text())
-        # All values came from the ZIP, raw, including credentials.
+        # Legacy credentials still come from the ZIP, except the instance-bound
+        # MCP bearer key, which cannot be imported from an untrusted artifact.
         assert restored["url"] == "http://restored:9191"
         assert restored["username"] == "restored_user"
         assert restored["password"] == "raw-restored-pass"
         assert restored["smtp_password"] == "raw-restored-smtp"
+        assert restored["mcp_api_key"] == "destination-mcp-key"


### PR DESCRIPTION
## Summary
- validate and sanitize historical legacy settings while preserving the destination MCP key
- bound legacy archive ingestion and validate SQLite integrity/schema before mutation
- install the exact validated artifact through staged, compensating replacement

## Tracking
- enhancedchannelmanager-9kwzp.2
- enhancedchannelmanager-9kwzp.4

## Verification
- frozen-scope code/security review approved at 2119a618
- independent canonical backend gate passed with 92.22% coverage
- current and historical producer compatibility covered
- encrypted DBAS behavior unchanged