### PR TITLE
v0.18.2-0002: repair reusable publish verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
   **Not included:** no score preview or explanation UI, no profiles, no compound rule groups, no per-channel profiles, no SQL migrations, and no new dependencies.
 
+### Fixed
+
+- **Post-merge dev publication checks now follow the actual reusable workflow and fail closed on incomplete evidence (bead `enhancedchannelmanager-69dxb`, build 0002).** The checker selects the exact successful `Tests` push attempt and its final reusable manifest job, requires the current mutable tag to contain exactly matching AMD64 and ARM64 version/full-commit markers, and treats a fresh pull as an additional marker cross-check rather than a fallback. Malformed API or manifest data, duplicate markers, missing platforms, command failures, and a request to skip both checks now return actionable failures. The result is explicitly a point-in-time consistency check that trusts registry writers, not cryptographic workflow-to-image attestation.
+
 ## [0.18.1] — 2026-08-30
 
 ### Security

--- a/backend/main.py
+++ b/backend/main.py
@@ -157,7 +157,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0001",
+    version="0.18.2-0002",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -131,7 +131,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0001"
+APP_VERSION = "0.18.2-0002"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/tests/unit/test_check_publish.py
+++ b/backend/tests/unit/test_check_publish.py
@@ -220,6 +220,29 @@ class TestSelectBuildRun:
     def test_returns_none_for_an_empty_list(self, script):
         assert script.select_build_run([], "Tests", "dev", TEST_SHA) is None
 
+    @pytest.mark.parametrize("field", ["id", "run_number", "run_attempt"])
+    @pytest.mark.parametrize(
+        "value",
+        [None, 0, -1, True, "1", 1.5],
+        ids=["missing", "zero", "negative", "bool", "string", "float"],
+    )
+    def test_rejects_non_positive_integer_candidate_metadata(
+        self, script, field, value
+    ):
+        run = _run(21)
+        run[field] = value
+        with pytest.raises(script.CheckError, match=rf"{field}.*positive integer"):
+            script.select_build_run([run], "Tests", "dev", TEST_SHA)
+
+    def test_mixed_candidate_metadata_never_raises_raw_type_error(self, script):
+        runs = [_run(22), _run(23) | {"run_number": "23"}]
+        with pytest.raises(script.CheckError, match="run_number.*positive integer"):
+            script.select_build_run(runs, "Tests", "dev", TEST_SHA)
+
+    def test_malformed_unrelated_run_is_ignored(self, script):
+        runs = [_run(24), _run(25, name="Other") | {"run_number": "bad"}]
+        assert script.select_build_run(runs, "Tests", "dev", TEST_SHA) == runs[0]
+
 
 class TestSelectPublishJob:
     def test_selects_live_0001_nested_manifest_job(self, script):
@@ -319,27 +342,26 @@ class TestParseImagetoolsConfig:
         assert env["GIT_COMMIT"] == TEST_SHA
         assert env[script.PLATFORMS_KEY] == "linux/amd64, linux/arm64"
 
-    def test_parses_a_single_platform_config(self, script):
+    def test_rejects_a_single_platform_config(self, script):
         payload = json.dumps(
-            {
-                "created": "now",
-                "config": {
-                    "Env": ["ECM_VERSION=0.18.1-0044", f"GIT_COMMIT={TEST_SHA}"]
-                },
-            }
+            {"config": {"Env": ["ECM_VERSION=0.18.1-0044", f"GIT_COMMIT={TEST_SHA}"]}}
         )
-        assert script.parse_imagetools_config(payload)["ECM_VERSION"] == "0.18.1-0044"
+        with pytest.raises(script.CheckError, match="linux/amd64.*linux/arm64"):
+            script.parse_imagetools_config(payload)
 
     def test_env_entries_with_equals_signs_in_the_value_survive(self, script):
         payload = json.dumps(
             {
-                "config": {
-                    "Env": [
-                        "OPTS=a=b=c",
-                        "ECM_VERSION=0.1.0-0001",
-                        f"GIT_COMMIT={TEST_SHA}",
-                    ]
+                platform: {
+                    "config": {
+                        "Env": [
+                            "OPTS=a=b=c",
+                            "ECM_VERSION=0.1.0-0001",
+                            f"GIT_COMMIT={TEST_SHA}",
+                        ]
+                    }
                 }
+                for platform in ("linux/amd64", "linux/arm64")
             }
         )
         env = script.parse_imagetools_config(payload)
@@ -379,6 +401,75 @@ class TestParseImagetoolsConfig:
         }
         with pytest.raises(script.CheckError, match="disagree"):
             script.parse_imagetools_config(json.dumps(payload))
+
+    @pytest.mark.parametrize("marker", ["ECM_VERSION", "GIT_COMMIT"])
+    @pytest.mark.parametrize("duplicate_value", ["same", "different"])
+    def test_rejects_duplicate_provenance_marker_per_platform(
+        self, script, marker, duplicate_value
+    ):
+        values = {"ECM_VERSION": TEST_VERSION, "GIT_COMMIT": TEST_SHA}
+        duplicate = values[marker] if duplicate_value == "same" else "conflict"
+        payload = {
+            platform: {
+                "config": {
+                    "Env": [
+                        f"ECM_VERSION={TEST_VERSION}",
+                        f"GIT_COMMIT={TEST_SHA}",
+                        f"{marker}={duplicate}",
+                    ]
+                }
+            }
+            for platform in ("linux/amd64", "linux/arm64")
+        }
+        with pytest.raises(
+            script.CheckError, match=rf"linux/amd64.*duplicate {marker}"
+        ):
+            script.parse_imagetools_config(json.dumps(payload))
+
+    @pytest.mark.parametrize(
+        "platforms",
+        [
+            ["linux/amd64"],
+            ["linux/amd64", "linux/s390x"],
+            ["linux/amd64", "linux/arm64", "linux/s390x"],
+            ["linux/amd64/v8", "linux/arm64"],
+        ],
+        ids=[
+            "missing-arm64",
+            "wrong-platform",
+            "unexpected-platform",
+            "malformed-platform",
+        ],
+    )
+    def test_requires_exact_ecm_platform_set(self, script, platforms):
+        payload = {
+            platform: {
+                "config": {
+                    "Env": [f"ECM_VERSION={TEST_VERSION}", f"GIT_COMMIT={TEST_SHA}"]
+                }
+            }
+            for platform in platforms
+        }
+        with pytest.raises(
+            script.CheckError, match="expected.*linux/amd64.*linux/arm64"
+        ):
+            script.parse_imagetools_config(json.dumps(payload))
+
+    def test_rejects_duplicate_platform_key_before_json_collapse(self, script):
+        config = json.dumps(
+            {
+                "config": {
+                    "Env": [f"ECM_VERSION={TEST_VERSION}", f"GIT_COMMIT={TEST_SHA}"]
+                }
+            }
+        )
+        payload = (
+            f'{{"linux/amd64":{config},"linux/amd64":{config},"linux/arm64":{config}}}'
+        )
+        with pytest.raises(
+            script.CheckError, match="duplicate JSON object key.*linux/amd64"
+        ):
+            script.parse_imagetools_config(payload)
 
 
 class TestProcessFailures:
@@ -585,6 +676,43 @@ class TestCommitIsOnBranch:
             script.commit_is_on_branch(TEST_SHA, "dev")
 
 
+class TestRepoSlug:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://github.com/MotWakorb/enhancedchannelmanager.git",
+            "ssh://git@github.com/MotWakorb/enhancedchannelmanager.git",
+            "git@github.com:MotWakorb/enhancedchannelmanager.git",
+        ],
+    )
+    def test_derives_slug_from_supported_github_origin(self, script, monkeypatch, url):
+        monkeypatch.setattr(script, "_git", lambda *args: url + "\n")
+        monkeypatch.setattr(
+            script,
+            "_run",
+            lambda *args, **kwargs: pytest.fail(
+                "repo_slug must not call gh or cwd-sensitive commands"
+            ),
+        )
+        assert script.repo_slug() == "MotWakorb/enhancedchannelmanager"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://gitlab.com/MotWakorb/enhancedchannelmanager.git",
+            "git@github.com:owner.git",
+            "https://github.com/owner/repo/extra",
+            "https://github.com/owner/repo.git?ref=main",
+            "/local/repository",
+            "https://github.com/bad owner/repo.git",
+        ],
+    )
+    def test_rejects_non_github_or_malformed_origin(self, script, monkeypatch, url):
+        monkeypatch.setattr(script, "_git", lambda *args: url + "\n")
+        with pytest.raises(script.CheckError, match="GitHub origin|owner/repo"):
+            script.repo_slug()
+
+
 @pytest.fixture
 def main_boundaries(script, monkeypatch):
     runs = [_run(1921)]
@@ -595,19 +723,41 @@ def main_boundaries(script, monkeypatch):
         script.PLATFORMS_KEY: "linux/amd64, linux/arm64",
     }
     calls = []
-    monkeypatch.setattr(script, "resolve_commit", lambda ref: TEST_SHA)
-    monkeypatch.setattr(script, "commit_subject", lambda sha: "merge subject")
-    monkeypatch.setattr(script, "expected_version_at", lambda sha: TEST_VERSION)
-    monkeypatch.setattr(script, "commit_is_on_branch", lambda sha, branch: True)
-    monkeypatch.setattr(script, "repo_slug", lambda: "owner/repo")
-    monkeypatch.setattr(script, "fetch_workflow_runs", lambda slug, sha: runs)
+    monkeypatch.setattr(
+        script, "resolve_commit", lambda ref: calls.append("resolve") or TEST_SHA
+    )
+    monkeypatch.setattr(
+        script, "commit_subject", lambda sha: calls.append("subject") or "merge subject"
+    )
+    monkeypatch.setattr(
+        script,
+        "expected_version_at",
+        lambda sha: calls.append("version") or TEST_VERSION,
+    )
+    monkeypatch.setattr(
+        script,
+        "commit_is_on_branch",
+        lambda sha, branch: calls.append("orientation") or True,
+    )
+    monkeypatch.setattr(
+        script, "repo_slug", lambda: calls.append("slug") or "owner/repo"
+    )
+    monkeypatch.setattr(
+        script,
+        "fetch_workflow_runs",
+        lambda slug, sha: calls.append("runs") or runs,
+    )
 
     def fetch_jobs(slug, run_id, run_attempt):
-        calls.append((slug, run_id, run_attempt))
+        calls.append(("jobs", slug, run_id, run_attempt))
         return jobs
 
     monkeypatch.setattr(script, "fetch_workflow_jobs", fetch_jobs)
-    monkeypatch.setattr(script, "read_published_marker", lambda ref, use_pull: marker)
+    monkeypatch.setattr(
+        script,
+        "read_published_marker",
+        lambda ref, use_pull: calls.append(("image", use_pull)) or marker,
+    )
     return {"runs": runs, "jobs": jobs, "marker": marker, "calls": calls}
 
 
@@ -617,12 +767,68 @@ class TestMainVerdict:
     ):
         assert script.main(["--commit", TEST_SHA, "--pull"]) == 0
         output = capsys.readouterr().out
