### PR TITLE
fix: stream archived logo restoration

### DIFF
--- a/backend/dbas/importers/logos.py
+++ b/backend/dbas/importers/logos.py
@@ -769,8 +769,9 @@ async def import_logos(
             declared-size cap) run BEFORE hydration so a logo that is already
             rejectable is never read. A provider failure (``None`` / raise) is
             a per-logo ``VALIDATION_ERROR`` with a path-free message, never a
-            crash. ``None`` (the default, the archive-restore path) leaves
-            behaviour byte-for-byte unchanged.
+            crash. Archive restore supplies this loader from its still-open,
+            already-validated ZIP; legacy in-memory records still work with the
+            default ``None`` because they carry ``content_b64`` directly.
 
     Returns:
         A :class:`LogoImportResult` with safe aggregate counters.

--- a/backend/dbas/restore_artifact.py
+++ b/backend/dbas/restore_artifact.py
@@ -12,10 +12,9 @@ unpacked into structured records.
 Decode pipeline (validate-before-decode, never the reverse)
 -----------------------------------------------------------
 1. :func:`routers.backup.validate_artifact_manifest` runs FIRST (version gate +
-   per-member SHA-256). It is the caller's responsibility to call it before
-   :func:`decode_artifact_to_plan`; this module re-asserts the manifest is
-   present and parses it but does NOT re-run integrity (the caller already did,
-   on the same open ``ZipFile``). The orchestrator then re-checks the
+   per-member SHA-256) and passes its parsed manifest to
+   :func:`decode_artifact_to_plan`; decode never reads it a second time. The
+   orchestrator then re-checks the
    schema-version a SECOND time in pre-flight (defence in depth — .17 + .18).
 
 2. Per-category YAML (``categories/<section>.yaml``) is parsed and the entity
@@ -62,7 +61,6 @@ logger = logging.getLogger(__name__)
 _CATEGORY_DIR = "categories"
 _LOGO_DIR = "binary/logos"
 _BINARY_METADATA = "binary/metadata.json"
-_MANIFEST_NAME = "manifest.json"
 _LOGO_READ_CHUNK_BYTES = (64 * 1024) - 1  # divisible by 3 for base64 chunking
 
 # Artifact category-file (section) -> the EntityType it restores. The section
@@ -460,27 +458,7 @@ def logo_content_provider(
     return load
 
 
-def _parse_manifest(zf: zipfile.ZipFile) -> dict:
-    """Parse the cleartext ``manifest.json`` header, or return ``{}`` if absent.
-
-    The caller is expected to have already run
-    :func:`routers.backup.validate_artifact_manifest` (which refuses a missing /
-    malformed / newer-version manifest). This is a best-effort re-parse so the
-    plan carries the manifest for pre-flight's second version check.
-    """
-    import json
-
-    if _MANIFEST_NAME not in zf.namelist():
-        return {}
-    try:
-        manifest = json.loads(zf.read(_MANIFEST_NAME))
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-        logger.warning("[DBAS-RESTORE] Manifest unreadable during decode: %s", exc)
-        return {}
-    return manifest if isinstance(manifest, dict) else {}
-
-
-def decode_artifact_to_plan(zf: zipfile.ZipFile) -> ImportPlan:
+def decode_artifact_to_plan(zf: zipfile.ZipFile, *, manifest: dict) -> ImportPlan:
     """Decode a validated DBAS artifact into an :class:`ImportPlan`.
 
     PRECONDITION: the caller has already run
@@ -496,6 +474,7 @@ def decode_artifact_to_plan(zf: zipfile.ZipFile) -> ImportPlan:
 
     Args:
         zf: An OPEN, already-validated artifact ``ZipFile`` (read mode).
+        manifest: The parsed object returned by ``validate_artifact_manifest``.
 
     Returns:
         The :class:`ImportPlan` — categories default to ``selected=True`` so the
@@ -511,7 +490,6 @@ def decode_artifact_to_plan(zf: zipfile.ZipFile) -> ImportPlan:
 
     guard_artifact_against_zip_bomb(zf)
 
-    manifest = _parse_manifest(zf)
     categories = _decode_categories(zf)
 
     # lc6zu — the SETTINGS category (core_settings + comskip blobs) decodes

--- a/backend/dbas/restore_artifact.py
+++ b/backend/dbas/restore_artifact.py
@@ -23,22 +23,19 @@ Decode pipeline (validate-before-decode, never the reverse)
    slice. Each artifact section maps to exactly one :class:`EntityType`.
 
 3. The binary subtree (``binary/logos/<rel>`` + ``binary/metadata.json``) is
-   decoded into the per-logo records the logos importer (.15) consumes:
-   ``{"name", "filename", "content_b64", "size"}``. The bytes are base64-encoded
-   here so the importer's one-at-a-time decode/upload loop (.15, D8) drives the
-   memory profile — this module never decodes a logo's IMAGE bytes, only reads
-   the stored file bytes and re-encodes them as the transport the importer
-   already expects.
+   decoded into metadata-only per-logo records. :func:`logo_content_provider`
+   reads and base64-encodes one member only when the importer reaches that logo,
+   so the plan never retains aggregate logo payloads.
 
 ZIP-SLIP / PATH-TRAVERSAL SAFETY (the untrusted-upload surface)
 ---------------------------------------------------------------
-This module NEVER extracts a member to the filesystem — it only ``zf.read()``s
-named members it itself chose (the manifest-listed categories + the enumerated
-binary subtree). Even so, every member name pulled from the artifact's own
-listing is screened by :func:`_is_safe_member` (reject absolute paths, ``..``
-segments, and backslash separators) before it is read, so a crafted archive
-entry can never widen the read surface. The logos importer (.15) independently
-re-validates each filename basename before any upload — defence in depth.
+This module NEVER extracts a member to the filesystem. It reads named metadata
+members and streams only logo members it chose from the enumerated binary
+subtree. Every member name pulled from the artifact's own listing is screened by
+:func:`_is_safe_member` (reject absolute paths, ``..`` segments, and backslash
+separators) before it is read, so a crafted archive entry can never widen the
+read surface. The logos importer (.15) independently re-validates each filename
+basename before any upload — defence in depth.
 
 Conventions (``docs/style_guide.md``): ``snake_case``; Google-style docstrings;
 lazy ``%``-formatted logging; no secrets in any log line.
@@ -50,6 +47,7 @@ import base64
 import logging
 import posixpath
 import zipfile
+from collections.abc import Awaitable, Callable
 
 import yaml
 
@@ -65,6 +63,7 @@ _CATEGORY_DIR = "categories"
 _LOGO_DIR = "binary/logos"
 _BINARY_METADATA = "binary/metadata.json"
 _MANIFEST_NAME = "manifest.json"
+_LOGO_READ_CHUNK_BYTES = (64 * 1024) - 1  # divisible by 3 for base64 chunking
 
 # Artifact category-file (section) -> the EntityType it restores. The section
 # key is the YAML leaf the builder wrote under ``dispatcharr`` / ``database``.
@@ -371,7 +370,7 @@ def _decode_logo_records(zf: zipfile.ZipFile) -> list[dict]:
     consumes::
 
         {"name": <display name or basename-stem>, "filename": <basename>,
-         "content_b64": <base64 of the file bytes>, "size": <byte length>,
+         "archive_member": <validated ZIP member>, "size": <byte length>,
          "id": <source Dispatcharr logo id, when correlated>}
 
     ``id`` + display ``name`` come from the builder's source-logo correlation in
@@ -397,7 +396,6 @@ def _decode_logo_records(zf: zipfile.ZipFile) -> list[dict]:
         info = zf.getinfo(name)
         if info.is_dir():
             continue
-        raw = zf.read(name)
         basename = posixpath.basename(name)
         if not basename:
             continue
@@ -405,8 +403,8 @@ def _decode_logo_records(zf: zipfile.ZipFile) -> list[dict]:
         record = {
             "name": stem,
             "filename": basename,
-            "content_b64": base64.b64encode(raw).decode("ascii"),
-            "size": len(raw),
+            "archive_member": name,
+            "size": info.file_size,
         }
         # Metadata is keyed by the file's logos-dir-relative path (== the member
         # name minus the binary/logos/ prefix).
@@ -420,6 +418,46 @@ def _decode_logo_records(zf: zipfile.ZipFile) -> list[dict]:
                 record["name"] = display_name
         records.append(record)
     return records
+
+
+def _read_logo_content_b64(zf: zipfile.ZipFile, member: str) -> str:
+    """Base64-encode one logo member without materializing its raw bytes."""
+    encoded = bytearray()
+    with zf.open(member, "r") as source:
+        while chunk := source.read(_LOGO_READ_CHUNK_BYTES):
+            encoded.extend(base64.b64encode(chunk))
+    return encoded.decode("ascii")
+
+
+def logo_content_provider(
+    zf: zipfile.ZipFile,
+) -> Callable[[dict], Awaitable[str | None]]:
+    """Return an async, bounded loader for metadata-only archive logo records.
+
+    The caller must keep ``zf`` open until orchestration finishes. Records are
+    accepted only when they still point inside the screened logo subtree and the
+    ZIP metadata remains within the importer's existing per-logo limit.
+    """
+    from dbas.importers.logos import MAX_LOGO_BYTES
+
+    async def load(record: dict) -> str | None:
+        member = record.get("archive_member")
+        prefix = _LOGO_DIR + "/"
+        if (
+            not isinstance(member, str)
+            or not member.startswith(prefix)
+            or not _is_safe_member(member)
+        ):
+            return None
+        try:
+            info = zf.getinfo(member)
+        except KeyError:
+            return None
+        if info.is_dir() or info.file_size > MAX_LOGO_BYTES:
+            return None
+        return _read_logo_content_b64(zf, member)
+
+    return load
 
 
 def _parse_manifest(zf: zipfile.ZipFile) -> dict:

--- a/backend/dbas/restore_orchestrator.py
+++ b/backend/dbas/restore_orchestrator.py
@@ -286,6 +286,9 @@ class ApplyContext:
     # ``channel_group_id`` from it; nothing else in the run can supply that
     # without a second full channel list and a race against this run's creates.
     matched_existing_channels: dict[int, dict] = field(default_factory=dict)
+    # Optional lazy loader for metadata-only archived logo records. Archive
+    # restore wires this to its still-open validated ZIP; sync uses its own step.
+    logo_content_provider: Callable[[dict], Awaitable[str | None]] | None = None
 
     def flush_ledger(self) -> None:
         """Durably persist the shared ledger (per-create flush; no-op on dry-run).
@@ -758,6 +761,7 @@ async def run_restore(
     channel_reattach_mode: ChannelReattachMode = ChannelReattachMode.PRESERVE,
     allow_fuzzy_stream_match: bool = True,
     non_fatal_categories: frozenset[EntityType] | None = None,
+    logo_content_provider: Callable[[dict], Awaitable[str | None]] | None = None,
 ) -> RestoreReport:
     # ``non_fatal_categories`` (bead …-10wnq): override
     # :data:`NON_FATAL_FAILURE_CATEGORIES` for THIS run. ``None`` keeps the
@@ -925,6 +929,7 @@ async def run_restore(
         is_dry_run=report.is_dry_run,
         persist_ledger=per_create_persist,
         channel_reattach_mode=channel_reattach_mode,
+        logo_content_provider=logo_content_provider,
     )
 
     # --- 2. Ordered apply (the hard Phase-2 sequence). ---
@@ -1753,6 +1758,7 @@ def _importer_step_builders() -> dict[str, ImporterCallable]:
             # with destination ids resolved through the CHANNEL remap the
             # channels step populated earlier in this same run.
             archive_channels=_entities(ctx, EntityType.CHANNEL),
+            content_provider=ctx.logo_content_provider,
         )
         # Put each restored channel's logo BACK on it (bead …-dfkbn item 1).
         # ``logo_id`` is dropped from the channel create payload (source id), and
