### PR TITLE
enhancedchannelmanager-ub0aw: Roll v0.18.1 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-## [0.18.1] — 2026-08-29
+## [0.18.1] — 2026-08-30
 
 ### Security
 


### PR DESCRIPTION
## What

Updates only the `v0.18.1` changelog heading date from `2026-08-29` to `2026-08-30`.

## Why

The release cut crossed UTC midnight during stabilization. PR #938 Release Cut Gate run `33290311523` failed G5 because the documented gate compares the heading against the current UTC date. G5 stopped before the corrected G1b implementation could execute live.

Bead: `enhancedchannelmanager-ub0aw`
Parent release head: `f1fbaa880c1ac74dfc5d2808fd80101a8ca7f1f0`
Commit: `a45e2a164f0c87463d116123ac337cfde179d890`

## Verification

- [x] Exact committed diff is one line in `CHANGELOG.md`.
- [x] Empty `[Unreleased]` remains above `[0.18.1]`.
- [x] `[Unreleased]` and `[0.18.1]` links remain correct.
- [x] Release SBOM verify passes.
- [x] All-SBOM audit passes.
- [x] `git diff --check` passes.
- [x] Independent code review approved with no findings.

Full backend/frontend gates were not rerun because no executable, dependency, version, or SBOM input changed. PR #938 will rerun its full required checks after this merge.

## Rollback

Revert `a45e2a16`. Reverting while UTC remains `2026-08-30` restores the known G5 failure.