-        assert main_boundaries["calls"] == [("owner/repo", 33440983429, 1)]
+        assert ("jobs", "owner/repo", 33440983429, 1) in main_boundaries["calls"]
+        assert ("image", True) in main_boundaries["calls"]
         assert "attempt 1" in output
         assert "reusable publish job succeeded" in output
         assert "linux/amd64, linux/arm64" in output
         assert "GIT_COMMIT matches the exact resolved SHA" in output
         assert "PASS:" in output
+        assert "current mutable tag" in output
+        assert "does not bind image bytes" in output
+        assert "built from a successful" not in output
+
+    @pytest.mark.parametrize(
+        ("args", "result", "workflow_runs", "image_runs", "verdict"),
+        [
+            ([], 0, True, True, "current mutable tag"),
+            (["--skip-workflow"], 0, False, True, "workflow evidence skipped"),
+            (["--skip-image"], 0, True, False, "mutable-tag marker check skipped"),
+            (
+                ["--pull", "--skip-image"],
+                0,
+                True,
+                False,
+                "mutable-tag marker check skipped",
+            ),
+            (
+                ["--skip-workflow", "--skip-image"],
+                2,
+                False,
+                False,
+                "cannot be used together",
+            ),
+        ],
+        ids=[
+            "default",
+            "workflow-only-skip",
+            "image-only-skip",
+            "pull-with-image-skip",
+            "both-skipped",
+        ],
+    )
+    def test_skip_modes_run_only_truthfully_claimed_boundaries(
+        self,
+        script,
+        main_boundaries,
+        capsys,
+        args,
+        result,
+        workflow_runs,
+        image_runs,
+        verdict,
+    ):
+        assert script.main(["--commit", TEST_SHA, *args]) == result
+        calls = main_boundaries["calls"]
+        output = capsys.readouterr()
+        assert ("runs" in calls) is workflow_runs
+        assert (
+            any(isinstance(call, tuple) and call[0] == "image" for call in calls)
+            is image_runs
+        )
+        assert verdict in output.out + output.err
+        if result == 2:
+            assert calls == []
 
     @pytest.mark.parametrize(
         ("status", "conclusion"),

--- a/backend/tests/unit/test_check_publish.py
+++ b/backend/tests/unit/test_check_publish.py
@@ -324,6 +324,13 @@ class TestPaginatedGitHubData:
 
 
 class TestParseImagetoolsConfig:
+    """Manifest invariant: unique object keys; exact platforms; object platform
+    and config values; string-list Env; one of each marker; platform agreement.
+
+    Version and full lowercase SHA equality are enforced by the verdict layer.
+    Every malformed external shape must become an actionable CheckError.
+    """
+
     def test_parses_a_multi_platform_manifest(self, script):
         payload = """
         {
@@ -373,8 +380,89 @@ class TestParseImagetoolsConfig:
             script.parse_imagetools_config("not json")
 
     def test_raises_when_no_config_env_is_present(self, script):
-        with pytest.raises(script.CheckError):
-            script.parse_imagetools_config('{"linux/amd64": {"rootfs": {}}}')
+        payload = {
+            platform: {
+                "config": (
+                    {}
+                    if platform == "linux/amd64"
+                    else {
+                        "Env": [
+                            f"ECM_VERSION={TEST_VERSION}",
+                            f"GIT_COMMIT={TEST_SHA}",
+                        ]
+                    }
+                )
+            }
+            for platform in ("linux/amd64", "linux/arm64")
+        }
+        with pytest.raises(script.CheckError, match="env block for linux/amd64"):
+            script.parse_imagetools_config(json.dumps(payload))
+
+    @pytest.mark.parametrize(
+        ("platform_value", "message"),
+        [
+            ({}, "linux/amd64.*config field"),
+            ({"config": None}, "linux/amd64.*config.*object"),
+            ({"config": []}, "linux/amd64.*config.*object"),
+            ({"config": "invalid"}, "linux/amd64.*config.*object"),
+            ({"config": 17}, "linux/amd64.*config.*object"),
+        ],
+        ids=["absent", "null", "list", "string", "scalar"],
+    )
+    def test_rejects_malformed_config_with_exact_platform_set(
+        self, script, platform_value, message
+    ):
+        valid = {
+            "config": {
+                "Env": [
+                    f"ECM_VERSION={TEST_VERSION}",
+                    f"GIT_COMMIT={TEST_SHA}",
+                ]
+            }
+        }
+        payload = {"linux/amd64": platform_value, "linux/arm64": valid}
+        with pytest.raises(script.CheckError, match=message):
+            script.parse_imagetools_config(json.dumps(payload))
+
+    @pytest.mark.parametrize("platform_value", [None, [], "invalid", 17])
+    def test_rejects_non_object_platform_value(self, script, platform_value):
+        payload = {
+            "linux/amd64": platform_value,
+            "linux/arm64": {
+                "config": {
+                    "Env": [
+                        f"ECM_VERSION={TEST_VERSION}",
+                        f"GIT_COMMIT={TEST_SHA}",
+                    ]
+                }
+            },
+        }
+        with pytest.raises(
+            script.CheckError, match="platform linux/amd64 value.*object"
+        ):
+            script.parse_imagetools_config(json.dumps(payload))
+
+    @pytest.mark.parametrize("env", [None, "invalid", ["ECM_VERSION=valid", 17]])
+    def test_rejects_env_that_is_not_a_list_of_strings(self, script, env):
+        payload = {
+            platform: {
+                "config": {
+                    "Env": (
+                        env
+                        if platform == "linux/amd64"
+                        else [
+                            f"ECM_VERSION={TEST_VERSION}",
+                            f"GIT_COMMIT={TEST_SHA}",
+                        ]
+                    )
+                }
+            }
+            for platform in ("linux/amd64", "linux/arm64")
+        }
+        with pytest.raises(
+            script.CheckError, match="env block for linux/amd64.*list of strings"
+        ):
+            script.parse_imagetools_config(json.dumps(payload))
 
     @pytest.mark.parametrize("marker", ["ECM_VERSION", "GIT_COMMIT"])
     def test_rejects_marker_missing_from_any_platform(self, script, marker):

--- a/backend/tests/unit/test_check_publish.py
+++ b/backend/tests/unit/test_check_publish.py
@@ -13,6 +13,7 @@ a single-branch, depth-1 clone that carries no remote-tracking refs at
 all. A test for a git helper must supply its own git history: borrowing
 the ambient repository's shape tests the checkout, not the code.
 """
+
 from __future__ import annotations
 
 import importlib.util
@@ -129,16 +130,45 @@ def repo(tmp_path, script, monkeypatch) -> FakeRepo:
     return fake
 
 
-def _run(number, *, event="push", branch="dev", name=None, attempt=1, conclusion="success"):
+TEST_SHA = "a" * 40
+TEST_VERSION = "0.18.2-0001"
+
+
+def _run(
+    number,
+    *,
+    event="push",
+    branch="dev",
+    name=None,
+    attempt=1,
+    status="completed",
+    conclusion="success",
+):
     return {
-        "name": name or "Publish Verified Images",
+        "id": 33440983429,
+        "name": name or "Tests",
+        "head_sha": TEST_SHA,
         "head_branch": branch,
         "event": event,
         "run_number": number,
         "run_attempt": attempt,
-        "status": "completed",
+        "status": status,
         "conclusion": conclusion,
         "html_url": f"https://example.invalid/runs/{number}",
+    }
+
+
+def _job(
+    name="Publish Verified Dev Images / Publish Verified Multi-Arch Manifests",
+    *,
+    status="completed",
+    conclusion="success",
+):
+    return {
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "html_url": "https://example.invalid/jobs/98294803170",
     }
 
 
@@ -148,7 +178,7 @@ def _run(number, *, event="push", branch="dev", name=None, attempt=1, conclusion
 class TestSelectBuildRun:
     def test_picks_the_matching_push_run(self, script):
         runs = [_run(10)]
-        chosen = script.select_build_run(runs, "Publish Verified Images", "dev")
+        chosen = script.select_build_run(runs, "Tests", "dev", TEST_SHA)
         assert chosen is not None and chosen["run_number"] == 10
 
     def test_ignores_pull_request_runs_for_the_same_sha(self, script):
@@ -159,18 +189,22 @@ class TestSelectBuildRun:
             _run(11, event="pull_request", branch="feature", conclusion="success"),
             _run(12, event="push", conclusion="failure"),
         ]
-        chosen = script.select_build_run(runs, "Publish Verified Images", "dev")
+        chosen = script.select_build_run(runs, "Tests", "dev", TEST_SHA)
         assert chosen is not None
         assert chosen["run_number"] == 12
         assert chosen["conclusion"] == "failure"
 
     def test_ignores_other_workflows(self, script):
-        runs = [_run(13, name="Tests")]
-        assert script.select_build_run(runs, "Publish Verified Images", "dev") is None
+        runs = [_run(13, name="Build and Push Docker Image")]
+        assert script.select_build_run(runs, "Tests", "dev", TEST_SHA) is None
 
     def test_ignores_runs_on_another_branch(self, script):
         runs = [_run(14, branch="main")]
-        assert script.select_build_run(runs, "Publish Verified Images", "dev") is None
+        assert script.select_build_run(runs, "Tests", "dev", TEST_SHA) is None
+
+    def test_ignores_api_result_for_a_different_sha(self, script):
+        runs = [_run(15) | {"head_sha": "b" * 40}]
+        assert script.select_build_run(runs, "Tests", "dev", TEST_SHA) is None
 
     def test_prefers_the_latest_attempt_of_a_rerun(self, script):
         """A re-run that fixes a flake is the state of record, not the
@@ -180,11 +214,87 @@ class TestSelectBuildRun:
             _run(20, attempt=1, conclusion="failure"),
             _run(20, attempt=2, conclusion="success"),
         ]
-        chosen = script.select_build_run(runs, "Publish Verified Images", "dev")
+        chosen = script.select_build_run(runs, "Tests", "dev", TEST_SHA)
         assert chosen is not None and chosen["run_attempt"] == 2
 
     def test_returns_none_for_an_empty_list(self, script):
-        assert script.select_build_run([], "Publish Verified Images", "dev") is None
+        assert script.select_build_run([], "Tests", "dev", TEST_SHA) is None
+
+
+class TestSelectPublishJob:
+    def test_selects_live_0001_nested_manifest_job(self, script):
+        jobs = [
+            _job(name="Publish Verified Dev Images / Authorize Exact-SHA Publication"),
+            _job(name="Publish Verified Dev Images / Publish Images (AMD64)"),
+            _job(name="Publish Verified Dev Images / Publish Images (ARM64)"),
+            _job(),
+        ]
+        assert script.select_publish_job(jobs) == jobs[-1]
+
+    def test_rejects_missing_or_similarly_named_job(self, script):
+        jobs = [_job(name="Publish Verified Dev Images / Publish Images (AMD64)")]
+        assert script.select_publish_job(jobs) is None
+
+    def test_rejects_duplicate_exact_jobs(self, script):
+        with pytest.raises(script.CheckError, match="2 jobs"):
+            script.select_publish_job([_job(), _job()])
+
+
+class TestPaginatedGitHubData:
+    @pytest.mark.parametrize(
+        ("fetch", "key", "endpoint"),
+        [
+            ("runs", "workflow_runs", "actions/runs?head_sha=" + TEST_SHA),
+            ("jobs", "jobs", "actions/runs/123/attempts/4/jobs"),
+        ],
+    )
+    def test_combines_every_page(self, script, monkeypatch, fetch, key, endpoint):
+        calls = []
+        first = _run(10, name="Other") if key == "workflow_runs" else _job(name="Other")
+        second = _run(11) if key == "workflow_runs" else _job()
+
+        def fake_run(cmd, *, timeout=300):
+            calls.append(cmd)
+            stdout = json.dumps({key: [first]}) + "\n" + json.dumps({key: [second]})
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(script.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(script, "_run", fake_run)
+        if fetch == "runs":
+            result = script.fetch_workflow_runs("owner/repo", TEST_SHA)
+        else:
+            result = script.fetch_workflow_jobs("owner/repo", 123, 4)
+
+        assert result == [first, second]
+        assert "--paginate" in calls[0]
+        assert any(endpoint in part for part in calls[0])
+
+    @pytest.mark.parametrize(
+        "payload",
+        ["not-json", "[]", '{"workflow_runs": {}}', '{"workflow_runs": [null]}'],
+    )
+    def test_malformed_run_pagination_fails_closed(self, script, monkeypatch, payload):
+        monkeypatch.setattr(script.shutil, "which", lambda name: "/usr/bin/gh")
+        monkeypatch.setattr(
+            script,
+            "_run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                cmd, 0, stdout=payload, stderr=""
+            ),
+        )
+        with pytest.raises(script.CheckError, match="gh api|paginated|workflow_runs"):
+            script.fetch_workflow_runs("owner/repo", TEST_SHA)
+
+    def test_malformed_attempt_job_pagination_fails_closed(self, script, monkeypatch):
+        monkeypatch.setattr(
+            script,
+            "_run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                cmd, 0, stdout='{"jobs": [null]}', stderr=""
+            ),
+        )
+        with pytest.raises(script.CheckError, match="jobs item 1 is not an object"):
+            script.fetch_workflow_jobs("owner/repo", 123, 4)
 
 
 # --- Image config parsing ---------------------------------------------------
@@ -196,23 +306,42 @@ class TestParseImagetoolsConfig:
         {
           "linux/amd64": {
             "config": {"Env": ["PATH=/bin", "ECM_VERSION=0.18.1-0043",
-                               "GIT_COMMIT=abc1234"]}
+                               "GIT_COMMIT=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]}
           },
           "linux/arm64": {
-            "config": {"Env": ["ECM_VERSION=0.18.1-0043"]}
+            "config": {"Env": ["ECM_VERSION=0.18.1-0043",
+                               "GIT_COMMIT=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]}
           }
         }
         """
         env = script.parse_imagetools_config(payload)
         assert env["ECM_VERSION"] == "0.18.1-0043"
-        assert env["GIT_COMMIT"] == "abc1234"
+        assert env["GIT_COMMIT"] == TEST_SHA
+        assert env[script.PLATFORMS_KEY] == "linux/amd64, linux/arm64"
 
     def test_parses_a_single_platform_config(self, script):
-        payload = '{"created": "now", "config": {"Env": ["ECM_VERSION=0.18.1-0044"]}}'
+        payload = json.dumps(
+            {
+                "created": "now",
+                "config": {
+                    "Env": ["ECM_VERSION=0.18.1-0044", f"GIT_COMMIT={TEST_SHA}"]
+                },
+            }
+        )
         assert script.parse_imagetools_config(payload)["ECM_VERSION"] == "0.18.1-0044"
 
     def test_env_entries_with_equals_signs_in_the_value_survive(self, script):
-        payload = '{"config": {"Env": ["OPTS=a=b=c", "ECM_VERSION=0.1.0-0001"]}}'
+        payload = json.dumps(
+            {
+                "config": {
+                    "Env": [
+                        "OPTS=a=b=c",
+                        "ECM_VERSION=0.1.0-0001",
+                        f"GIT_COMMIT={TEST_SHA}",
+                    ]
+                }
+            }
+        )
         env = script.parse_imagetools_config(payload)
         assert env["OPTS"] == "a=b=c"
         assert env["ECM_VERSION"] == "0.1.0-0001"
@@ -224,6 +353,100 @@ class TestParseImagetoolsConfig:
     def test_raises_when_no_config_env_is_present(self, script):
         with pytest.raises(script.CheckError):
             script.parse_imagetools_config('{"linux/amd64": {"rootfs": {}}}')
+
+    @pytest.mark.parametrize("marker", ["ECM_VERSION", "GIT_COMMIT"])
+    def test_rejects_marker_missing_from_any_platform(self, script, marker):
+        complete = {"ECM_VERSION": TEST_VERSION, "GIT_COMMIT": TEST_SHA}
+        incomplete = {key: value for key, value in complete.items() if key != marker}
+        payload = {
+            "linux/amd64": {
+                "config": {"Env": [f"{k}={v}" for k, v in complete.items()]}
+            },
+            "linux/arm64": {
+                "config": {"Env": [f"{k}={v}" for k, v in incomplete.items()]}
+            },
+        }
+        with pytest.raises(script.CheckError, match=marker):
+            script.parse_imagetools_config(json.dumps(payload))
+
+    @pytest.mark.parametrize("marker", ["ECM_VERSION", "GIT_COMMIT"])
+    def test_rejects_platform_marker_disagreement(self, script, marker):
+        first = {"ECM_VERSION": TEST_VERSION, "GIT_COMMIT": TEST_SHA}
+        second = first | {marker: "different"}
+        payload = {
+            platform: {"config": {"Env": [f"{k}={v}" for k, v in markers.items()]}}
+            for platform, markers in (("linux/amd64", first), ("linux/arm64", second))
+        }
+        with pytest.raises(script.CheckError, match="disagree"):
+            script.parse_imagetools_config(json.dumps(payload))
+
+
+class TestProcessFailures:
+    def test_timeout_becomes_actionable_check_error(self, script, monkeypatch):
+        monkeypatch.setattr(
+            script.subprocess,
+            "run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+            ),
+        )
+        with pytest.raises(script.CheckError, match="timed out.*17"):
+            script._run(["slow"], timeout=17)
+
+    def test_launch_failure_becomes_actionable_check_error(self, script, monkeypatch):
+        monkeypatch.setattr(
+            script.subprocess,
+            "run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError("missing")),
+        )
+        with pytest.raises(script.CheckError, match="could not launch"):
+            script._run(["missing"])
+
+
+class TestPublishedMarkerRead:
+    def test_pull_is_additive_after_mandatory_manifest_proof(self, script, monkeypatch):
+        events = []
+        marker = {"ECM_VERSION": TEST_VERSION, "GIT_COMMIT": TEST_SHA}
+        monkeypatch.setattr(script.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(
+            script,
+            "read_marker_via_imagetools",
+            lambda ref: events.append("manifest") or marker,
+        )
+        monkeypatch.setattr(
+            script,
+            "read_marker_via_pull",
+            lambda ref: events.append("pull") or marker.copy(),
+        )
+        assert (
+            script.read_published_marker("example/image:dev", use_pull=True) == marker
+        )
+        assert events == ["manifest", "pull"]
+
+    def test_pull_cannot_rescue_failed_manifest_proof(self, script, monkeypatch):
+        pulled = []
+        monkeypatch.setattr(script.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(
+            script,
+            "read_marker_via_imagetools",
+            lambda ref: (_ for _ in ()).throw(script.CheckError("manifest failed")),
+        )
+        monkeypatch.setattr(
+            script, "read_marker_via_pull", lambda ref: pulled.append(ref)
+        )
+        with pytest.raises(script.CheckError, match="manifest failed"):
+            script.read_published_marker("example/image:dev", use_pull=True)
+        assert pulled == []
+
+    @pytest.mark.parametrize("marker", ["ECM_VERSION", "GIT_COMMIT"])
+    def test_pull_markers_must_match_manifest(self, script, monkeypatch, marker):
+        manifest = {"ECM_VERSION": TEST_VERSION, "GIT_COMMIT": TEST_SHA}
+        host = manifest | {marker: "different"}
+        monkeypatch.setattr(script.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(script, "read_marker_via_imagetools", lambda ref: manifest)
+        monkeypatch.setattr(script, "read_marker_via_pull", lambda ref: host)
+        with pytest.raises(script.CheckError, match=marker):
+            script.read_published_marker("example/image:dev", use_pull=True)
 
 
 # --- Repo-side facts --------------------------------------------------------
@@ -238,7 +461,9 @@ class TestExpectedVersion:
         The fixture's working tree says 0.0.0-dirty and each commit says
         something else, so a working-tree read cannot pass this.
         """
-        assert (repo.root / "frontend" / "package.json").read_text().count("0.0.0-dirty")
+        assert (
+            (repo.root / "frontend" / "package.json").read_text().count("0.0.0-dirty")
+        )
         assert script.expected_version_at(repo.tip) == "0.2.0-0002"
         assert script.expected_version_at(repo.first) == "0.1.0-0001"
         assert script.expected_version_at("dev") == "0.2.0-0002"
@@ -279,7 +504,9 @@ class TestExpectedVersion:
         assert "does not exist in this checkout" not in message
 
     def test_malformed_package_json_raises_check_error(self, script, repo):
-        (repo.root / "frontend" / "package.json").write_text("{not json", encoding="utf-8")
+        (repo.root / "frontend" / "package.json").write_text(
+            "{not json", encoding="utf-8"
+        )
         broken = repo.commit("break package.json")
         with pytest.raises(script.CheckError, match="not valid JSON"):
             script.expected_version_at(broken)
@@ -331,3 +558,161 @@ class TestCommitIsOnBranch:
 
     def test_unknown_branch_returns_none(self, script, repo):
         assert script.commit_is_on_branch(repo.tip, "no-such-branch-xyzzy") is None
+
+    def test_rev_parse_operational_error_is_not_a_missing_ref(
+        self, script, monkeypatch
+    ):
+        monkeypatch.setattr(
+            script,
+            "_run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                cmd, 128, stdout="", stderr="fatal: corrupt ref database"
+            ),
+        )
+        with pytest.raises(script.CheckError, match="rev-parse.*corrupt ref database"):
+            script.commit_is_on_branch(TEST_SHA, "dev")
+
+    def test_merge_base_operational_error_is_reported(self, script, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            if "rev-parse" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, stdout=TEST_SHA, stderr="")
+            return subprocess.CompletedProcess(
+                cmd, 2, stdout="", stderr="fatal: invalid commit graph"
+            )
+
+        monkeypatch.setattr(script, "_run", fake_run)
+        with pytest.raises(script.CheckError, match="merge-base.*invalid commit graph"):
+            script.commit_is_on_branch(TEST_SHA, "dev")
+
+
+@pytest.fixture
+def main_boundaries(script, monkeypatch):
+    runs = [_run(1921)]
+    jobs = [_job()]
+    marker = {
+        "ECM_VERSION": TEST_VERSION,
+        "GIT_COMMIT": TEST_SHA,
+        script.PLATFORMS_KEY: "linux/amd64, linux/arm64",
+    }
+    calls = []
+    monkeypatch.setattr(script, "resolve_commit", lambda ref: TEST_SHA)
+    monkeypatch.setattr(script, "commit_subject", lambda sha: "merge subject")
+    monkeypatch.setattr(script, "expected_version_at", lambda sha: TEST_VERSION)
+    monkeypatch.setattr(script, "commit_is_on_branch", lambda sha, branch: True)
+    monkeypatch.setattr(script, "repo_slug", lambda: "owner/repo")
+    monkeypatch.setattr(script, "fetch_workflow_runs", lambda slug, sha: runs)
+
+    def fetch_jobs(slug, run_id, run_attempt):
+        calls.append((slug, run_id, run_attempt))
+        return jobs
+
+    monkeypatch.setattr(script, "fetch_workflow_jobs", fetch_jobs)
+    monkeypatch.setattr(script, "read_published_marker", lambda ref, use_pull: marker)
+    return {"runs": runs, "jobs": jobs, "marker": marker, "calls": calls}
+
+
+class TestMainVerdict:
+    def test_live_0001_topology_passes_exact_attempt_and_markers(
+        self, script, main_boundaries, capsys
+    ):
+        assert script.main(["--commit", TEST_SHA, "--pull"]) == 0
+        output = capsys.readouterr().out
+        assert main_boundaries["calls"] == [("owner/repo", 33440983429, 1)]
+        assert "attempt 1" in output
+        assert "reusable publish job succeeded" in output
+        assert "linux/amd64, linux/arm64" in output
+        assert "GIT_COMMIT matches the exact resolved SHA" in output
+        assert "PASS:" in output
+
+    @pytest.mark.parametrize(
+        ("status", "conclusion"),
+        [("in_progress", None), ("completed", "failure")],
+    )
+    def test_tests_run_must_be_completed_successfully(
+        self, script, main_boundaries, capsys, status, conclusion
+    ):
+        main_boundaries["runs"][0].update(status=status, conclusion=conclusion)
+        assert script.main(["--commit", TEST_SHA]) == 1
+        assert "FAIL:" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        ("status", "conclusion"),
+        [("in_progress", None), ("completed", "failure"), ("completed", "skipped")],
+    )
+    def test_nested_manifest_job_must_be_completed_successfully(
+        self, script, main_boundaries, capsys, status, conclusion
+    ):
+        main_boundaries["jobs"][0].update(status=status, conclusion=conclusion)
+        assert script.main(["--commit", TEST_SHA]) == 1
+        assert "FAIL:" in capsys.readouterr().err
+
+    def test_missing_nested_manifest_job_fails(self, script, main_boundaries, capsys):
+        main_boundaries["jobs"].clear()
+        assert script.main(["--commit", TEST_SHA]) == 1
+        assert "no 'Publish Verified Dev Images" in capsys.readouterr().err
+
+    def test_duplicate_nested_manifest_job_is_incomplete(
+        self, script, main_boundaries, capsys
+    ):
+        main_boundaries["jobs"].append(_job())
+        assert script.main(["--commit", TEST_SHA]) == 1
+        output = capsys.readouterr()
+        assert "2 jobs" in output.err
+        assert "INCOMPLETE:" in output.err
+
+    @pytest.mark.parametrize(
+        "built_from",
+        [None, "unknown", TEST_SHA[:12], "A" * 40, "b" * 40],
+        ids=["missing", "malformed", "abbreviated", "uppercase", "stale"],
+    )
+    def test_git_commit_marker_must_be_exact_full_lowercase_sha(
+        self, script, main_boundaries, capsys, built_from
+    ):
+        if built_from is None:
+            main_boundaries["marker"].pop("GIT_COMMIT")
+        else:
+            main_boundaries["marker"]["GIT_COMMIT"] = built_from
+        assert script.main(["--commit", TEST_SHA]) == 1
+        output = capsys.readouterr()
+        assert "GIT_COMMIT" in output.err
+        assert "FAIL:" in output.err
+
+    def test_version_marker_must_match_target_commit(
+        self, script, main_boundaries, capsys
+    ):
+        main_boundaries["marker"]["ECM_VERSION"] = "0.18.2-0000"
+        assert script.main(["--commit", TEST_SHA]) == 1
+        assert "ECM_VERSION mismatch" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        "boundary",
+        ["fetch_workflow_runs", "fetch_workflow_jobs", "read_published_marker"],
+    )
+    def test_api_or_manifest_error_returns_incomplete(
+        self, script, main_boundaries, monkeypatch, capsys, boundary
+    ):
+        monkeypatch.setattr(
+            script,
+            boundary,
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                script.CheckError("actionable boundary failure")
+            ),
+        )
+        assert script.main(["--commit", TEST_SHA]) == 1
+        output = capsys.readouterr()
+        assert "INCOMPLETE:" in output.err
+        assert "actionable boundary failure" in output.err
+
+    def test_git_orientation_error_is_incomplete_but_other_proof_runs(
+        self, script, main_boundaries, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(
+            script,
+            "commit_is_on_branch",
+            lambda *args: (_ for _ in ()).throw(script.CheckError("git timed out")),
+        )
+        assert script.main(["--commit", TEST_SHA]) == 1
+        output = capsys.readouterr()
+        assert "COULD NOT CHECK branch orientation" in output.out
+        assert "reusable publish job succeeded" in output.out
+        assert "INCOMPLETE:" in output.err

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -161,7 +161,7 @@ gh pr merge <#> --merge --delete-branch
 git checkout dev && git pull
 git status  # MUST show "up to date with origin"
 
-# Confirm the image actually published (see below - this step is NOT optional)
+# Check publish evidence and current tag markers (see below; this is NOT optional)
 .venv/bin/python scripts/check_publish.py
 ```
 
@@ -205,7 +205,7 @@ All four required checks gate their real work on `scripts/classify_changed_paths
 
 Read that summary before treating a green rollup as proof the suite passed. `gh run view <run-id>` links it, or open the run in the browser.
 
-#### Confirm the image published
+#### Check publish evidence and current tag markers
 
 A merged PR is not a published image. Merging to `dev` triggers independent
 **Tests** and **Build and Push Docker Image** verification workflows. Image
@@ -234,10 +234,10 @@ So after `git checkout dev && git pull`, run:
 
 The script checks two things for the merge commit at `HEAD`:
 
-1. The exact SHA's **Tests** push run concluded `success`, and its final reusable **Publish Verified Dev Images / Publish Verified Multi-Arch Manifests** job concluded `success` on that exact run attempt. An overall green Tests run without exactly one such job is not publication proof.
-2. Every platform config represented by the published tag carries both build markers, all platforms agree, `ECM_VERSION` equals the version in `frontend/package.json` **at that commit**, and `GIT_COMMIT` equals the full 40-character resolved commit SHA exactly. Missing, abbreviated, malformed, conflicting, or stale markers fail the check.
+1. The exact SHA's **Tests** push run concluded `success`, and its final reusable **Publish Verified Dev Images / Publish Verified Multi-Arch Manifests** job concluded `success` on that exact run attempt. An overall green Tests run without exactly one such job is not publish-job evidence.
+2. The manifest contains exactly `linux/amd64` and `linux/arm64`, with neither a missing, duplicate, malformed, nor unexpected platform. Each config carries exactly one `ECM_VERSION` and one full 40-character `GIT_COMMIT`; both platforms agree, the version equals `frontend/package.json` **at that commit**, and the commit marker equals the resolved SHA. Missing, duplicate, malformed, conflicting, or stale markers fail the check.
 
-Both must hold. A green workflow with stale or cross-platform markers means the push did not land consistently on the tag. Correct markers with failed workflow evidence do not prove publication provenance.
+Both must hold. The script reports the exact workflow attempt/job outcome and current mutable-tag marker values as separate evidence. This point-in-time check trusts actors allowed to write the tag; it does not cryptographically bind image bytes to that workflow job.
 
 **It is a post-merge check, deliberately not a CI gate.** A check that runs after the merge cannot gate the merge it follows, and adding it to the PR flow would put a permanently-failing context on every open PR. Running it *before* the merge is the one way to misread it: on a feature branch the version bump has not reached `dev` yet, so the registry cannot possibly carry it. The script detects that case and prints a `PRE-MERGE RUN` banner saying the mismatch is expected.
 
@@ -252,10 +252,10 @@ Useful flags:
 | Flag | Effect |
 | --- | --- |
 | `--commit <sha>` | Verify a specific commit instead of `HEAD`. |
-| `--pull` | After mandatory inspection of every represented manifest platform, drop and re-pull the tag and require the host image's `ECM_VERSION` and full `GIT_COMMIT` to match that manifest proof. A successful pull cannot rescue failed manifest inspection. |
-| `--skip-workflow` / `--skip-image` | Run only one of the two checks. |
+| `--pull` | After mandatory inspection of exactly `linux/amd64` and `linux/arm64`, drop and re-pull the tag and require the host image's `ECM_VERSION` and full `GIT_COMMIT` to match those manifest markers. A successful pull cannot rescue failed manifest inspection. |
+| `--skip-workflow` / `--skip-image` | Run only one of the two checks. The flags cannot be combined because that would check nothing. With `--skip-image`, `--pull` has no image operation to perform. |
 
-The default check always proves every platform represented by the manifest; it does not require a hardcoded architecture set, so a valid single-platform image remains supported. The additive `--pull` check then proves that a fresh host pull resolves to the same markers. The same "prove the image before you trust it" discipline applies to any other manual image check.
+The default check requires the ECM platform contract: exactly `linux/amd64` and `linux/arm64`, each carrying one copy of both markers. The additive `--pull` check confirms that a fresh host pull resolves to the same marker values. Image history/digest lookup remains a fallback for historical images that predate these markers.
 
 ### 7. File Beads for Remaining Work
 

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -210,10 +210,12 @@ Read that summary before treating a green rollup as proof the suite passed. `gh 
 A merged PR is not a published image. Merging to `dev` triggers independent
 **Tests** and **Build and Push Docker Image** verification workflows. Image
 builds and scans no longer wait on a polling job: a wedged test runner cannot
-hide image-build evidence. Completion of either workflow triggers **Publish
-Verified Images**, which publishes only when both exact-SHA push workflows are
-successful and the SHA is still the current branch head. Until then, mutable
-tags retain their last known-good image.
+hide image-build evidence. After its required test jobs succeed, the **Tests**
+workflow calls `publish-images.yml` as the reusable **Publish Verified Dev
+Images** job. That called workflow publishes only when the exact-SHA build
+evidence is successful and the SHA is still the current `dev` head. There is
+no separate **Publish Verified Images** Actions run on the dev path. Until
+publication succeeds, mutable tags retain their last known-good image.
 
 The published `:dev` tag has silently lagged `dev` four times, from four unrelated causes:
 
@@ -232,10 +234,10 @@ So after `git checkout dev && git pull`, run:
 
 The script checks two things for the merge commit at `HEAD`:
 
-1. The **Publish Verified Images** workflow run for that commit concluded `success`.
-2. The published tag's build marker (`ECM_VERSION`, baked into the image from the `ECM_VERSION` build-arg) equals the version in `frontend/package.json` **at that commit**.
+1. The exact SHA's **Tests** push run concluded `success`, and its final reusable **Publish Verified Dev Images / Publish Verified Multi-Arch Manifests** job concluded `success` on that exact run attempt. An overall green Tests run without exactly one such job is not publication proof.
+2. Every platform config represented by the published tag carries both build markers, all platforms agree, `ECM_VERSION` equals the version in `frontend/package.json` **at that commit**, and `GIT_COMMIT` equals the full 40-character resolved commit SHA exactly. Missing, abbreviated, malformed, conflicting, or stale markers fail the check.
 
-Both must hold. A green workflow with a stale marker means the push did not land on the tag. A correct marker with a failed workflow means the tag is still serving an older build.
+Both must hold. A green workflow with stale or cross-platform markers means the push did not land consistently on the tag. Correct markers with failed workflow evidence do not prove publication provenance.
 
 **It is a post-merge check, deliberately not a CI gate.** A check that runs after the merge cannot gate the merge it follows, and adding it to the PR flow would put a permanently-failing context on every open PR. Running it *before* the merge is the one way to misread it: on a feature branch the version bump has not reached `dev` yet, so the registry cannot possibly carry it. The script detects that case and prints a `PRE-MERGE RUN` banner saying the mismatch is expected.
 
@@ -250,10 +252,10 @@ Useful flags:
 | Flag | Effect |
 | --- | --- |
 | `--commit <sha>` | Verify a specific commit instead of `HEAD`. |
-| `--pull` | Read the marker by dropping and re-pulling the tag, the heavier check, instead of reading the registry config blob. |
+| `--pull` | After mandatory inspection of every represented manifest platform, drop and re-pull the tag and require the host image's `ECM_VERSION` and full `GIT_COMMIT` to match that manifest proof. A successful pull cannot rescue failed manifest inspection. |
 | `--skip-workflow` / `--skip-image` | Run only one of the two checks. |
 
-The same "prove the image before you trust it" discipline applies to any other manual image check you run: drop the local tag, pull it fresh, and read the version markers baked into the image before trusting it, the same way `--pull` above does.
+The default check always proves every platform represented by the manifest; it does not require a hardcoded architecture set, so a valid single-platform image remains supported. The additive `--pull` check then proves that a fresh host pull resolves to the same markers. The same "prove the image before you trust it" discipline applies to any other manual image check.
 
 ### 7. File Beads for Remaining Work
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -70,7 +70,7 @@ Three further releases have since been promoted: **0.17.0** (2026-05-16), **0.17
 
 ## Where to read the version
 
-Four places all show the same string:
+Four places all show the same version string:
 
 - **UI**: the header status pill (and About dialog) render `frontend/package.json` at build time.
 - **Docker image label**: `docker inspect ecm-ecm-1 --format '{{ index .Config.Labels "org.opencontainers.image.version" }}'`, or the GHCR tag itself.
@@ -78,6 +78,11 @@ Four places all show the same string:
 - **`package.json`** in the repo at the SHA the build was cut from.
 
 All four are populated from the same source; if they disagree, something has been hand-edited post-build and the image should be treated as suspect.
+
+Current images also expose the full 40-character source marker as `GIT_COMMIT`.
+`scripts/check_publish.py` requires exactly one `ECM_VERSION` and one
+`GIT_COMMIT` on each of the `linux/amd64` and `linux/arm64` configs, requires
+the platforms to agree, and compares both markers with the target commit.
 
 ## Checking whether a fix is in your build
 
@@ -88,13 +93,33 @@ You have a bead ID or PR number, you have a running ECM container, and you want 
 ```bash
 docker exec ecm-ecm-1 sh -c 'echo $ECM_VERSION'
 # Example output: 0.16.0-0051
+
+docker exec ecm-ecm-1 sh -c 'echo $GIT_COMMIT'
+# Example output: the full 40-character source commit marker
 ```
 
-### 2. Map the build number to a commit
+### 2. Read the source commit marker
 
-Every dev build comes from exactly one commit on `dev`. The CI build workflow stamps the version onto the image, so the mapping is one-to-one, but it is not currently encoded in the image itself. You recover it from git by matching the build number against the version bump commit.
+For a current image, `GIT_COMMIT` directly supplies the commit marker to check.
+Cross-check the registry manifest rather than relying only on a running host's
+selected platform:
 
-The version bump lands in `frontend/package.json` at the time of the build, so:
+```bash
+docker buildx imagetools inspect \
+  ghcr.io/motwakorb/enhancedchannelmanager:dev \
+  --format '{{json .Image}}'
+```
+
+Both `linux/amd64` and `linux/arm64` must expose the same full SHA and version.
+The supported automated check is:
+
+```bash
+python scripts/check_publish.py --commit <target-sha>
+```
+
+For a historical image that predates `GIT_COMMIT`, recover the likely source
+commit from image history/digests and the version bump history. The version bump
+lands in `frontend/package.json`, so this remains a useful fallback:
 
 ```bash
 # Clone or update a local copy of the repo, then:
@@ -103,9 +128,12 @@ git log --all --oneline --follow -S '"version": "0.16.0-0051"' -- frontend/packa
 # Expected: one commit, the one that set this version.
 ```
 
-Alternative: if you know roughly when the build was cut, jump to the GitHub Actions run log. Each `build-amd64` run prints the resolved version in step "Extract version and set release channel". The workflow run URL is the canonical audit trail.
+Alternative historical fallback: if you know roughly when the build was cut,
+use the image digest and GitHub Actions run logs. Each `build-amd64` run prints
+the resolved version in step "Extract version and set release channel".
 
-The commit SHA that sets `frontend/package.json` to your `BUILD` number is the tip of the tree your image was built from.
+For historical unmarked images, corroborate the candidate SHA with the image
+digest and run records before using it as the tip SHA below.
 
 ### 3. Confirm the fix SHA is an ancestor
 
@@ -133,7 +161,8 @@ If the bead ID or PR number appears in the `[Unreleased]` section of [`CHANGELOG
 ## What this scheme does not guarantee
 
 - **Monotone feature presence across releases.** A feature visible in `0.16.0-0051` can be absent from a later promoted release if the PO explicitly decides to revert or defer. Always check against the target release's CHANGELOG, not the build stream.
-- **Reproducible binaries.** The `BUILD` number and commit SHA map is one-to-one, but the image bytes also depend on base-image digests and dependency resolver state at build time. For byte-identical reproducibility use the image digest (`docker inspect ... --format '{{ .Id }}'`), not the version string.
+- **Artifact-to-workflow attestation.** `GIT_COMMIT` and `ECM_VERSION` are image config markers, and registry tags are mutable. Their agreement with a target plus a successful workflow attempt is a point-in-time consistency check that trusts registry writers; it does not cryptographically bind image bytes to that workflow job.
+- **Reproducible binaries.** The image bytes also depend on base-image digests and dependency resolver state at build time. For byte-identical reproducibility use the image digest (`docker inspect ... --format '{{ .Id }}'`), not the version string.
 - **External identification of a release.** `0.16.0-0051` is an internal dev-build identifier; only a tagged release like `0.17.0` is a stable external reference. Do not cite dev builds in external bug reports without also providing the commit SHA.
 
 ## Related

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0001",
+  "version": "0.18.2-0002",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/check_publish.py
+++ b/scripts/check_publish.py
@@ -482,18 +482,25 @@ def parse_imagetools_config(payload: str) -> dict[str, str]:
     configs: list[tuple[str, dict]] = []
     for platform in EXPECTED_PLATFORMS:
         value = data[platform]
-        if not isinstance(value, dict) or "config" not in value:
+        if not isinstance(value, dict):
+            raise CheckError(f"imagetools platform {platform} value must be an object")
+        if "config" not in value:
+            raise CheckError(f"imagetools platform {platform} carries no config field")
+        config = value["config"]
+        if not isinstance(config, dict):
             raise CheckError(
-                f"imagetools output carried no image config for {platform}"
+                f"imagetools platform {platform} config must be an object, "
+                f"got {type(config).__name__}"
             )
-        configs.append((platform, value))
+        configs.append((platform, config))
 
     mappings: list[dict[str, str]] = []
-    for platform, entry in configs:
-        env = entry.get("config", {}).get("Env")
+    for platform, config in configs:
+        env = config.get("Env")
         if not isinstance(env, list) or not all(isinstance(item, str) for item in env):
             raise CheckError(
-                f"imagetools output carried no image config env block for {platform}"
+                f"imagetools output carried no image config env block for {platform}; "
+                "expected a list of strings"
             )
         mapping = _env_list_to_mapping(env, context=f"image config for {platform}")
         for marker in (MARKER_ENV, COMMIT_ENV):

--- a/scripts/check_publish.py
+++ b/scripts/check_publish.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Confirm that a merge to `dev` actually reached the container registry.
+"""Check workflow evidence and current registry-tag markers after a dev merge.
 
 This is a POST-MERGE check (bead enhancedchannelmanager-t8fqg). It is not
 a CI gate and must never become one: a check that runs after the merge
@@ -28,19 +28,20 @@ unrelated merge republished it by accident.
   1. The "Tests" push run for the commit under test concluded `success`,
      and its reusable publish workflow completed the final multi-arch
      manifest job successfully on that exact run attempt.
-  2. Every represented platform carries matching `ECM_VERSION` and full
+  2. The expected linux/amd64 and linux/arm64 configs carry matching
+     `ECM_VERSION` and full
      `GIT_COMMIT` markers. They must equal `frontend/package.json` AT THAT
      COMMIT and the exact resolved commit SHA.
 
-Both must hold. A green workflow with a stale marker means the push
-silently did not land on the tag; a correct marker with a failed workflow
-means the tag is carrying an older successful build.
+Both must hold. The checks intentionally report workflow evidence and current
+tag-marker evidence separately; neither cryptographically binds image bytes to
+the workflow job. The mutable tag check also trusts actors allowed to write it.
 
-The image is always read through every represented platform's registry
-config (`docker buildx imagetools inspect`), which does not download layers.
-Pass `--pull` to add host-level proof after that mandatory manifest proof.
+The image is always read through both expected platforms' registry configs
+(`docker buildx imagetools inspect`), which does not download layers.
+Pass `--pull` to add a host-level marker cross-check after that inspection.
 A pull cannot rescue failed manifest inspection. See `docs/shipping.md`
-section 6, "Confirm the image published".
+section 6, "Check publish evidence and current tag markers".
 
 ## Refs it needs
 
@@ -88,6 +89,7 @@ PUBLISH_JOB_NAME = "Publish Verified Dev Images / Publish Verified Multi-Arch Ma
 MARKER_ENV = "ECM_VERSION"
 COMMIT_ENV = "GIT_COMMIT"
 PLATFORMS_KEY = "_ECM_MANIFEST_PLATFORMS"
+EXPECTED_PLATFORMS = ("linux/amd64", "linux/arm64")
 
 _SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
 
@@ -274,16 +276,27 @@ def commit_is_on_branch(sha: str, branch: str) -> bool | None:
 
 
 def repo_slug() -> str:
-    result = _run(
-        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]
-    )
-    if result.returncode == 0 and result.stdout.strip():
-        return result.stdout.strip()
     url = _git("remote", "get-url", "origin").strip()
-    match = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?$", url)
-    if not match:
-        raise CheckError(f"cannot derive owner/repo from origin remote {url!r}")
-    return match.group(1)
+    scp_match = re.fullmatch(r"git@github\.com:([^/]+)/([^/]+)", url)
+    if scp_match:
+        owner, repo = scp_match.groups()
+    else:
+        url_match = re.fullmatch(
+            r"(?:https://github\.com/|ssh://git@github\.com/)([^/]+)/([^/?#]+)",
+            url,
+        )
+        if not url_match:
+            raise CheckError(
+                f"cannot derive owner/repo from GitHub origin remote {url!r}"
+            )
+        owner, repo = url_match.groups()
+
+    repo = repo.removesuffix(".git")
+    if not re.fullmatch(
+        r"[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?", owner
+    ) or not re.fullmatch(r"[A-Za-z0-9_.-]+", repo):
+        raise CheckError(f"GitHub origin does not carry a valid owner/repo: {url!r}")
+    return f"{owner}/{repo}"
 
 
 # --- Check 1: the workflow run ----------------------------------------------
@@ -394,9 +407,17 @@ def select_build_run(
     ]
     if not candidates:
         return None
+    for run in candidates:
+        for field in ("id", "run_number", "run_attempt"):
+            value = run.get(field)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                raise CheckError(
+                    f"candidate {workflow_name!r} run field {field!r} must be a "
+                    f"positive integer, got {value!r}"
+                )
     return max(
         candidates,
-        key=lambda run: (run.get("run_number") or 0, run.get("run_attempt") or 0),
+        key=lambda run: (run["run_number"], run["run_attempt"]),
     )
 
 
@@ -413,39 +434,59 @@ def select_publish_job(jobs: list[dict]) -> dict | None:
 # --- Check 2: the published build marker ------------------------------------
 
 
-def _env_list_to_mapping(env: list[str]) -> dict[str, str]:
+def _env_list_to_mapping(
+    env: list[str], *, context: str = "image config"
+) -> dict[str, str]:
     mapping: dict[str, str] = {}
     for entry in env:
         name, separator, value = entry.partition("=")
         if separator:
+            if name in (MARKER_ENV, COMMIT_ENV) and name in mapping:
+                raise CheckError(f"{context} carries duplicate {name} entries")
             mapping[name] = value
     return mapping
+
+
+def _unique_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise CheckError(
+                f"imagetools output carries duplicate JSON object key {key!r}"
+            )
+        value[key] = item
+    return value
 
 
 def parse_imagetools_config(payload: str) -> dict[str, str]:
     """Pull the image's env mapping out of `imagetools inspect` JSON.
 
-    The payload is either a single image config or one config per platform.
-    Every represented platform must carry both provenance markers, and all
-    platforms must agree before one mapping can represent the tag.
+    The payload must contain exactly the supported ECM platform configs. Both
+    must carry one copy of each marker and agree before one mapping can
+    represent the current tag.
     """
     try:
-        data = json.loads(payload)
+        data = json.loads(payload, object_pairs_hook=_unique_json_object)
     except json.JSONDecodeError as error:
         raise CheckError(f"unparseable imagetools output: {error}") from error
 
-    configs: list[tuple[str, dict]] = []
-    if isinstance(data, dict) and "config" in data:
-        configs.append(("single image", data))
-    elif isinstance(data, dict):
-        for platform, value in data.items():
-            if not isinstance(value, dict) or "config" not in value:
-                raise CheckError(
-                    f"imagetools output carried no image config for {platform}"
-                )
-            configs.append((platform, value))
-    if not configs:
+    if not isinstance(data, dict):
         raise CheckError("imagetools output carried no image configs")
+    actual_platforms = set(data)
+    if actual_platforms != set(EXPECTED_PLATFORMS):
+        raise CheckError(
+            f"imagetools platform set mismatch: expected {', '.join(EXPECTED_PLATFORMS)}; "
+            f"found {', '.join(sorted(actual_platforms)) or 'none'}"
+        )
+
+    configs: list[tuple[str, dict]] = []
+    for platform in EXPECTED_PLATFORMS:
+        value = data[platform]
+        if not isinstance(value, dict) or "config" not in value:
+            raise CheckError(
+                f"imagetools output carried no image config for {platform}"
+            )
+        configs.append((platform, value))
 
     mappings: list[dict[str, str]] = []
     for platform, entry in configs:
@@ -454,7 +495,7 @@ def parse_imagetools_config(payload: str) -> dict[str, str]:
             raise CheckError(
                 f"imagetools output carried no image config env block for {platform}"
             )
-        mapping = _env_list_to_mapping(env)
+        mapping = _env_list_to_mapping(env, context=f"image config for {platform}")
         for marker in (MARKER_ENV, COMMIT_ENV):
             if marker not in mapping:
                 raise CheckError(f"image config for {platform} carries no {marker}")
@@ -521,7 +562,7 @@ def read_published_marker(ref: str, *, use_pull: bool) -> dict[str, str]:
                     f"fresh-pull host {marker} mismatch: manifest carries "
                     f"{manifest.get(marker)!r}, host image carries {host.get(marker)!r}"
                 )
-        print("  OK: fresh-pull host markers match the mandatory manifest proof.")
+        print("  OK: fresh-pull host markers match the registry manifest markers.")
     return manifest
 
 
@@ -535,8 +576,8 @@ def _banner(text: str) -> str:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "POST-MERGE check: confirm the merge commit's image actually "
-            "published. Run this AFTER `gh pr merge`, not before."
+            "POST-MERGE check: inspect the exact workflow attempt and current "
+            "mutable-tag markers. Run this AFTER `gh pr merge`, not before."
         )
     )
     parser.add_argument(
@@ -564,6 +605,14 @@ def main(argv: list[str] | None = None) -> int:
         "--skip-image", action="store_true", help="Skip the published-image check."
     )
     args = parser.parse_args(argv)
