### PR TITLE
fix: resolve MCP startup settings warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,9 @@ volumes:
 as shown, then recreate. Recreating the containers alone is not enough. The
 sidecar images from v0.18.1 onward default `MCP_SECRETS_DIR` to
 `/run/secrets/ecm-mcp`, so without that volume the sidecar finds an empty
-directory and reports `api_key_status: file_not_found` permanently. After both
-services are recreated with the shared volume, ECM publishes an existing key
-from `settings.json` during backend startup. Generate a key under **Settings >
-MCP Integration** only if one was not already configured; saving settings or
-regenerating the key also republishes the projection.
+directory and reports `api_key_status: file_not_found` permanently. Generate or
+regenerate the key under **Settings > MCP Integration** once the volume is in
+place; that is what publishes the projection.
 
 Or if you're building from source, use the MCP compose overlay:
 

--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@ volumes:
 as shown, then recreate. Recreating the containers alone is not enough. The
 sidecar images from v0.18.1 onward default `MCP_SECRETS_DIR` to
 `/run/secrets/ecm-mcp`, so without that volume the sidecar finds an empty
-directory and reports `api_key_status: file_not_found` permanently. Generate or
-regenerate the key under **Settings > MCP Integration** once the volume is in
-place; that is what publishes the projection.
+directory and reports `api_key_status: file_not_found` permanently. After both
+services are recreated with the shared volume, ECM publishes an existing key
+from `settings.json` during backend startup. Generate a key under **Settings >
+MCP Integration** only if one was not already configured; saving settings or
+regenerating the key also republishes the projection.
 
 Or if you're building from source, use the MCP compose overlay:
 

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -22,6 +22,7 @@ from config import (
     normalize_mcp_allowed_host,
 )
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.server import Settings as FastMCPSettings
 from mcp.server.transport_security import TransportSecuritySettings
 
 # MCP OAuth offering RETIRED (bd-9axgc). The OAuth Resource-Server verify path
@@ -50,6 +51,11 @@ logger = logging.getLogger(__name__)
 
 # Create MCP server using the high-level FastMCP API.
 #
+# MCP 1.29.0 leaves Settings.lifespan as an unresolved forward reference even
+# after its module has finished importing. Rebuild that dependency model before
+# FastMCP constructs it so pydantic-settings can inspect the field correctly.
+FastMCPSettings.model_rebuild()
+
 _MCP_SDK_ALLOWED_HOSTS = [
     variant
     for host in MCP_ALLOWED_HOSTS

--- a/mcp-server/tests/test_startup_warnings.py
+++ b/mcp-server/tests/test_startup_warnings.py
@@ -1,0 +1,25 @@
+"""Regression tests for warnings emitted while constructing the MCP server."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+MCP_SERVER_DIR = Path(__file__).resolve().parents[1]
+
+
+def test_import_does_not_emit_incomplete_field_definition_warning(tmp_path) -> None:
+    completed = subprocess.run(
+        [sys.executable, "-W", "always", "-c", "import server"],
+        cwd=MCP_SERVER_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            **os.environ,
+            "MCP_SECRETS_DIR": str(tmp_path),
+        },
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "IncompleteFieldDefinitionWarning" not in completed.stderr


### PR DESCRIPTION
## Summary
- rebuild the MCP SDK FastMCP Settings model before server construction
- resolve the mcp 1.29.0 lifespan forward reference without filtering warnings
- leave credential projection, health, bind, Compose, and permissions behavior unchanged

## Tracking
- enhancedchannelmanager-71von

## Verification
- frozen code review approved at 44df35b1
- independent MCP suite: 753 passed
- exact warning regression included

The separately reported disconnected/503 deployments require applying the current Compose overlay; this PR does not weaken or bypass that deployment contract.