### PR TITLE
fix: require explicit authorization for scheduled sync apply

### DIFF
--- a/backend/export_models.py
+++ b/backend/export_models.py
@@ -115,9 +115,9 @@ class SyncTarget(Base):
     it is excluded from the public OpenAPI surface by virtue of having no
     router. Do not add endpoints here until v0.18.1 (bead 0i2vt.4).
 
-    Mirrors CloudStorageTarget's credential-freshness contract:
-    ``credential_version`` bumps on every credentials write (same-txn, via the
-    listeners below) and ``token_revoked_at`` hard-stops a stale scheduled op.
+    ``credential_version`` is the server-side scheduled-authorization version.
+    It advances in the same transaction whenever credentials or destination
+    identity/security changes, and ``token_revoked_at`` hard-stops a stale op.
     """
     __tablename__ = "sync_targets"
 
@@ -289,7 +289,10 @@ def _sync_target_init_credential_version(mapper, connection, target):
 
 @event.listens_for(SyncTarget, "before_update")
 def _sync_target_bump_credential_version(mapper, connection, target):
-    """Same-txn credential_version bump on a credentials write (see CloudStorageTarget)."""
-    hist = sa_inspect(target).attrs.credentials.history
-    if hist.has_changes():
+    """Invalidate scheduled authorization on execution-sensitive changes."""
+    state = sa_inspect(target)
+    if any(
+        state.attrs[field].history.has_changes()
+        for field in ("credentials", "base_url", "insecure")
+    ):
         target.credential_version = (target.credential_version or 0) + 1

--- a/backend/routers/sync_targets.py
+++ b/backend/routers/sync_targets.py
@@ -6,8 +6,8 @@ A SyncTarget is a remote Dispatcharr-B instance ECM can push config to
 
 * credentials are Fernet-encrypted at rest via ``cloud_storage.crypto`` and are
   NEVER returned decrypted — every response masks them (last-4 only);
-* ``credential_version`` bumps same-txn on a credentials write via the ORM
-  before_update listener on the model (``export_models.py``) — a rename or
+* ``credential_version`` bumps same-txn when credentials, ``base_url``, or
+  ``insecure`` changes via the ORM listener (``export_models.py``); a rename or
   enable-toggle does NOT bump it;
 * every route is admin-gated (``auth.RequireAdminIfEnabled``), reads and writes
   alike, and that gate ADMITS the static MCP service principal — see
@@ -530,8 +530,8 @@ async def update_sync_target(
     """Update a sync target. Admin only.
 
     Credentials are re-encrypted only if provided. The credential_version bumps
-    (same-txn, via the ORM listener) ONLY when ``credentials`` is actually
-    written — a rename or enable-toggle does not.
+    (same-txn, via the ORM listener) when credentials, base_url, or insecure
+    changes; a rename or enable-toggle does not.
 
     bead 9kwzp.10 item 3, and the sharpest member of the group: this is the
     route that can repoint a ``base_url``, replace the credentials and clear

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -63,6 +63,15 @@ def _reject_mcp_privileged_task(task_id: str, caller_is_mcp: bool) -> None:
         )
 
 
+def _authorize_privileged_task_write(
+    task_id: str, is_admin: bool, caller_is_mcp: bool
+) -> None:
+    """Require a human admin for privileged task configuration or activation."""
+    if is_privileged_task_id(task_id) and not is_admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
+    _reject_mcp_privileged_task(task_id, caller_is_mcp)
+
+
 # -------------------------------------------------------------------------
 # Request / Response models
 # -------------------------------------------------------------------------
@@ -569,8 +578,14 @@ async def get_task(task_id: str):
 
 
 @router.patch("/api/tasks/{task_id}", tags=["Tasks"])
-async def update_task(task_id: str, config: TaskConfigUpdate):
+async def update_task(
+    task_id: str,
+    config: TaskConfigUpdate,
+    is_admin: bool = ResolveIsAdminIfEnabled,
+    caller_is_mcp: bool = ResolveIsMcpServicePrincipalIfEnabled,
+):
     """Update task configuration."""
+    _authorize_privileged_task_write(task_id, is_admin, caller_is_mcp)
     logger.debug("[TASKS] PATCH /api/tasks/%s", task_id)
     try:
         from task_registry import get_registry
@@ -736,9 +751,30 @@ def _validate_schedule_parameters(task_id: str, parameters: Optional[dict]) -> N
     try:
         from task_registry import get_registry
         task_class = get_registry().get_task_class(task_id)
-    except Exception as e:  # pragma: no cover - registry lookup is best-effort
+    except Exception as e:
+        if is_privileged_task_id(task_id):
+            logger.error(
+                "[TASKS] Cannot validate privileged task schedule for %s: %s",
+                task_id,
+                e,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    f"Cannot validate privileged task schedule for {task_id}: "
+                    "task registry is unavailable"
+                ),
+            ) from e
         logger.debug("[TASKS] Could not validate schedule parameters for %s: %s", task_id, e)
         return
+    if task_class is None and is_privileged_task_id(task_id):
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"Cannot validate privileged task schedule for {task_id}: "
+                "task is not registered"
+            ),
+        )
     validator = getattr(task_class, "validate_schedule_parameters", None) if task_class else None
     if validator:
         try:
@@ -926,10 +962,11 @@ async def list_task_schedules(task_id: str):
 async def create_task_schedule(
     task_id: str,
     data: TaskScheduleCreate,
+    is_admin: bool = ResolveIsAdminIfEnabled,
     caller_is_mcp: bool = ResolveIsMcpServicePrincipalIfEnabled,
 ):
     """Create a new schedule for a task."""
-    _reject_mcp_privileged_task(task_id, caller_is_mcp)
+    _authorize_privileged_task_write(task_id, is_admin, caller_is_mcp)
     logger.debug("[TASKS] POST /api/tasks/%s/schedules - type=%s", task_id, data.schedule_type)
     try:
         from models import TaskSchedule, ScheduledTask
@@ -1010,10 +1047,11 @@ async def update_task_schedule(
     task_id: str,
     schedule_id: int,
     data: TaskScheduleUpdate,
+    is_admin: bool = ResolveIsAdminIfEnabled,
     caller_is_mcp: bool = ResolveIsMcpServicePrincipalIfEnabled,
 ):
     """Update a task schedule."""
-    _reject_mcp_privileged_task(task_id, caller_is_mcp)
+    _authorize_privileged_task_write(task_id, is_admin, caller_is_mcp)
     logger.debug("[TASKS] PATCH /api/tasks/%s/schedules/%s", task_id, schedule_id)
     try:
         from models import TaskSchedule, ScheduledTask