+
+    if args.skip_workflow and args.skip_image:
+        print(
+            "FATAL: --skip-workflow and --skip-image cannot be used together; "
+            "at least one check is required.",
+            file=sys.stderr,
+        )
+        return 2
 
     try:
         sha = resolve_commit(args.commit)
@@ -663,7 +712,7 @@ def main(argv: list[str] | None = None) -> int:
                     if publish_job is None:
                         failures.append(
                             f"the Tests attempt carried no {PUBLISH_JOB_NAME!r} job. "
-                            "A green test rollup alone does not prove publication."
+                            "A green test rollup alone is not publish-job evidence."
                         )
                         print("  publish job: not found")
                     else:
@@ -682,7 +731,7 @@ def main(argv: list[str] | None = None) -> int:
                         elif publish_conclusion != "success":
                             failures.append(
                                 f"the reusable publish job concluded {publish_conclusion!r}, "
-                                "so publication was not proven. Re-run the failed Tests "
+                                "so publish-job evidence is not successful. Re-run the failed Tests "
                                 "workflow from the URL above once the cause is understood."
                             )
                         else:
@@ -715,7 +764,7 @@ def main(argv: list[str] | None = None) -> int:
             elif actual != expected:
                 failures.append(
                     f"{MARKER_ENV} mismatch: expected {expected!r}, published "
-                    f"tag {ref} carries {actual!r} (built from "
+                    f"tag {ref} carries {actual!r} ({COMMIT_ENV} marker: "
                     f"{built_from[:12] if built_from else 'missing'}). "
                     f"The registry is lagging the commit "
                     f"under test."
@@ -725,8 +774,8 @@ def main(argv: list[str] | None = None) -> int:
 
             if built_from is None:
                 failures.append(
-                    f"the published image carries no {COMMIT_ENV}. Exact-SHA "
-                    "publication cannot be proven from the registry tag."
+                    f"the published image carries no {COMMIT_ENV}. The current "
+                    "registry tag cannot be matched to the target SHA."
                 )
             elif not re.fullmatch(r"[0-9a-f]{40}", built_from):
                 failures.append(
@@ -750,7 +799,10 @@ def main(argv: list[str] | None = None) -> int:
     # ahead of the evidence it refers to.
     sys.stdout.flush()
     if failures:
-        print("FAIL: the published image does not match this commit.", file=sys.stderr)
+        print(
+            "FAIL: required workflow and current-tag evidence did not all pass.",
+            file=sys.stderr,
+        )
         for failure in failures:
             print(f"  - {failure}", file=sys.stderr)
         if on_branch is False:
@@ -761,8 +813,8 @@ def main(argv: list[str] | None = None) -> int:
             )
         else:
             print(
-                "\nSee docs/shipping.md section 6, step 'Confirm the image "
-                "published'. Do not leave dev and the registry diverged: "
+                "\nSee docs/shipping.md section 6, step 'Check publish evidence "
+                "and current tag markers'. Do not leave dev and the registry diverged: "
                 "re-run the failed workflow rather than waiting for the next "
                 "merge to republish by accident.",
                 file=sys.stderr,
@@ -784,19 +836,23 @@ def main(argv: list[str] | None = None) -> int:
     # Claim only what actually ran. A PASS line that asserts the registry
     # carries the right marker after `--skip-image` is a lie the operator
     # has no way to see through.
-    if args.skip_workflow and args.skip_image:
-        print(f"PASS: nothing was checked (both checks skipped) for {sha[:12]}.")
-    elif args.skip_image:
-        print(f"PASS: {sha[:12]} has a successful build run (image check skipped).")
+    if args.skip_image:
+        print(
+            f"PASS: exact Tests attempt and reusable publish job succeeded for "
+            f"{sha} (mutable-tag marker check skipped)."
+        )
     elif args.skip_workflow:
         print(
-            f"PASS: {ref} carries {expected} from exact commit {sha} "
-            "(workflow-run check skipped)."
+            f"PASS: current mutable tag {ref} exposes {MARKER_ENV}={expected} and "
+            f"{COMMIT_ENV}={sha} (workflow evidence skipped; point-in-time marker "
+            "check only)."
         )
     else:
         print(
-            f"PASS: {ref} carries {expected} from exact commit {sha}, built "
-            "from a successful Tests run and reusable publish job."
+            f"PASS: exact Tests attempt and reusable publish job succeeded, and "
+            f"current mutable tag {ref} exposes {MARKER_ENV}={expected} and "
+            f"{COMMIT_ENV}={sha}. This point-in-time check trusts registry writers; "
+            "it does not bind image bytes to the workflow job."
         )
     return 0
 

--- a/scripts/check_publish.py
+++ b/scripts/check_publish.py
@@ -25,23 +25,22 @@ unrelated merge republished it by accident.
 
 ## What it checks
 
-  1. The "Publish Verified Images" workflow run for the commit under
-     test concluded `success`.
-  2. The published tag's build marker (`ECM_VERSION`, baked into the
-     image by the Dockerfile from the `ECM_VERSION` build-arg) equals the
-     version in `frontend/package.json` AT THAT COMMIT.
+  1. The "Tests" push run for the commit under test concluded `success`,
+     and its reusable publish workflow completed the final multi-arch
+     manifest job successfully on that exact run attempt.
+  2. Every represented platform carries matching `ECM_VERSION` and full
+     `GIT_COMMIT` markers. They must equal `frontend/package.json` AT THAT
+     COMMIT and the exact resolved commit SHA.
 
 Both must hold. A green workflow with a stale marker means the push
 silently did not land on the tag; a correct marker with a failed workflow
 means the tag is carrying an older successful build.
 
-The image is read through the registry's config blob
-(`docker buildx imagetools inspect`), which does not download layers.
-Pass `--pull` for the heavier form used by the restore drill's image
-gate: remove the local tag, pull it fresh, and read the marker out of the
-pulled image. See `docs/shipping.md` section 6, "Confirm the image
-published" ("prove the image before you trust it"), for that idiom and
-for where this script sits in the flow.
+The image is always read through every represented platform's registry
+config (`docker buildx imagetools inspect`), which does not download layers.
+Pass `--pull` to add host-level proof after that mandatory manifest proof.
+A pull cannot rescue failed manifest inspection. See `docs/shipping.md`
+section 6, "Confirm the image published".
 
 ## Refs it needs
 
@@ -68,6 +67,7 @@ of surfacing git's raw `ambiguous argument` error.
 Exits 0 when the registry matches `dev`, 1 when it does not or when a
 check could not be completed.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -83,9 +83,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_IMAGE = "ghcr.io/motwakorb/enhancedchannelmanager"
 DEFAULT_TAG = "dev"
 DEFAULT_BRANCH = "dev"
-WORKFLOW_NAME = "Publish Verified Images"
+WORKFLOW_NAME = "Tests"
+PUBLISH_JOB_NAME = "Publish Verified Dev Images / Publish Verified Multi-Arch Manifests"
 MARKER_ENV = "ECM_VERSION"
 COMMIT_ENV = "GIT_COMMIT"
+PLATFORMS_KEY = "_ECM_MANIFEST_PLATFORMS"
 
 _SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
 
@@ -98,9 +100,16 @@ class CheckError(RuntimeError):
 
 
 def _run(cmd: list[str], *, timeout: int = 300) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        cmd, capture_output=True, text=True, check=False, timeout=timeout
-    )
+    try:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, check=False, timeout=timeout
+        )
+    except subprocess.TimeoutExpired as error:
+        raise CheckError(
+            f"command timed out after {timeout}s: {' '.join(cmd)}"
+        ) from error
+    except OSError as error:
+        raise CheckError(f"could not launch {cmd[0]!r}: {error}") from error
 
 
 def _git(*args: str) -> str:
