### PR TITLE
enhancedchannelmanager-ylg1r: Fail closed on paginated CodeQL alerts

### DIFF
--- a/.github/workflows/release-cut-gate.yml
+++ b/.github/workflows/release-cut-gate.yml
@@ -189,11 +189,15 @@ jobs:
           # is the GitHub-normalized severity (vs. .rule.severity which is
           # the CodeQL native level). HIGH and CRITICAL are the gating tiers
           # per ADR-004 G1b.
-          alerts=$(gh api --paginate 'repos/${{ github.repository }}/code-scanning/alerts?state=open&per_page=100' \
-            --jq '[.[] | select(.rule.security_severity_level == "high" or .rule.security_severity_level == "critical")
-                       | {number, severity: .rule.security_severity_level, rule_id: .rule.id, html_url}]')
+          all_alerts=$(gh api --paginate 'repos/${{ github.repository }}/code-scanning/alerts?state=open&per_page=100' \
+            | jq -se 'if length > 0 and all(.[]; type == "array") then add
+                      else error("CodeQL API must return one or more JSON array pages") end')
+          alerts=$(printf '%s\n' "$all_alerts" | jq -e \
+            '[.[] | select(.rule.security_severity_level == "high" or .rule.security_severity_level == "critical")
+                  | {number, severity: .rule.security_severity_level, rule_id: .rule.id, html_url}]')
 
-          count=$(echo "$alerts" | jq 'length')
+          count=$(printf '%s\n' "$alerts" | jq -er \
+            'if type == "array" then length else error("filtered CodeQL alerts must be an array") end')
           if [[ "$count" -gt 0 ]]; then
             echo "::error::G1b FAIL: $count open HIGH/CRITICAL CodeQL alert(s) not dismissed."
             echo "Open alerts:"

--- a/backend/tests/unit/test_release_gate_policy.py
+++ b/backend/tests/unit/test_release_gate_policy.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = Path(
@@ -17,6 +20,18 @@ SCRIPT = Path(
 )
 WORKFLOW = ROOT / ".github" / "workflows" / "release-cut-gate.yml"
 
+FAKE_GH = """#!/bin/sh
+printf '%s' "$GH_TEST_OUTPUT"
+exit "$GH_TEST_EXIT_CODE"
+"""
+
+FAKE_COUNT_JQ = """#!/bin/sh
+if [ "$1" = "-er" ]; then
+    exit 23
+fi
+exec "$GH_TEST_REAL_JQ" "$@"
+"""
+
 
 @pytest.fixture(scope="module")
 def policy():
@@ -25,6 +40,49 @@ def policy():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _g1b_script() -> str:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["release-cut-gate"]["steps"]
+    return next(step["run"] for step in steps if step.get("name", "").startswith("G1b"))
+
+
+def _run_g1b(
+    tmp_path: Path,
+    pages: list[object],
+    *,
+    raw_output: str | None = None,
+    gh_exit_code: int = 0,
+    count_failure: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(FAKE_GH, encoding="utf-8")
+    gh.chmod(0o755)
+    output = raw_output
+    if output is None:
+        output = "".join(f"{json.dumps(page)}\n" for page in pages)
+    env = os.environ | {
+        "GH_TEST_OUTPUT": output,
+        "GH_TEST_EXIT_CODE": str(gh_exit_code),
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+    }
+    if count_failure:
+        real_jq = shutil.which("jq")
+        assert real_jq
+        jq = bin_dir / "jq"
+        jq.write_text(FAKE_COUNT_JQ, encoding="utf-8")
+        jq.chmod(0o755)
+        env["GH_TEST_REAL_JQ"] = real_jq
+    return subprocess.run(
+        ["bash", "-c", _g1b_script()],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
 
 
 @pytest.mark.parametrize(
@@ -123,3 +181,79 @@ def test_workflow_consumes_dedicated_authoritative_board_and_policy_helper():
     assert "scripts/release_gate_policy.py check-board" in workflow
     assert "--status open" not in workflow
     assert "gates skipped, passing" not in workflow
+
+
+@pytest.mark.parametrize("severity", ["high", "critical"])
+def test_g1b_blocks_high_alert_on_later_api_page(tmp_path, severity):
+    result = _run_g1b(
+        tmp_path,
+        [
+            [],
+            [
+                {
+                    "number": 42,
+                    "rule": {
+                        "security_severity_level": severity,
+                        "id": "py/example-gating-alert",
+                    },
+                    "html_url": "https://example.invalid/alerts/42",
+                }
+            ],
+        ],
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "G1b FAIL: 1 open HIGH/CRITICAL CodeQL alert" in result.stdout
+    assert "G1b PASS" not in result.stdout
+
+
+def test_g1b_passes_with_no_qualifying_alerts_across_pages(tmp_path):
+    result = _run_g1b(
+        tmp_path,
+        [
+            [
+                {
+                    "number": 1,
+                    "rule": {
+                        "security_severity_level": "medium",
+                        "id": "py/example-medium",
+                    },
+                    "html_url": "https://example.invalid/alerts/1",
+                }
+            ],
+            [],
+        ],
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "G1b PASS: 0 open HIGH/CRITICAL CodeQL alerts" in result.stdout
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize(
+    "raw_output",
+    [
+        "not-json\n",
+        '{"message":"unexpected API response"}\n',
+        "",
+    ],
+)
+def test_g1b_fails_closed_on_malformed_or_non_array_api_output(tmp_path, raw_output):
+    result = _run_g1b(tmp_path, [], raw_output=raw_output)
+
+    assert result.returncode != 0
+    assert "G1b PASS" not in result.stdout
+
+
+def test_g1b_fails_closed_when_api_request_fails(tmp_path):
+    result = _run_g1b(tmp_path, [[]], gh_exit_code=22)
+
+    assert result.returncode != 0
+    assert "G1b PASS" not in result.stdout
+
+
+def test_g1b_fails_closed_when_count_fails(tmp_path):
+    result = _run_g1b(tmp_path, [[]], count_failure=True)
+
+    assert result.returncode != 0
+    assert "G1b PASS" not in result.stdout


### PR DESCRIPTION
## What

Fixes the required Release Cut Gate G1b pagination path so every GitHub API page is aggregated and validated before HIGH/CRITICAL filtering and numeric counting.

## Why

PR #938 run 33267212798 job 99139294514 received two empty alert pages. The existing `gh api --paginate --jq` invocation emitted `[]\n[]`; `jq length` produced `0\n0`; Bash logged an arithmetic syntax error inside the `if` condition and still printed `G1b PASS`. The current candidate independently has zero HIGH/CRITICAL CodeQL alerts, but the required gate was fail-open and could not prove that state.

Bead: `enhancedchannelmanager-ylg1r`
Parent release candidate: `af366a2495712a0cdf59fbd8ce282c03c7de4f82`
Fix commit: `39efdeed585865267304c627d4e9e6bcf1c8d779`

## Implementation

- Slurp one or more paginated JSON-array responses and reject empty, malformed, or non-array output.
- Flatten pages before filtering.
- Require the filtered result to remain an array and the count to be one raw integer.
- Exercise the exact workflow shell step through YAML extraction with multipage fixtures and explicit failure injection.

## Verification

- [x] Red-first dangerous mutant reproduced the false PASS with a later-page HIGH/CRITICAL alert.
- [x] Release-gate policy tests: 27 passed.
- [x] MCP supply-chain policy tests: 17 passed.
- [x] MCP supply-chain checker: PASS.
- [x] `git diff --check`: PASS.
- [x] Independent code review: Approved, no findings.
- [x] Independent security review: Approved; no Critical/High/Medium blockers.

## Security Review Residuals

- Low/P2: malformed individual alert objects can be ignored if GitHub returns a valid page array with missing fields. GitHub API schema plus separate exact-head CodeQL checks mitigate this; it is not release-blocking for the scoped pagination fix.
- Informational/P3: additional one-page and per-jq-stage failure fixtures would deepen defense-in-depth test coverage.

## Rollback

Revert `39efdeed`. Reverting restores the known fail-open G1b behavior, so release cuts must remain stopped unless a replacement fix is present.