### PR TITLE
v0.18.1-0165: Stop logging trusted-network values (dz5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **Malformed trusted-media-network settings no longer echo their raw values into attribution debug logs (bead `enhancedchannelmanager-dz5`, build 0165).** The skip diagnostic remains available using fixed text only.
+
 - **Supported MCP Compose deployments now reconcile the owner-only API-key authority before readiness instead of leaving the sidecar permanently not ready (bead `enhancedchannelmanager-71von`, build 0164).** Fresh installs and upgrades use the canonical credential lifecycle to provision or republish `api-key` without requiring an operator API call, while explicit revocation remains revoked and `/health` remains fail-closed. The container gate now proves both fresh startup and recreation from persisted settings. Startup also leaves syntactically valid non-object `settings.json` content byte-for-byte intact: authority validation and orphan reconciliation still run, but startup-only settings writers are suppressed so recovery evidence is not replaced by defaults.
 
 ### Added

--- a/backend/main.py
+++ b/backend/main.py
@@ -150,7 +150,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.1-0164",
+    version="0.18.1-0165",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -124,7 +124,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.1-0164"
+APP_VERSION = "0.18.1-0165"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/services/attribution_reconciler.py
+++ b/backend/services/attribution_reconciler.py
@@ -506,10 +506,7 @@ def _parse_networks(cidrs: list[str]) -> list[ipaddress._BaseNetwork]:
         try:
             networks.append(ipaddress.ip_network(token, strict=False))
         except ValueError:
-            logger.debug(
-                "[ATTR-RECONCILE] Skipping unparsable trusted-network entry %r",
-                token,
-            )
+            logger.debug("[ATTR-RECONCILE] Skipping unparsable trusted-network entry")
     return networks
 
 

--- a/backend/tests/services/test_attribution_reconciler.py
+++ b/backend/tests/services/test_attribution_reconciler.py
@@ -23,6 +23,8 @@ Synthetic identities only.
 """
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from services.attribution_reconciler import (
@@ -89,6 +91,23 @@ def _assigned_names(result) -> dict[str, str | None]:
         a.client_id: (a.user.user_name if a.user else None)
         for a in result.assignments
     }
+
+
+def test_malformed_trusted_network_log_does_not_retain_input(caplog):
+    sensitive_value = "username:provider-password@example.invalid"
+
+    with caplog.at_level(logging.DEBUG, logger="services.attribution_reconciler"):
+        assert build_trusted_networks(configured_cidrs=[sensitive_value]) == []
+
+    records = [
+        record
+        for record in caplog.records
+        if record.name == "services.attribution_reconciler"
+    ]
+    assert [record.getMessage() for record in records] == [
+        "[ATTR-RECONCILE] Skipping unparsable trusted-network entry"
+    ]
+    assert all(sensitive_value not in repr(record.args) for record in records)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_attribution_reconciler.py
+++ b/backend/tests/services/test_attribution_reconciler.py
@@ -27,6 +27,7 @@ import logging
 
 import pytest
 
+from observability import JsonFormatter
 from services.attribution_reconciler import (
     AMBIGUOUS_GROUP_PREDICATE,
     CandidateUser,
@@ -108,6 +109,7 @@ def test_malformed_trusted_network_log_does_not_retain_input(caplog):
         "[ATTR-RECONCILE] Skipping unparsable trusted-network entry"
     ]
     assert all(sensitive_value not in repr(record.args) for record in records)
+    assert all(sensitive_value not in JsonFormatter().format(record) for record in records)
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.1-0164",
+  "version": "0.18.1-0165",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## enhancedchannelmanager-dz5

### What
Removes raw malformed trusted-network values from the attribution reconciler debug log while retaining a fixed-vocabulary skip diagnostic. Adds a regression test that proves credential-shaped input is absent from both the rendered log message and logger arguments. Bumps the required version touchpoints to `0.18.1-0165` and records the fix in the changelog.

### Why
Fixes GitHub CodeQL alert 1948 (`py/clear-text-logging-sensitive-data`, High): operator-configured `trusted_media_networks` entries flow through the persisted bandwidth and live stats attribution paths into `_parse_networks`, which previously logged malformed entries verbatim.

Alert: https://github.com/MotWakorb/enhancedchannelmanager/security/code-scanning/1948

### Verification
- Red-first regression: failed before the sink change because the credential-shaped input appeared in the DEBUG message; passes after the fix.
- Focused backend tests: 119 passed.
- Canonical backend gate: 11,833 passed, 3 skipped, 2 deselected; 79.80% coverage.
- Frontend: lint and typecheck passed; 3,589 tests passed; production build passed.
- Python syntax compile passed.
- `scripts/generate_sbom.py verify` passed; no dependency manifest changed, so regeneration was not required.

### Security
- Raw settings values, credentials, identifiers, and aggregates are not logged by the changed diagnostic.
- No dependency or infrastructure changes.

### Deployment
No migration or operator action required. Rollback is a revert of commit `29f60c34e6b149ff497066c6fe12a3da31a13fbf`.

Do not merge from this PR creation session; parent owns review and merge authorization.