@@ -226,20 +235,48 @@ def commit_is_on_branch(sha: str, branch: str) -> bool | None:
     as "the commit is not on the branch".
     """
     for ref in (f"origin/{branch}", branch):
-        probe = _run(["git", "-C", str(REPO_ROOT), "rev-parse", "--verify", ref], timeout=60)
-        if probe.returncode != 0:
+        probe_cmd = [
+            "git",
+            "-C",
+            str(REPO_ROOT),
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            ref,
+        ]
+        probe = _run(probe_cmd, timeout=60)
+        if probe.returncode == 1:
             continue
-        result = _run(
-            ["git", "-C", str(REPO_ROOT), "merge-base", "--is-ancestor", sha, ref],
-            timeout=60,
+        if probe.returncode != 0:
+            raise CheckError(
+                f"{' '.join(probe_cmd)} failed ({probe.returncode}): "
+                f"{probe.stderr.strip() or 'no stderr'}"
+            )
+        ancestor_cmd = [
+            "git",
+            "-C",
+            str(REPO_ROOT),
+            "merge-base",
+            "--is-ancestor",
+            sha,
+            ref,
+        ]
+        result = _run(ancestor_cmd, timeout=60)
+        if result.returncode == 0:
+            return True
+        if result.returncode == 1:
+            return False
+        raise CheckError(
+            f"{' '.join(ancestor_cmd)} failed ({result.returncode}): "
+            f"{result.stderr.strip() or 'no stderr'}"
         )
-        if result.returncode in (0, 1):
-            return result.returncode == 0
     return None
 
 
 def repo_slug() -> str:
-    result = _run(["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
+    result = _run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]
+    )
     if result.returncode == 0 and result.stdout.strip():
         return result.stdout.strip()
     url = _git("remote", "get-url", "origin").strip()
@@ -263,6 +300,7 @@ def fetch_workflow_runs(slug: str, sha: str) -> list[dict]:
         [
             "gh",
             "api",
+            "--paginate",
             "-H",
             "Accept: application/vnd.github+json",
             f"repos/{slug}/actions/runs?head_sha={sha}&per_page=100",
@@ -273,14 +311,73 @@ def fetch_workflow_runs(slug: str, sha: str) -> list[dict]:
             f"gh api call for workflow runs failed: {result.stderr.strip()}"
         )
     try:
-        payload = json.loads(result.stdout)
+        pages = _decode_json_pages(result.stdout)
     except json.JSONDecodeError as error:
         raise CheckError(f"unparseable gh api response: {error}") from error
-    runs = payload.get("workflow_runs")
-    return runs if isinstance(runs, list) else []
+    return _combine_paginated_items(pages, "workflow_runs")
 
 
-def select_build_run(runs: list[dict], workflow_name: str, branch: str) -> dict | None:
+def fetch_workflow_jobs(slug: str, run_id: int, run_attempt: int) -> list[dict]:
+    result = _run(
+        [
+            "gh",
+            "api",
+            "--paginate",
+            "-H",
+            "Accept: application/vnd.github+json",
+            f"repos/{slug}/actions/runs/{run_id}/attempts/{run_attempt}/jobs?per_page=100",
+        ]
+    )
+    if result.returncode != 0:
+        raise CheckError(
+            f"gh api call for workflow jobs failed: {result.stderr.strip()}"
+        )
+    try:
+        pages = _decode_json_pages(result.stdout)
+    except json.JSONDecodeError as error:
+        raise CheckError(
+            f"unparseable gh api response for workflow jobs: {error}"
+        ) from error
+    return _combine_paginated_items(pages, "jobs")
+
+
+def _decode_json_pages(payload: str) -> list[object]:
+    """Decode consecutive JSON documents emitted by ``gh api --paginate``."""
+    decoder = json.JSONDecoder()
+    pages: list[object] = []
+    offset = 0
+    while offset < len(payload):
+        while offset < len(payload) and payload[offset].isspace():
+            offset += 1
+        if offset == len(payload):
+            break
+        page, offset = decoder.raw_decode(payload, offset)
+        pages.append(page)
+    if not pages:
+        raise CheckError("paginated gh api response was empty")
+    return pages
+
+
+def _combine_paginated_items(pages: list[object], key: str) -> list[dict]:
+    combined: list[dict] = []
+    for page_number, page in enumerate(pages, start=1):
+        if not isinstance(page, dict) or not isinstance(page.get(key), list):
+            raise CheckError(
+                f"paginated gh api response page {page_number} carried invalid {key}"
+            )
+        for item_number, item in enumerate(page[key], start=1):
+            if not isinstance(item, dict):
+                raise CheckError(
+                    f"paginated gh api response page {page_number} {key} item "
+                    f"{item_number} is not an object"
+                )
+            combined.append(item)
+    return combined
+
+
+def select_build_run(
+    runs: list[dict], workflow_name: str, branch: str, sha: str
+) -> dict | None:
     """Pick the newest `workflow_name` run for `branch`, re-runs included.
 
     GitHub returns the same workflow once per attempt and once per event