@@ -1123,10 +1161,11 @@ async def update_task_schedule(
 async def delete_task_schedule(
     task_id: str,
     schedule_id: int,
+    is_admin: bool = ResolveIsAdminIfEnabled,
     caller_is_mcp: bool = ResolveIsMcpServicePrincipalIfEnabled,
 ):
     """Delete a task schedule."""
-    _reject_mcp_privileged_task(task_id, caller_is_mcp)
+    _authorize_privileged_task_write(task_id, is_admin, caller_is_mcp)
     logger.debug("[TASKS] DELETE /api/tasks/%s/schedules/%s", task_id, schedule_id)
     try:
         from models import TaskSchedule

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -783,6 +783,36 @@ def _validate_schedule_parameters(task_id: str, parameters: Optional[dict]) -> N
             raise HTTPException(status_code=422, detail=str(e)) from e
 
 
+def _bind_sync_schedule_credential_version(
+    session, task_id: str, parameters: dict
+) -> dict:
+    """Bind confirmed sync apply to the target's current server-side version."""
+    if not task_id.startswith(PRIVILEGED_TASK_ID_PREFIXES):
+        return parameters
+
+    from export_models import SyncTarget
+    from task_registry import get_registry
+
+    task_class = get_registry().get_task_class(task_id)
+    target_id = getattr(task_class, "bound_sync_target_id", None)
+    if target_id is None:
+        raise HTTPException(
+            status_code=422,
+            detail="Cannot authorize sync schedule: task has no bound sync target",
+        )
+
+    target = session.query(SyncTarget).filter(SyncTarget.id == target_id).first()
+    if target is None or target.credential_version is None:
+        raise HTTPException(
+            status_code=422,
+            detail="Cannot authorize sync schedule: sync target is unavailable",
+        )
+
+    bound = dict(parameters)
+    bound["cloud_credential_version"] = int(target.credential_version)
+    return bound
+
+
 @router.get("/api/tasks/{task_id}/parameter-schema", tags=["Tasks"])
 async def get_task_parameter_schema(task_id: str):
     """Get the parameter schema for a task type.
@@ -1000,6 +1030,9 @@ async def create_task_schedule(
             # Set task-specific parameters if provided (strip internal metadata keys)
             if data.parameters:
                 clean_params = {k: v for k, v in data.parameters.items() if not k.startswith("_")}
+                clean_params = _bind_sync_schedule_credential_version(
+                    session, task_id, clean_params
+                )
                 schedule.set_parameters(clean_params)
 
             # Calculate next run time
@@ -1114,6 +1147,9 @@ async def update_task_schedule(
                 schedule.day_of_month = data.day_of_month
             if data.parameters is not None:
                 clean_params = {k: v for k, v in data.parameters.items() if not k.startswith("_")}
+                clean_params = _bind_sync_schedule_credential_version(
+                    session, task_id, clean_params
+                )
                 schedule.set_parameters(clean_params)
 
             # Recalculate next run time

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -713,6 +713,40 @@ def _run_parameter_schema(task_id: str) -> Optional[dict]:
     return schema
 
 
+def _schedule_parameter_schema(task_id: str) -> Optional[dict]:
+    """Return schedule-only parameters declared by the registered task class."""
+    try:
+        from task_registry import get_registry
+        task_class = get_registry().get_task_class(task_id)
+    except Exception as e:  # pragma: no cover - registry lookup is best-effort
+        logger.debug("[TASKS] Could not read schedule parameters for %s: %s", task_id, e)
+        return None
+    schema = (
+        getattr(task_class, "schedule_parameter_schema", None)
+        if task_class
+        else None
+    )
+    if not schema or not schema.get("parameters"):
+        return None
+    return schema
+
+
+def _validate_schedule_parameters(task_id: str, parameters: Optional[dict]) -> None:
+    """Apply task-specific invariants before a schedule can be persisted."""
+    try:
+        from task_registry import get_registry
+        task_class = get_registry().get_task_class(task_id)
+    except Exception as e:  # pragma: no cover - registry lookup is best-effort
+        logger.debug("[TASKS] Could not validate schedule parameters for %s: %s", task_id, e)
+        return
+    validator = getattr(task_class, "validate_schedule_parameters", None) if task_class else None
+    if validator:
+        try:
+            validator(parameters)
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+
+
 @router.get("/api/tasks/{task_id}/parameter-schema", tags=["Tasks"])
 async def get_task_parameter_schema(task_id: str):
     """Get the parameter schema for a task type.
@@ -725,7 +759,8 @@ async def get_task_parameter_schema(task_id: str):
     per-entry shape; the keys are separate because their lifetimes are.
     """
     logger.debug("[TASKS] GET /api/tasks/%s/parameter-schema", task_id)
-    schema = TASK_PARAMETER_SCHEMAS.get(task_id)
+    declared_schedule_schema = _schedule_parameter_schema(task_id)
+    schema = declared_schedule_schema or TASK_PARAMETER_SCHEMAS.get(task_id)
     run_schema = _run_parameter_schema(task_id)
     if not schema and not run_schema:
         # Return empty schema for tasks without special parameters
@@ -907,6 +942,8 @@ async def create_task_schedule(
             if not task:
                 raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
 
+            _validate_schedule_parameters(task_id, data.parameters)
+
             # Create the schedule
             schedule = TaskSchedule(
                 task_id=task_id,
@@ -992,6 +1029,13 @@ async def update_task_schedule(
 
             if not schedule:
                 raise HTTPException(status_code=404, detail=f"Schedule {schedule_id} not found for task {task_id}")
+
+            effective_parameters = (
+                data.parameters
+                if data.parameters is not None
+                else schedule.get_parameters()
+            )
+            _validate_schedule_parameters(task_id, effective_parameters)
 
             # Update fields if provided
             if data.name is not None:

--- a/backend/task_engine.py
+++ b/backend/task_engine.py
@@ -1051,6 +1051,10 @@ class TaskEngine:
             if prepare_invocation:
                 prepare_invocation(triggered_by)
 
+            prepare_parameters = getattr(instance, "prepare_invocation_parameters", None)
+            if prepare_parameters:
+                parameters = prepare_parameters(triggered_by, schedule_id, parameters)
+
             if triggered_by == "scheduled":
                 validator = getattr(instance, "validate_schedule_parameters", None)
                 if validator:

--- a/backend/task_engine.py
+++ b/backend/task_engine.py
@@ -901,23 +901,27 @@ class TaskEngine:
         Returns:
             TaskResult or None if task not found
         """
-        # Get parameters from the first triggered schedule (if any)
-        # Multiple schedules could trigger at the same time; use the first one's parameters
-        schedule_parameters = None
-        schedule_id = None
-        if triggered_schedules:
-            first_schedule = triggered_schedules[0]
-            schedule_parameters = first_schedule.get_parameters()
-            schedule_id = first_schedule.id
+        results = []
+        for schedule in triggered_schedules:
+            schedule_parameters = schedule.get_parameters()
             if schedule_parameters:
-                logger.info("[%s] Using parameters from schedule %s: %s", task_id, schedule_id,
-                            _param_keys(schedule_parameters))
-
-        # Execute the task with parameters
-        result = await self._execute_task(task_id, triggered_by, parameters=schedule_parameters, schedule_id=schedule_id)
+                logger.info(
+                    "[%s] Using parameters from schedule %s: %s",
+                    task_id,
+                    schedule.id,
+                    _param_keys(schedule_parameters),
+                )
+            result = await self._execute_task(
+                task_id,
+                triggered_by,
+                parameters=schedule_parameters,
+                schedule_id=schedule.id,
+            )
+            if result:
+                results.append((schedule.id, result))
 
         # Update next_run_at for triggered schedules
-        if result:
+        if results:
             try:
                 from database import get_session
                 from models import TaskSchedule, ScheduledTask
@@ -925,11 +929,11 @@ class TaskEngine:
 
                 session = get_session()
                 try:
-                    for schedule in triggered_schedules:
+                    for schedule_id, schedule_result in results:
                         # Update last_run_at and recalculate next run time
-                        db_schedule = session.query(TaskSchedule).get(schedule.id)
+                        db_schedule = session.query(TaskSchedule).get(schedule_id)
                         if db_schedule:
-                            db_schedule.last_run_at = result.completed_at
+                            db_schedule.last_run_at = schedule_result.completed_at
                             if db_schedule.enabled:
                                 db_schedule.next_run_at = calculate_next_run(
                                     schedule_type=db_schedule.schedule_type,
@@ -938,9 +942,9 @@ class TaskEngine:
                                     timezone=db_schedule.timezone,
                                     days_of_week=db_schedule.get_days_of_week_list(),
                                     day_of_month=db_schedule.day_of_month,
-                                    last_run=result.completed_at,
+                                    last_run=schedule_result.completed_at,
                                 )
-                            logger.debug("[%s] Updated schedule %s last_run_at=%s, next_run_at=%s", task_id, db_schedule.id, result.completed_at, db_schedule.next_run_at)
+                            logger.debug("[%s] Updated schedule %s last_run_at=%s, next_run_at=%s", task_id, db_schedule.id, schedule_result.completed_at, db_schedule.next_run_at)
 
                     # Update parent task's next_run_at (earliest of all enabled schedules)
                     all_schedules = session.query(TaskSchedule).filter(
@@ -964,7 +968,7 @@ class TaskEngine:
             except Exception as e:
                 logger.exception("[%s] Failed to update schedule next_run_at: %s", task_id, e)
 
-        return result
+        return results[-1][1] if results else None
 
     async def _execute_task(
         self,

--- a/backend/task_engine.py
+++ b/backend/task_engine.py
@@ -9,6 +9,7 @@ Background service that manages and executes scheduled tasks:
 - Provides error handling and retry logic
 """
 import asyncio
+import copy
 import contextlib
 import logging
 from datetime import datetime
@@ -1037,8 +1038,15 @@ class TaskEngine:
             if triggered_by == "scheduled"
             else None
         )
+        invocation_config = None
 
         try:
+            # Registry instances are long-lived singletons. Treat run parameters
+            # as an overlay on their hydrated persisted/default configuration,
+            # then restore that baseline in ``finally`` before another schedule
+            # or manual run can observe it.
+            invocation_config = copy.deepcopy(instance.get_config())
+
             # Apply schedule parameters to the task instance
             if parameters and hasattr(instance, 'update_config'):
                 try:
@@ -1400,11 +1408,17 @@ class TaskEngine:
             )
 
         finally:
-            instance.set_run_trigger("manual")
-            if _scheduler_source_token is not None:
-                journal.reset_mutation_source(_scheduler_source_token)
-            async with self._lock:
-                self._active_tasks.discard(task_id)
+            try:
+                if invocation_config is not None:
+                    instance.restore_invocation_config(invocation_config)
+            except Exception as e:
+                logger.exception("[%s] Failed to restore invocation config: %s", task_id, e)
+            finally:
+                instance.set_run_trigger("manual")
+                if _scheduler_source_token is not None:
+                    journal.reset_mutation_source(_scheduler_source_token)
+                async with self._lock:
+                    self._active_tasks.discard(task_id)
 
     async def run_task(self, task_id: str, schedule_id: Optional[int] = None, parameters: Optional[dict] = None) -> Optional[TaskResult]:
         """

--- a/backend/task_engine.py
+++ b/backend/task_engine.py
@@ -1047,6 +1047,10 @@ class TaskEngine:
             # or manual run can observe it.
             invocation_config = copy.deepcopy(instance.get_config())
 
+            prepare_invocation = getattr(instance, "prepare_invocation", None)
+            if prepare_invocation:
+                prepare_invocation(triggered_by)
+
             if triggered_by == "scheduled":
                 validator = getattr(instance, "validate_schedule_parameters", None)
                 if validator:

--- a/backend/task_engine.py
+++ b/backend/task_engine.py
@@ -1100,6 +1100,7 @@ class TaskEngine:
                 user_initiated=(triggered_by == "manual"),
             )
 
+            instance.set_run_trigger(triggered_by)
             result = await instance.run()
 
             # Update execution record
@@ -1395,6 +1396,7 @@ class TaskEngine:
             )
 
         finally:
+            instance.set_run_trigger("manual")
             if _scheduler_source_token is not None:
                 journal.reset_mutation_source(_scheduler_source_token)
             async with self._lock:

--- a/backend/task_engine.py
+++ b/backend/task_engine.py
@@ -1047,14 +1047,16 @@ class TaskEngine:
             # or manual run can observe it.
             invocation_config = copy.deepcopy(instance.get_config())
 
+            if triggered_by == "scheduled":
+                validator = getattr(instance, "validate_schedule_parameters", None)
+                if validator:
+                    validator(parameters)
+
             # Apply schedule parameters to the task instance
             if parameters and hasattr(instance, 'update_config'):
-                try:
-                    instance.update_config(parameters)
-                    logger.info("[%s] Applied schedule parameters: %s", task_id,
-                                _param_keys(parameters))
-                except Exception as e:
-                    logger.warning("[%s] Failed to apply parameters: %s", task_id, e)
+                instance.update_config(parameters)
+                logger.info("[%s] Applied schedule parameters: %s", task_id,
+                            _param_keys(parameters))
 
             logger.info("[%s] Starting task execution (triggered_by=%s)", task_id, triggered_by)
 
@@ -1354,6 +1356,7 @@ class TaskEngine:
 
         except Exception as e:
             logger.exception("[%s] Task execution failed: %s", task_id, e)
+            failure_error = getattr(e, "error_code", str(e))
 
             # Determine alert category for granular filtering
             alert_category = "probe_failures" if task_id == "stream_probe" else None
@@ -1393,7 +1396,7 @@ class TaskEngine:
                         execution.completed_at = datetime.utcnow()
                         execution.status = "failed"
                         execution.success = False
-                        execution.error = str(e)
+                        execution.error = failure_error
                         session.commit()
                     session.close()
                 except Exception as db_err:
@@ -1402,7 +1405,7 @@ class TaskEngine:
             return TaskResult(
                 success=False,
                 message=f"Task execution failed: {str(e)}",
-                error=str(e),
+                error=failure_error,
                 started_at=datetime.utcnow(),
                 completed_at=datetime.utcnow(),
             )

--- a/backend/task_scheduler.py
+++ b/backend/task_scheduler.py
@@ -452,6 +452,16 @@ class TaskScheduler(ABC):
         """
         pass
 
+    def restore_invocation_config(self, config: dict) -> None:
+        """Restore a config snapshot after an invocation-specific overlay.
+
+        The task engine uses this after every run so schedule and ad-hoc
+        parameters cannot become state on the registry singleton. Subclasses
+        only need to override this when ``update_config(get_config())`` is not
+        round-trippable.
+        """
+        self.update_config(config)
+
     # -------------------------------------------------------------------------
     # Notification Callbacks (set by task_engine for progress notifications)
     # -------------------------------------------------------------------------

--- a/backend/task_scheduler.py
+++ b/backend/task_scheduler.py
@@ -325,6 +325,7 @@ class TaskScheduler(ABC):
     # — the dbas_backup passphrase is a manual-run transient that must never be
     # written to a schedule.
     run_parameter_schema: Optional[dict] = None
+    schedule_parameter_schema: Optional[dict] = None
 
     def __init__(self, schedule_config: Optional[ScheduleConfig] = None):
         """Initialize the task scheduler."""
@@ -347,6 +348,11 @@ class TaskScheduler(ABC):
         self._send_alerts: bool = True  # Whether to send external alerts (Discord, Telegram, etc.)
         self._last_notification_update: float = 0
         self._notification_update_interval: float = 2.0  # Update every 2 seconds max
+        self._run_trigger = "manual"
+
+    def set_run_trigger(self, triggered_by: str) -> None:
+        """Set whether the current invocation is manual or scheduler-driven."""
+        self._run_trigger = triggered_by
 
     # -------------------------------------------------------------------------
     # Abstract methods (must be implemented by subclasses)

--- a/backend/tasks/black_screen_scan.py
+++ b/backend/tasks/black_screen_scan.py
@@ -68,6 +68,13 @@ class BlackScreenScanTask(TaskScheduler):
                     self.task_id, self._sample_duration_override, self._max_concurrent_override,
                     self._channel_groups, self._auto_sync_groups)
 
+    def restore_invocation_config(self, config: dict) -> None:
+        """Restore the exact baseline, preserving ``None`` as scan-all."""
+        self._sample_duration_override = config["sample_duration"]
+        self._max_concurrent_override = config["max_concurrent"]
+        self._channel_groups = config["channel_groups"]
+        self._auto_sync_groups = config["auto_sync_groups"]
+
     def set_prober(self, prober):
         """Set the StreamProber instance to use for black screen detection."""
         self._prober = prober

--- a/backend/tasks/dbas_sync.py
+++ b/backend/tasks/dbas_sync.py
@@ -357,6 +357,14 @@ class DbasSyncTask(TaskScheduler):
         self.confirm_apply = False
         self.cloud_credential_version = None
 
+    def prepare_invocation_parameters(
+        self, triggered_by: str, schedule_id: Optional[int], parameters: Optional[dict]
+    ) -> Optional[dict]:
+        """Never treat stored schedule parameters as manual apply authority."""
+        if triggered_by == "manual" and schedule_id is not None:
+            return None
+        return parameters
+
     def update_config(self, config: dict) -> None:
         if "sync_target_id" in config:
             val = config["sync_target_id"]

--- a/backend/tasks/dbas_sync.py
+++ b/backend/tasks/dbas_sync.py
@@ -352,6 +352,11 @@ class DbasSyncTask(TaskScheduler):
             "cloud_credential_version": self.cloud_credential_version,
         }
 
+    def prepare_invocation(self, triggered_by: str) -> None:
+        """Disarm inherited singleton state before this run's explicit overlay."""
+        self.confirm_apply = False
+        self.cloud_credential_version = None
+
     def update_config(self, config: dict) -> None:
         if "sync_target_id" in config:
             val = config["sync_target_id"]
@@ -392,6 +397,17 @@ class DbasSyncTask(TaskScheduler):
                         "Scheduled sync refused: confirm_apply=true is required. "
                         "Edit this schedule and explicitly enable apply.",
                         error="SCHEDULE_APPLY_NOT_CONFIRMED",
+                    )
+                if (
+                    self._run_trigger == "scheduled"
+                    and self.cloud_credential_version is None
+                ):
+                    return self._fail(
+                        datetime.now(timezone.utc),
+                        "Scheduled sync refused: no server-captured credential "
+                        "version is present. Edit and save this schedule to "
+                        "reauthorize apply.",
+                        error="SCHEDULE_CREDENTIAL_VERSION_MISSING",
                     )
                 if self._bound_target_conflict is not None:
                     return self._fail(

--- a/backend/tasks/dbas_sync.py
+++ b/backend/tasks/dbas_sync.py
@@ -271,8 +271,9 @@ class DbasSyncTask(TaskScheduler):
       under this task id would run it outside its own lock and misattribute
       the run history). On the unbound base class it selects the target and
       is required.
