### PR TITLE
[enhancedchannelmanager-8gmk8.2] Allow scheduled probes without reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- **Scheduled stream probes can refresh health metadata without changing curated stream order (bead `enhancedchannelmanager-8gmk8.2`, build 0003).** Each Stream Probe schedule now has an **Allow stream reordering** option. It remains enabled by default and still follows the global auto-reorder setting; disabling it suppresses reordering for only that schedule invocation, including group-scoped probes, without affecting other probe runs.
+
 - **Smart Sort can now use signed additive Points rules as an alternative to the existing ordered Priority strategy (bead `enhancedchannelmanager-npueh.5`).** Rules can reward or penalize resolution, bitrate, framerate, video codec, M3U priority, audio channels, custom streams, catch-up, failed streams, black screens, and low FPS. Every matching rule contributes to the total, higher totals sort first, and final ties use ascending stream ID. Priority remains the default for existing settings. Both configurations survive mode changes, and cached clients that omit the new settings preserve the stored strategy and rules.
 
   The same selected Smart Sort strategy is used by manual stream ordering, probe-completion and scheduled-probe reordering, Channel Pipeline, and Event Sync. Direct one-field sorts remain legacy Priority sorts. See the [Channel Defaults guide](docs/user_guide/settings/channel-defaults.md#choose-how-smart-sort-ranks-streams) for rule units, operators, missing-value behavior, and worked examples.

--- a/backend/main.py
+++ b/backend/main.py
@@ -157,7 +157,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0002",
+    version="0.18.2-0003",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -131,7 +131,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0002"
+APP_VERSION = "0.18.2-0003"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -629,6 +629,23 @@ async def update_task(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+def _validate_run_parameters(task_id: str, parameters: Optional[dict]) -> None:
+    """Apply task-specific invariants before ad-hoc parameters reach the engine."""
+    try:
+        from task_registry import get_registry
+        task_class = get_registry().get_task_class(task_id)
+    except Exception as e:
+        logger.debug("[TASKS] Could not validate run parameters for %s: %s", task_id, e)
+        return
+
+    validator = getattr(task_class, "validate_run_parameters", None) if task_class else None
+    if validator:
+        try:
+            validator(parameters)
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+
+
 @router.post("/api/tasks/{task_id}/run", tags=["Tasks"])
 async def run_task(
     task_id: str,
@@ -653,6 +670,7 @@ async def run_task(
     # few truthy spellings would leave coercion and future-parameter bypasses.
     _reject_mcp_privileged_task(task_id, caller_is_mcp)
     try:
+        _validate_run_parameters(task_id, request.parameters if request else None)
         from task_engine import get_engine
         engine = get_engine()
         schedule_id = request.schedule_id if request else None

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -223,6 +223,13 @@ TASK_PARAMETER_SCHEMAS = {
                 "source": "channel_groups",  # Tells UI to fetch from channel groups API
             },
             {
+                "name": "allow_reorder_after_probe",
+                "type": "boolean",
+                "label": "Allow stream reordering",
+                "description": "Allow this schedule to apply the global auto-reorder setting after probing",
+                "default": True,
+            },
+            {
                 "name": "timeout",
                 "type": "number",
                 "label": "Timeout (seconds)",

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -773,6 +773,17 @@ def _schedule_parameter_schema(task_id: str) -> Optional[dict]:
 
 def _validate_schedule_parameters(task_id: str, parameters: Optional[dict]) -> None:
     """Apply task-specific invariants before a schedule can be persisted."""
+    if (
+        task_id == "stream_probe"
+        and parameters is not None
+        and "allow_reorder_after_probe" in parameters
+        and type(parameters["allow_reorder_after_probe"]) is not bool
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="allow_reorder_after_probe must be a boolean",
+        )
+
     try:
         from task_registry import get_registry
         task_class = get_registry().get_task_class(task_id)

--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -2401,7 +2401,14 @@ class StreamProber:
             **self._sort_settings_snapshot(),
         )
 
-    async def probe_all_streams(self, channel_groups_override: list[str] = None, skip_m3u_refresh: bool = False, stream_ids_filter: list[int] = None, start_send_alerts: bool = True):
+    async def probe_all_streams(
+        self,
+        channel_groups_override: list[str] = None,
+        skip_m3u_refresh: bool = False,
+        stream_ids_filter: list[int] = None,
+        start_send_alerts: bool = True,
+        allow_reorder_after_probe: bool = True,
+    ):
         """Probe all streams that are in channels (runs in background).
 
         Uses parallel probing - streams from different M3U accounts (or same M3U with
@@ -2415,9 +2422,12 @@ class StreamProber:
             stream_ids_filter: Optional list of specific stream IDs to probe.
                               If provided, only these streams will be probed (useful for re-probing failed streams).
             start_send_alerts: Whether the info-level "probe started" notification
-                              should dispatch an external alert. Callers pass the
-                              gated ``send_alerts AND alert_on_info`` value so the
-                              start alert respects the per-task config (GH #462).
+                               should dispatch an external alert. Callers pass the
+                               gated ``send_alerts AND alert_on_info`` value so the
+                               start alert respects the per-task config (GH #462).
+            allow_reorder_after_probe: Whether this invocation may apply the global
+                                       auto-reorder setting. False suppresses reorder
+                                       without changing the shared setting.
         """
         logger.info("[STREAM-PROBE] probe_all_streams called with channel_groups_override=%s, skip_m3u_refresh=%s, stream_ids_filter=%s", channel_groups_override, skip_m3u_refresh, len(stream_ids_filter) if stream_ids_filter else 0)
         logger.info("[STREAM-PROBE] Settings: parallel_probing_enabled=%s, max_concurrent_probes=%s, "
@@ -3064,8 +3074,12 @@ class StreamProber:
 
             # Auto-reorder streams if configured
             reordered_channels = []
-            logger.info("[STREAM-PROBE-SORT] Checking auto_reorder_after_probe setting: %s", self.auto_reorder_after_probe)
-            if self.auto_reorder_after_probe:
+            logger.info(
+                "[STREAM-PROBE-SORT] Checking auto_reorder_after_probe=%s, allow_reorder_after_probe=%s",
+                self.auto_reorder_after_probe,
+                allow_reorder_after_probe,
+            )
+            if self.auto_reorder_after_probe and allow_reorder_after_probe:
                 logger.info("[STREAM-PROBE] Auto-reorder is enabled, reordering streams in probed channels...")
                 self._probe_progress_status = "reordering"
                 self._probe_progress_current_stream = "Reordering streams..."

--- a/backend/tasks/stream_probe.py
+++ b/backend/tasks/stream_probe.py
@@ -61,6 +61,19 @@ class StreamProbeTask(TaskScheduler):
             "max_concurrent": self._max_concurrent_override,
         }
 
+    @classmethod
+    def validate_schedule_parameters(cls, parameters: Optional[dict]) -> None:
+        cls.validate_run_parameters(parameters)
+
+    @classmethod
+    def validate_run_parameters(cls, parameters: Optional[dict]) -> None:
+        if (
+            parameters is not None
+            and "allow_reorder_after_probe" in parameters
+            and type(parameters["allow_reorder_after_probe"]) is not bool
+        ):
+            raise ValueError("allow_reorder_after_probe must be a boolean")
+
     def update_config(self, config: dict) -> None:
         """Update stream probe configuration from schedule parameters.
 
@@ -77,7 +90,8 @@ class StreamProbeTask(TaskScheduler):
         if "auto_sync_groups" in config:
             self._auto_sync_groups = bool(config["auto_sync_groups"])
         if "allow_reorder_after_probe" in config:
-            self._allow_reorder_after_probe = bool(config["allow_reorder_after_probe"])
+            self.validate_run_parameters(config)
+            self._allow_reorder_after_probe = config["allow_reorder_after_probe"]
         if "timeout" in config:
             self._timeout_override = config["timeout"]
         if "max_concurrent" in config:

--- a/backend/tasks/stream_probe.py
+++ b/backend/tasks/stream_probe.py
@@ -47,6 +47,7 @@ class StreamProbeTask(TaskScheduler):
         # Schedule parameter overrides
         self._channel_groups: Optional[list] = None  # None = not configured (probe all), [] = explicitly empty (probe nothing)
         self._auto_sync_groups: bool = False  # Probe all current groups at runtime
+        self._allow_reorder_after_probe: bool = True
         self._timeout_override: Optional[int] = None
         self._max_concurrent_override: Optional[int] = None
 
@@ -55,6 +56,7 @@ class StreamProbeTask(TaskScheduler):
         return {
             "channel_groups": self._channel_groups,
             "auto_sync_groups": self._auto_sync_groups,
+            "allow_reorder_after_probe": self._allow_reorder_after_probe,
             "timeout": self._timeout_override,
             "max_concurrent": self._max_concurrent_override,
         }
@@ -64,6 +66,7 @@ class StreamProbeTask(TaskScheduler):
 
         Supported parameters:
         - channel_groups: list[str] - which channel groups to probe
+        - allow_reorder_after_probe: bool - allow the global reorder setting for this run
         - timeout: int - probe timeout in seconds
         - max_concurrent: int - max concurrent probe operations
         """
@@ -73,6 +76,8 @@ class StreamProbeTask(TaskScheduler):
             self._channel_groups = val if val is not None else []
         if "auto_sync_groups" in config:
             self._auto_sync_groups = bool(config["auto_sync_groups"])
+        if "allow_reorder_after_probe" in config:
+            self._allow_reorder_after_probe = bool(config["allow_reorder_after_probe"])
         if "timeout" in config:
             self._timeout_override = config["timeout"]
         if "max_concurrent" in config:
@@ -86,6 +91,7 @@ class StreamProbeTask(TaskScheduler):
         """Restore the exact baseline, preserving ``None`` as probe-all."""
         self._channel_groups = config["channel_groups"]
         self._auto_sync_groups = config["auto_sync_groups"]
+        self._allow_reorder_after_probe = config["allow_reorder_after_probe"]
         self._timeout_override = config["timeout"]
         self._max_concurrent_override = config["max_concurrent"]
 
@@ -199,6 +205,7 @@ class StreamProbeTask(TaskScheduler):
                     # externally when this task opted into info alerts. self._send_alerts
                     # is the engine-gated (send_alerts AND alert_on_info) value (GH #462).
                     start_send_alerts=self._send_alerts,
+                    allow_reorder_after_probe=self._allow_reorder_after_probe,
                 )
             )
 
@@ -340,5 +347,6 @@ class StreamProbeTask(TaskScheduler):
             # Clear all schedule parameter overrides
             self._channel_groups = None
             self._auto_sync_groups = False
+            self._allow_reorder_after_probe = True
             self._timeout_override = None
             self._max_concurrent_override = None

--- a/backend/tasks/stream_probe.py
+++ b/backend/tasks/stream_probe.py
@@ -90,6 +90,9 @@ class StreamProbeTask(TaskScheduler):
         if "auto_sync_groups" in config:
             self._auto_sync_groups = bool(config["auto_sync_groups"])
         if "allow_reorder_after_probe" in config:
+            # A present malformed value must remain fail-closed if a hydration
+            # caller catches validation errors and keeps this instance alive.
+            self._allow_reorder_after_probe = False
             self.validate_run_parameters(config)
             self._allow_reorder_after_probe = config["allow_reorder_after_probe"]
         if "timeout" in config:

--- a/backend/tests/routers/test_tasks.py
+++ b/backend/tests/routers/test_tasks.py
@@ -732,6 +732,34 @@ class TestCreateTaskSchedule:
             "allow_reorder_after_probe must be a boolean"
         )
 
+    @pytest.mark.parametrize("lookup_result", [None, RuntimeError("registry unavailable")])
+    @pytest.mark.asyncio
+    async def test_rejects_malformed_reorder_when_registry_class_is_unavailable(
+        self, async_client, test_session, lookup_result
+    ):
+        _create_scheduled_task(test_session, task_id="stream_probe")
+        registry = MagicMock()
+        if isinstance(lookup_result, Exception):
+            registry.get_task_class.side_effect = lookup_result
+        else:
+            registry.get_task_class.return_value = lookup_result
+
+        with patch("task_registry.get_registry", return_value=registry):
+            response = await async_client.post(
+                "/api/tasks/stream_probe/schedules",
+                json={
+                    "schedule_type": "daily",
+                    "schedule_time": "06:00",
+                    "parameters": {"allow_reorder_after_probe": "false"},
+                },
+            )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == (
+            "allow_reorder_after_probe must be a boolean"
+        )
+        assert test_session.query(TaskSchedule).filter_by(task_id="stream_probe").count() == 0
+
     @pytest.mark.asyncio
     async def test_returns_404_for_unknown_task(self, async_client):
         """Returns 404 when task not found."""
@@ -896,6 +924,34 @@ class TestUpdateTaskSchedule:
         assert response.json()["detail"] == (
             "allow_reorder_after_probe must be a boolean"
         )
+
+    @pytest.mark.parametrize("lookup_result", [None, RuntimeError("registry unavailable")])
+    @pytest.mark.asyncio
+    async def test_rejects_malformed_reorder_update_when_registry_class_is_unavailable(
+        self, async_client, test_session, lookup_result
+    ):
+        _create_scheduled_task(test_session, task_id="stream_probe")
+        schedule = _create_task_schedule(test_session, task_id="stream_probe")
+        schedule.set_parameters({"allow_reorder_after_probe": False})
+        test_session.commit()
+        registry = MagicMock()
+        if isinstance(lookup_result, Exception):
+            registry.get_task_class.side_effect = lookup_result
+        else:
+            registry.get_task_class.return_value = lookup_result
+
+        with patch("task_registry.get_registry", return_value=registry):
+            response = await async_client.patch(
+                f"/api/tasks/stream_probe/schedules/{schedule.id}",
+                json={"parameters": {"allow_reorder_after_probe": "false"}},
+            )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == (
+            "allow_reorder_after_probe must be a boolean"
+        )
+        test_session.refresh(schedule)
+        assert schedule.get_parameters()["allow_reorder_after_probe"] is False
 
     @pytest.mark.parametrize("value", [True, False])
     @pytest.mark.asyncio

--- a/backend/tests/routers/test_tasks.py
+++ b/backend/tests/routers/test_tasks.py
@@ -357,6 +357,25 @@ class TestGetParameterSchema:
         assert len(data["parameters"]) > 0
 
     @pytest.mark.asyncio
+    async def test_stream_probe_schema_allows_reorder_by_default(self, async_client):
+        response = await async_client.get("/api/tasks/stream_probe/parameter-schema")
+
+        assert response.status_code == 200
+        parameters = {
+            parameter["name"]: parameter for parameter in response.json()["parameters"]
+        }
+        assert parameters["allow_reorder_after_probe"] == {
+            "name": "allow_reorder_after_probe",
+            "type": "boolean",
+            "label": "Allow stream reordering",
+            "description": (
+                "Allow this schedule to apply the global auto-reorder setting "
+                "after probing"
+            ),
+            "default": True,
+        }
+
+    @pytest.mark.asyncio
     async def test_returns_empty_for_unknown(self, async_client):
         """Returns empty schema for unknown task type."""
         response = await async_client.get("/api/tasks/unknown_task/parameter-schema")
@@ -599,6 +618,37 @@ class TestCreateTaskSchedule:
         data = response.json()
         assert data["schedule_type"] == "daily"
         assert data["schedule_time"] == "06:00"
+
+    @pytest.mark.asyncio
+    async def test_persists_stream_probe_reorder_choice_as_json(
+        self, async_client, test_session
+    ):
+        _create_scheduled_task(test_session, task_id="stream_probe")
+
+        response = await async_client.post(
+            "/api/tasks/stream_probe/schedules",
+            json={
+                "schedule_type": "daily",
+                "schedule_time": "06:00",
+                "parameters": {
+                    "channel_groups": [7],
+                    "allow_reorder_after_probe": False,
+                },
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["parameters"] == {
+            "channel_groups": [7],
+            "allow_reorder_after_probe": False,
+        }
+        persisted = test_session.query(TaskSchedule).filter_by(
+            id=response.json()["id"]
+        ).one()
+        assert persisted.get_parameters() == {
+            "channel_groups": [7],
+            "allow_reorder_after_probe": False,
+        }
 
     @pytest.mark.asyncio
     async def test_returns_404_for_unknown_task(self, async_client):

--- a/backend/tests/routers/test_tasks.py
+++ b/backend/tests/routers/test_tasks.py
@@ -246,6 +246,58 @@ class TestRunTask:
         assert response.status_code == 200
         mock_engine.run_task.assert_called_once_with("stream_probe", schedule_id=None, parameters=None)
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("false", id="string"),
+            pytest.param(1, id="number"),
+            pytest.param(None, id="null"),
+            pytest.param([], id="array"),
+            pytest.param({}, id="object"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_stream_probe_run_rejects_non_boolean_reorder_option(
+        self, async_client, value
+    ):
+        mock_engine = MagicMock()
+        mock_engine.run_task = AsyncMock()
+
+        with patch("task_engine.get_engine", return_value=mock_engine):
+            response = await async_client.post(
+                "/api/tasks/stream_probe/run",
+                json={"parameters": {"allow_reorder_after_probe": value}},
+            )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == (
+            "allow_reorder_after_probe must be a boolean"
+        )
+        mock_engine.run_task.assert_not_awaited()
+
+    @pytest.mark.parametrize("value", [True, False])
+    @pytest.mark.asyncio
+    async def test_stream_probe_run_accepts_boolean_reorder_option(
+        self, async_client, value
+    ):
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {"success": True}
+        mock_engine = MagicMock()
+        mock_engine.run_task = AsyncMock(return_value=mock_result)
+
+        with patch("task_engine.get_engine", return_value=mock_engine):
+            response = await async_client.post(
+                "/api/tasks/stream_probe/run",
+                json={"parameters": {"allow_reorder_after_probe": value}},
+            )
+
+        assert response.status_code == 200
+        mock_engine.run_task.assert_awaited_once_with(
+            "stream_probe",
+            schedule_id=None,
+            parameters={"allow_reorder_after_probe": value},
+        )
+
     @pytest.mark.asyncio
     async def test_returns_404_for_unknown(self, async_client):
         """Returns 404 when task not found."""
@@ -650,6 +702,36 @@ class TestCreateTaskSchedule:
             "allow_reorder_after_probe": False,
         }
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("false", id="string"),
+            pytest.param(1, id="number"),
+            pytest.param(None, id="null"),
+            pytest.param([], id="array"),
+            pytest.param({}, id="object"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_rejects_non_boolean_stream_probe_reorder_option(
+        self, async_client, test_session, value
+    ):
+        _create_scheduled_task(test_session, task_id="stream_probe")
+
+        response = await async_client.post(
+            "/api/tasks/stream_probe/schedules",
+            json={
+                "schedule_type": "daily",
+                "schedule_time": "06:00",
+                "parameters": {"allow_reorder_after_probe": value},
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == (
+            "allow_reorder_after_probe must be a boolean"
+        )
+
     @pytest.mark.asyncio
     async def test_returns_404_for_unknown_task(self, async_client):
         """Returns 404 when task not found."""
@@ -787,6 +869,49 @@ class TestUpdateTaskSchedule:
         assert response.status_code == 200
         data = response.json()
         assert data["schedule_time"] == "09:00"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("false", id="string"),
+            pytest.param(1, id="number"),
+            pytest.param(None, id="null"),
+            pytest.param([], id="array"),
+            pytest.param({}, id="object"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_rejects_non_boolean_stream_probe_reorder_option(
+        self, async_client, test_session, value
+    ):
+        _create_scheduled_task(test_session, task_id="stream_probe")
+        schedule = _create_task_schedule(test_session, task_id="stream_probe")
+
+        response = await async_client.patch(
+            f"/api/tasks/stream_probe/schedules/{schedule.id}",
+            json={"parameters": {"allow_reorder_after_probe": value}},
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == (
+            "allow_reorder_after_probe must be a boolean"
+        )
+
+    @pytest.mark.parametrize("value", [True, False])
+    @pytest.mark.asyncio
+    async def test_accepts_boolean_stream_probe_reorder_option(
+        self, async_client, test_session, value
+    ):
+        _create_scheduled_task(test_session, task_id="stream_probe")
+        schedule = _create_task_schedule(test_session, task_id="stream_probe")
+
+        response = await async_client.patch(
+            f"/api/tasks/stream_probe/schedules/{schedule.id}",
+            json={"parameters": {"allow_reorder_after_probe": value}},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["parameters"]["allow_reorder_after_probe"] is value
 
     @pytest.mark.asyncio
     async def test_returns_404_for_unknown(self, async_client, test_session):

--- a/backend/tests/unit/test_stream_probe_reorder_option.py
+++ b/backend/tests/unit/test_stream_probe_reorder_option.py
@@ -38,7 +38,7 @@ def _task_prober() -> SimpleNamespace:
     )
 
 
-def test_stream_probe_config_rejects_non_boolean_reorder_option():
+def test_stream_probe_config_rejects_non_boolean_reorder_option_fail_closed():
     task = StreamProbeTask()
 
     with pytest.raises(
@@ -46,7 +46,7 @@ def test_stream_probe_config_rejects_non_boolean_reorder_option():
     ):
         task.update_config({"allow_reorder_after_probe": "false"})
 
-    assert task.get_config()["allow_reorder_after_probe"] is True
+    assert task.get_config()["allow_reorder_after_probe"] is False
 
 
 def test_stream_probe_config_missing_reorder_option_keeps_legacy_default():

--- a/backend/tests/unit/test_stream_probe_reorder_option.py
+++ b/backend/tests/unit/test_stream_probe_reorder_option.py
@@ -1,0 +1,174 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+import stream_prober
+from models import StreamStats
+from stream_prober import StreamProber
+from tasks.stream_probe import StreamProbeTask
+
+
+def _task_prober() -> SimpleNamespace:
+    return SimpleNamespace(
+        _probing_in_progress=False,
+        _probe_progress_total=0,
+        _probe_progress_current=0,
+        _probe_progress_status="completed",
+        _probe_progress_current_stream="",
+        _probe_progress_success_count=0,
+        _probe_progress_failed_count=0,
+        _probe_progress_skipped_count=0,
+        _probe_progress_black_screen_count=0,
+        _probe_progress_low_fps_count=0,
+        _probe_success_streams=[],
+        _probe_failed_streams=[],
+        probe_timeout=30,
+        max_concurrent_probes=3,
+        auto_reorder_after_probe=True,
+        client=SimpleNamespace(
+            get_channel_groups=AsyncMock(
+                return_value=[{"id": 7, "name": "Sports"}]
+            )
+        ),
+        probe_all_streams=AsyncMock(return_value={"status": "completed"}),
+        cancel_probe=MagicMock(),
+        _failure_breakdown=MagicMock(return_value=[]),
+    )
+
+
+@pytest.mark.asyncio
+async def test_scheduled_probe_reorder_choice_is_invocation_local_and_group_scoped():
+    prober = _task_prober()
+    task = StreamProbeTask()
+    task.set_prober(prober)
+
+    task.update_config({
+        "channel_groups": [7],
+        "allow_reorder_after_probe": False,
+    })
+    first = await task.execute()
+    second = await task.execute()
+
+    assert first.success is True
+    assert second.success is True
+    assert prober.probe_all_streams.await_args_list == [
+        call(
+            channel_groups_override=["Sports"],
+            skip_m3u_refresh=False,
+            start_send_alerts=True,
+            allow_reorder_after_probe=False,
+        ),
+        call(
+            channel_groups_override=None,
+            skip_m3u_refresh=False,
+            start_send_alerts=True,
+            allow_reorder_after_probe=True,
+        ),
+    ]
+    assert prober.auto_reorder_after_probe is True
+
+
+@pytest.mark.parametrize(
+    ("global_reorder", "invocation_override", "groups", "expected_order"),
+    [
+        (True, None, None, [20, 10]),
+        (True, False, ["Sports"], [10, 20]),
+        (False, True, None, [10, 20]),
+    ],
+    ids=["default-follows-global", "disabled", "does-not-force-global"],
+)
+@pytest.mark.asyncio
+async def test_probe_all_reorder_gate_preserves_metadata_and_channel_order(
+    test_engine,
+    monkeypatch,
+    global_reorder,
+    invocation_override,
+    groups,
+    expected_order,
+):
+    session_factory = sessionmaker(bind=test_engine, expire_on_commit=False)
+    monkeypatch.setattr(stream_prober, "get_session", session_factory)
+
+    client = AsyncMock()
+    client.get_m3u_accounts.return_value = []
+    channel_order = [10, 20]
+    prober = StreamProber(
+        client=client,
+        auto_reorder_after_probe=global_reorder,
+        parallel_probing_enabled=False,
+    )
+    prober._persist_probe_history = lambda: None
+
+    async def reorder(group_names, _stream_to_channels):
+        assert group_names == groups
+        channel_order[:] = [20, 10]
+        return [{"channel_id": 1}]
+
+    ffprobe_data = {
+        "streams": [
+            {
+                "codec_type": "video",
+                "codec_name": "h264",
+                "width": 1920,
+                "height": 1080,
+                "r_frame_rate": "30/1",
+            }
+        ],
+        "format": {"format_name": "mpegts"},
+    }
+    fetch_channel_stream_ids = AsyncMock(
+        return_value=({20}, {20: ["Channel"]}, {20: 1})
+    )
+
+    kwargs = {"channel_groups_override": groups}
+    if invocation_override is not None:
+        kwargs["allow_reorder_after_probe"] = invocation_override
+
+    with patch.object(
+        prober, "_fetch_channel_stream_ids", fetch_channel_stream_ids
+    ), patch.object(
+        prober,
+        "_fetch_all_streams",
+        AsyncMock(
+            return_value=[
+                {"id": 20, "name": "1080p", "url": "http://example.test/20"}
+            ]
+        ),
+    ), patch.object(
+        prober, "_run_ffprobe", AsyncMock(return_value=ffprobe_data)
+    ), patch.object(
+        prober, "_measure_stream_bitrate", AsyncMock(return_value=5_000_000)
+    ), patch.object(
+        prober, "_push_stats_to_dispatcharr", AsyncMock()
+    ), patch.object(
+        prober, "_create_probe_notification", AsyncMock()
+    ), patch.object(
+        prober, "_update_probe_notification", AsyncMock()
+    ), patch.object(
+        prober, "_finalize_probe_notification", AsyncMock()
+    ), patch.object(
+        prober, "_auto_reorder_channels", AsyncMock(side_effect=reorder)
+    ) as reorder_mock, patch(
+        "stream_prober.asyncio.sleep", AsyncMock()
+    ):
+        result = await prober.probe_all_streams(**kwargs)
+
+    assert result["status"] == "completed"
+    fetch_channel_stream_ids.assert_awaited_once_with(groups)
+    assert channel_order == expected_order
+    if expected_order == [20, 10]:
+        reorder_mock.assert_awaited_once()
+    else:
+        reorder_mock.assert_not_awaited()
+
+    session = session_factory()
+    try:
+        stats = session.query(StreamStats).filter_by(stream_id=20).one()
+        assert stats.probe_status == "success"
+        assert stats.resolution == "1920x1080"
+        assert stats.video_codec == "h264"
+        assert stats.video_bitrate == 5_000_000
+    finally:
+        session.close()

--- a/backend/tests/unit/test_stream_probe_reorder_option.py
+++ b/backend/tests/unit/test_stream_probe_reorder_option.py
@@ -38,6 +38,25 @@ def _task_prober() -> SimpleNamespace:
     )
 
 
+def test_stream_probe_config_rejects_non_boolean_reorder_option():
+    task = StreamProbeTask()
+
+    with pytest.raises(
+        ValueError, match="allow_reorder_after_probe must be a boolean"
+    ):
+        task.update_config({"allow_reorder_after_probe": "false"})
+
+    assert task.get_config()["allow_reorder_after_probe"] is True
+
+
+def test_stream_probe_config_missing_reorder_option_keeps_legacy_default():
+    task = StreamProbeTask()
+
+    task.update_config({"channel_groups": [7]})
+
+    assert task.get_config()["allow_reorder_after_probe"] is True
+
+
 @pytest.mark.asyncio
 async def test_scheduled_probe_reorder_choice_is_invocation_local_and_group_scoped():
     prober = _task_prober()

--- a/backend/tests/unit/test_stream_probe_task_smart_sort.py
+++ b/backend/tests/unit/test_stream_probe_task_smart_sort.py
@@ -74,6 +74,7 @@ async def test_scheduled_probe_uses_resolved_smart_sort_configuration(strategy):
         channel_groups_override=None,
         skip_m3u_refresh=False,
         start_send_alerts=True,
+        allow_reorder_after_probe=True,
     )
 
 

--- a/backend/tests/unit/test_task_registry_config_persist.py
+++ b/backend/tests/unit/test_task_registry_config_persist.py
@@ -275,6 +275,31 @@ class TestRestartRoundtrip:
         assert inst is not None
         assert inst.get_config() == JournalNoisePurgeTask().get_config()
 
+    def test_malformed_present_stream_probe_reorder_hydrates_fail_closed(
+        self, test_session, monkeypatch
+    ):
+        from tasks.stream_probe import StreamProbeTask
+        from tests.fixtures.factories import create_scheduled_task
+
+        create_scheduled_task(
+            test_session,
+            task_id="stream_probe",
+            task_name="Stream Probe",
+            description="x",
+            enabled=True,
+            schedule_type="manual",
+            config={"allow_reorder_after_probe": "false"},
+        )
+        monkeypatch.setattr("task_registry.get_session", lambda: test_session)
+        reg = TaskRegistry()
+        reg.register(StreamProbeTask)
+
+        reg.sync_from_database()
+
+        inst = reg.get_task_instance("stream_probe")
+        assert inst is not None
+        assert inst.get_config()["allow_reorder_after_probe"] is False
+
 
 class TestScheduleOverlayNotPersisted:
     """Delta re-review BLOCK (gjb01): per-schedule TaskSchedule.parameters are

--- a/docs/user_guide/settings/scheduled-tasks.md
+++ b/docs/user_guide/settings/scheduled-tasks.md
@@ -35,6 +35,17 @@ Now here. Trigger those from their own page instead.
 update to reflect the change. A disabled task shows a paused-circle badge
 and **Next Run: Disabled**.
 
+### Probe selected groups without changing stream order
+
+When adding or editing a **Stream Probe** schedule, select the channel groups
+to probe and turn off **Allow stream reordering**. The probe still saves fresh
+resolution, bitrate, codec, and health metadata, but that run leaves each
+channel's stream order unchanged. Other schedules keep their own setting.
+
+Leaving the option on preserves the existing behavior: the schedule follows
+the global auto-reorder setting under **Settings → Maintenance**. It does not
+turn reordering on when that global setting is off.
+
 ### Check whether a task's last few runs succeeded
 
 1. Go to **Settings → Scheduled Tasks**.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0002",
+  "version": "0.18.2-0003",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/ScheduleEditor.test.tsx
+++ b/frontend/src/components/ScheduleEditor.test.tsx
@@ -196,6 +196,121 @@ describe('ScheduleEditor', () => {
       expect(batchInput).toBeInTheDocument();
     });
 
+    it('saves parameters in schema, task default, then stored schedule precedence', async () => {
+      const user = userEvent.setup();
+      render(
+        <ScheduleEditor
+          {...defaultProps}
+          schedule={{ ...mockSchedule, parameters: { timeout: 60 } }}
+          parameterSchema={parameterSchema}
+          defaultParameters={{ batch_size: 25, timeout: 45 }}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: /update schedule/i }));
+
+      await waitFor(() => expect(mockOnSave).toHaveBeenCalledWith(
+        expect.objectContaining({ parameters: { batch_size: 25, timeout: 60 } }),
+      ));
+    });
+
+    it('saves the Stream Probe reorder schema default without checkbox interaction', async () => {
+      const user = userEvent.setup();
+      const streamProbeSchema: TaskParameterSchema[] = [
+        {
+          name: 'channel_groups',
+          type: 'number_array',
+          label: 'Channel Groups',
+          description: 'Which channel groups to include in the probe',
+          default: [],
+        },
+        {
+          name: 'allow_reorder_after_probe',
+          type: 'boolean',
+          label: 'Allow stream reordering',
+          description: 'Allow this schedule to apply the global setting',
+          default: true,
+        },
+      ];
+
+      render(
+        <ScheduleEditor
+          {...defaultProps}
+          taskId="stream_probe"
+          parameterSchema={streamProbeSchema}
+          defaultParameters={{ channel_groups: [7] }}
+        />
+      );
+
+      expect(screen.getByRole('checkbox', { name: /allow stream reordering/i })).toBeChecked();
+      await user.click(screen.getByRole('button', { name: /add schedule/i }));
+
+      await waitFor(() => expect(mockOnSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parameters: {
+            channel_groups: [7],
+            allow_reorder_after_probe: true,
+          },
+        }),
+      ));
+    });
+
+    it('saves false after disabling Stream Probe reordering', async () => {
+      const user = userEvent.setup();
+      const streamProbeSchema: TaskParameterSchema[] = [{
+        name: 'allow_reorder_after_probe',
+        type: 'boolean',
+        label: 'Allow stream reordering',
+        description: 'Allow this schedule to apply the global setting',
+        default: true,
+      }];
+
+      render(
+        <ScheduleEditor
+          {...defaultProps}
+          taskId="stream_probe"
+          parameterSchema={streamProbeSchema}
+          defaultParameters={{}}
+        />
+      );
+
+      const checkbox = screen.getByRole('checkbox', { name: /allow stream reordering/i });
+      await user.click(checkbox);
+      await user.click(screen.getByRole('button', { name: /add schedule/i }));
+
+      await waitFor(() => expect(mockOnSave).toHaveBeenCalledWith(
+        expect.objectContaining({ parameters: { allow_reorder_after_probe: false } }),
+      ));
+    });
+
+    it('persists defaults when the parameter schema loads after the editor opens', async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(<ScheduleEditor {...defaultProps} taskId="stream_probe" />);
+      const streamProbeSchema: TaskParameterSchema[] = [{
+        name: 'allow_reorder_after_probe',
+        type: 'boolean',
+        label: 'Allow stream reordering',
+        description: 'Allow this schedule to apply the global setting',
+        default: true,
+      }];
+
+      rerender(
+        <ScheduleEditor
+          {...defaultProps}
+          taskId="stream_probe"
+          parameterSchema={streamProbeSchema}
+          defaultParameters={{}}
+        />
+      );
+
+      expect(await screen.findByRole('checkbox', { name: /allow stream reordering/i })).toBeChecked();
+      await user.click(screen.getByRole('button', { name: /add schedule/i }));
+
+      await waitFor(() => expect(mockOnSave).toHaveBeenCalledWith(
+        expect.objectContaining({ parameters: { allow_reorder_after_probe: true } }),
+      ));
+    });
+
     it('requires explicit apply confirmation for a recurring sync schedule', async () => {
       const user = userEvent.setup();
       const syncSchema: TaskParameterSchema[] = [{

--- a/frontend/src/components/ScheduleEditor.test.tsx
+++ b/frontend/src/components/ScheduleEditor.test.tsx
@@ -311,6 +311,83 @@ describe('ScheduleEditor', () => {
       ));
     });
 
+    it('keeps a user-disabled boolean when async defaults arrive later', async () => {
+      const user = userEvent.setup();
+      const streamProbeSchema: TaskParameterSchema[] = [{
+        name: 'allow_reorder_after_probe',
+        type: 'boolean',
+        label: 'Allow stream reordering',
+        description: 'Allow this schedule to apply the global setting',
+        default: true,
+      }];
+      const { rerender } = render(
+        <ScheduleEditor
+          {...defaultProps}
+          taskId="stream_probe"
+          parameterSchema={streamProbeSchema}
+        />
+      );
+
+      await user.click(screen.getByRole('checkbox', { name: /allow stream reordering/i }));
+      rerender(
+        <ScheduleEditor
+          {...defaultProps}
+          taskId="stream_probe"
+          parameterSchema={streamProbeSchema}
+          defaultParameters={{ allow_reorder_after_probe: true }}
+        />
+      );
+
+      expect(screen.getByRole('checkbox', { name: /allow stream reordering/i })).not.toBeChecked();
+      await user.click(screen.getByRole('button', { name: /add schedule/i }));
+      await waitFor(() => expect(mockOnSave).toHaveBeenCalledWith(
+        expect.objectContaining({ parameters: { allow_reorder_after_probe: false } }),
+      ));
+    });
+
+    it('keeps a user-cleared array when async defaults and options arrive later', async () => {
+      const user = userEvent.setup();
+      const groupSchema: TaskParameterSchema[] = [{
+        name: 'channel_groups',
+        type: 'number_array',
+        label: 'Channel Groups',
+        description: 'Which channel groups to probe',
+        default: [],
+        source: 'channel_groups',
+      }];
+      const { rerender } = render(
+        <ScheduleEditor
+          {...defaultProps}
+          taskId="stream_probe"
+          parameterSchema={groupSchema}
+          parameterOptions={{ channel_groups: [{ value: 7, label: 'Sports' }] }}
+          defaultParameters={{ channel_groups: [7] }}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: /select none/i }));
+      rerender(
+        <ScheduleEditor
+          {...defaultProps}
+          taskId="stream_probe"
+          parameterSchema={groupSchema}
+          parameterOptions={{
+            channel_groups: [
+              { value: 7, label: 'Sports' },
+              { value: 8, label: 'News' },
+            ],
+          }}
+          defaultParameters={{ channel_groups: [7, 8] }}
+        />
+      );
+
+      expect(screen.getByText('0 of 2 selected')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: /add schedule/i }));
+      await waitFor(() => expect(mockOnSave).toHaveBeenCalledWith(
+        expect.objectContaining({ parameters: { channel_groups: [] } }),
+      ));
+    });
+
     it('requires explicit apply confirmation for a recurring sync schedule', async () => {
       const user = userEvent.setup();
       const syncSchema: TaskParameterSchema[] = [{

--- a/frontend/src/components/ScheduleEditor.tsx
+++ b/frontend/src/components/ScheduleEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import type { TaskSchedule, TaskScheduleType, TaskScheduleCreate, TaskScheduleUpdate, TaskParameterSchema } from '../services/api';
 import { CustomSelect } from './CustomSelect';
 import './ModalBase.css';
@@ -58,6 +58,23 @@ const TIMEZONE_OPTIONS = [
   { value: 'Australia/Sydney', label: 'Sydney' },
 ];
 
+function resolveParameters(
+  parameterSchema?: TaskParameterSchema[],
+  defaultParameters?: Record<string, unknown>,
+  scheduleParameters?: Record<string, unknown> | null,
+): Record<string, unknown> {
+  const schemaDefaults = (parameterSchema || []).reduce((defaults, parameter) => {
+    if (parameter.default !== undefined) defaults[parameter.name] = parameter.default;
+    return defaults;
+  }, {} as Record<string, unknown>);
+
+  return {
+    ...schemaDefaults,
+    ...defaultParameters,
+    ...scheduleParameters,
+  };
+}
+
 export function ScheduleEditor({ schedule, onSave, onCancel, saving, taskId, parameterSchema, parameterOptions, defaultParameters }: ScheduleEditorProps) {
   // Form state
   const [name, setName] = useState(schedule?.name || '');
@@ -71,18 +88,22 @@ export function ScheduleEditor({ schedule, onSave, onCancel, saving, taskId, par
   const [useCustomInterval, setUseCustomInterval] = useState(false);
 
   // Task-specific parameters state
-  const [parameters, setParameters] = useState<Record<string, unknown>>(() => {
-    // Initialize from schedule parameters (editing)
-    if (schedule?.parameters) return schedule.parameters;
-    // Use provided defaults for new schedules
-    if (defaultParameters && Object.keys(defaultParameters).length > 0) return defaultParameters;
-    // Fall back to schema defaults
-    if (!parameterSchema) return {};
-    return parameterSchema.reduce((acc, param) => {
-      if (param.default !== undefined) acc[param.name] = param.default;
-      return acc;
-    }, {} as Record<string, unknown>);
-  });
+  const touchedParameters = useRef(new Set<string>());
+  const [parameters, setParameters] = useState<Record<string, unknown>>(() =>
+    resolveParameters(parameterSchema, defaultParameters, schedule?.parameters)
+  );
+
+  // The modal loads schema, task defaults, and options asynchronously. Rebuild
+  // untouched values as those inputs arrive without overwriting user edits.
+  useEffect(() => {
+    setParameters((current) => {
+      const resolved = resolveParameters(parameterSchema, defaultParameters, schedule?.parameters);
+      touchedParameters.current.forEach((name) => {
+        resolved[name] = current[name];
+      });
+      return resolved;
+    });
+  }, [parameterSchema, defaultParameters, schedule?.parameters]);
 
   // Check if browser timezone is in our list
   const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -98,11 +119,13 @@ export function ScheduleEditor({ schedule, onSave, onCancel, saving, taskId, par
 
   // Helper to update a single parameter
   const updateParameter = (name: string, value: unknown) => {
+    touchedParameters.current.add(name);
     setParameters(prev => ({ ...prev, [name]: value }));
   };
 
   // Helper to toggle a value in an array parameter
   const toggleArrayParameter = (name: string, value: string | number) => {
+    touchedParameters.current.add(name);
     setParameters(prev => {
       const arr = (prev[name] as (string | number)[]) || [];
       const newArr = arr.includes(value)

--- a/frontend/src/components/TaskEditorModal.test.tsx
+++ b/frontend/src/components/TaskEditorModal.test.tsx
@@ -99,6 +99,16 @@ function makeCleanupTask(configOverrides: Record<string, unknown> = {}): TaskSta
   };
 }
 
+function makeStreamProbeTask(): TaskStatus {
+  return {
+    ...makeCleanupTask(),
+    task_id: 'stream_probe',
+    task_name: 'Stream Probe',
+    task_description: 'Probe streams',
+    config: {},
+  };
+}
+
 describe('TaskEditorModal — bd-ia28g retention fields', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -160,6 +170,53 @@ describe('TaskEditorModal — bd-ia28g retention fields', () => {
     await user.click(cancel);
     await user.keyboard('{Escape}');
     expect(screen.getByRole('dialog', { name: 'Edit Schedule' })).toBe(dialog);
+  });
+
+  it('merges task defaults into a partial Stream Probe schedule while stored values win', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.getTaskParameterSchema).mockResolvedValue({
+      task_id: 'stream_probe',
+      description: 'Stream Probe parameters',
+      parameters: [
+        { name: 'channel_groups', type: 'number_array', label: 'Channel Groups', description: 'Groups', default: [], source: 'channel_groups' },
+        { name: 'allow_reorder_after_probe', type: 'boolean', label: 'Allow stream reordering', description: 'Reorder', default: true },
+        { name: 'timeout', type: 'number', label: 'Timeout', description: 'Timeout', default: 30 },
+        { name: 'max_concurrent', type: 'number', label: 'Max Concurrent', description: 'Concurrency', default: 3 },
+      ],
+    });
+    vi.mocked(api.getChannelGroups).mockResolvedValue([
+      { id: 7, name: 'Sports', channel_count: 4, is_auto_sync: false },
+    ] as Awaited<ReturnType<typeof api.getChannelGroups>>);
+    vi.mocked(api.getSettings).mockResolvedValue({
+      stream_probe_timeout: 45,
+      max_concurrent_probes: 9,
+    } as Awaited<ReturnType<typeof api.getSettings>>);
+    vi.mocked(api.getTaskSchedules).mockResolvedValue({ schedules: [{
+      id: 8, task_id: 'stream_probe', name: 'Partial', enabled: true, schedule_type: 'daily',
+      schedule_time: '03:00', timezone: 'UTC', interval_seconds: null, days_of_week: null,
+      day_of_month: null, week_parity: null, parameters: { timeout: 77 }, next_run_at: null,
+      last_run_at: null, description: '', created_at: '', updated_at: null,
+    }] });
+    const updateSchedule = vi.spyOn(api, 'updateTaskSchedule').mockResolvedValue(undefined as never);
+
+    render(<TaskEditorModal task={makeStreamProbeTask()} onClose={vi.fn()} onSaved={vi.fn()} />);
+    await user.click(await screen.findByRole('button', { name: 'Edit schedule' }));
+    await user.click(within(screen.getByRole('dialog', { name: 'Edit Schedule' })).getByRole(
+      'button', { name: /update schedule/i },
+    ));
+
+    await waitFor(() => expect(updateSchedule).toHaveBeenCalledWith(
+      'stream_probe',
+      8,
+      expect.objectContaining({
+        parameters: {
+          channel_groups: [7],
+          allow_reorder_after_probe: true,
+          timeout: 77,
+          max_concurrent: 9,
+        },
+      }),
+    ));
   });
 
   it('renders the channel pipeline BLOB retention input with the config value', async () => {

--- a/frontend/src/components/TaskEditorModal.tsx
+++ b/frontend/src/components/TaskEditorModal.tsx
@@ -927,6 +927,7 @@ export function TaskEditorModal({ task, onClose, onSaved, openAddSchedule }: Tas
               taskId={task.task_id}
               parameterSchema={task.task_id === 'cleanup' ? [] : parameterSchema}
               parameterOptions={parameterOptions}
+              defaultParameters={defaultParameters}
             />
           </div>
         </ModalOverlay>


### PR DESCRIPTION
## What
- Add an explicit per-schedule `Allow stream reordering` option for Stream Probe tasks.
- Pass the option invocation-locally so disabling one schedule does not mutate shared prober state or affect other runs.
- Preserve probe metadata updates while suppressing post-probe channel stream reordering.
- Persist schema defaults explicitly in add/edit flows and strictly reject malformed non-boolean values.
- Document the operator workflow and advance the app version to `0.18.2-0003`.

## Why
Teamarr-managed channels need fresh stream health metadata without ECM replacing intentional stream ordering.

Bead: `enhancedchannelmanager-8gmk8.2`
Closes #900

## Verification
- Backend gate: 12,249 passed, 3 skipped, 2 deselected; 80.76% coverage
- Frontend tests: 3,627 passed
- Frontend ESLint: passed
- Frontend TypeScript: passed
- Frontend production build: passed
- `mkdocs build --strict`: passed
- Independent code review: approved, no Block or Warning findings
- Independent security review: approved, no findings

## Deployment
- No database migration or infrastructure change
- Rollback: revert the three feature-branch commits