@@ -292,11 +389,25 @@ def select_build_run(runs: list[dict], workflow_name: str, branch: str) -> dict 
         for run in runs
         if run.get("name") == workflow_name
         and run.get("head_branch") == branch
+        and run.get("head_sha") == sha
         and run.get("event") == "push"
     ]
     if not candidates:
         return None
-    return max(candidates, key=lambda run: (run.get("run_number") or 0, run.get("run_attempt") or 0))
+    return max(
+        candidates,
+        key=lambda run: (run.get("run_number") or 0, run.get("run_attempt") or 0),
+    )
+
+
+def select_publish_job(jobs: list[dict]) -> dict | None:
+    matches = [job for job in jobs if job.get("name") == PUBLISH_JOB_NAME]
+    if len(matches) > 1:
+        raise CheckError(
+            f"the Tests attempt carried {len(matches)} jobs named {PUBLISH_JOB_NAME!r}; "
+            "exactly one is required"
+        )
+    return matches[0] if matches else None
 
 
 # --- Check 2: the published build marker ------------------------------------
@@ -314,35 +425,61 @@ def _env_list_to_mapping(env: list[str]) -> dict[str, str]:
 def parse_imagetools_config(payload: str) -> dict[str, str]:
     """Pull the image's env mapping out of `imagetools inspect` JSON.
 
-    The payload is either a single image config or, for a multi-arch
-    manifest list, one config per platform. Every platform of a given tag
-    is built from the same source, so the first config with an env block
-    is representative; a disagreement between platforms is reported by
-    the caller as a mismatch, not silently averaged.
+    The payload is either a single image config or one config per platform.
+    Every represented platform must carry both provenance markers, and all
+    platforms must agree before one mapping can represent the tag.
     """
     try:
         data = json.loads(payload)
     except json.JSONDecodeError as error:
         raise CheckError(f"unparseable imagetools output: {error}") from error
 