-    - ``confirm_apply``: bool — ``False`` (default) is a counts-only DRY-RUN
-      preview (zero writes to B); ``True`` APPLIES source-wins (A overwrites B).
+    - ``confirm_apply``: bool — manual invocations default to a counts-only
+      DRY-RUN preview (zero writes to B). Schedules must persist an explicit
+      ``True`` and APPLY source-wins (A overwrites B).
     - ``cloud_credential_version``: Optional[int] — the target's
       ``credential_version`` captured when the schedule was configured. Re-checked
       FRESH against the DB at fire time; a mismatch aborts the run.
@@ -287,8 +288,8 @@ class DbasSyncTask(TaskScheduler):
     bound_sync_target_id: Optional[int] = None
     task_description = (
         "One-way push of this instance's config (and channels) to a remote "
-        "Dispatcharr-B SyncTarget. Dry-run preview by default; apply is opt-in. "
-        "Scheduled (operator opts into an interval) or manual."
+        "Dispatcharr-B SyncTarget. Manual runs preview by default; enabled "
+        "schedules explicitly apply changes to keep the replica converged."
     )
     default_enabled = False
     # Per-invocation state, not durable settings: this task runs off
@@ -297,6 +298,30 @@ class DbasSyncTask(TaskScheduler):
     # The fail-safe direction on restart is disarmed, so the registry must
     # neither persist nor rehydrate this surface (gjb01).
     persist_config = False
+    schedule_parameter_schema = {
+        "description": "Recurring cross-instance sync parameters",
+        "parameters": [
+            {
+                "name": "confirm_apply",
+                "type": "boolean",
+                "label": "Apply changes on every scheduled run",
+                "description": (
+                    "Required. Each scheduled run writes source changes to the "
+                    "managed replica; manual Sync now remains a preview."
+                ),
+                "default": False,
+                "required": True,
+            }
+        ],
+    }
+
+    @classmethod
+    def validate_schedule_parameters(cls, parameters: Optional[dict]) -> None:
+        if not parameters or parameters.get("confirm_apply") is not True:
+            raise ValueError(
+                "Cross-instance sync schedules require confirm_apply=true so "
+                "they cannot silently run as previews"
+            )
 
     def __init__(self, schedule_config: Optional[ScheduleConfig] = None):
         if schedule_config is None:
@@ -346,7 +371,7 @@ class DbasSyncTask(TaskScheduler):
                 # Explicit null on the unbound base clears the selection.
                 self.sync_target_id = None
         if "confirm_apply" in config:
-            self.confirm_apply = bool(config["confirm_apply"])
+            self.confirm_apply = config["confirm_apply"] is True
         if "cloud_credential_version" in config:
             val = config["cloud_credential_version"]
             self.cloud_credential_version = int(val) if val is not None else None
@@ -357,6 +382,13 @@ class DbasSyncTask(TaskScheduler):
         # excluded a same-target overlap before we get here.
         async with _get_sync_semaphore():
             try:
+                if self._run_trigger == "scheduled" and not self.confirm_apply:
+                    return self._fail(
+                        datetime.now(timezone.utc),
+                        "Scheduled sync refused: confirm_apply=true is required. "
+                        "Edit this schedule and explicitly enable apply.",
+                        error="SCHEDULE_APPLY_NOT_CONFIRMED",
+                    )
                 if self._bound_target_conflict is not None:
                     return self._fail(
                         datetime.now(timezone.utc),

--- a/backend/tasks/dbas_sync.py
+++ b/backend/tasks/dbas_sync.py
@@ -118,6 +118,10 @@ LEGACY_SYNC_TASK_ID = "dbas_sync"
 SYNC_TASK_ID_PREFIX = "dbas_sync_"
 
 
+class _ScheduleApplyNotConfirmedError(ValueError):
+    error_code = "SCHEDULE_APPLY_NOT_CONFIRMED"
+
+
 def sync_task_id_for(target_id: int) -> str:
     """The registered task id for one SyncTarget (``dbas_sync_<id>``)."""
     return "%s%d" % (SYNC_TASK_ID_PREFIX, target_id)
@@ -318,7 +322,7 @@ class DbasSyncTask(TaskScheduler):
     @classmethod
     def validate_schedule_parameters(cls, parameters: Optional[dict]) -> None:
         if not parameters or parameters.get("confirm_apply") is not True:
-            raise ValueError(
+            raise _ScheduleApplyNotConfirmedError(
                 "Cross-instance sync schedules require confirm_apply=true so "
                 "they cannot silently run as previews"
             )

--- a/backend/tasks/stream_probe.py
+++ b/backend/tasks/stream_probe.py
@@ -82,6 +82,13 @@ class StreamProbeTask(TaskScheduler):
                    self.task_id, self._channel_groups, self._auto_sync_groups,
                    self._timeout_override, self._max_concurrent_override)
 
+    def restore_invocation_config(self, config: dict) -> None:
+        """Restore the exact baseline, preserving ``None`` as probe-all."""
+        self._channel_groups = config["channel_groups"]
+        self._auto_sync_groups = config["auto_sync_groups"]
+        self._timeout_override = config["timeout"]
+        self._max_concurrent_override = config["max_concurrent"]
+
     def set_prober(self, prober):
         """Set the StreamProber instance to delegate to.
 

--- a/backend/tests/integration/test_task_engine_schedule_config_isolation.py
+++ b/backend/tests/integration/test_task_engine_schedule_config_isolation.py
@@ -1,0 +1,222 @@
+"""Scheduled parameters are per-invocation overlays, not singleton config."""
+
+import json
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+import database
+import task_registry
+from models import ScheduledTask, TaskSchedule
+from task_engine import TaskEngine
+from task_scheduler import TaskResult, TaskScheduler
+from tasks.black_screen_scan import BlackScreenScanTask
+from tasks.stream_probe import StreamProbeTask
+
+
+class _ConfigRecordingTask(TaskScheduler):
+    task_id = "test_schedule_config_isolation"
+    task_name = "Schedule Config Isolation Test"
+    task_description = "Records the effective config for each invocation"
+
+    seen: list[dict] = []
+
+    def __init__(self, schedule_config=None):
+        super().__init__(schedule_config)
+        self.first = "default-first"
+        self.second = "default-second"
+
+    def get_config(self) -> dict:
+        return {"first": self.first, "second": self.second}
+
+    def update_config(self, config: dict) -> None:
+        if "first" in config:
+            self.first = config["first"]
+        if "second" in config:
+            self.second = config["second"]
+
+    async def run(self) -> TaskResult:
+        if self.first == "raise":
+            self.seen.append(self.get_config().copy())
+            raise RuntimeError("deliberate schedule failure")
+        return await super().run()
+
+    async def execute(self) -> TaskResult:
+        effective = self.get_config().copy()
+        self.seen.append(effective)
+        now = datetime.utcnow()
+        return TaskResult(
+            success=True,
+            message="recorded",
+            started_at=now,
+            completed_at=now,
+        )
+
+
+@pytest.fixture
+def _scheduled_task_runtime(test_engine, monkeypatch):
+    session_factory = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=test_engine,
+        expire_on_commit=False,
+    )
+    monkeypatch.setattr(database, "_SessionLocal", session_factory)
+
+    registry = task_registry.get_registry()
+    registry.register(_ConfigRecordingTask)
+    instance = _ConfigRecordingTask()
+    instance.update_config({"first": "persisted-first"})
+    registry._instances[_ConfigRecordingTask.task_id] = instance
+    _ConfigRecordingTask.seen = []
+
+    session = session_factory()
+    session.add(
+        ScheduledTask(
+            task_id=_ConfigRecordingTask.task_id,
+            task_name=_ConfigRecordingTask.task_name,
+            description=_ConfigRecordingTask.task_description,
+            enabled=True,
+            schedule_type="manual",
+            config=json.dumps({"first": "persisted-first"}),
+        )
+    )
+    session.commit()
+    session.close()
+
+    yield registry, instance, session_factory
+
+    registry.unregister(_ConfigRecordingTask.task_id)
+    registry._instances.pop(_ConfigRecordingTask.task_id, None)
+
+
+def _schedule(session_factory, *, name: str, parameters: dict | None) -> TaskSchedule:
+    due_at = datetime.utcnow() - timedelta(minutes=1)
+    schedule = TaskSchedule(
+        task_id=_ConfigRecordingTask.task_id,
+        name=name,
+        enabled=True,
+        schedule_type="interval",
+        interval_seconds=3600,
+        parameters=json.dumps(parameters) if parameters is not None else None,
+        next_run_at=due_at,
+    )
+    session = session_factory()
+    session.add(schedule)
+    session.commit()
+    session.refresh(schedule)
+    session.expunge(schedule)
+    session.close()
+    return schedule
+
+
+def _assert_schedules_advanced(session_factory, *schedule_ids: int) -> None:
+    session = session_factory()
+    try:
+        rows = session.query(TaskSchedule).filter(TaskSchedule.id.in_(schedule_ids)).all()
+        assert len(rows) == len(schedule_ids)
+        assert all(row.last_run_at is not None for row in rows)
+        assert all(row.next_run_at > row.last_run_at for row in rows)
+    finally:
+        session.close()
+
+
+def _assert_persisted_and_singleton_config_unchanged(
+    instance: _ConfigRecordingTask, session_factory
+) -> None:
+    assert instance.get_config() == {
+        "first": "persisted-first",
+        "second": "default-second",
+    }
+    session = session_factory()
+    try:
+        row = session.query(ScheduledTask).filter_by(
+            task_id=_ConfigRecordingTask.task_id
+        ).one()
+        assert json.loads(row.config) == {"first": "persisted-first"}
+    finally:
+        session.close()
+
+
+@pytest.mark.parametrize("task_class", [StreamProbeTask, BlackScreenScanTask])
+def test_exact_restore_preserves_none_as_all_groups(task_class):
+    task = task_class()
+    baseline = task.get_config().copy()
+
+    task.update_config({"channel_groups": ["sports"]})
+    task.restore_invocation_config(baseline)
+
+    assert task.get_config()["channel_groups"] is None
+
+
+@pytest.mark.asyncio
+async def test_co_due_empty_schedule_uses_baseline_not_previous_override(
+    _scheduled_task_runtime,
+):
+    registry, instance, session_factory = _scheduled_task_runtime
+    first = _schedule(
+        session_factory,
+        name="overridden",
+        parameters={"first": "schedule-first", "second": "schedule-second"},
+    )
+    empty = _schedule(session_factory, name="empty", parameters=None)
+
+    await TaskEngine()._execute_task_with_schedules(
+        _ConfigRecordingTask.task_id, [first, empty]
+    )
+
+    assert _ConfigRecordingTask.seen == [
+        {"first": "schedule-first", "second": "schedule-second"},
+        {"first": "persisted-first", "second": "default-second"},
+    ]
+    _assert_schedules_advanced(session_factory, first.id, empty.id)
+    _assert_persisted_and_singleton_config_unchanged(instance, session_factory)
+
+
+@pytest.mark.asyncio
+async def test_co_due_partial_schedule_merges_only_its_own_override(
+    _scheduled_task_runtime,
+):
+    registry, instance, session_factory = _scheduled_task_runtime
+    first = _schedule(
+        session_factory,
+        name="full",
+        parameters={"first": "schedule-first", "second": "schedule-second"},
+    )
+    partial = _schedule(
+        session_factory, name="partial", parameters={"second": "partial-second"}
+    )
+
+    await TaskEngine()._execute_task_with_schedules(
+        _ConfigRecordingTask.task_id, [first, partial]
+    )
+
+    assert _ConfigRecordingTask.seen == [
+        {"first": "schedule-first", "second": "schedule-second"},
+        {"first": "persisted-first", "second": "partial-second"},
+    ]
+    _assert_schedules_advanced(session_factory, first.id, partial.id)
+    _assert_persisted_and_singleton_config_unchanged(instance, session_factory)
+
+
+@pytest.mark.asyncio
+async def test_schedule_config_is_restored_after_task_exception(
+    _scheduled_task_runtime,
+):
+    registry, instance, session_factory = _scheduled_task_runtime
+    failing = _schedule(
+        session_factory,
+        name="raising",
+        parameters={"first": "raise", "second": "schedule-second"},
+    )
+
+    result = await TaskEngine()._execute_task_with_schedules(
+        _ConfigRecordingTask.task_id, [failing]
+    )
+
+    assert result is not None
+    assert result.success is False
+    assert result.error == "deliberate schedule failure"
+    _assert_schedules_advanced(session_factory, failing.id)
+    _assert_persisted_and_singleton_config_unchanged(instance, session_factory)

--- a/backend/tests/routers/test_o8tbv_privileged_task_authz.py
+++ b/backend/tests/routers/test_o8tbv_privileged_task_authz.py
@@ -253,6 +253,7 @@ class TestPrivilegedTaskScheduleGate:
     async def test_auth_disabled_privileged_schedule_write_is_allowed(
         self, async_client, test_session
     ):
+        from export_models import SyncTarget
         from models import ScheduledTask
         from tasks.dbas_sync import make_sync_task_class
 
@@ -262,6 +263,15 @@ class TestPrivilegedTaskScheduleGate:
             description="Sync",
             enabled=True,
             schedule_type="manual",
+        ))
+        test_session.add(SyncTarget(
+            id=7,
+            name="Replica",
+            base_url="https://replica.example.com",
+            credentials="{}",
+            enabled=True,
+            credential_version=3,
+            insecure=False,
         ))
         test_session.commit()
         registry = MagicMock()
@@ -278,3 +288,4 @@ class TestPrivilegedTaskScheduleGate:
             )
 
         assert response.status_code == 200
+        assert response.json()["parameters"]["cloud_credential_version"] == 3

--- a/backend/tests/routers/test_o8tbv_privileged_task_authz.py
+++ b/backend/tests/routers/test_o8tbv_privileged_task_authz.py
@@ -173,3 +173,108 @@ class TestPrivilegedTaskCancelGate:
 
         assert resp.status_code == 200
         engine.cancel_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestPrivilegedTaskScheduleGate:
+    async def test_non_admin_cannot_enable_privileged_parent(self, async_client):
+        from main import app
+
+        cleanup = _override_admin(app, is_admin=False)
+        registry = MagicMock()
+        try:
+            with patch("task_registry.get_registry", return_value=registry):
+                response = await async_client.patch(
+                    "/api/tasks/dbas_sync_7", json={"enabled": True}
+                )
+        finally:
+            cleanup()
+
+        assert response.status_code == 403
+        registry.update_task_config.assert_not_called()
+
+    async def test_non_admin_cannot_create_privileged_schedule(self, async_client):
+        from main import app
+
+        cleanup = _override_admin(app, is_admin=False)
+        try:
+            response = await async_client.post(
+                "/api/tasks/dbas_sync_7/schedules",
+                json={
+                    "schedule_type": "daily",
+                    "schedule_time": "06:00",
+                    "parameters": {"confirm_apply": True},
+                },
+            )
+        finally:
+            cleanup()
+
+        assert response.status_code == 403
+
+    async def test_non_admin_cannot_update_privileged_schedule(self, async_client):
+        from main import app
+
+        cleanup = _override_admin(app, is_admin=False)
+        try:
+            response = await async_client.patch(
+                "/api/tasks/dbas_sync_7/schedules/1",
+                json={"enabled": True, "parameters": {"confirm_apply": True}},
+            )
+        finally:
+            cleanup()
+
+        assert response.status_code == 403
+
+    async def test_non_admin_ordinary_schedule_write_is_unchanged(
+        self, async_client, test_session
+    ):
+        from main import app
+        from models import ScheduledTask
+
+        test_session.add(ScheduledTask(
+            task_id="stream_probe",
+            task_name="Stream Probe",
+            description="Probe streams",
+            enabled=True,
+            schedule_type="manual",
+        ))
+        test_session.commit()
+        cleanup = _override_admin(app, is_admin=False)
+        try:
+            response = await async_client.post(
+                "/api/tasks/stream_probe/schedules",
+                json={"schedule_type": "daily", "schedule_time": "06:00"},
+            )
+        finally:
+            cleanup()
+
+        assert response.status_code == 200
+
+    async def test_auth_disabled_privileged_schedule_write_is_allowed(
+        self, async_client, test_session
+    ):
+        from models import ScheduledTask
+        from tasks.dbas_sync import make_sync_task_class
+
+        test_session.add(ScheduledTask(
+            task_id="dbas_sync_7",
+            task_name="Cross-Instance Sync",
+            description="Sync",
+            enabled=True,
+            schedule_type="manual",
+        ))
+        test_session.commit()
+        registry = MagicMock()
+        registry.get_task_class.return_value = make_sync_task_class(7, "Replica")
+
+        with patch("task_registry.get_registry", return_value=registry):
+            response = await async_client.post(
+                "/api/tasks/dbas_sync_7/schedules",
+                json={
+                    "schedule_type": "daily",
+                    "schedule_time": "06:00",
+                    "parameters": {"confirm_apply": True},
+                },
+            )
+
+        assert response.status_code == 200

--- a/backend/tests/routers/test_sync_targets.py
+++ b/backend/tests/routers/test_sync_targets.py
@@ -3,8 +3,8 @@
 Covers, per the bead's acceptance criteria:
 * CRUD happy paths (create / list / get / update / delete);
 * credentials are MASKED in every response (never plaintext, never ciphertext);
-* credential_version bumps when credentials change on update but NOT on a
-  rename / enable-toggle;
+* credential_version bumps when credentials or destination security changes on
+  update but NOT on a rename / enable-toggle;
 * base_url with a non-http scheme is rejected (config-time validation);
 * the admin gate is enforced when auth is enabled.
 
@@ -137,7 +137,7 @@ class TestListGetSyncTargets:
 
 
 # ---------------------------------------------------------------------------
-# Update — credential_version bump semantics
+# Update — scheduled-authorization version bump semantics
 # ---------------------------------------------------------------------------
 
 class TestUpdateSyncTarget:
@@ -194,6 +194,56 @@ class TestUpdateSyncTarget:
         assert resp.json()["credential_version"] == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("update", "expected_value"),
+        [
+            ({"base_url": "https://redirected.example.com"}, "https://redirected.example.com"),
+            ({"insecure": True}, True),
+        ],
+    )
+    async def test_destination_security_change_invalidates_scheduled_apply(
+        self, async_client, test_session, update, expected_value
+    ):
+        """Destination changes advance the server-side scheduled auth token."""
+        from unittest.mock import AsyncMock, patch
+
+        from tasks import dbas_sync
+        from tasks.dbas_sync import DbasSyncTask
+
+        created = await async_client.post(
+            "/api/sync-targets",
+            json={
+                "name": "authorized-destination",
+                "base_url": "https://original.example.com",
+                "credentials": {"token": "stabletoken12345"},
+            },
+        )
+        target_id = created.json()["id"]
+        authorized_version = created.json()["credential_version"]
+
+        resp = await async_client.put(f"/api/sync-targets/{target_id}", json=update)
+
+        assert resp.status_code == 200
+        field = next(iter(update))
+        assert resp.json()[field] == expected_value
+        assert resp.json()["credential_version"] == authorized_version + 1
+
+        test_session.expire_all()
+        with patch.object(dbas_sync, "run_sync", new=AsyncMock()) as mock_run:
+            task = DbasSyncTask()
+            task.set_run_trigger("scheduled")
+            task.update_config({
+                "sync_target_id": target_id,
+                "confirm_apply": True,
+                "cloud_credential_version": authorized_version,
+            })
+            result = await task.execute()
+
+        assert mock_run.await_count == 0
+        assert result.success is False
+        assert result.error == "CREDENTIAL_FRESHNESS_ABORT"
+
+    @pytest.mark.asyncio
     async def test_update_fuzzy_and_insecure_flags(self, async_client):
         created = await async_client.post(
             "/api/sync-targets",
@@ -208,7 +258,7 @@ class TestUpdateSyncTarget:
         assert resp.json()["fuzzy_stream_matching"] is True
         assert resp.json()["insecure"] is True
         assert resp.json()["sync_logos"] is True
-        assert resp.json()["credential_version"] == 1  # metadata-only
+        assert resp.json()["credential_version"] == 2  # insecure invalidates authorization
 
     @pytest.mark.asyncio
     async def test_correction_leaves_the_row_settings_alone(self, async_client, test_session):
@@ -302,7 +352,7 @@ class TestUpdateSyncTarget:
         )
         assert resp.status_code == 200
         assert resp.json()["base_url"] == "https://k.example.com"
-        assert resp.json()["credential_version"] == 1  # no credentials write
+        assert resp.json()["credential_version"] == 2  # base_url invalidates authorization
 
         test_session.expire_all()
         row = test_session.query(SyncTarget).filter_by(id=tid).first()

--- a/backend/tests/routers/test_tasks.py
+++ b/backend/tests/routers/test_tasks.py
@@ -642,6 +642,31 @@ class TestCreateTaskSchedule:
         assert response.status_code == 200
         assert response.json()["parameters"] == {"confirm_apply": True}
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("lookup_result", [None, RuntimeError("registry unavailable")])
+    async def test_privileged_schedule_fails_closed_when_task_class_unavailable(
+        self, async_client, test_session, lookup_result
+    ):
+        _create_scheduled_task(test_session, task_id="dbas_sync_7")
+        registry = MagicMock()
+        if isinstance(lookup_result, Exception):
+            registry.get_task_class.side_effect = lookup_result
+        else:
+            registry.get_task_class.return_value = lookup_result
+
+        with patch("task_registry.get_registry", return_value=registry):
+            response = await async_client.post(
+                "/api/tasks/dbas_sync_7/schedules",
+                json={
+                    "schedule_type": "daily",
+                    "schedule_time": "06:00",
+                    "parameters": {"confirm_apply": True},
+                },
+            )
+
+        assert response.status_code == 503
+        assert "cannot validate privileged task schedule" in response.json()["detail"].lower()
+
 
 class TestUpdateTaskSchedule:
     """Tests for PATCH /api/tasks/{task_id}/schedules/{schedule_id}."""

--- a/backend/tests/routers/test_tasks.py
+++ b/backend/tests/routers/test_tasks.py
@@ -349,6 +349,36 @@ class TestGetParameterSchema:
         data = response.json()
         assert data["parameters"] == []
 
+    @pytest.mark.asyncio
+    async def test_sync_schedule_schema_requires_visible_apply_confirmation(
+        self, async_client
+    ):
+        from tasks.dbas_sync import make_sync_task_class
+
+        task_class = make_sync_task_class(7, "Living Room B")
+        registry = MagicMock()
+        registry.get_task_class.return_value = task_class
+
+        with patch("task_registry.get_registry", return_value=registry):
+            response = await async_client.get(
+                "/api/tasks/dbas_sync_7/parameter-schema"
+            )
+
+        assert response.status_code == 200
+        assert response.json()["parameters"] == [
+            {
+                "name": "confirm_apply",
+                "type": "boolean",
+                "label": "Apply changes on every scheduled run",
+                "description": (
+                    "Required. Each scheduled run writes source changes to the "
+                    "managed replica; manual Sync now remains a preview."
+                ),
+                "default": False,
+                "required": True,
+            }
+        ]
+
 
 class TestGetRunParameterSchema:
     """Ad-hoc run parameters are discoverable (bead ``enhancedchannelmanager-sdpzy``).
@@ -564,6 +594,54 @@ class TestCreateTaskSchedule:
 
         assert response.status_code == 404
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("parameters", [None, {}, {"confirm_apply": False}])
+    async def test_sync_schedule_requires_explicit_apply(
+        self, async_client, test_session, parameters
+    ):
+        from tasks.dbas_sync import make_sync_task_class
+
+        _create_scheduled_task(test_session, task_id="dbas_sync_7")
+        registry = MagicMock()
+        registry.get_task_class.return_value = make_sync_task_class(7, "Living Room B")
+        payload = {
+            "schedule_type": "daily",
+            "schedule_time": "06:00",
+        }
+        if parameters is not None:
+            payload["parameters"] = parameters
+
+        with patch("task_registry.get_registry", return_value=registry):
+            response = await async_client.post(
+                "/api/tasks/dbas_sync_7/schedules", json=payload
+            )
+
+        assert response.status_code == 422
+        assert "confirm_apply=true" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_sync_schedule_persists_explicit_apply(
+        self, async_client, test_session
+    ):
+        from tasks.dbas_sync import make_sync_task_class
+
+        _create_scheduled_task(test_session, task_id="dbas_sync_7")
+        registry = MagicMock()
+        registry.get_task_class.return_value = make_sync_task_class(7, "Living Room B")
+
+        with patch("task_registry.get_registry", return_value=registry):
+            response = await async_client.post(
+                "/api/tasks/dbas_sync_7/schedules",
+                json={
+                    "schedule_type": "daily",
+                    "schedule_time": "06:00",
+                    "parameters": {"confirm_apply": True},
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["parameters"] == {"confirm_apply": True}
+
 
 class TestUpdateTaskSchedule:
     """Tests for PATCH /api/tasks/{task_id}/schedules/{schedule_id}."""
@@ -599,6 +677,26 @@ class TestUpdateTaskSchedule:
         )
 
         assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_legacy_sync_schedule_cannot_remain_implicit_preview(
+        self, async_client, test_session
+    ):
+        from tasks.dbas_sync import make_sync_task_class
+
+        _create_scheduled_task(test_session, task_id="dbas_sync_7")
+        schedule = _create_task_schedule(test_session, task_id="dbas_sync_7")
+        registry = MagicMock()
+        registry.get_task_class.return_value = make_sync_task_class(7, "Living Room B")
+
+        with patch("task_registry.get_registry", return_value=registry):
+            response = await async_client.patch(
+                f"/api/tasks/dbas_sync_7/schedules/{schedule.id}",
+                json={"schedule_time": "09:00"},
+            )
+
+        assert response.status_code == 422
+        assert "confirm_apply=true" in response.json()["detail"]
 
 
 class TestDeleteTaskSchedule:

--- a/backend/tests/routers/test_tasks.py
+++ b/backend/tests/routers/test_tasks.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from models import ScheduledTask, TaskSchedule
+from export_models import SyncTarget
 
 
 def _create_scheduled_task(session, task_id="stream_probe", **overrides):
@@ -49,6 +50,21 @@ def _create_task_schedule(session, task_id="stream_probe", **overrides):
     session.add(record)
     session.commit()
     session.refresh(record)
+    return record
+
+
+def _create_sync_target(session, target_id=7, credential_version=1):
+    record = SyncTarget(
+        id=target_id,
+        name="Living Room B",
+        base_url="https://living-room.example.com",
+        credentials="{}",
+        enabled=True,
+        credential_version=credential_version,
+        insecure=False,
+    )
+    session.add(record)
+    session.commit()
     return record
 
 
@@ -626,6 +642,7 @@ class TestCreateTaskSchedule:
         from tasks.dbas_sync import make_sync_task_class
 
         _create_scheduled_task(test_session, task_id="dbas_sync_7")
+        _create_sync_target(test_session, credential_version=4)
         registry = MagicMock()
         registry.get_task_class.return_value = make_sync_task_class(7, "Living Room B")
 
@@ -640,7 +657,37 @@ class TestCreateTaskSchedule:
             )
 
         assert response.status_code == 200
-        assert response.json()["parameters"] == {"confirm_apply": True}
+        assert response.json()["parameters"] == {
+            "confirm_apply": True,
+            "cloud_credential_version": 4,
+        }
+
+    @pytest.mark.asyncio
+    async def test_sync_schedule_replaces_client_forged_credential_version(
+        self, async_client, test_session
+    ):
+        from tasks.dbas_sync import make_sync_task_class
+
+        _create_scheduled_task(test_session, task_id="dbas_sync_7")
+        _create_sync_target(test_session, credential_version=6)
+        registry = MagicMock()
+        registry.get_task_class.return_value = make_sync_task_class(7, "Living Room B")
+
+        with patch("task_registry.get_registry", return_value=registry):
+            response = await async_client.post(
+                "/api/tasks/dbas_sync_7/schedules",
+                json={
+                    "schedule_type": "daily",
+                    "schedule_time": "06:00",
+                    "parameters": {
+                        "confirm_apply": True,
+                        "cloud_credential_version": 999,
+                    },
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["parameters"]["cloud_credential_version"] == 6
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("lookup_result", [None, RuntimeError("registry unavailable")])
@@ -722,6 +769,36 @@ class TestUpdateTaskSchedule:
 
         assert response.status_code == 422
         assert "confirm_apply=true" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_sync_schedule_reauthorization_refreshes_credential_version(
+        self, async_client, test_session
+    ):
+        from tasks.dbas_sync import make_sync_task_class
+
+        _create_scheduled_task(test_session, task_id="dbas_sync_7")
+        _create_sync_target(test_session, credential_version=8)
+        schedule = _create_task_schedule(
+            test_session,
+            task_id="dbas_sync_7",
+            parameters='{"confirm_apply": true, "cloud_credential_version": 2}',
+        )
+        registry = MagicMock()
+        registry.get_task_class.return_value = make_sync_task_class(7, "Living Room B")
+
+        with patch("task_registry.get_registry", return_value=registry):
+            response = await async_client.patch(
+                f"/api/tasks/dbas_sync_7/schedules/{schedule.id}",
+                json={
+                    "parameters": {
+                        "confirm_apply": True,
+                        "cloud_credential_version": 2,
+                    },
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["parameters"]["cloud_credential_version"] == 8
 
 
 class TestDeleteTaskSchedule:

--- a/backend/tests/tasks/test_dbas_sync_concurrency.py
+++ b/backend/tests/tasks/test_dbas_sync_concurrency.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.orm import sessionmaker
@@ -51,7 +51,7 @@ import database
 import observability
 from dbas.restore_contracts import RestoreOutcome, RestoreReport
 from export_models import SyncTarget
-from models import ScheduledTask, TaskSchedule
+from models import ScheduledTask, TaskExecution, TaskSchedule
 from task_registry import get_registry
 from tasks import dbas_sync
 
@@ -1042,6 +1042,57 @@ async def _tick_and_wait(engine, fired, *, timeout=5) -> bool:
                 break
             await asyncio.sleep(0.01)
     return True
+
+
+@pytest.mark.asyncio
+async def test_due_schedule_without_apply_confirmation_fails_instead_of_previewing(
+    _wire_db, _clean_registry, _fresh_semaphore
+):
+    """The real scheduler seam must carry trigger context into DbasSyncTask."""
+    from task_engine import TaskEngine
+
+    registry = _clean_registry
+    session = _wire_db()
+    target = _make_target(session, name="replica-1")
+    target_id = target.id
+    session.close()
+    task_id = dbas_sync.sync_task_id_for(target_id)
+    _startup(registry)
+
+    session = _wire_db()
+    session.query(ScheduledTask).filter(
+        ScheduledTask.task_id == task_id
+    ).update({"enabled": True})
+    session.add(TaskSchedule(
+        task_id=task_id,
+        name="legacy preview schedule",
+        enabled=True,
+        schedule_type="interval",
+        interval_seconds=3600,
+        parameters=None,
+        next_run_at=datetime.utcnow() - timedelta(minutes=5),
+    ))
+    session.commit()
+    session.close()
+
+    engine = TaskEngine()
+    with patch.object(dbas_sync, "run_sync", new=AsyncMock()) as mock_run:
+        await engine._check_and_run_due_tasks()
+        execution = None
+        for _ in range(200):
+            session = _wire_db()
+            execution = session.query(TaskExecution).filter(
+                TaskExecution.task_id == task_id,
+                TaskExecution.status != "running",
+            ).first()
+            session.close()
+            if execution is not None:
+                break
+            await asyncio.sleep(0.01)
+
+    assert mock_run.await_count == 0
+    assert execution is not None
+    assert execution.error == "SCHEDULE_APPLY_NOT_CONFIRMED"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/tasks/test_dbas_sync_concurrency.py
+++ b/backend/tests/tasks/test_dbas_sync_concurrency.py
@@ -1096,6 +1096,113 @@ async def test_due_schedule_without_apply_confirmation_fails_instead_of_previewi
 
 
 @pytest.mark.asyncio
+async def test_parent_apply_confirmation_cannot_authorize_empty_legacy_schedule(
+    _wire_db, _clean_registry, _fresh_semaphore
+):
+    """Only the current schedule row may authorize a destructive apply."""
+    from task_engine import TaskEngine
+
+    registry = _clean_registry
+    session = _wire_db()
+    target = _make_target(session, name="replica-1")
+    task_id = dbas_sync.sync_task_id_for(target.id)
+    session.close()
+    _startup(registry)
+
+    instance = registry.get_task_instance(task_id)
+    instance.update_config({"confirm_apply": True})
+
+    session = _wire_db()
+    session.query(ScheduledTask).filter(
+        ScheduledTask.task_id == task_id
+    ).update({"enabled": True})
+    session.add(TaskSchedule(
+        task_id=task_id,
+        name="empty legacy schedule",
+        enabled=True,
+        schedule_type="interval",
+        interval_seconds=3600,
+        parameters=None,
+        next_run_at=datetime.utcnow() - timedelta(minutes=5),
+    ))
+    session.commit()
+    session.close()
+
+    engine = TaskEngine()
+    with patch.object(dbas_sync, "run_sync", new=AsyncMock()) as mock_run:
+        await engine._check_and_run_due_tasks()
+        execution = None
+        for _ in range(200):
+            session = _wire_db()
+            execution = session.query(TaskExecution).filter(
+                TaskExecution.task_id == task_id,
+                TaskExecution.status != "running",
+            ).first()
+            session.close()
+            if execution is not None:
+                break
+            await asyncio.sleep(0.01)
+
+    assert mock_run.await_count == 0
+    assert execution is not None
+    assert execution.error == "SCHEDULE_APPLY_NOT_CONFIRMED"
+
+
+@pytest.mark.asyncio
+async def test_partially_applied_invalid_schedule_parameters_abort_before_sync(
+    _wire_db, _clean_registry, _fresh_semaphore
+):
+    """A later conversion error must invalidate an earlier confirm_apply mutation."""
+    from task_engine import TaskEngine
+
+    registry = _clean_registry
+    session = _wire_db()
+    target = _make_target(session, name="replica-1")
+    task_id = dbas_sync.sync_task_id_for(target.id)
+    session.close()
+    _startup(registry)
+
+    session = _wire_db()
+    session.query(ScheduledTask).filter(
+        ScheduledTask.task_id == task_id
+    ).update({"enabled": True})
+    session.add(TaskSchedule(
+        task_id=task_id,
+        name="invalid credential version",
+        enabled=True,
+        schedule_type="interval",
+        interval_seconds=3600,
+        parameters=json.dumps({
+            "confirm_apply": True,
+            "cloud_credential_version": "invalid",
+        }),
+        next_run_at=datetime.utcnow() - timedelta(minutes=5),
+    ))
+    session.commit()
+    session.close()
+
+    engine = TaskEngine()
+    with patch.object(dbas_sync, "run_sync", new=AsyncMock()) as mock_run:
+        await engine._check_and_run_due_tasks()
+        execution = None
+        for _ in range(200):
+            session = _wire_db()
+            execution = session.query(TaskExecution).filter(
+                TaskExecution.task_id == task_id,
+                TaskExecution.status != "running",
+            ).first()
+            session.close()
+            if execution is not None:
+                break
+            await asyncio.sleep(0.01)
+
+    assert mock_run.await_count == 0
+    assert execution is not None
+    assert execution.success is False
+    assert "invalid literal" in execution.error
+
+
+@pytest.mark.asyncio
 async def test_co_due_sync_schedules_keep_independent_confirmation_lifecycles(
     _wire_db, _clean_registry, _fresh_semaphore
 ):

--- a/backend/tests/tasks/test_dbas_sync_concurrency.py
+++ b/backend/tests/tasks/test_dbas_sync_concurrency.py
@@ -1096,6 +1096,84 @@ async def test_due_schedule_without_apply_confirmation_fails_instead_of_previewi
 
 
 @pytest.mark.asyncio
+async def test_co_due_sync_schedules_keep_independent_confirmation_lifecycles(
+    _wire_db, _clean_registry, _fresh_semaphore
+):
+    """A confirmed row cannot authorize or successfully advance a legacy row."""
+    from task_engine import TaskEngine
+
+    registry = _clean_registry
+    session = _wire_db()
+    target = _make_target(session, name="replica-1")
+    task_id = dbas_sync.sync_task_id_for(target.id)
+    session.close()
+    _startup(registry)
+
+    due_at = datetime.utcnow() - timedelta(minutes=5)
+    session = _wire_db()
+    session.query(ScheduledTask).filter(
+        ScheduledTask.task_id == task_id
+    ).update({"enabled": True})
+    confirmed = TaskSchedule(
+        task_id=task_id,
+        name="confirmed",
+        enabled=True,
+        schedule_type="interval",
+        interval_seconds=3600,
+        parameters=json.dumps({"confirm_apply": True}),
+        next_run_at=due_at,
+    )
+    legacy = TaskSchedule(
+        task_id=task_id,
+        name="legacy unconfirmed",
+        enabled=True,
+        schedule_type="interval",
+        interval_seconds=3600,
+        parameters=None,
+        next_run_at=due_at,
+    )
+    session.add_all([confirmed, legacy])
+    session.commit()
+    confirmed_id = confirmed.id
+    legacy_id = legacy.id
+    session.close()
+
+    applied = []
+
+    async def _fake_run_sync(sync_target, *, confirm_apply=False, **_kw):
+        applied.append(confirm_apply)
+        return _success_report()
+
+    engine = TaskEngine()
+    with patch.object(dbas_sync, "run_sync", side_effect=_fake_run_sync):
+        await engine._check_and_run_due_tasks()
+        for _ in range(300):
+            session = _wire_db()
+            executions = session.query(TaskExecution).filter(
+                TaskExecution.task_id == task_id,
+                TaskExecution.status != "running",
+            ).order_by(TaskExecution.id).all()
+            session.close()
+            if len(executions) == 2:
+                break
+            await asyncio.sleep(0.01)
+
+    assert applied == [True]
+    assert len(executions) == 2
+    assert sum(execution.success is True for execution in executions) == 1
+    assert [execution.error for execution in executions].count(
+        "SCHEDULE_APPLY_NOT_CONFIRMED"
+    ) == 1
+
+    session = _wire_db()
+    confirmed_row = session.query(TaskSchedule).get(confirmed_id)
+    legacy_row = session.query(TaskSchedule).get(legacy_id)
+    assert confirmed_row.last_run_at is not None
+    assert legacy_row.last_run_at is not None
+    session.close()
+
+
+@pytest.mark.asyncio
 async def test_enabled_parent_survives_a_normal_restart_and_fires(
     _wire_db, _clean_registry, _fresh_semaphore
 ):

--- a/backend/tests/tasks/test_dbas_sync_concurrency.py
+++ b/backend/tests/tasks/test_dbas_sync_concurrency.py
@@ -1193,6 +1193,48 @@ async def test_parent_apply_confirmation_cannot_authorize_parameterless_manual_r
 
 
 @pytest.mark.asyncio
+async def test_schedule_apply_confirmation_cannot_authorize_manual_run_now(
+    _wire_db, _clean_registry, _fresh_semaphore
+):
+    """Run Now may select a schedule, but it must not replay apply authority."""
+    from task_engine import TaskEngine
+
+    registry = _clean_registry
+    session = _wire_db()
+    target = _make_target(session, name="replica-1")
+    task_id = dbas_sync.sync_task_id_for(target.id)
+    schedule = TaskSchedule(
+        task_id=task_id,
+        name="authorized scheduled apply",
+        enabled=True,
+        schedule_type="interval",
+        interval_seconds=3600,
+        parameters=json.dumps({
+            "confirm_apply": True,
+            "cloud_credential_version": target.credential_version,
+        }),
+    )
+    session.add(schedule)
+    session.commit()
+    schedule_id = schedule.id
+    session.close()
+    _startup(registry)
+
+    confirmations = []
+
+    async def _fake_run_sync(_target, *, confirm_apply=False, **_kwargs):
+        confirmations.append(confirm_apply)
+        return RestoreReport(is_dry_run=not confirm_apply)
+
+    engine = TaskEngine()
+    with patch.object(dbas_sync, "run_sync", side_effect=_fake_run_sync):
+        result = await engine.run_task(task_id, schedule_id=schedule_id)
+
+    assert result.details["is_dry_run"] is True
+    assert confirmations == [False]
+
+
+@pytest.mark.asyncio
 async def test_explicit_manual_apply_confirmation_still_authorizes_current_run(
     _wire_db, _clean_registry, _fresh_semaphore
 ):

--- a/backend/tests/tasks/test_dbas_sync_concurrency.py
+++ b/backend/tests/tasks/test_dbas_sync_concurrency.py
@@ -722,16 +722,10 @@ def test_migration_leaves_parent_off_when_child_was_disabled(_wire_db, _clean_re
 
 
 @pytest.mark.asyncio
-async def test_migrated_schedule_fires_on_first_due_tick(
+async def test_migrated_schedule_fails_visibly_until_reauthorized(
     _wire_db, _clean_registry, _fresh_semaphore
 ):
-    """END-TO-END through the scheduler, not just registration state: seed the
-    legacy working schedule with a DUE next_run_at, run the real startup
-    sequence (register_sync_target_tasks -> sync_from_database), then let the
-    engine's due-task scan run. The migrated schedule must actually FIRE.
-
-    This is the regression the review demanded: asserting on row/registry state
-    alone passed while the run silently never happened (parent gate off)."""
+    """Migration cannot invent a server-bound destructive authorization."""
     from task_engine import TaskEngine
 
     session = _wire_db()
@@ -748,28 +742,24 @@ async def test_migrated_schedule_fires_on_first_due_tick(
     registry = get_registry()
     registry.sync_from_database()
 
-    fired = asyncio.Event()
-    seen = {}
-
-    async def _fake_run_sync(sync_target, *, confirm_apply=False, **_kw):
-        seen["target_id"] = sync_target.id
-        seen["confirm_apply"] = confirm_apply
-        fired.set()
-        return _success_report()
-
     engine = TaskEngine()
-    with patch.object(dbas_sync, "run_sync", side_effect=_fake_run_sync):
+    with patch.object(dbas_sync, "run_sync", new=AsyncMock()) as mock_run:
         await engine._check_and_run_due_tasks()
-        await asyncio.wait_for(fired.wait(), timeout=5)
-        # Let the spawned run finish before the patch is torn down.
+        execution = None
         for _ in range(200):
-            if not engine._active_tasks:
+            session = _wire_db()
+            execution = session.query(TaskExecution).filter(
+                TaskExecution.task_id == dbas_sync.sync_task_id_for(target_id),
+                TaskExecution.status != "running",
+            ).first()
+            session.close()
+            if execution is not None:
                 break
             await asyncio.sleep(0.01)
 
-    assert seen["target_id"] == target_id
-    # The migrated schedule's own parameters still drive the run.
-    assert seen["confirm_apply"] is True
+    assert mock_run.await_count == 0
+    assert execution is not None
+    assert execution.error == "SCHEDULE_CREDENTIAL_VERSION_MISSING"
 
 
 # ---------------------------------------------------------------------------
@@ -1015,7 +1005,10 @@ def _seed_per_target_schedule(session, task_id, *, enabled=True, next_run_at=Non
     session.add(TaskSchedule(
         task_id=task_id, name="hourly", enabled=enabled,
         schedule_type="interval", interval_seconds=3600,
-        parameters=json.dumps(parameters or {"confirm_apply": True}),
+        parameters=json.dumps(parameters or {
+            "confirm_apply": True,
+            "cloud_credential_version": 1,
+        }),
         next_run_at=next_run_at,
     ))
     session.commit()
@@ -1042,6 +1035,22 @@ async def _tick_and_wait(engine, fired, *, timeout=5) -> bool:
                 break
             await asyncio.sleep(0.01)
     return True
+
+
+async def _wait_for_execution_count(session_factory, task_id, error, count):
+    for _ in range(200):
+        session = session_factory()
+        actual = session.query(TaskExecution).filter(
+            TaskExecution.task_id == task_id,
+            TaskExecution.error == error,
+        ).count()
+        session.close()
+        if actual == count:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(
+        f"expected {count} {error} executions for {task_id}, found {actual}"
+    )
 
 
 @pytest.mark.asyncio
@@ -1149,6 +1158,72 @@ async def test_parent_apply_confirmation_cannot_authorize_empty_legacy_schedule(
 
 
 @pytest.mark.asyncio
+async def test_parent_apply_confirmation_cannot_authorize_parameterless_manual_run(
+    _wire_db, _clean_registry, _fresh_semaphore
+):
+    """A generic manual Run Now must preview despite inherited singleton config."""
+    from task_engine import TaskEngine
+
+    registry = _clean_registry
+    session = _wire_db()
+    target = _make_target(session, name="replica-1")
+    task_id = dbas_sync.sync_task_id_for(target.id)
+    session.close()
+    _startup(registry)
+
+    instance = registry.get_task_instance(task_id)
+    instance.update_config({"confirm_apply": True})
+
+    confirmations = []
+
+    async def _fake_run_sync(_target, *, confirm_apply=False, **_kwargs):
+        confirmations.append(confirm_apply)
+        report = RestoreReport(is_dry_run=not confirm_apply)
+        if confirm_apply:
+            report.outcome = RestoreOutcome.SUCCESS
+        return report
+
+    engine = TaskEngine()
+    with patch.object(dbas_sync, "run_sync", side_effect=_fake_run_sync):
+        result = await engine.run_task(task_id)
+
+    assert result.success is True
+    assert result.details["is_dry_run"] is True
+    assert confirmations == [False]
+
+
+@pytest.mark.asyncio
+async def test_explicit_manual_apply_confirmation_still_authorizes_current_run(
+    _wire_db, _clean_registry, _fresh_semaphore
+):
+    """The dedicated interactive Apply path remains an explicit one-shot apply."""
+    from task_engine import TaskEngine
+
+    registry = _clean_registry
+    session = _wire_db()
+    target = _make_target(session, name="replica-1")
+    task_id = dbas_sync.sync_task_id_for(target.id)
+    session.close()
+    _startup(registry)
+
+    confirmations = []
+
+    async def _fake_run_sync(_target, *, confirm_apply=False, **_kwargs):
+        confirmations.append(confirm_apply)
+        return _success_report()
+
+    engine = TaskEngine()
+    with patch.object(dbas_sync, "run_sync", side_effect=_fake_run_sync):
+        result = await engine.run_task(
+            task_id, parameters={"confirm_apply": True}
+        )
+
+    assert result.success is True
+    assert result.details["is_dry_run"] is False
+    assert confirmations == [True]
+
+
+@pytest.mark.asyncio
 async def test_partially_applied_invalid_schedule_parameters_abort_before_sync(
     _wire_db, _clean_registry, _fresh_semaphore
 ):
@@ -1227,7 +1302,10 @@ async def test_co_due_sync_schedules_keep_independent_confirmation_lifecycles(
         enabled=True,
         schedule_type="interval",
         interval_seconds=3600,
-        parameters=json.dumps({"confirm_apply": True}),
+        parameters=json.dumps({
+            "confirm_apply": True,
+            "cloud_credential_version": 1,
+        }),
         next_run_at=due_at,
     )
     legacy = TaskSchedule(
@@ -1379,13 +1457,10 @@ async def test_disabled_parent_stays_disabled_across_restart(
 
 
 @pytest.mark.asyncio
-async def test_migrated_schedule_still_fires_on_the_second_startup(
+async def test_migrated_schedule_stays_enabled_but_unauthorized_after_restart(
     _wire_db, _clean_registry, _fresh_semaphore
 ):
-    """The upgrade path end to end: legacy migration on startup #1 (fires), then
-    a plain restart on startup #2 with NO legacy rows left. The second boot is
-    where the freshly materialized default-disabled instance used to overwrite
-    the parent the migration had just enabled."""
+    """Restart preserves the parent gate without authorizing a legacy apply."""
     from task_engine import TaskEngine
 
     registry = _clean_registry
@@ -1399,20 +1474,15 @@ async def test_migrated_schedule_still_fires_on_the_second_startup(
     session.close()
     task_id = dbas_sync.sync_task_id_for(target_id)
 
-    fired = asyncio.Event()
-    seen = {}
-
-    async def _fake_run_sync(sync_target, *, confirm_apply=False, **_kw):
-        seen["target_id"] = sync_target.id
-        seen["confirm_apply"] = confirm_apply
-        fired.set()
-        return _success_report()
-
-    # --- startup #1: migration + first due run ----------------------------
+    # --- startup #1: migration + refused due run --------------------------
     _startup(registry)
     engine = TaskEngine()
-    with patch.object(dbas_sync, "run_sync", side_effect=_fake_run_sync):
-        assert await _tick_and_wait(engine, fired), "migrated schedule never fired"
+    with patch.object(dbas_sync, "run_sync", new=AsyncMock()) as mock_run:
+        await engine._check_and_run_due_tasks()
+        await _wait_for_execution_count(
+            _wire_db, task_id, "SCHEDULE_CREDENTIAL_VERSION_MISSING", 1
+        )
+    assert mock_run.await_count == 0
 
     session = _wire_db()
     assert session.query(TaskSchedule).filter(
@@ -1429,15 +1499,13 @@ async def test_migrated_schedule_still_fires_on_the_second_startup(
     _simulate_process_restart(registry)
     _startup(registry)
 
-    fired.clear()
-    seen.clear()
     engine = TaskEngine()
-    with patch.object(dbas_sync, "run_sync", side_effect=_fake_run_sync):
-        assert await _tick_and_wait(engine, fired), (
-            "migrated schedule stopped firing after a restart"
+    with patch.object(dbas_sync, "run_sync", new=AsyncMock()) as mock_run:
+        await engine._check_and_run_due_tasks()
+        await _wait_for_execution_count(
+            _wire_db, task_id, "SCHEDULE_CREDENTIAL_VERSION_MISSING", 2
         )
-    assert seen["target_id"] == target_id
-    assert seen["confirm_apply"] is True
+    assert mock_run.await_count == 0
 
     session = _wire_db()
     assert _parent_enabled(session, task_id) is True, (

--- a/backend/tests/tasks/test_dbas_sync_task.py
+++ b/backend/tests/tasks/test_dbas_sync_task.py
@@ -313,7 +313,11 @@ async def test_execute_calls_run_sync_with_target_and_confirm_apply(_wire_db):
 
     with patch.object(dbas_sync, "run_sync", side_effect=_fake_run_sync) as mock_run:
         task = DbasSyncTask()
-        task.update_config({"sync_target_id": target_id, "confirm_apply": True})
+        task.update_config({
+            "sync_target_id": target_id,
+            "confirm_apply": True,
+            "cloud_credential_version": 1,
+        })
         result = await task.execute()
 
     assert mock_run.await_count == 1
@@ -344,7 +348,11 @@ async def test_scheduled_execute_applies_only_with_explicit_confirmation(_wire_d
     with patch.object(dbas_sync, "run_sync", side_effect=_fake_run_sync):
         task = DbasSyncTask()
         task.set_run_trigger("scheduled")
-        task.update_config({"sync_target_id": target_id, "confirm_apply": True})
+        task.update_config({
+            "sync_target_id": target_id,
+            "confirm_apply": True,
+            "cloud_credential_version": 1,
+        })
         result = await task.execute()
 
     assert captured["confirm_apply"] is True
@@ -375,6 +383,28 @@ async def test_scheduled_execute_refuses_missing_apply_confirmation(_wire_db):
 
 
 @pytest.mark.asyncio
+async def test_scheduled_execute_refuses_missing_credential_version(_wire_db):
+    """Legacy schedules must be reauthorized before destructive execution."""
+    from tasks import dbas_sync
+    from tasks.dbas_sync import DbasSyncTask
+
+    session = _wire_db()
+    target = _make_target(session)
+    target_id = target.id
+    session.close()
+
+    with patch.object(dbas_sync, "run_sync", new=AsyncMock()) as mock_run:
+        task = DbasSyncTask()
+        task.set_run_trigger("scheduled")
+        task.update_config({"sync_target_id": target_id, "confirm_apply": True})
+        result = await task.execute()
+
+    assert mock_run.await_count == 0
+    assert result.success is False
+    assert result.error == "SCHEDULE_CREDENTIAL_VERSION_MISSING"
+
+
+@pytest.mark.asyncio
 async def test_confirmed_scheduled_run_resets_before_direct_manual_run(_wire_db):
     """The same bound singleton must return to manual-preview state after apply."""
     from tasks import dbas_sync
@@ -393,7 +423,7 @@ async def test_confirmed_scheduled_run_resets_before_direct_manual_run(_wire_db)
 
     with patch.object(dbas_sync, "run_sync", side_effect=_fake_run_sync):
         task.set_run_trigger("scheduled")
-        task.update_config({"confirm_apply": True})
+        task.update_config({"confirm_apply": True, "cloud_credential_version": 1})
         scheduled_result = await task.execute()
         task.set_run_trigger("manual")
         manual_result = await task.execute()

--- a/backend/tests/tasks/test_dbas_sync_task.py
+++ b/backend/tests/tasks/test_dbas_sync_task.py
@@ -325,6 +325,56 @@ async def test_execute_calls_run_sync_with_target_and_confirm_apply(_wire_db):
 
 
 @pytest.mark.asyncio
+async def test_scheduled_execute_applies_only_with_explicit_confirmation(_wire_db):
+    """A recurring invocation is an apply operation, not a dry-run preview."""
+    from tasks import dbas_sync
+    from tasks.dbas_sync import DbasSyncTask
+
+    session = _wire_db()
+    target = _make_target(session)
+    target_id = target.id
+    session.close()
+
+    captured = {}
+
+    async def _fake_run_sync(sync_target, *, confirm_apply=False, session=None, **_kw):
+        captured["confirm_apply"] = confirm_apply
+        return _success_report()
+
+    with patch.object(dbas_sync, "run_sync", side_effect=_fake_run_sync):
+        task = DbasSyncTask()
+        task.set_run_trigger("scheduled")
+        task.update_config({"sync_target_id": target_id, "confirm_apply": True})
+        result = await task.execute()
+
+    assert captured["confirm_apply"] is True
+    assert result.success is True
+    assert result.details["is_dry_run"] is False
+
+
+@pytest.mark.asyncio
+async def test_scheduled_execute_refuses_missing_apply_confirmation(_wire_db):
+    """A malformed/legacy schedule must fail loudly, never fall back to preview."""
+    from tasks import dbas_sync
+    from tasks.dbas_sync import DbasSyncTask
+
+    session = _wire_db()
+    target = _make_target(session)
+    target_id = target.id
+    session.close()
+
+    with patch.object(dbas_sync, "run_sync", new=AsyncMock()) as mock_run:
+        task = DbasSyncTask()
+        task.set_run_trigger("scheduled")
+        task.update_config({"sync_target_id": target_id})
+        result = await task.execute()
+
+    assert mock_run.await_count == 0
+    assert result.success is False
+    assert result.error == "SCHEDULE_APPLY_NOT_CONFIRMED"
+
+
+@pytest.mark.asyncio
 async def test_execute_dry_run_default_maps_to_success(_wire_db):
     """confirm_apply defaults False -> run_sync called with confirm_apply=False;
     a dry-run report (no outcome) maps to a successful TaskResult."""

--- a/backend/tests/tasks/test_dbas_sync_task.py
+++ b/backend/tests/tasks/test_dbas_sync_task.py
@@ -375,6 +375,35 @@ async def test_scheduled_execute_refuses_missing_apply_confirmation(_wire_db):
 
 
 @pytest.mark.asyncio
+async def test_confirmed_scheduled_run_resets_before_direct_manual_run(_wire_db):
+    """The same bound singleton must return to manual-preview state after apply."""
+    from tasks import dbas_sync
+    from tasks.dbas_sync import make_sync_task_class
+
+    session = _wire_db()
+    target = _make_target(session)
+    target_id = target.id
+    session.close()
+    task = make_sync_task_class(target_id, "Replica")()
+    confirmations = []
+
+    async def _fake_run_sync(sync_target, *, confirm_apply=False, **_kw):
+        confirmations.append(confirm_apply)
+        return _success_report() if confirm_apply else _dry_run_report()
+
+    with patch.object(dbas_sync, "run_sync", side_effect=_fake_run_sync):
+        task.set_run_trigger("scheduled")
+        task.update_config({"confirm_apply": True})
+        scheduled_result = await task.execute()
+        task.set_run_trigger("manual")
+        manual_result = await task.execute()
+
+    assert scheduled_result.details["is_dry_run"] is False
+    assert manual_result.details["is_dry_run"] is True
+    assert confirmations == [True, False]
+
+
+@pytest.mark.asyncio
 async def test_execute_dry_run_default_maps_to_success(_wire_db):
     """confirm_apply defaults False -> run_sync called with confirm_apply=False;
     a dry-run report (no outcome) maps to a successful TaskResult."""

--- a/backend/tests/unit/test_cloud_sync_target_credentials.py
+++ b/backend/tests/unit/test_cloud_sync_target_credentials.py
@@ -186,7 +186,6 @@ class TestSyncTargetCredentialVersion:
         test_session.commit()
 
         target.enabled = False
-        target.base_url = "https://dispatcharr-c.example"
         test_session.commit()
         test_session.refresh(target)
         assert target.credential_version == 1

--- a/backend/tests/unit/test_task_registry_config_persist.py
+++ b/backend/tests/unit/test_task_registry_config_persist.py
@@ -513,6 +513,7 @@ class TestScheduleOverlayNotPersisted:
                 super().__init__(schedule_config)
                 self.channel_groups = None
                 self.timeout = 60
+                self.executed_config = None
 
             def get_config(self) -> dict:
                 return {"channel_groups": self.channel_groups, "timeout": self.timeout}
@@ -524,6 +525,7 @@ class TestScheduleOverlayNotPersisted:
                     self.timeout = config["timeout"]
 
             async def execute(self) -> TaskResult:
+                self.executed_config = self.get_config().copy()
                 now = datetime.utcnow()
                 return TaskResult(
                     success=True, message="ok",
@@ -556,10 +558,15 @@ class TestScheduleOverlayNotPersisted:
                 parameters={"channel_groups": ["sports"], "timeout": 17},
             )
             assert result is not None and result.success is True
-            # The overlay DID reach the live instance for the run.
+            # The overlay reached this invocation, then the singleton returned
+            # to the operator's persisted/default baseline.
             live = registry.get_task_instance(_ProbeShapedTask.task_id)
-            assert live.channel_groups == ["sports"]
-            assert live.timeout == 17
+            assert live.executed_config == {
+                "channel_groups": ["sports"],
+                "timeout": 17,
+            }
+            assert live.channel_groups is None
+            assert live.timeout == 30
 
             # ...but the stored snapshot is still the operator's save.
             row = (
@@ -573,8 +580,7 @@ class TestScheduleOverlayNotPersisted:
             assert stored == {"timeout": 30}
 
             # Final-delta BLOCK 1: an enabled-only PATCH through the real
-            # update path, with the run's overlay still live on the
-            # singleton, must not capture the overlay either.
+            # update path must not capture the completed run's overlay either.
             registry.update_task_config(_ProbeShapedTask.task_id, enabled=False)
             test_session.expire_all()
             row = (

--- a/frontend/src/components/ScheduleEditor.test.tsx
+++ b/frontend/src/components/ScheduleEditor.test.tsx
@@ -195,6 +195,41 @@ describe('ScheduleEditor', () => {
       const batchInput = screen.getByDisplayValue('30');
       expect(batchInput).toBeInTheDocument();
     });
+
+    it('requires explicit apply confirmation for a recurring sync schedule', async () => {
+      const user = userEvent.setup();
+      const syncSchema: TaskParameterSchema[] = [{
+        name: 'confirm_apply',
+        type: 'boolean',
+        label: 'Apply changes on every scheduled run',
+        description: 'Required. Scheduled runs write source changes to the managed replica.',
+        default: false,
+        required: true,
+      }];
+
+      render(
+        <ScheduleEditor
+          {...defaultProps}
+          taskId="dbas_sync_7"
+          parameterSchema={syncSchema}
+        />
+      );
+
+      const apply = screen.getByRole('checkbox', {
+        name: /apply changes on every scheduled run/i,
+      });
+      const save = screen.getByRole('button', { name: /add schedule/i });
+      expect(apply).not.toBeChecked();
+      expect(save).toBeDisabled();
+
+      await user.click(apply);
+      expect(save).toBeEnabled();
+      await user.click(save);
+
+      await waitFor(() => expect(mockOnSave).toHaveBeenCalledWith(
+        expect.objectContaining({ parameters: { confirm_apply: true } }),
+      ));
+    });
   });
 
   describe('interactions', () => {

--- a/frontend/src/components/ScheduleEditor.test.tsx
+++ b/frontend/src/components/ScheduleEditor.test.tsx
@@ -220,6 +220,12 @@ describe('ScheduleEditor', () => {
       });
       const save = screen.getByRole('button', { name: /add schedule/i });
       expect(apply).not.toBeChecked();
+      expect(apply).toBeRequired();
+      const helpId = apply.getAttribute('aria-describedby');
+      expect(helpId).toBeTruthy();
+      expect(document.getElementById(helpId!)).toHaveTextContent(
+        /scheduled runs write source changes to the managed replica/i,
+      );
       expect(save).toBeDisabled();
 
       await user.click(apply);

--- a/frontend/src/components/ScheduleEditor.tsx
+++ b/frontend/src/components/ScheduleEditor.tsx
@@ -143,6 +143,12 @@ export function ScheduleEditor({ schedule, onSave, onCancel, saving, taskId, par
     await onSave(data);
   };
 
+  const missingRequiredParameter = parameterSchema?.some((param) => {
+    if (!param.required) return false;
+    const value = parameters[param.name] ?? param.default;
+    return param.type === 'boolean' ? value !== true : value === undefined || value === '';
+  }) ?? false;
+
   const handleIntervalPreset = (value: number) => {
     setIntervalSeconds(value);
     setUseCustomInterval(false);
@@ -536,7 +542,7 @@ export function ScheduleEditor({ schedule, onSave, onCancel, saving, taskId, par
         <button
           type="button"
           onClick={handleSave}
-          disabled={saving || (scheduleType !== 'interval' && !scheduleTime)}
+          disabled={saving || missingRequiredParameter || (scheduleType !== 'interval' && !scheduleTime)}
           className="modal-btn modal-btn-primary"
         >
           {saving ? (

--- a/frontend/src/components/ScheduleEditor.tsx
+++ b/frontend/src/components/ScheduleEditor.tsx
@@ -433,8 +433,10 @@ export function ScheduleEditor({ schedule, onSave, onCancel, saving, taskId, par
       {parameterSchema && parameterSchema.length > 0 && (
         <div className="parameters-section">
           <h4 className="section-title">Task Parameters</h4>
-          {parameterSchema.map((param) => (
-            <div key={param.name} className="form-group">
+          {parameterSchema.map((param) => {
+            const descriptionId = `schedule-parameter-${param.name}-description`;
+            return (
+              <div key={param.name} className="form-group">
               {/* Show note before timeout for stream_probe */}
               {taskId === 'stream_probe' && param.name === 'timeout' && (
                 <p className="parameters-note">
@@ -442,7 +444,7 @@ export function ScheduleEditor({ schedule, onSave, onCancel, saving, taskId, par
                 </p>
               )}
               <label>{param.label}</label>
-              <p className="param-description">{param.description}</p>
+              <p id={descriptionId} className="param-description">{param.description}</p>
 
               {/* Number input */}
               {param.type === 'number' && (
@@ -473,6 +475,8 @@ export function ScheduleEditor({ schedule, onSave, onCancel, saving, taskId, par
                     type="checkbox"
                     checked={(parameters[param.name] as boolean) ?? param.default ?? false}
                     onChange={(e) => updateParameter(param.name, e.target.checked)}
+                    required={param.required}
+                    aria-describedby={descriptionId}
                   />
                   <span>{param.label || 'Enabled'}</span>
                 </label>
@@ -527,8 +531,9 @@ export function ScheduleEditor({ schedule, onSave, onCancel, saving, taskId, par
                   Empty = applies to all. Options not yet loaded.
                 </div>
               )}
-            </div>
-          ))}
+              </div>
+            );
+          })}
         </div>
       )}
 

--- a/frontend/src/components/ScheduledTasksSection.runNowNotifications.test.tsx
+++ b/frontend/src/components/ScheduledTasksSection.runNowNotifications.test.tsx
@@ -58,6 +58,15 @@ function makeMonitorTask(): TaskStatus {
   } as unknown as TaskStatus;
 }
 
+function makeSyncTask(): TaskStatus {
+  return {
+    ...makeMonitorTask(),
+    task_id: 'dbas_sync_7',
+    task_name: 'Cross-Instance Sync: Living Room B',
+    config: { confirm_apply: true },
+  } as TaskStatus;
+}
+
 function runResult(overrides: Partial<Awaited<ReturnType<typeof api.runTask>>>) {
   return {
     success: true,
@@ -105,5 +114,21 @@ describe('ScheduledTasksSection — Run Now completed-with-warnings', () => {
     await waitFor(() => expect(notify.success).toHaveBeenCalledTimes(1));
     expect(notify.warning).not.toHaveBeenCalled();
     expect(notify.error).not.toHaveBeenCalled();
+  });
+
+  it('does not inherit parent apply config into a generic sync Run Now', async () => {
+    (api.getTasks as ReturnType<typeof vi.fn>).mockResolvedValue({ tasks: [makeSyncTask()] });
+    (api.runTask as ReturnType<typeof vi.fn>).mockResolvedValue(
+      runResult({ success: true, message: 'Preview complete' })
+    );
+
+    render(<ScheduledTasksSection />);
+    fireEvent.click(await screen.findByRole('button', { name: /run now/i }));
+
+    await waitFor(() => expect(api.runTask).toHaveBeenCalledWith(
+      'dbas_sync_7',
+      undefined,
+      undefined,
+    ));
   });
 });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2918,6 +2918,7 @@ export interface TaskParameterSchema {
   label: string;
   description: string;
   default?: unknown;
+  required?: boolean;
   min?: number;
   max?: number;
   source?: string;  // e.g., 'channel_groups', 'm3u_accounts', 'epg_sources'


### PR DESCRIPTION
## Summary
- keep generic manual Sync now in preview mode
- require schedule-local human opt-in and server-bound destination authorization
- isolate co-due schedule parameters and fail closed on malformed or stale authorization
- enforce admin controls and accessible destructive-action confirmation

## Tracking
- enhancedchannelmanager-s675b

## Verification
- frozen code and security reviews approved at a393a956
- independent backend gate passed with 92.27% coverage
- independent frontend gate: 3,570 tests, lint, typecheck, and production build passed