@@ -1867,6 +1873,7 @@ async def run_dry_run(
     ledger_dir: Path | None = None,
     max_entities_per_category: int = None,  # type: ignore[assignment]
     channel_reattach_mode: ChannelReattachMode = ChannelReattachMode.PRESERVE,
+    logo_content_provider: Callable[[dict], Awaitable[str | None]] | None = None,
 ) -> RestoreReport:
     """Produce the counts-only restore PLAN for an archive — never mutates.
 
@@ -1915,4 +1922,5 @@ async def run_dry_run(
         ledger_dir=ledger_dir,
         max_entities_per_category=max_entities_per_category,
         channel_reattach_mode=channel_reattach_mode,
+        logo_content_provider=logo_content_provider,
     )

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -1652,6 +1652,7 @@ _RESTORE_MAX_UPLOAD_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
 # checklist's ratified defaults (A4): 100x per-entry ratio, 1 GiB cumulative
 # uncompressed, 10,000 entries.
 _ARTIFACT_MAX_ENTRIES = 10_000
+_ARTIFACT_MAX_MANIFEST_BYTES = 1 * 1024 * 1024  # 1 MiB
 _ARTIFACT_MAX_MEMBER_UNCOMPRESSED = 1 * 1024 * 1024 * 1024  # 1 GiB per member
 _ARTIFACT_MAX_TOTAL_UNCOMPRESSED = 1 * 1024 * 1024 * 1024  # 1 GiB cumulative
 _ARTIFACT_MAX_ENTRY_RATIO = 100  # max decompressed:compressed per entry
@@ -3146,7 +3147,39 @@ def guard_artifact_against_zip_bomb(
                 raise HTTPException(status_code=400, detail="Backup archive rejected")
 
 
-def _verify_artifact_member_integrity(zf: zipfile.ZipFile, manifest: dict) -> None:
+def _is_unambiguous_artifact_member_name(name: str, *, directory: bool) -> bool:
+    """Accept one canonical relative POSIX member spelling."""
+    if not name or "\x00" in name or "\\" in name or name.startswith("/"):
+        return False
+    path = name[:-1] if directory and name.endswith("/") else name
+    if not path or (directory != name.endswith("/")):
+        return False
+    return all(part not in ("", ".", "..") for part in path.split("/"))
+
+
+def _read_artifact_manifest(zf: zipfile.ZipFile, info: zipfile.ZipInfo) -> dict:
+    """Read and parse the manifest under its dedicated small-object bound."""
+    if info.is_dir() or info.file_size > _ARTIFACT_MAX_MANIFEST_BYTES:
+        logger.warning("[BACKUP] Refusing restore: artifact manifest exceeds its size limit")
+        raise HTTPException(status_code=400, detail="Invalid backup manifest")
+    try:
+        with zf.open(info, "r") as source:
+            raw = source.read(_ARTIFACT_MAX_MANIFEST_BYTES + 1)
+        if len(raw) > _ARTIFACT_MAX_MANIFEST_BYTES:
+            raise ValueError("manifest exceeds bounded read")
+        manifest = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError, KeyError) as exc:
+        logger.warning("[BACKUP] Refusing restore: unreadable artifact manifest: %s", exc)
+        raise HTTPException(status_code=400, detail="Invalid backup manifest")
+    if not isinstance(manifest, dict):
+        logger.warning("[BACKUP] Refusing restore: artifact manifest is not an object")
+        raise HTTPException(status_code=400, detail="Invalid backup manifest")
+    return manifest
+
+
+def _verify_artifact_member_integrity(
+    zf: zipfile.ZipFile, manifest: dict, infos: list[zipfile.ZipInfo]
+) -> None:
     """Verify each manifest-listed member's SHA-256 against the ZIP bytes.
 
     Pairs with the version gate at the same chokepoint (grooming: validate
@@ -3166,7 +3199,13 @@ def _verify_artifact_member_integrity(zf: zipfile.ZipFile, manifest: dict) -> No
         logger.warning("[BACKUP] Refusing restore: manifest has no per-file hash list")
         raise HTTPException(status_code=400, detail="Backup integrity check failed")
 
-    names = set(zf.namelist())
+    members_by_name = {
+        info.filename: info
+        for info in infos
+        if not info.is_dir() and info.filename != ARTIFACT_MANIFEST_NAME
+    }
+    manifest_paths: set[str] = set()
+    entries_to_hash: list[tuple[str, str]] = []
     for entry in files:
         if not isinstance(entry, dict):
             logger.warning("[BACKUP] Refusing restore: malformed manifest file entry %r", entry)
@@ -3176,11 +3215,31 @@ def _verify_artifact_member_integrity(zf: zipfile.ZipFile, manifest: dict) -> No
         if not isinstance(path, str) or not isinstance(expected, str):
             logger.warning("[BACKUP] Refusing restore: malformed manifest file entry %r", entry)
             raise HTTPException(status_code=400, detail="Backup integrity check failed")
-        if path not in names:
+        if (
+            path == ARTIFACT_MANIFEST_NAME
+            or not _is_unambiguous_artifact_member_name(path, directory=False)
+            or path in manifest_paths
+        ):
+            logger.warning("[BACKUP] Refusing restore: duplicate or ambiguous manifest path %r", path)
+            raise HTTPException(status_code=400, detail="Backup integrity check failed")
+        manifest_paths.add(path)
+        if path not in members_by_name:
             logger.warning("[BACKUP] Refusing restore: manifest member %s absent from artifact", path)
             raise HTTPException(status_code=400, detail="Backup integrity check failed")
+        entries_to_hash.append((path, expected))
+
+    member_paths = set(members_by_name)
+    if manifest_paths != member_paths:
+        logger.warning(
+            "[BACKUP] Refusing restore: manifest membership differs from archive "
+            "(unlisted=%r, missing=%r)",
+            sorted(member_paths - manifest_paths), sorted(manifest_paths - member_paths),
+        )
+        raise HTTPException(status_code=400, detail="Backup integrity check failed")
+
+    for path, expected in entries_to_hash:
         digest = hashlib.sha256()
-        with zf.open(path, "r") as member:
+        with zf.open(members_by_name[path], "r") as member:
             while chunk := member.read(_ARTIFACT_HASH_CHUNK_BYTES):
                 digest.update(chunk)
         actual = digest.hexdigest()
@@ -3197,11 +3256,14 @@ def validate_artifact_manifest(zf: zipfile.ZipFile) -> dict:
 
     Runs BEFORE any restore mutation, in this order:
 
-    1. parse the cleartext ``manifest.json`` header,
-    2. **version gate** — refuse a newer/unknown schema_version (the highest
+    1. reject duplicate or ambiguous ZIP member names from central-directory
+       metadata,
+    2. bounded-parse the cleartext ``manifest.json`` header,
+    3. **version gate** — refuse a newer/unknown schema_version (the highest
        priority: an incompatible artifact is rejected before we even trust its
        integrity claims), then
-    3. **integrity** — verify each manifest-listed member's SHA-256.
+    4. **integrity** — require one manifest row per non-directory payload and
+       verify each member's SHA-256.
 
     Returns the parsed manifest on success. Refusals raise ``HTTPException(400)``
     with a user-facing message that leaks NO schema internals; the version
@@ -3212,19 +3274,22 @@ def validate_artifact_manifest(zf: zipfile.ZipFile) -> dict:
     # below. A high-ratio member must be refused before it can be decompressed.
     guard_artifact_against_zip_bomb(zf)
 
-    if ARTIFACT_MANIFEST_NAME not in zf.namelist():
+    infos = zf.infolist()
+    seen_names: set[str] = set()
+    for info in infos:
+        if info.filename in seen_names:
+            logger.warning("[BACKUP] Refusing restore: duplicate archive member %r", info.filename)
+            raise HTTPException(status_code=400, detail="Backup integrity check failed")
+        seen_names.add(info.filename)
+        if not _is_unambiguous_artifact_member_name(info.filename, directory=info.is_dir()):
+            logger.warning("[BACKUP] Refusing restore: ambiguous archive member %r", info.filename)
+            raise HTTPException(status_code=400, detail="Backup integrity check failed")
+
+    if ARTIFACT_MANIFEST_NAME not in seen_names:
         logger.warning("[BACKUP] Refusing restore: artifact missing %s", ARTIFACT_MANIFEST_NAME)
         raise HTTPException(status_code=400, detail="Not a valid ECM backup artifact")
 
-    try:
-        manifest = json.loads(zf.read(ARTIFACT_MANIFEST_NAME))
-    except (json.JSONDecodeError, KeyError) as e:
-        logger.warning("[BACKUP] Refusing restore: unreadable artifact manifest: %s", e)
-        raise HTTPException(status_code=400, detail="Invalid backup manifest")
-
-    if not isinstance(manifest, dict):
-        logger.warning("[BACKUP] Refusing restore: artifact manifest is not an object")
-        raise HTTPException(status_code=400, detail="Invalid backup manifest")
+    manifest = _read_artifact_manifest(zf, zf.getinfo(ARTIFACT_MANIFEST_NAME))
 
     # 2. Version gate FIRST — refuse an incompatible artifact before trusting
     #    anything else about it. Translate the internal exception into the
@@ -3235,7 +3300,7 @@ def validate_artifact_manifest(zf: zipfile.ZipFile) -> dict:
         raise HTTPException(status_code=400, detail=str(e))
 
     # 3. Integrity AFTER the version is known-supported.
-    _verify_artifact_member_integrity(zf, manifest)
+    _verify_artifact_member_integrity(zf, manifest, infos)
 
     return manifest
 

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -1655,6 +1655,7 @@ _ARTIFACT_MAX_ENTRIES = 10_000
 _ARTIFACT_MAX_MEMBER_UNCOMPRESSED = 1 * 1024 * 1024 * 1024  # 1 GiB per member
 _ARTIFACT_MAX_TOTAL_UNCOMPRESSED = 1 * 1024 * 1024 * 1024  # 1 GiB cumulative
 _ARTIFACT_MAX_ENTRY_RATIO = 100  # max decompressed:compressed per entry
+_ARTIFACT_HASH_CHUNK_BYTES = 1024 * 1024
 # A small stored entry (e.g. a 12-byte manifest) has a degenerate ratio; only
 # entries whose compressed size exceeds this floor are ratio-checked, so a tiny
 # stored file is not falsely flagged. The cumulative + per-entry-size caps still
@@ -3104,6 +3105,15 @@ def guard_artifact_against_zip_bomb(
     for info in infos:
         uncompressed = info.file_size
         compressed = info.compress_size
+        if (
+            info.filename.startswith(ARTIFACT_LOGO_DIR + "/")
+            and uncompressed > MAX_LOGO_BYTES
+        ):
+            logger.warning(
+                "[BACKUP] Refusing restore: logo member %s declared size exceeds %d bytes",
+                info.filename, MAX_LOGO_BYTES,
+            )
+            raise HTTPException(status_code=400, detail="Backup archive rejected")
         if uncompressed > _ARTIFACT_MAX_MEMBER_UNCOMPRESSED:
             logger.warning(
                 "[BACKUP] Refusing restore: member %s declared size exceeds %d bytes",
@@ -3169,7 +3179,11 @@ def _verify_artifact_member_integrity(zf: zipfile.ZipFile, manifest: dict) -> No
         if path not in names:
             logger.warning("[BACKUP] Refusing restore: manifest member %s absent from artifact", path)
             raise HTTPException(status_code=400, detail="Backup integrity check failed")
-        actual = hashlib.sha256(zf.read(path)).hexdigest()
+        digest = hashlib.sha256()
+        with zf.open(path, "r") as member:
+            while chunk := member.read(_ARTIFACT_HASH_CHUNK_BYTES):
+                digest.update(chunk)
+        actual = digest.hexdigest()
         if actual != expected:
             logger.warning(
                 "[BACKUP] Refusing restore: integrity mismatch on member %s "

--- a/backend/tasks/dbas_restore.py
+++ b/backend/tasks/dbas_restore.py
@@ -377,6 +377,7 @@ class DbasRestoreTask(TaskScheduler):
         assert zf is not None
 
         is_apply = bool(self.confirm_apply)
+        client = get_client()
 
         # Every importer count is a claim about the destination. Prove it can be
         # read before either preview or apply reaches the orchestrator, then keep
@@ -392,7 +393,6 @@ class DbasRestoreTask(TaskScheduler):
         client = ReadObservingClient(client, report, reject_mutations=True)
 
         try:
-            client = get_client()
             if is_apply:
                 report = await run_restore(
                     plan=plan,

--- a/backend/tasks/dbas_restore.py
+++ b/backend/tasks/dbas_restore.py
@@ -356,8 +356,8 @@ class DbasRestoreTask(TaskScheduler):
         zf = None
         try:
             zf = zipfile.ZipFile(artifact_path, "r")
-            validate_artifact_manifest(zf)   # .17 — raises HTTPException(400) on refusal
-            plan = decode_artifact_to_plan(zf)  # decode metadata from the validated ZIP
+            manifest = validate_artifact_manifest(zf)  # .17 — raises HTTPException(400)
+            plan = decode_artifact_to_plan(zf, manifest=manifest)
         except zipfile.BadZipFile:
             if zf is not None:
                 zf.close()

--- a/backend/tasks/dbas_restore.py
+++ b/backend/tasks/dbas_restore.py
@@ -338,7 +338,7 @@ class DbasRestoreTask(TaskScheduler):
         # module's import-time path (mirrors DbasBackupTask's deferred imports).
         from dispatcharr_client import get_client
         from routers.backup import validate_artifact_manifest
-        from dbas.restore_artifact import decode_artifact_to_plan
+        from dbas.restore_artifact import decode_artifact_to_plan, logo_content_provider
         from dbas.restore_orchestrator import run_dry_run, run_restore, new_restore_id
         from dbas.restore_contracts import IdRemapTable, RestoreReport, RollbackLedger
         from dbas.restore_orchestrator import default_importer_steps
@@ -353,21 +353,32 @@ class DbasRestoreTask(TaskScheduler):
         # SHA-256, BEFORE any decode or importer. A refusal here means ZERO
         # mutation ever happened.
         self._stage("preflight")
+        zf = None
         try:
-            with zipfile.ZipFile(artifact_path, "r") as zf:
-                validate_artifact_manifest(zf)   # .17 — raises HTTPException(400) on refusal
-                plan = decode_artifact_to_plan(zf)  # decode the validated ZIP
+            zf = zipfile.ZipFile(artifact_path, "r")
+            validate_artifact_manifest(zf)   # .17 — raises HTTPException(400) on refusal
+            plan = decode_artifact_to_plan(zf)  # decode metadata from the validated ZIP
         except zipfile.BadZipFile:
+            if zf is not None:
+                zf.close()
             return self._fail(started_at, "Uploaded artifact is not a valid archive")
         except HTTPException as exc:
+            if zf is not None:
+                zf.close()
             # .17 refused (version/integrity). NO importer ran. Surface the
             # sanitized message; never leak schema internals.
             return self._fail(started_at, str(exc.detail))
+        except Exception:
+            if zf is not None:
+                zf.close()
+            raise
+
+        assert zf is not None
 
         is_apply = bool(self.confirm_apply)
-        client = get_client()
 
         try:
+            client = get_client()
             if is_apply:
                 report = await run_restore(
                     plan=plan,
@@ -386,6 +397,7 @@ class DbasRestoreTask(TaskScheduler):
                     # yet at channel-import time). The Tier-3 floor belongs to
                     # the cross-instance SYNC path (ruling 1b), not to this one.
                     allow_fuzzy_stream_match=True,
+                    logo_content_provider=logo_content_provider(zf),
                 )
             else:
                 # The preview MUST run under the SAME mode the apply will, or it
@@ -394,10 +406,13 @@ class DbasRestoreTask(TaskScheduler):
                     plan=plan,
                     client=client,
                     channel_reattach_mode=self.channel_reattach_mode,
+                    logo_content_provider=logo_content_provider(zf),
                 )
         except Exception as exc:  # noqa: BLE001 - any orchestration error is a sanitized failure
             logger.exception("[DBAS-RESTORE] Restore orchestration failed: %s", exc)
             return self._fail(started_at, "Restore failed during orchestration")
+        finally:
+            zf.close()
 
         # --- Per-category stages: emit one tick per restoreStages key with the
         #     category's realized (apply) or planned (dry-run) counts. ---------

--- a/backend/tests/dbas/test_restore_artifact_decode.py
+++ b/backend/tests/dbas/test_restore_artifact_decode.py
@@ -5,8 +5,8 @@ validated new-format DBAS artifact ZIP into the orchestrator's
 :class:`~dbas.preflight.ImportPlan`:
 
   * per-category YAML (``categories/<section>.yaml``) -> PlanCategory entities,
-  * the binary logo subtree (``binary/logos/<rel>``) -> .15 logo records
-    (``name`` / ``filename`` / ``content_b64`` / ``size``),
+  * the binary logo subtree (``binary/logos/<rel>``) -> metadata-only .15 logo
+    records (``name`` / ``filename`` / ``archive_member`` / ``size``),
   * the cleartext manifest carried through for pre-flight's version gate,
   * zip-slip / path-traversal member-name safety.
 """
@@ -235,18 +235,34 @@ class TestSettingsAgentsDecode:
 
 
 class TestLogoDecode:
-    def test_decodes_logo_records(self):
-        art = _build_artifact(logos={"espn.png": _PNG_BYTES})
+    def test_decodes_logo_records_without_materializing_payloads(self):
+        art = _build_artifact(
+            logos={
+                "espn.png": _PNG_BYTES,
+                "cnn.png": _PNG_BYTES,
+                "bbc.png": _PNG_BYTES,
+            }
+        )
         with _open(art) as zf:
+            read_members = []
+            original_read = zf.read
+
+            def tracked_read(member, *args, **kwargs):
+                name = member.filename if isinstance(member, zipfile.ZipInfo) else member
+                read_members.append(name)
+                return original_read(member, *args, **kwargs)
+
+            zf.read = tracked_read
             plan = decode_artifact_to_plan(zf)
         logos = plan.category(EntityType.LOGO).entities
-        assert len(logos) == 1
+        assert len(logos) == 3
         rec = logos[0]
         assert rec["filename"] == "espn.png"
         assert rec["name"] == "espn"
         assert rec["size"] == len(_PNG_BYTES)
-        # content_b64 round-trips to the original bytes (the .15 importer decodes it).
-        assert base64.b64decode(rec["content_b64"]) == _PNG_BYTES
+        assert rec["archive_member"] == "binary/logos/espn.png"
+        assert all("content_b64" not in logo for logo in logos)
+        assert not any(name.startswith("binary/logos/") for name in read_members)
 
     def test_nested_logo_basename(self):
         art = _build_artifact(logos={"sub/dir/cnn.png": _PNG_BYTES})

--- a/backend/tests/dbas/test_restore_artifact_decode.py
+++ b/backend/tests/dbas/test_restore_artifact_decode.py
@@ -21,7 +21,7 @@ import yaml
 
 from dbas.restore_artifact import (
     _is_safe_member,
-    decode_artifact_to_plan,
+    decode_artifact_to_plan as _decode_artifact_to_plan,
 )
 from dbas.restore_contracts import EntityType
 
@@ -99,6 +99,10 @@ def _build_artifact(
 
 def _open(zip_bytes: bytes) -> zipfile.ZipFile:
     return zipfile.ZipFile(io.BytesIO(zip_bytes), "r")
+
+
+def decode_artifact_to_plan(zf: zipfile.ZipFile):
+    return _decode_artifact_to_plan(zf, manifest={"schema_version": 1})
 
 
 class TestCategoryDecode:

--- a/backend/tests/dbas/test_restore_roundtrip.py
+++ b/backend/tests/dbas/test_restore_roundtrip.py
@@ -20,7 +20,7 @@ import pytest
 
 from routers import backup as backup_mod
 from routers.backup import build_backup_artifact, validate_artifact_manifest
-from dbas.restore_artifact import decode_artifact_to_plan
+from dbas.restore_artifact import decode_artifact_to_plan, logo_content_provider
 from dbas.restore_contracts import EntityType
 from dbas.restore_orchestrator import run_dry_run
 
@@ -226,7 +226,12 @@ async def test_build_then_decode_then_dry_run(tmp_path):
     assert "sekrit-core-value" not in str(core_values)
     assert settings_cat.entities[1]["values"] == {"comskip_ini": "[main]"}
 
-    report = await run_dry_run(plan=plan, client=_restore_client())
+    with zipfile.ZipFile(art.zip_path, "r") as logo_zf:
+        report = await run_dry_run(
+            plan=plan,
+            client=_restore_client(),
+            logo_content_provider=logo_content_provider(logo_zf),
+        )
 
     # Dry-run produced a coherent plan (no mutation, no realized outcome).
     assert report.is_dry_run is True
@@ -414,27 +419,34 @@ async def test_real_apply_roundtrip_mutates_every_category_with_dry_run_parity(t
     plan = _augment_plan_all_categories(plan)
 
     # --- 1. Dry-run first (the default-ON preview the operator sees). --------
-    dry_report = await run_dry_run(plan=plan, client=_restore_client())
-    assert dry_report.is_dry_run is True
+    with zipfile.ZipFile(art.zip_path, "r") as logo_zf:
+        provider = logo_content_provider(logo_zf)
+        dry_report = await run_dry_run(
+            plan=plan,
+            client=_restore_client(),
+            logo_content_provider=provider,
+        )
+        assert dry_report.is_dry_run is True
 
-    # Every registry category has non-zero planned work — nothing previews empty.
-    for entity_type in _ALL_REGISTRY_CATEGORIES:
-        dry_cat = dry_report.category(entity_type)
-        planned = dry_cat.would_create + dry_cat.would_update + dry_cat.would_skip
-        assert planned > 0, "dry-run planned nothing for %s" % entity_type.value
+        # Every registry category has non-zero planned work — nothing previews empty.
+        for entity_type in _ALL_REGISTRY_CATEGORIES:
+            dry_cat = dry_report.category(entity_type)
+            planned = dry_cat.would_create + dry_cat.would_update + dry_cat.would_skip
+            assert planned > 0, "dry-run planned nothing for %s" % entity_type.value
 
-    # --- 2. Real apply (confirm_apply=True) through the FULL apply registry. --
-    client = _apply_client()
-    apply_report = await run_restore(
-        plan=plan,
-        client=client,
-        steps=default_importer_steps(),
-        report=RestoreReport(is_dry_run=False),
-        ledger=RollbackLedger(restore_id=new_restore_id()),
-        remap=IdRemapTable(),
-        confirm_apply=True,
-        ledger_dir=tmp_path,
-    )
+        # --- 2. Real apply (confirm_apply=True) through the FULL apply registry. --
+        client = _apply_client()
+        apply_report = await run_restore(
+            plan=plan,
+            client=client,
+            steps=default_importer_steps(),
+            report=RestoreReport(is_dry_run=False),
+            ledger=RollbackLedger(restore_id=new_restore_id()),
+            remap=IdRemapTable(),
+            confirm_apply=True,
+            ledger_dir=tmp_path,
+            logo_content_provider=provider,
+        )
     assert apply_report.is_dry_run is False
     assert apply_report.outcome == RestoreOutcome.SUCCESS
 
@@ -1011,18 +1023,20 @@ async def test_uploaded_logo_round_trips_from_archived_bytes(tmp_path):
     assert record["id"] == 13
     assert record["name"] == "Drill Uploaded Logo"
     assert record["filename"] == "drill-logo.png"
-    assert base64.b64decode(record["content_b64"]) == png
-
     client = AsyncMock()
     client.get_all_logos_paginated = AsyncMock(return_value=[])
     client.upload_logo_file = AsyncMock(return_value={"id": 995})
     report = RestoreReport(is_dry_run=False)
     remap = IdRemapTable()
 
-    await import_logos(
-        archive_logos=entities, client=client, selected=True, report=report,
-        ledger=RollbackLedger(restore_id="r"), remap=remap,
-    )
+    with zipfile.ZipFile(art.zip_path, "r") as zf:
+        provider = logo_content_provider(zf)
+        assert base64.b64decode(await provider(record)) == png
+        await import_logos(
+            archive_logos=entities, client=client, selected=True, report=report,
+            ledger=RollbackLedger(restore_id="r"), remap=remap,
+            content_provider=provider,
+        )
 
     client.create_logo.assert_not_awaited()
     client.upload_logo_file.assert_awaited_once()
@@ -1098,18 +1112,22 @@ async def test_preview_of_a_real_artifact_predicts_the_apply_exactly(tmp_path):
         client.create_logo = AsyncMock(return_value={"id": 996})
         return client
 
-    dry_report = RestoreReport(is_dry_run=True)
-    await import_logos(
-        archive_logos=entities, client=_fresh_client(), selected=True,
-        report=dry_report, ledger=RollbackLedger(restore_id="d"),
-        remap=IdRemapTable(), is_dry_run=True,
-    )
-    apply_report = RestoreReport(is_dry_run=False)
-    await import_logos(
-        archive_logos=entities, client=_fresh_client(), selected=True,
-        report=apply_report, ledger=RollbackLedger(restore_id="a"),
-        remap=IdRemapTable(), is_dry_run=False,
-    )
+    with zipfile.ZipFile(art.zip_path, "r") as zf:
+        provider = logo_content_provider(zf)
+        dry_report = RestoreReport(is_dry_run=True)
+        await import_logos(
+            archive_logos=entities, client=_fresh_client(), selected=True,
+            report=dry_report, ledger=RollbackLedger(restore_id="d"),
+            remap=IdRemapTable(), is_dry_run=True,
+            content_provider=provider,
+        )
+        apply_report = RestoreReport(is_dry_run=False)
+        await import_logos(
+            archive_logos=entities, client=_fresh_client(), selected=True,
+            report=apply_report, ledger=RollbackLedger(restore_id="a"),
+            remap=IdRemapTable(), is_dry_run=False,
+            content_provider=provider,
+        )
 
     dry = dry_report.category(EntityType.LOGO)
     applied = apply_report.category(EntityType.LOGO)
@@ -1245,8 +1263,6 @@ async def test_channel_ends_up_on_the_dispatcharr_bytes_not_a_stale_local_copy(t
     # authoritative copy. Two would be unresolvable on the restore side.
     claiming_44 = [e for e in logo_entities if e.get("id") == 44]
     assert len(claiming_44) == 1
-    assert base64.b64decode(claiming_44[0]["content_b64"]) == png
-
     client = AsyncMock()
     client.get_all_logos_paginated = AsyncMock(return_value=[])
     client.upload_logo_file = AsyncMock(return_value={"id": 995})
@@ -1254,11 +1270,15 @@ async def test_channel_ends_up_on_the_dispatcharr_bytes_not_a_stale_local_copy(t
     remap.add(EntityType.CHANNEL, 5, 505)
     report = RestoreReport(is_dry_run=False)
 
-    await import_logos(
-        archive_logos=logo_entities, archive_channels=archive_channels,
-        client=client, selected=True, report=report,
-        ledger=RollbackLedger(restore_id="r"), remap=remap,
-    )
+    with zipfile.ZipFile(art.zip_path, "r") as zf:
+        provider = logo_content_provider(zf)
+        assert base64.b64decode(await provider(claiming_44[0])) == png
+        await import_logos(
+            archive_logos=logo_entities, archive_channels=archive_channels,
+            client=client, selected=True, report=report,
+            ledger=RollbackLedger(restore_id="r"), remap=remap,
+            content_provider=provider,
+        )
     await reattach_channel_logos(
         # Predates the mode: no population information, so nothing
         # is preserved and the pass behaves as it always did.

--- a/backend/tests/dbas/test_restore_roundtrip.py
+++ b/backend/tests/dbas/test_restore_roundtrip.py
@@ -186,8 +186,8 @@ async def test_build_then_decode_then_dry_run(tmp_path):
 
     with zipfile.ZipFile(art.zip_path, "r") as zf:
         # .17 validation passes on a freshly built artifact (version + integrity).
-        validate_artifact_manifest(zf)
-        plan = decode_artifact_to_plan(zf)
+        manifest = validate_artifact_manifest(zf)
+        plan = decode_artifact_to_plan(zf, manifest=manifest)
 
     # The decoded plan carries the two M3U accounts the builder gathered...
     assert len(plan.category(EntityType.M3U_ACCOUNT).entities) == 2
@@ -414,8 +414,8 @@ async def test_real_apply_roundtrip_mutates_every_category_with_dry_run_parity(t
 
     art = await _build_real_artifact(tmp_path)
     with zipfile.ZipFile(art.zip_path, "r") as zf:
-        validate_artifact_manifest(zf)
-        plan = decode_artifact_to_plan(zf)
+        manifest = validate_artifact_manifest(zf)
+        plan = decode_artifact_to_plan(zf, manifest=manifest)
     plan = _augment_plan_all_categories(plan)
 
     # --- 1. Dry-run first (the default-ON preview the operator sees). --------
@@ -990,8 +990,8 @@ async def _build_artifact_with_source_logos(
 
 def _decoded_logo_entities(art):
     with zipfile.ZipFile(art.zip_path, "r") as zf:
-        validate_artifact_manifest(zf)
-        plan = decode_artifact_to_plan(zf)
+        manifest = validate_artifact_manifest(zf)
+        plan = decode_artifact_to_plan(zf, manifest=manifest)
     return plan.category(EntityType.LOGO).entities
 
 
@@ -1159,8 +1159,8 @@ async def test_unrestorable_logo_reports_its_affected_channels(tmp_path):
     )
 
     with zipfile.ZipFile(art.zip_path, "r") as zf:
-        validate_artifact_manifest(zf)
-        plan = decode_artifact_to_plan(zf)
+        manifest = validate_artifact_manifest(zf)
+        plan = decode_artifact_to_plan(zf, manifest=manifest)
     logo_entities = plan.category(EntityType.LOGO).entities
     archive_channels = plan.category(EntityType.CHANNEL).entities
     assert [e["id"] for e in logo_entities] == [30]
@@ -1254,8 +1254,8 @@ async def test_channel_ends_up_on_the_dispatcharr_bytes_not_a_stale_local_copy(t
     )
 
     with zipfile.ZipFile(art.zip_path, "r") as zf:
-        validate_artifact_manifest(zf)
-        plan = decode_artifact_to_plan(zf)
+        manifest = validate_artifact_manifest(zf)
+        plan = decode_artifact_to_plan(zf, manifest=manifest)
     logo_entities = plan.category(EntityType.LOGO).entities
     archive_channels = plan.category(EntityType.CHANNEL).entities
 
@@ -1316,8 +1316,8 @@ async def test_channel_ends_up_on_the_dispatcharr_bytes_not_a_stale_local_copy(t
 
 def _decoded_channel_entities(art):
     with zipfile.ZipFile(art.zip_path, "r") as zf:
-        validate_artifact_manifest(zf)
-        plan = decode_artifact_to_plan(zf)
+        manifest = validate_artifact_manifest(zf)
+        plan = decode_artifact_to_plan(zf, manifest=manifest)
     return plan.category(EntityType.CHANNEL).entities
 
 

--- a/backend/tests/dbas/test_restore_state_loss_artifact.py
+++ b/backend/tests/dbas/test_restore_state_loss_artifact.py
@@ -86,7 +86,7 @@ def test_decoder_merges_the_logo_inventory_with_the_binary_subtree():
         "binary/logos/espn.png": "notarealpng",
     })
     with zf:
-        plan = decode_artifact_to_plan(zf)
+        plan = decode_artifact_to_plan(zf, manifest={"schema_version": 1})
 
     logos = plan.category(EntityType.LOGO).entities
     by_id = {entity.get("id"): entity for entity in logos}
@@ -118,7 +118,7 @@ def test_decoder_produces_an_ecm_settings_category():
         ),
     })
     with zf:
-        plan = decode_artifact_to_plan(zf)
+        plan = decode_artifact_to_plan(zf, manifest={"schema_version": 1})
 
     cat = plan.category(EntityType.ECM_SETTINGS)
     assert cat is not None
@@ -133,7 +133,7 @@ def test_ecm_settings_category_is_empty_when_the_member_is_absent():
 
     zf = _artifact({"manifest.json": '{"schema_version": 1}'})
     with zf:
-        plan = decode_artifact_to_plan(zf)
+        plan = decode_artifact_to_plan(zf, manifest={"schema_version": 1})
 
     cat = plan.category(EntityType.ECM_SETTINGS)
     assert cat is not None and cat.entities == []

--- a/backend/tests/dbas/test_restore_state_loss_artifact.py
+++ b/backend/tests/dbas/test_restore_state_loss_artifact.py
@@ -91,8 +91,9 @@ def test_decoder_merges_the_logo_inventory_with_the_binary_subtree():
     logos = plan.category(EntityType.LOGO).entities
     by_id = {entity.get("id"): entity for entity in logos}
     assert set(by_id) == {21, 22}
-    # 21 kept its bytes AND gained the archived URL.
-    assert by_id[21]["content_b64"]
+    # 21 kept a lazy reference to its bytes AND gained the archived URL.
+    assert by_id[21]["archive_member"] == "binary/logos/espn.png"
+    assert "content_b64" not in by_id[21]
     assert by_id[21]["url"] == "https://cdn/espn.png"
     # 22 has no bytes anywhere — the URL is the only way back.
     assert "content_b64" not in by_id[22]

--- a/backend/tests/routers/test_o8tbv_zipbomb_guard.py
+++ b/backend/tests/routers/test_o8tbv_zipbomb_guard.py
@@ -140,6 +140,19 @@ class TestGuardAgainstZipBomb:
         finally:
             zf.close()
 
+    def test_oversized_logo_refused_from_metadata(self):
+        zf = _open_with_declared_sizes([
+            ("manifest.json", 200, 120),
+            ("binary/logos/oversized.png", backup_mod.MAX_LOGO_BYTES + 1, 49_000_000),
+        ])
+        try:
+            with pytest.raises(HTTPException) as ei:
+                guard_artifact_against_zip_bomb(zf)
+            assert ei.value.status_code == 400
+            assert ei.value.detail == "Backup archive rejected"
+        finally:
+            zf.close()
+
 
 class TestGuardWiredIntoReadSites:
     """The guard must run at BOTH read sites before any zf.read()."""
@@ -197,3 +210,36 @@ class TestGuardWiredIntoReadSites:
             assert "bomb.bin" not in read_targets
         finally:
             zf.close()
+
+
+class TestManifestIntegrityMemoryShape:
+    def test_integrity_hashes_logo_without_reading_it_whole(self):
+        import hashlib
+        import json
+
+        from routers.backup import validate_artifact_manifest
+
+        logo = b"\x89PNG\r\n\x1a\n" + (b"x" * 128_000)
+        manifest = {
+            "schema_version": 1,
+            "files": [{
+                "path": "binary/logos/a.png",
+                "sha256": hashlib.sha256(logo).hexdigest(),
+            }],
+        }
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_STORED) as out:
+            out.writestr("manifest.json", json.dumps(manifest))
+            out.writestr("binary/logos/a.png", logo)
+        buf.seek(0)
+
+        with zipfile.ZipFile(buf, "r") as zf:
+            original_read = zf.read
+
+            def tracked_read(member, *args, **kwargs):
+                name = member.filename if isinstance(member, zipfile.ZipInfo) else member
+                assert name != "binary/logos/a.png"
+                return original_read(member, *args, **kwargs)
+
+            zf.read = tracked_read
+            validate_artifact_manifest(zf)

--- a/backend/tests/routers/test_o8tbv_zipbomb_guard.py
+++ b/backend/tests/routers/test_o8tbv_zipbomb_guard.py
@@ -22,7 +22,9 @@ is read, and that a normal artifact still passes.
 """
 from __future__ import annotations
 
+import hashlib
 import io
+import json
 import zipfile
 from unittest.mock import patch
 
@@ -31,6 +33,29 @@ from fastapi import HTTPException
 
 from routers import backup as backup_mod
 from routers.backup import guard_artifact_against_zip_bomb
+
+
+def _manifest_artifact(entries, manifest_paths=None):
+    """Build an artifact while preserving duplicate ZIP member names."""
+    if manifest_paths is None:
+        manifest_paths = [name for name, _ in entries if not name.endswith("/")]
+    hashes = {}
+    for name, content in entries:
+        hashes.setdefault(name, hashlib.sha256(content).hexdigest())
+    manifest = {
+        "schema_version": 1,
+        "files": [
+            {"path": path, "sha256": hashes.get(path, hashlib.sha256(b"missing").hexdigest())}
+            for path in manifest_paths
+        ],
+    }
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("manifest.json", json.dumps(manifest))
+        for name, content in entries:
+            zf.writestr(name, content)
+    buf.seek(0)
+    return buf
 
 
 def _zip_from_infos(entries):
@@ -205,7 +230,7 @@ class TestGuardWiredIntoReadSites:
         zf.read = _tracked_read  # type: ignore[assignment]
         try:
             with pytest.raises(HTTPException) as ei:
-                decode_artifact_to_plan(zf)
+                decode_artifact_to_plan(zf, manifest={})
             assert ei.value.status_code == 400
             assert "bomb.bin" not in read_targets
         finally:
@@ -243,3 +268,122 @@ class TestManifestIntegrityMemoryShape:
 
             zf.read = tracked_read
             validate_artifact_manifest(zf)
+
+
+class TestManifestMembershipIsOneToOne:
+    @pytest.mark.parametrize(
+        "entries,manifest_paths",
+        [
+            (
+                [("binary/logos/a.png", b"one"), ("binary/logos/a.png", b"one")],
+                ["binary/logos/a.png"],
+            ),
+            (
+                [("categories/a.yaml", b"a")],
+                ["categories/a.yaml", "categories/a.yaml"],
+            ),
+            (
+                [("categories/a.yaml", b"a"), ("binary/logos/unlisted.png", b"x")],
+                ["categories/a.yaml"],
+            ),
+            (
+                [("categories/a.yaml", b"a")],
+                ["categories/a.yaml", "categories/missing.yaml"],
+            ),
+            (
+                [("categories/a.yaml", b"a")],
+                ["manifest.json", "categories/a.yaml"],
+            ),
+            (
+                [("categories/", b""), ("categories/a.yaml", b"a")],
+                ["categories/", "categories/a.yaml"],
+            ),
+        ],
+        ids=[
+            "duplicate-zip-name",
+            "duplicate-manifest-path",
+            "unlisted-member",
+            "missing-member",
+            "manifest-listed",
+            "directory-listed",
+        ],
+    )
+    def test_rejects_non_bijective_manifest_membership(self, entries, manifest_paths):
+        from routers.backup import validate_artifact_manifest
+
+        with zipfile.ZipFile(_manifest_artifact(entries, manifest_paths), "r") as zf:
+            with pytest.raises(HTTPException, match="Backup integrity check failed"):
+                validate_artifact_manifest(zf)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "./categories/a.yaml",
+            "categories//a.yaml",
+            "categories/../a.yaml",
+            "/categories/a.yaml",
+            "categories\\a.yaml",
+        ],
+    )
+    def test_rejects_ambiguous_or_unsafe_member_names(self, name):
+        from routers.backup import validate_artifact_manifest
+
+        with zipfile.ZipFile(_manifest_artifact([(name, b"a")]), "r") as zf:
+            with pytest.raises(HTTPException, match="Backup integrity check failed"):
+                validate_artifact_manifest(zf)
+
+    def test_rejects_ambiguous_manifest_path_even_when_zip_name_is_canonical(self):
+        from routers.backup import validate_artifact_manifest
+
+        artifact = _manifest_artifact(
+            [("categories/a.yaml", b"a")], ["categories/./a.yaml"]
+        )
+        with zipfile.ZipFile(artifact, "r") as zf:
+            with pytest.raises(HTTPException, match="Backup integrity check failed"):
+                validate_artifact_manifest(zf)
+
+    def test_manifest_and_true_directory_entries_are_the_only_unlisted_exclusions(self):
+        from routers.backup import validate_artifact_manifest
+
+        artifact = _manifest_artifact(
+            [("categories/", b""), ("categories/a.yaml", b"a")],
+            ["categories/a.yaml"],
+        )
+        with zipfile.ZipFile(artifact, "r") as zf:
+            manifest = validate_artifact_manifest(zf)
+        assert [entry["path"] for entry in manifest["files"]] == ["categories/a.yaml"]
+
+    def test_unlisted_member_is_rejected_before_any_payload_is_opened(self):
+        from routers.backup import validate_artifact_manifest
+
+        artifact = _manifest_artifact(
+            [("categories/a.yaml", b"a"), ("binary/logos/unlisted.png", b"x")],
+            ["categories/a.yaml"],
+        )
+        with zipfile.ZipFile(artifact, "r") as zf:
+            opened = []
+            original_open = zf.open
+
+            def tracked_open(member, *args, **kwargs):
+                name = member.filename if isinstance(member, zipfile.ZipInfo) else member
+                opened.append(name)
+                return original_open(member, *args, **kwargs)
+
+            zf.open = tracked_open
+            with pytest.raises(HTTPException, match="Backup integrity check failed"):
+                validate_artifact_manifest(zf)
+        assert opened == ["manifest.json"]
+
+
+class TestManifestSpecificReadBound:
+    def test_oversized_manifest_is_rejected_before_read(self):
+        from routers.backup import validate_artifact_manifest
+
+        buf = _manifest_artifact([])
+        with zipfile.ZipFile(buf, "r") as zf:
+            manifest_info = zf.getinfo("manifest.json")
+            manifest_info.file_size = backup_mod._ARTIFACT_MAX_MANIFEST_BYTES + 1
+            with patch.object(zf, "open") as opened:
+                with pytest.raises(HTTPException, match="Invalid backup manifest"):
+                    validate_artifact_manifest(zf)
+            opened.assert_not_called()

--- a/backend/tests/tasks/test_dbas_restore_task.py
+++ b/backend/tests/tasks/test_dbas_restore_task.py
@@ -70,6 +70,13 @@ def _write_artifact(tmp_path: Path, *, schema_version=1, newer=False) -> Path:
     return art
 
 
+def _write_raw_manifest_artifact(tmp_path: Path, manifest: bytes) -> Path:
+    art = tmp_path / "raw-manifest.zip"
+    with zipfile.ZipFile(art, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("manifest.json", manifest)
+    return art
+
+
 def _make_task(artifact_path: Path, *, confirm_apply=False) -> DbasRestoreTask:
     task = DbasRestoreTask(ScheduleConfig(schedule_type=ScheduleType.MANUAL))
     task.update_config(
@@ -223,6 +230,62 @@ class TestValidateBeforeMutate:
         dry.assert_not_awaited()
         apply.assert_not_awaited()
         assert result.success is False
+
+    async def test_duplicate_logo_member_is_refused_before_orchestrator(self, tmp_path):
+        art = _write_artifact(tmp_path)
+        with zipfile.ZipFile(art, "a") as zf:
+            zf.writestr("binary/logos/espn.png", _PNG_BYTES)
+        dry = AsyncMock(return_value=_dry_run_report())
+        apply = AsyncMock(return_value=_apply_report())
+
+        with patch("dbas.restore_orchestrator.run_dry_run", dry), \
+             patch("dbas.restore_orchestrator.run_restore", apply), \
+             patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            result = await _make_task(art, confirm_apply=True).execute()
+
+        assert result.success is False
+        dry.assert_not_awaited()
+        apply.assert_not_awaited()
+
+    async def test_valid_manifest_is_read_once_and_reused_for_decode(self, tmp_path):
+        art = _write_artifact(tmp_path)
+        reads = []
+        original_open = zipfile.ZipFile.open
+
+        def tracked_open(zf, member, *args, **kwargs):
+            name = member.filename if isinstance(member, zipfile.ZipInfo) else member
+            reads.append(name)
+            return original_open(zf, member, *args, **kwargs)
+
+        with patch.object(zipfile.ZipFile, "open", tracked_open), \
+             patch("dbas.restore_orchestrator.run_dry_run", AsyncMock(return_value=_dry_run_report())), \
+             patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            result = await _make_task(art).execute()
+
+        assert result.success is True
+        assert reads.count("manifest.json") == 1
+
+    @pytest.mark.parametrize(
+        "manifest",
+        [
+            b"{not-json",
+            b"{" + (b" " * (1024 * 1024)),
+        ],
+        ids=["malformed", "oversized"],
+    )
+    async def test_invalid_manifest_is_refused_before_orchestrator(self, tmp_path, manifest):
+        art = _write_raw_manifest_artifact(tmp_path, manifest)
+        dry = AsyncMock(return_value=_dry_run_report())
+        apply = AsyncMock(return_value=_apply_report())
+
+        with patch("dbas.restore_orchestrator.run_dry_run", dry), \
+             patch("dbas.restore_orchestrator.run_restore", apply), \
+             patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            result = await _make_task(art, confirm_apply=True).execute()
+
+        assert result.success is False
+        dry.assert_not_awaited()
+        apply.assert_not_awaited()
 
     async def test_missing_artifact_fails_cleanly(self, tmp_path):
         task = _make_task(tmp_path / "does-not-exist.zip")

--- a/backend/tests/tasks/test_dbas_restore_task.py
+++ b/backend/tests/tasks/test_dbas_restore_task.py
@@ -128,6 +128,51 @@ class TestDryRunDefault:
         assert apply.await_args.kwargs["confirm_apply"] is True
         assert result.details["is_dry_run"] is False
 
+    async def test_logo_payload_is_loaded_lazily_while_archive_is_open(self, tmp_path):
+        art = _write_artifact(tmp_path)
+        task = _make_task(art, confirm_apply=False)
+        loaded = []
+        captured = []
+
+        async def dry_run(*, plan, logo_content_provider, **_kwargs):
+            record = plan.category(EntityType.LOGO).entities[0]
+            assert "content_b64" not in record
+            loaded.append(base64.b64decode(await logo_content_provider(record)))
+            captured.append((logo_content_provider, record))
+            return _dry_run_report()
+
+        with patch(
+            "dbas.restore_orchestrator.run_dry_run",
+            AsyncMock(side_effect=dry_run),
+        ), patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            result = await task.execute()
+
+        assert result.success is True
+        assert loaded == [_PNG_BYTES]
+        with pytest.raises(ValueError, match="already closed"):
+            await captured[0][0](captured[0][1])
+
+    async def test_archive_closes_when_orchestration_raises(self, tmp_path):
+        art = _write_artifact(tmp_path)
+        task = _make_task(art, confirm_apply=False)
+        captured = []
+
+        async def failing_dry_run(*, plan, logo_content_provider, **_kwargs):
+            captured.append(
+                (logo_content_provider, plan.category(EntityType.LOGO).entities[0])
+            )
+            raise RuntimeError("boom")
+
+        with patch(
+            "dbas.restore_orchestrator.run_dry_run",
+            AsyncMock(side_effect=failing_dry_run),
+        ), patch("dispatcharr_client.get_client", return_value=AsyncMock()):
+            result = await task.execute()
+
+        assert result.success is False
+        with pytest.raises(ValueError, match="already closed"):
+            await captured[0][0](captured[0][1])
+
     async def test_apply_states_the_archive_restores_full_ladder_policy(self, tmp_path):
         """The archive restore STATES ``allow_fuzzy_stream_match=True``.
 


### PR DESCRIPTION
## Summary
- hydrate archived logo payloads one at a time instead of materializing aggregate content
- stream checksums and enforce per-logo and manifest limits before mutation
- require one-to-one canonical manifest membership and preserve cleanup/rollback behavior

## Tracking
- enhancedchannelmanager-drc55

## Verification
- frozen-scope code review approved at 8a34e780
- independent canonical backend gate passed with 92.22% coverage
- malformed, duplicate, oversized, checksum, compatibility, and cleanup paths covered