-    configs: list[dict] = []
+    configs: list[tuple[str, dict]] = []
     if isinstance(data, dict) and "config" in data:
-        configs.append(data)
+        configs.append(("single image", data))
     elif isinstance(data, dict):
-        for value in data.values():
-            if isinstance(value, dict) and "config" in value:
-                configs.append(value)
+        for platform, value in data.items():
+            if not isinstance(value, dict) or "config" not in value:
+                raise CheckError(
+                    f"imagetools output carried no image config for {platform}"
+                )
+            configs.append((platform, value))
+    if not configs:
+        raise CheckError("imagetools output carried no image configs")
 
-    for entry in configs:
+    mappings: list[dict[str, str]] = []
+    for platform, entry in configs:
         env = entry.get("config", {}).get("Env")
-        if isinstance(env, list):
-            return _env_list_to_mapping(env)
-    raise CheckError("imagetools output carried no image config env block")
+        if not isinstance(env, list) or not all(isinstance(item, str) for item in env):
+            raise CheckError(
+                f"imagetools output carried no image config env block for {platform}"
+            )
+        mapping = _env_list_to_mapping(env)
+        for marker in (MARKER_ENV, COMMIT_ENV):
+            if marker not in mapping:
+                raise CheckError(f"image config for {platform} carries no {marker}")
+        mappings.append(mapping)
+
+    for marker in (MARKER_ENV, COMMIT_ENV):
+        values = {mapping[marker] for mapping in mappings}
+        if len(values) != 1:
+            raise CheckError(
+                f"image platforms disagree on {marker}: {sorted(values)!r}"
+            )
+    return mappings[0] | {PLATFORMS_KEY: ", ".join(platform for platform, _ in configs)}
 
 
 def read_marker_via_imagetools(ref: str) -> dict[str, str]:
     result = _run(
-        ["docker", "buildx", "imagetools", "inspect", ref, "--format", "{{json .Image}}"]
+        [
+            "docker",
+            "buildx",
+            "imagetools",
+            "inspect",
+            ref,
+            "--format",
+            "{{json .Image}}",
+        ]
     )
     if result.returncode != 0:
         raise CheckError(
@@ -375,17 +512,17 @@ def read_published_marker(ref: str, *, use_pull: bool) -> dict[str, str]:
             "docker is not installed, so the published image cannot be read. "
             "Pass --skip-image to check only the workflow run."
         )
+    manifest = read_marker_via_imagetools(ref)
     if use_pull:
-        return read_marker_via_pull(ref)
-    try:
-        return read_marker_via_imagetools(ref)
-    except CheckError as error:
-        print(
-            f"  note: registry config read unavailable ({error}); "
-            "falling back to a full pull.",
-            file=sys.stderr,
-        )
-        return read_marker_via_pull(ref)
+        host = read_marker_via_pull(ref)
+        for marker in (MARKER_ENV, COMMIT_ENV):
+            if host.get(marker) != manifest.get(marker):
+                raise CheckError(
+                    f"fresh-pull host {marker} mismatch: manifest carries "
+                    f"{manifest.get(marker)!r}, host image carries {host.get(marker)!r}"
+                )
+        print("  OK: fresh-pull host markers match the mandatory manifest proof.")
+    return manifest
 
 
 # --- Reporting --------------------------------------------------------------
@@ -417,8 +554,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--pull",
         action="store_true",
-        help="Read the marker by removing and re-pulling the tag (the restore "
-        "drill's image gate) instead of reading the registry config blob.",
+        help="After mandatory manifest inspection, remove and re-pull the tag "
+        "and require the host image markers to match.",
     )
     parser.add_argument(
         "--skip-workflow", action="store_true", help="Skip the workflow-run check."
@@ -437,14 +574,24 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     ref = f"{args.image}:{args.tag}"
-    on_branch = commit_is_on_branch(sha, args.branch)
+    failures: list[str] = []
+    errors: list[str] = []
+    orientation_error: str | None = None
+    try:
+        on_branch = commit_is_on_branch(sha, args.branch)
+    except CheckError as error:
+        on_branch = None
+        orientation_error = f"branch orientation could not be determined: {error}"
+        errors.append(orientation_error)
 
     print(_banner("Post-merge publish check"))
     print(f"  commit under test : {sha[:12]}  {subject}")
     print(f"  expected version  : {expected}   (frontend/package.json at that commit)")
     print(f"  published tag     : {ref}")
 
-    if on_branch is False:
+    if orientation_error is not None:
+        print(f"\n  COULD NOT CHECK branch orientation: {orientation_error}")
+    elif on_branch is False:
         print(
             f"\n  PRE-MERGE RUN. {sha[:12]} is not an ancestor of "
             f"'{args.branch}'. This check verifies what the registry carries "
@@ -463,18 +610,15 @@ def main(argv: list[str] | None = None) -> int:
             f"want that context in the verdict."
         )
 
-    failures: list[str] = []
-    errors: list[str] = []
-
     # --- Check 1 ---
-    print("\n[1/2] Publish Verified Images workflow run")
+    print("\n[1/2] Tests run and reusable publish job")
     if args.skip_workflow:
         print("  SKIPPED (--skip-workflow)")
     else:
         try:
             slug = repo_slug()
             runs = fetch_workflow_runs(slug, sha)
-            run = select_build_run(runs, WORKFLOW_NAME, args.branch)
+            run = select_build_run(runs, WORKFLOW_NAME, args.branch, sha)
             if run is None:
                 failures.append(
                     f"no {WORKFLOW_NAME!r} push run exists for {sha[:12]} on "
@@ -488,7 +632,9 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 status = run.get("status")
                 conclusion = run.get("conclusion")
-                print(f"  run       : #{run.get('run_number')} attempt {run.get('run_attempt')}")
+                print(
+                    f"  run       : #{run.get('run_number')} attempt {run.get('run_attempt')}"
+                )
                 print(f"  status    : {status}")
                 print(f"  conclusion: {conclusion}")
                 print(f"  url       : {run.get('html_url')}")
@@ -505,7 +651,44 @@ def main(argv: list[str] | None = None) -> int:
                         f"from the URL above once the cause is understood."
                     )
                 else:
-                    print("  OK: the merge commit's image build succeeded.")
+                    run_id = run.get("id")
+                    run_attempt = run.get("run_attempt")
+                    if not isinstance(run_id, int) or not isinstance(run_attempt, int):
+                        raise CheckError(
+                            "the selected Tests run has no integer id/run_attempt; "
+                            "attempt-specific job inspection is impossible"
+                        )
+                    jobs = fetch_workflow_jobs(slug, run_id, run_attempt)
+                    publish_job = select_publish_job(jobs)
+                    if publish_job is None:
+                        failures.append(
+                            f"the Tests attempt carried no {PUBLISH_JOB_NAME!r} job. "
+                            "A green test rollup alone does not prove publication."
+                        )
+                        print("  publish job: not found")
+                    else:
+                        publish_status = publish_job.get("status")
+                        publish_conclusion = publish_job.get("conclusion")
+                        print(f"  publish job status    : {publish_status}")
+                        print(f"  publish job conclusion: {publish_conclusion}")
+                        print(
+                            f"  publish job url       : {publish_job.get('html_url')}"
+                        )
+                        if publish_status != "completed":
+                            failures.append(
+                                f"the reusable publish job is still {publish_status!r}. "
+                                "Nothing has published yet; re-run this check when it finishes."
+                            )
+                        elif publish_conclusion != "success":
+                            failures.append(
+                                f"the reusable publish job concluded {publish_conclusion!r}, "
+                                "so publication was not proven. Re-run the failed Tests "
+                                "workflow from the URL above once the cause is understood."
+                            )
+                        else:
+                            print(
+                                "  OK: the exact attempt's reusable publish job succeeded."
+                            )
         except CheckError as error:
             errors.append(str(error))
             print(f"  COULD NOT CHECK: {error}")
@@ -518,9 +701,11 @@ def main(argv: list[str] | None = None) -> int:
         try:
             env = read_published_marker(ref, use_pull=args.pull)
             actual = env.get(MARKER_ENV)
-            built_from = env.get(COMMIT_ENV, "unknown")
+            built_from = env.get(COMMIT_ENV)
+            platforms = env.get(PLATFORMS_KEY, "unknown")
+            print(f"  manifest platforms: {platforms}")
             print(f"  {MARKER_ENV}   : {actual}")
-            print(f"  {COMMIT_ENV}    : {built_from[:12] if built_from else 'unknown'}")
+            print(f"  {COMMIT_ENV}    : {built_from[:12] if built_from else 'missing'}")
             if actual is None:
                 failures.append(
                     f"the published image carries no {MARKER_ENV}. The image "
@@ -529,13 +714,32 @@ def main(argv: list[str] | None = None) -> int:
                 )
             elif actual != expected:
                 failures.append(
-                    f"build marker mismatch: expected {expected!r}, published "
+                    f"{MARKER_ENV} mismatch: expected {expected!r}, published "
                     f"tag {ref} carries {actual!r} (built from "
-                    f"{built_from[:12]}). The registry is lagging the commit "
+                    f"{built_from[:12] if built_from else 'missing'}). "
+                    f"The registry is lagging the commit "
                     f"under test."
                 )
             else:
-                print(f"  OK: published marker matches {expected}.")
+                print(f"  OK: {MARKER_ENV} matches {expected}.")
+
+            if built_from is None:
+                failures.append(
+                    f"the published image carries no {COMMIT_ENV}. Exact-SHA "
+                    "publication cannot be proven from the registry tag."
+                )
+            elif not re.fullmatch(r"[0-9a-f]{40}", built_from):
+                failures.append(
+                    f"the published {COMMIT_ENV} marker {built_from!r} is not a "
+                    "full 40-character lowercase commit SHA."
+                )
+            elif built_from != sha:
+                failures.append(
+                    f"{COMMIT_ENV} mismatch: expected the exact SHA {sha}, but "
+                    f"published tag {ref} carries {built_from}."
+                )
+            else:
+                print(f"  OK: {COMMIT_ENV} matches the exact resolved SHA.")
         except CheckError as error:
             errors.append(str(error))
             print(f"  COULD NOT CHECK: {error}")
@@ -563,10 +767,16 @@ def main(argv: list[str] | None = None) -> int:
                 "merge to republish by accident.",
                 file=sys.stderr,
             )
+        if errors:
+            print("\nINCOMPLETE: one or more checks could not run.", file=sys.stderr)
+            for error in errors:
+                print(f"  - {error}", file=sys.stderr)
         return 1
 
     if errors:
-        print("INCOMPLETE: no mismatch found, but a check could not run.", file=sys.stderr)
+        print(
+            "INCOMPLETE: no mismatch found, but a check could not run.", file=sys.stderr
+        )
         for error in errors:
             print(f"  - {error}", file=sys.stderr)
         return 1
@@ -579,11 +789,14 @@ def main(argv: list[str] | None = None) -> int:
     elif args.skip_image:
         print(f"PASS: {sha[:12]} has a successful build run (image check skipped).")
     elif args.skip_workflow:
-        print(f"PASS: {ref} carries {expected} (workflow-run check skipped).")
+        print(
+            f"PASS: {ref} carries {expected} from exact commit {sha} "
+            "(workflow-run check skipped)."
+        )
     else:
         print(
-            f"PASS: {ref} carries {expected}, built from a successful run "
-            f"of {sha[:12]}."
+            f"PASS: {ref} carries {expected} from exact commit {sha}, built "
+            "from a successful Tests run and reusable publish job."
         )
     return 0
 


### PR DESCRIPTION
## Summary
- follow the actual dev publication topology by selecting the exact successful Tests push attempt and its nested final reusable manifest job
- paginate GitHub run/job evidence and fail closed on malformed metadata, duplicate jobs, command failures, and skipped checks
- require exactly linux/amd64 and linux/arm64 with unique, agreeing ECM_VERSION and full GIT_COMMIT markers
- make --pull an additive host marker cross-check after mandatory manifest inspection
- document point-in-time mutable-tag and registry-writer trust limits; update shipping, versioning, and changelog guidance

## Verification
- canonical backend gate: 12,217 passed, 3 skipped, 2 deselected; 80.42% coverage
- focused verifier and publication-policy suite: 169 passed
- Ruff lint/format and py_compile passed
- strict MkDocs build passed
- frontend production build passed
- changed-path classifier and version-touchpoint checks passed
- code review approved with zero findings
- security review approved with zero findings

## Live proof
`python scripts/check_publish.py --commit dec34435a3a68c465d1dbc7ec89750f3c661d5a4 --pull` passed against the current published dev image. It selected Tests run #1985 attempt 1 and nested job 99653258958, then matched linux/amd64 and linux/arm64 markers to ECM_VERSION=0.18.2-0001 and the full target SHA.

## Scope
- targets dev only
- version advances exactly the three required touchpoints to 0.18.2-0002
- no package-lock, workflow, dependency, release, tag, or main changes
- this PR is intentionally left open for review and is not merged by this task

Bead: enhancedchannelmanager-69dxb