### PR TITLE
[enhancedchannelmanager-8gmk8.3] Fail closed on stale probe groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **Scheduled Stream Probe group filters now fail closed when no configured groups resolve (bead `enhancedchannelmanager-8gmk8.3`, build 0004).** An omitted group selection still probes all groups, while an explicit empty selection or an all-stale selection completes without probing metadata or reordering channels. Mixed selections probe and reorder only currently valid groups.
+
 - **Post-merge dev publication checks now follow the actual reusable workflow and fail closed on incomplete evidence (bead `enhancedchannelmanager-69dxb`, build 0002).** The checker selects the exact successful `Tests` push attempt and its final reusable manifest job, requires the current mutable tag to contain exactly matching AMD64 and ARM64 version/full-commit markers, and treats a fresh pull as an additional marker cross-check rather than a fallback. Malformed API or manifest data, duplicate markers, missing platforms, command failures, and a request to skip both checks now return actionable failures. The result is explicitly a point-in-time consistency check that trusts registry writers, not cryptographic workflow-to-image attestation.
 
 ## [0.18.1] — 2026-08-30

--- a/backend/main.py
+++ b/backend/main.py
@@ -157,7 +157,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0003",
+    version="0.18.2-0004",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -131,7 +131,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0003"
+APP_VERSION = "0.18.2-0004"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -1671,7 +1671,7 @@ class StreamProber:
                 break
         return all_streams
 
-    async def _fetch_channel_stream_ids(self, channel_groups_override: list[str] = None) -> tuple[set, dict, dict]:
+    async def _fetch_channel_stream_ids(self, channel_groups_override: list[str] | None = None) -> tuple[set, dict, dict]:
         """
         Fetch all unique stream IDs from channels (paginated).
         Only fetches from selected groups if channel_groups_override is set.
@@ -1679,7 +1679,7 @@ class StreamProber:
 
         Args:
             channel_groups_override: Optional list of channel group names to filter by.
-                                    If None or empty, probes all groups.
+                                    None probes all groups; an empty list probes none.
         """
         logger.debug("[STREAM-PROBE] _fetch_channel_stream_ids called with override=%s", channel_groups_override)
 
@@ -1687,8 +1687,12 @@ class StreamProber:
         stream_to_channels = {}  # stream_id -> list of channel names
         stream_to_channel_number = {}  # stream_id -> lowest channel number (for sorting)
 
-        # Determine which groups to filter by
+        if channel_groups_override == []:
+            return channel_stream_ids, stream_to_channels, stream_to_channel_number
+
+        # Presence, not truthiness, controls filtering: [] is an explicit no-op.
         groups_to_filter = channel_groups_override or []
+        filter_by_group = channel_groups_override is not None
         logger.debug("[STREAM-PROBE] groups_to_filter=%s", groups_to_filter)
 
         # If specific groups are selected, fetch all groups first to filter
@@ -1718,7 +1722,9 @@ class StreamProber:
                 logger.debug("[STREAM-PROBE] Filtering to %s groups", len(selected_group_ids))
             except Exception as e:
                 logger.error("[STREAM-PROBE] Failed to fetch channel groups for filtering: %s", e)
-                # Continue without filtering if we can't fetch groups
+
+            if not selected_group_ids:
+                return channel_stream_ids, stream_to_channels, stream_to_channel_number
 
         page = 1
         total_channels_seen = 0
@@ -1736,12 +1742,11 @@ class StreamProber:
                     channel_name = channel.get("name", f"Channel {channel.get('id', 'Unknown')}")
                     channel_group_id = channel.get("channel_group_id")
 
-                    # If groups are selected, filter by channel_group_id
-                    if selected_group_ids:
-                        if channel_group_id not in selected_group_ids:
-                            channels_excluded_wrong_group += 1
-                            excluded_channel_names.append(channel_name)
-                            continue  # Skip channels not in selected groups
+                    # An explicitly configured selection must never widen to all groups.
+                    if filter_by_group and channel_group_id not in selected_group_ids:
+                        channels_excluded_wrong_group += 1
+                        excluded_channel_names.append(channel_name)
+                        continue  # Skip channels not in selected groups
 
                     channel_number = channel.get("channel_number", 999999)  # Default high number for sorting
                     # Each channel has a "streams" field which is a list of stream IDs
@@ -1777,7 +1782,7 @@ class StreamProber:
         logger.debug("[STREAM-PROBE] Channel filtering summary:")
         logger.debug("[STREAM-PROBE]   Total channels seen: %s", total_channels_seen)
         logger.debug("[STREAM-PROBE]   Channels included: %s", channels_included)
-        if selected_group_ids:
+        if filter_by_group:
             logger.debug("[STREAM-PROBE]   Channels excluded (wrong group): %s", channels_excluded_wrong_group)
         if channels_with_no_streams > 0:
             logger.debug("[STREAM-PROBE]   Channels with no streams: %s", channels_with_no_streams)
@@ -1999,17 +2004,22 @@ class StreamProber:
             logger.debug("[STREAM-PROBE] Profile %s: rewrote URL", profile['id'])
         return rewritten
 
-    async def _auto_reorder_channels(self, channel_groups_override: list[str] = None, stream_to_channels: dict = None) -> list[dict]:
+    async def _auto_reorder_channels(self, channel_groups_override: list[str] | None = None, stream_to_channels: dict = None) -> list[dict]:
         """
         Auto-reorder streams in all channels from the selected groups using smart sort.
         Returns a list of dicts with {channel_id, channel_name, stream_count} for channels that were reordered.
         """
         reordered = []
+
+        if channel_groups_override == []:
+            return reordered
+
         sort_settings = self._sort_settings_snapshot()
 
         try:
-            # Determine which groups to filter by
+            # Presence, not truthiness, controls filtering: [] reorders nothing.
             groups_to_filter = channel_groups_override or []
+            filter_by_group = channel_groups_override is not None
             logger.info("[STREAM-PROBE-SORT] groups_to_filter=%s", groups_to_filter)
 
             # Get selected group IDs
@@ -2027,6 +2037,9 @@ class StreamProber:
                     logger.error("[STREAM-PROBE] Failed to fetch channel groups for auto-reorder: %s", e)
                     return []
 
+                if not selected_group_ids:
+                    return reordered
+
             # Fetch all channels and filter by selected groups
             page = 1
             channels_to_reorder = []
@@ -2035,11 +2048,10 @@ class StreamProber:
                     result = await self.client.get_channels(page=page, page_size=500)
                     channels = result.get("results", [])
                     for channel in channels:
-                        # Filter by channel_group_id if groups selected
-                        if selected_group_ids:
-                            channel_group_id = channel.get("channel_group_id")
-                            if channel_group_id not in selected_group_ids:
-                                continue
+                        # An explicitly configured selection must never widen to all groups.
+                        channel_group_id = channel.get("channel_group_id")
+                        if filter_by_group and channel_group_id not in selected_group_ids:
+                            continue
 
                         # Add all channels - we'll check stream count later when we fetch full details
                         # The paginated list might not include full stream data
@@ -2403,7 +2415,7 @@ class StreamProber:
 
     async def probe_all_streams(
         self,
-        channel_groups_override: list[str] = None,
+        channel_groups_override: list[str] | None = None,
         skip_m3u_refresh: bool = False,
         stream_ids_filter: list[int] = None,
         start_send_alerts: bool = True,
@@ -2416,7 +2428,7 @@ class StreamProber:
 
         Args:
             channel_groups_override: Optional list of channel group names to filter by.
-                                    If None or empty list, probes all groups.
+                                    None probes all groups; an empty list probes none.
             skip_m3u_refresh: If True, skip M3U refresh even if configured.
                              Use this for on-demand probes from the UI.
             stream_ids_filter: Optional list of specific stream IDs to probe.
@@ -2461,6 +2473,16 @@ class StreamProber:
         probed_count = 0
         start_time = datetime.utcnow()
         try:
+            if channel_groups_override == []:
+                self._last_probe_channel_stream_ids = set()
+                self._probe_progress_status = "completed"
+                self._save_probe_history(start_time, 0, reordered_channels=[])
+                return {
+                    "status": "completed",
+                    "probed": 0,
+                    "reordered_channels": 0,
+                }
+
             # Refresh M3U accounts if configured AND not explicitly skipped
             # On-demand probes from UI should skip refresh; only scheduled probes refresh
             if self.refresh_m3us_before_probe and not skip_m3u_refresh:
@@ -2491,6 +2513,15 @@ class StreamProber:
             if not stream_ids_filter:
                 self._last_probe_channel_stream_ids = set(channel_stream_ids)
                 logger.info("[STREAM-PROBE] Saved %s channel stream IDs for reprobe scoping", len(self._last_probe_channel_stream_ids))
+
+            if channel_groups_override is not None and not channel_stream_ids:
+                self._probe_progress_status = "completed"
+                self._save_probe_history(start_time, 0, reordered_channels=[])
+                return {
+                    "status": "completed",
+                    "probed": 0,
+                    "reordered_channels": 0,
+                }
 
             # Fetch M3U accounts to map account IDs to names and max_streams
             logger.info("[STREAM-PROBE] Fetching M3U accounts...")

--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -511,7 +511,9 @@ class StreamProber:
         self._probe_progress_low_fps_count = 0
         # Probe history - list of last 5 probe runs
         self._probe_history = []  # List of {timestamp, total, success_count, failed_count, status, success_streams, failed_streams}
-        # Channel stream IDs from the last scheduled probe (used to scope reprobes)
+        # Scope from the last successful scheduled probe (used to scope reprobes).
+        # None = no prior probe, "all" = all groups, "scoped" = selected groups.
+        self._last_probe_scope_kind: str | None = None
         self._last_probe_channel_stream_ids: set = set()
 
         # Profile-to-account mapping for connection tracking
@@ -1671,60 +1673,95 @@ class StreamProber:
                 break
         return all_streams
 
-    async def _fetch_channel_stream_ids(self, channel_groups_override: list[str] | None = None) -> tuple[set, dict, dict]:
+    async def _resolve_channel_group_ids(
+        self,
+        channel_groups_override: list[str] | None = None,
+        channel_group_ids_override: frozenset[int] | None = None,
+    ) -> frozenset[int] | None:
+        """Resolve one invocation's group scope to stable numeric IDs."""
+        if channel_groups_override is not None and channel_group_ids_override is not None:
+            raise ValueError("channel group names and IDs cannot both be provided")
+        if channel_groups_override is None and channel_group_ids_override is None:
+            return None
+
+        requested_ids = (
+            frozenset(channel_group_ids_override)
+            if channel_group_ids_override is not None
+            else None
+        )
+        requested_names = (
+            list(dict.fromkeys(channel_groups_override))
+            if channel_groups_override is not None
+            else None
+        )
+        if requested_ids == frozenset() or requested_names == []:
+            return frozenset()
+
+        all_groups = await self.client.get_channel_groups()
+        if requested_ids is not None:
+            available_ids = {group["id"] for group in all_groups}
+            resolved_ids = requested_ids & available_ids
+            stale_ids = requested_ids - resolved_ids
+            if stale_ids:
+                logger.warning(
+                    "[STREAM-PROBE] Requested channel group IDs not found: %s",
+                    sorted(stale_ids),
+                )
+            return frozenset(resolved_ids)
+
+        ids_by_name: dict[str, list[int]] = {}
+        for group in all_groups:
+            ids_by_name.setdefault(group.get("name"), []).append(group["id"])
+
+        resolved_ids: set[int] = set()
+        for requested_name in requested_names or []:
+            matching_ids = ids_by_name.get(requested_name, [])
+            if len(matching_ids) > 1:
+                raise ValueError(
+                    f"Ambiguous channel group name {requested_name!r}; use a numeric group ID"
+                )
+            if matching_ids:
+                resolved_ids.add(matching_ids[0])
+            else:
+                logger.warning(
+                    "[STREAM-PROBE] Requested channel group not found: %s",
+                    requested_name,
+                )
+        return frozenset(resolved_ids)
+
+    async def _fetch_channel_stream_ids(
+        self,
+        channel_groups_override: list[str] | None = None,
+        channel_group_ids_override: frozenset[int] | None = None,
+    ) -> tuple[set, dict, dict]:
         """
         Fetch all unique stream IDs from channels (paginated).
         Only fetches from selected groups if channel_groups_override is set.
         Returns: (set of stream IDs, dict mapping stream_id -> list of channel names, dict mapping stream_id -> lowest channel number)
 
         Args:
-            channel_groups_override: Optional list of channel group names to filter by.
-                                    None probes all groups; an empty list probes none.
+            channel_groups_override: Optional list of channel group names to resolve.
+            channel_group_ids_override: Invocation-local resolved numeric group IDs.
         """
-        logger.debug("[STREAM-PROBE] _fetch_channel_stream_ids called with override=%s", channel_groups_override)
+        logger.debug(
+            "[STREAM-PROBE] _fetch_channel_stream_ids called with names=%s, ids=%s",
+            channel_groups_override,
+            channel_group_ids_override,
+        )
 
         channel_stream_ids = set()
         stream_to_channels = {}  # stream_id -> list of channel names
         stream_to_channel_number = {}  # stream_id -> lowest channel number (for sorting)
 
-        if channel_groups_override == []:
+        selected_group_ids = (
+            await self._resolve_channel_group_ids(channel_groups_override)
+            if channel_groups_override is not None
+            else channel_group_ids_override
+        )
+        if selected_group_ids == frozenset():
             return channel_stream_ids, stream_to_channels, stream_to_channel_number
 
-        # Presence, not truthiness, controls filtering: [] is an explicit no-op.
-        groups_to_filter = channel_groups_override or []
-        filter_by_group = channel_groups_override is not None
-        logger.debug("[STREAM-PROBE] groups_to_filter=%s", groups_to_filter)
-
-        # If specific groups are selected, fetch all groups first to filter
-        selected_group_ids = set()
-        if groups_to_filter:
-            try:
-                all_groups = await self.client.get_channel_groups()
-                available_group_names = [g.get("name") for g in all_groups]
-                logger.debug("[STREAM-PROBE] Requested groups: %s", groups_to_filter)
-                logger.debug("[STREAM-PROBE] Available groups: %s", available_group_names)
-
-                matched_groups = []
-                unmatched_groups = []
-                for group in all_groups:
-                    group_name = group.get("name")
-                    if group_name in groups_to_filter:
-                        selected_group_ids.add(group["id"])
-                        matched_groups.append(f"{group_name} (id={group['id']})")
-
-                for requested in groups_to_filter:
-                    if requested not in [g.get("name") for g in all_groups]:
-                        unmatched_groups.append(requested)
-
-                logger.debug("[STREAM-PROBE] Matched groups: %s", matched_groups)
-                if unmatched_groups:
-                    logger.warning("[STREAM-PROBE] Requested groups NOT FOUND: %s", unmatched_groups)
-                logger.debug("[STREAM-PROBE] Filtering to %s groups", len(selected_group_ids))
-            except Exception as e:
-                logger.error("[STREAM-PROBE] Failed to fetch channel groups for filtering: %s", e)
-
-            if not selected_group_ids:
-                return channel_stream_ids, stream_to_channels, stream_to_channel_number
+        filter_by_group = selected_group_ids is not None
 
         page = 1
         total_channels_seen = 0
@@ -1736,47 +1773,43 @@ class StreamProber:
         while True:
             try:
                 result = await self.client.get_channels(page=page, page_size=500)
-                channels = result.get("results", [])
-                for channel in channels:
-                    total_channels_seen += 1
-                    channel_name = channel.get("name", f"Channel {channel.get('id', 'Unknown')}")
-                    channel_group_id = channel.get("channel_group_id")
+            except Exception:
+                logger.exception("[STREAM-PROBE] Failed to fetch channels page %s", page)
+                raise
+            channels = result.get("results", [])
+            for channel in channels:
+                total_channels_seen += 1
+                channel_name = channel.get("name", f"Channel {channel.get('id', 'Unknown')}")
+                channel_group_id = channel.get("channel_group_id")
 
-                    # An explicitly configured selection must never widen to all groups.
-                    if filter_by_group and channel_group_id not in selected_group_ids:
-                        channels_excluded_wrong_group += 1
-                        excluded_channel_names.append(channel_name)
-                        continue  # Skip channels not in selected groups
+                if filter_by_group and channel_group_id not in selected_group_ids:
+                    channels_excluded_wrong_group += 1
+                    excluded_channel_names.append(channel_name)
+                    continue
 
-                    channel_number = channel.get("channel_number", 999999)  # Default high number for sorting
-                    # Each channel has a "streams" field which is a list of stream IDs
-                    stream_ids = channel.get("streams", [])
+                channel_number = channel.get("channel_number", 999999)
+                stream_ids = channel.get("streams", [])
 
-                    if not stream_ids:
-                        channels_with_no_streams += 1
-                        logger.debug("[STREAM-PROBE] Channel '%s' has no streams, skipping", channel_name)
-                        continue
+                if not stream_ids:
+                    channels_with_no_streams += 1
+                    logger.debug("[STREAM-PROBE] Channel '%s' has no streams, skipping", channel_name)
+                    continue
 
-                    channels_included += 1
-                    channel_stream_ids.update(stream_ids)
-                    logger.debug("[STREAM-PROBE] Including channel '%s' with %s stream(s)", channel_name, len(stream_ids))
+                channels_included += 1
+                channel_stream_ids.update(stream_ids)
+                logger.debug("[STREAM-PROBE] Including channel '%s' with %s stream(s)", channel_name, len(stream_ids))
 
-                    # Map each stream to its channel names and track lowest channel number
-                    for stream_id in stream_ids:
-                        if stream_id not in stream_to_channels:
-                            stream_to_channels[stream_id] = []
-                        stream_to_channels[stream_id].append(channel_name)
-                        # Track the lowest channel number for this stream (for sorting)
-                        if stream_id not in stream_to_channel_number or channel_number < stream_to_channel_number[stream_id]:
-                            stream_to_channel_number[stream_id] = channel_number
-                if not result.get("next"):
-                    break
-                page += 1
-                if page > 50:  # Safety limit
-                    break
-            except Exception as e:
-                logger.error("[STREAM-PROBE] Failed to fetch channels page %s: %s", page, e)
+                for stream_id in stream_ids:
+                    if stream_id not in stream_to_channels:
+                        stream_to_channels[stream_id] = []
+                    stream_to_channels[stream_id].append(channel_name)
+                    if stream_id not in stream_to_channel_number or channel_number < stream_to_channel_number[stream_id]:
+                        stream_to_channel_number[stream_id] = channel_number
+            if not result.get("next"):
                 break
+            page += 1
+            if page > 50:
+                raise RuntimeError("Channel pagination exceeded the 50-page safety limit")
 
         # Log summary of channel filtering
         logger.debug("[STREAM-PROBE] Channel filtering summary:")
@@ -2004,41 +2037,31 @@ class StreamProber:
             logger.debug("[STREAM-PROBE] Profile %s: rewrote URL", profile['id'])
         return rewritten
 
-    async def _auto_reorder_channels(self, channel_groups_override: list[str] | None = None, stream_to_channels: dict = None) -> list[dict]:
+    async def _auto_reorder_channels(
+        self,
+        channel_groups_override: list[str] | None = None,
+        stream_to_channels: dict = None,
+        channel_group_ids_override: frozenset[int] | None = None,
+    ) -> list[dict]:
         """
         Auto-reorder streams in all channels from the selected groups using smart sort.
         Returns a list of dicts with {channel_id, channel_name, stream_count} for channels that were reordered.
         """
         reordered = []
 
-        if channel_groups_override == []:
+        selected_group_ids = (
+            await self._resolve_channel_group_ids(channel_groups_override)
+            if channel_groups_override is not None
+            else channel_group_ids_override
+        )
+        if selected_group_ids == frozenset():
             return reordered
 
         sort_settings = self._sort_settings_snapshot()
 
         try:
-            # Presence, not truthiness, controls filtering: [] reorders nothing.
-            groups_to_filter = channel_groups_override or []
-            filter_by_group = channel_groups_override is not None
-            logger.info("[STREAM-PROBE-SORT] groups_to_filter=%s", groups_to_filter)
-
-            # Get selected group IDs
-            selected_group_ids = set()
-            if groups_to_filter:
-                try:
-                    all_groups = await self.client.get_channel_groups()
-                    available_group_names = [g.get("name") for g in all_groups]
-                    logger.info("[STREAM-PROBE-SORT] Available groups: %s... (total: %s)", available_group_names[:10], len(all_groups))
-                    for group in all_groups:
-                        if group.get("name") in groups_to_filter:
-                            selected_group_ids.add(group["id"])
-                    logger.info("[STREAM-PROBE-SORT] Filtering to %s selected groups (matched: %s)", len(selected_group_ids), selected_group_ids)
-                except Exception as e:
-                    logger.error("[STREAM-PROBE] Failed to fetch channel groups for auto-reorder: %s", e)
-                    return []
-
-                if not selected_group_ids:
-                    return reordered
+            filter_by_group = selected_group_ids is not None
+            logger.info("[STREAM-PROBE-SORT] selected_group_ids=%s", selected_group_ids)
 
             # Fetch all channels and filter by selected groups
             page = 1
@@ -2416,6 +2439,7 @@ class StreamProber:
     async def probe_all_streams(
         self,
         channel_groups_override: list[str] | None = None,
+        channel_group_ids_override: frozenset[int] | None = None,
         skip_m3u_refresh: bool = False,
         stream_ids_filter: list[int] = None,
         start_send_alerts: bool = True,
@@ -2429,6 +2453,8 @@ class StreamProber:
         Args:
             channel_groups_override: Optional list of channel group names to filter by.
                                     None probes all groups; an empty list probes none.
+            channel_group_ids_override: Invocation-local scheduled group IDs. These
+                                        are validated once and never converted to names.
             skip_m3u_refresh: If True, skip M3U refresh even if configured.
                              Use this for on-demand probes from the UI.
             stream_ids_filter: Optional list of specific stream IDs to probe.
@@ -2441,7 +2467,7 @@ class StreamProber:
                                        auto-reorder setting. False suppresses reorder
                                        without changing the shared setting.
         """
-        logger.info("[STREAM-PROBE] probe_all_streams called with channel_groups_override=%s, skip_m3u_refresh=%s, stream_ids_filter=%s", channel_groups_override, skip_m3u_refresh, len(stream_ids_filter) if stream_ids_filter else 0)
+        logger.info("[STREAM-PROBE] probe_all_streams called with channel_groups_override=%s, channel_group_ids_override=%s, skip_m3u_refresh=%s, stream_ids_filter=%s", channel_groups_override, channel_group_ids_override, skip_m3u_refresh, len(stream_ids_filter) if stream_ids_filter else 0)
         logger.info("[STREAM-PROBE] Settings: parallel_probing_enabled=%s, max_concurrent_probes=%s, "
                      "profile_distribution_strategy=%s",
                      self.parallel_probing_enabled, self.max_concurrent_probes,
@@ -2473,9 +2499,16 @@ class StreamProber:
         probed_count = 0
         start_time = datetime.utcnow()
         try:
-            if channel_groups_override == []:
-                self._last_probe_channel_stream_ids = set()
+            resolved_group_ids = await self._resolve_channel_group_ids(
+                channel_groups_override,
+                channel_group_ids_override,
+            )
+            if resolved_group_ids == frozenset():
+                if stream_ids_filter is None:
+                    self._last_probe_scope_kind = "scoped"
+                    self._last_probe_channel_stream_ids = set()
                 self._probe_progress_status = "completed"
+                self._probe_progress_current_stream = ""
                 self._save_probe_history(start_time, 0, reordered_channels=[])
                 return {
                     "status": "completed",
@@ -2504,18 +2537,22 @@ class StreamProber:
 
             # Fetch all channel stream IDs and channel mappings
             self._probe_progress_status = "fetching"
-            logger.info("[STREAM-PROBE] Fetching channel stream IDs (override groups: %s)...", channel_groups_override)
-            channel_stream_ids, stream_to_channels, stream_to_channel_number = await self._fetch_channel_stream_ids(channel_groups_override)
+            logger.info("[STREAM-PROBE] Fetching channel stream IDs (resolved group IDs: %s)...", resolved_group_ids)
+            channel_stream_ids, stream_to_channels, stream_to_channel_number = await self._fetch_channel_stream_ids(
+                channel_group_ids_override=resolved_group_ids
+            )
             logger.info("[STREAM-PROBE] Found %s unique streams across all channels", len(channel_stream_ids))
 
             # Store channel stream IDs for scheduled probes (not reprobes)
             # so the reprobe task can scope to only these streams
-            if not stream_ids_filter:
+            if stream_ids_filter is None:
+                self._last_probe_scope_kind = "all" if resolved_group_ids is None else "scoped"
                 self._last_probe_channel_stream_ids = set(channel_stream_ids)
                 logger.info("[STREAM-PROBE] Saved %s channel stream IDs for reprobe scoping", len(self._last_probe_channel_stream_ids))
 
-            if channel_groups_override is not None and not channel_stream_ids:
+            if not channel_stream_ids:
                 self._probe_progress_status = "completed"
+                self._probe_progress_current_stream = ""
                 self._save_probe_history(start_time, 0, reordered_channels=[])
                 return {
                     "status": "completed",
@@ -3115,7 +3152,10 @@ class StreamProber:
                 self._probe_progress_status = "reordering"
                 self._probe_progress_current_stream = "Reordering streams..."
                 try:
-                    reordered_channels = await self._auto_reorder_channels(channel_groups_override, stream_to_channels)
+                    reordered_channels = await self._auto_reorder_channels(
+                        stream_to_channels=stream_to_channels,
+                        channel_group_ids_override=resolved_group_ids,
+                    )
                     logger.info("[STREAM-PROBE-SORT] Auto-reordered %s channels", len(reordered_channels))
                 except Exception as e:
                     logger.error("[STREAM-PROBE] Auto-reorder failed: %s", e)

--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -2083,11 +2083,13 @@ class StreamProber:
                     if not result.get("next"):
                         break
                     page += 1
-                    if page > 50:  # Safety limit
-                        break
+                    if page > 50:
+                        raise RuntimeError(
+                            "Channel pagination exceeded the 50-page safety limit"
+                        )
                 except Exception as e:
                     logger.error("[STREAM-PROBE] Failed to fetch channels page %s for auto-reorder: %s", page, e)
-                    break
+                    raise
 
             logger.info("[STREAM-PROBE-SORT] Found %s channels to potentially reorder", len(channels_to_reorder))
 
@@ -2273,6 +2275,7 @@ class StreamProber:
 
         except Exception as e:
             logger.error("[STREAM-PROBE] Auto-reorder channels failed: %s", e)
+            raise
 
         return reordered
 
@@ -2543,14 +2546,10 @@ class StreamProber:
             )
             logger.info("[STREAM-PROBE] Found %s unique streams across all channels", len(channel_stream_ids))
 
-            # Store channel stream IDs for scheduled probes (not reprobes)
-            # so the reprobe task can scope to only these streams
-            if stream_ids_filter is None:
-                self._last_probe_scope_kind = "all" if resolved_group_ids is None else "scoped"
-                self._last_probe_channel_stream_ids = set(channel_stream_ids)
-                logger.info("[STREAM-PROBE] Saved %s channel stream IDs for reprobe scoping", len(self._last_probe_channel_stream_ids))
-
             if not channel_stream_ids:
+                if stream_ids_filter is None:
+                    self._last_probe_scope_kind = "all" if resolved_group_ids is None else "scoped"
+                    self._last_probe_channel_stream_ids = set()
                 self._probe_progress_status = "completed"
                 self._probe_progress_current_stream = ""
                 self._save_probe_history(start_time, 0, reordered_channels=[])
@@ -3159,6 +3158,13 @@ class StreamProber:
                     logger.info("[STREAM-PROBE-SORT] Auto-reordered %s channels", len(reordered_channels))
                 except Exception as e:
                     logger.error("[STREAM-PROBE] Auto-reorder failed: %s", e)
+                    raise
+
+            # Publish reprobe scope only after the complete scheduled run succeeds.
+            if stream_ids_filter is None:
+                self._last_probe_scope_kind = "all" if resolved_group_ids is None else "scoped"
+                self._last_probe_channel_stream_ids = set(channel_stream_ids)
+                logger.info("[STREAM-PROBE] Saved %s channel stream IDs for reprobe scoping", len(self._last_probe_channel_stream_ids))
 
             # Save to probe history
             self._save_probe_history(start_time, probed_count, reordered_channels=reordered_channels)

--- a/backend/tasks/failed_stream_reprobe.py
+++ b/backend/tasks/failed_stream_reprobe.py
@@ -107,19 +107,29 @@ class FailedStreamReprobeTask(TaskScheduler):
 
         # Scope to only streams from the last scheduled probe's channel groups
         # This prevents reprobing event streams or streams from unselected groups
+        scope_kind = getattr(self._prober, "_last_probe_scope_kind", None)
         scoped_stream_ids = getattr(self._prober, '_last_probe_channel_stream_ids', set())
-        if scoped_stream_ids:
+        if scope_kind == "scoped":
             before_count = len(failed_ids)
             failed_ids = [sid for sid in failed_ids if sid in scoped_stream_ids]
             excluded = before_count - len(failed_ids)
             if excluded:
                 logger.info("[%s] Scoped from %d to %d failed streams (%d excluded — not in last probe's groups)",
                            self.task_id, before_count, len(failed_ids), excluded)
-        else:
+        elif scope_kind is None:
             logger.warning("[%s] No scoped channel stream IDs from last probe — reprobing all %d failed streams",
                           self.task_id, len(failed_ids))
 
         if not failed_ids:
+            self._set_progress(
+                total=0,
+                current=0,
+                status="completed",
+                current_item="",
+                success_count=0,
+                failed_count=0,
+                skipped_count=0,
+            )
             return TaskResult(
                 success=True,
                 message="No failed streams to re-probe",

--- a/backend/tasks/stream_probe.py
+++ b/backend/tasks/stream_probe.py
@@ -175,48 +175,27 @@ class StreamProbeTask(TaskScheduler):
                 self._prober.max_concurrent_probes = max(1, min(16, self._max_concurrent_override))
                 logger.info("[%s] Using schedule max_concurrent: %s", self.task_id, self._prober.max_concurrent_probes)
 
-            # Determine channel groups to use
-            # None = not configured (probe everything), [] = explicitly empty (probe nothing)
-            channel_groups = self._channel_groups if self._channel_groups is not None else None
+            channel_groups = None
+            channel_group_ids = None
 
             if self._auto_sync_groups:
                 # Auto-sync mode: always probe ALL current groups, ignore stored list
                 logger.info("[%s] Auto-sync enabled, probing all current groups", self.task_id)
-                channel_groups = None  # None = probe everything
-            elif channel_groups:
-                # Fixed-list mode: validate stored IDs/names against current groups
-                # Note: stale groups are auto-removed on schedule load, but validate
-                # here too in case groups were deleted between loads
-                try:
-                    current_groups = await self._prober.client.get_channel_groups()
-                    current_by_id = {g["id"]: g.get("name") for g in current_groups}
-                    current_by_name = {g.get("name"): g for g in current_groups}
-
-                    if channel_groups and isinstance(channel_groups[0], int):
-                        valid_ids = [gid for gid in channel_groups if gid in current_by_id]
-                        stale_count = len(channel_groups) - len(valid_ids)
-                        valid_groups = [current_by_id[gid] for gid in valid_ids]
-                    else:
-                        valid_groups = [g for g in channel_groups if g in current_by_name]
-                        stale_count = len(channel_groups) - len(valid_groups)
-
-                    if stale_count:
-                        logger.warning("[%s] Skipping %s stale group(s) (will be auto-removed on next schedule load)", self.task_id, stale_count)
-
-                    # Use validated group names; if all were stale, keep empty list
-                    # (empty = probe nothing, not probe everything)
-                    channel_groups = valid_groups
-                except Exception as e:
-                    logger.warning("[%s] Failed to validate channel groups: %s", self.task_id, e)
+            elif self._channel_groups is not None:
+                if all(isinstance(group, int) for group in self._channel_groups):
+                    channel_group_ids = frozenset(self._channel_groups)
+                else:
+                    channel_groups = list(self._channel_groups)
 
             # Start the probe in background so we can poll for progress
-            logger.info("[%s] Starting stream probe (groups: %s)", self.task_id, channel_groups)
+            logger.info("[%s] Starting stream probe (group names: %s, group IDs: %s)", self.task_id, channel_groups, channel_group_ids)
 
             import asyncio
             # Run probe_all_streams as a background task
             probe_task = asyncio.create_task(
                 self._prober.probe_all_streams(
                     channel_groups_override=channel_groups,
+                    channel_group_ids_override=channel_group_ids,
                     skip_m3u_refresh=False,  # Scheduled probes should refresh
                     # The "probe started" alert is info-level; only dispatch it
                     # externally when this task opted into info alerts. self._send_alerts
@@ -247,10 +226,18 @@ class StreamProbeTask(TaskScheduler):
                 await asyncio.sleep(1)  # Poll every second
 
             # Wait for the task to complete (in case of cancellation, this ensures cleanup)
-            try:
-                await probe_task
-            except Exception:
-                pass  # Any exception is handled below via prober state
+            probe_result = await probe_task
+
+            if probe_result and probe_result.get("status") == "failed":
+                error = probe_result.get("error", "Unknown probe failure")
+                self._set_progress(status="failed", current_item="")
+                return TaskResult(
+                    success=False,
+                    message=f"Stream probe failed: {error}",
+                    error=error,
+                    started_at=started_at,
+                    completed_at=datetime.utcnow(),
+                )
 
             # Get final results from prober
             success_count = self._prober._probe_progress_success_count
@@ -263,6 +250,7 @@ class StreamProbeTask(TaskScheduler):
                 failed_count=failed_count,
                 skipped_count=skipped_count,
                 status="completed" if not self._cancel_requested else "cancelled",
+                current_item="",
             )
 
             black_screen = self._prober._probe_progress_black_screen_count

--- a/backend/tests/unit/test_failed_stream_reprobe.py
+++ b/backend/tests/unit/test_failed_stream_reprobe.py
@@ -150,6 +150,7 @@ class TestFailedStreamReprobeTask:
         mock_prober._probe_success_streams = [{"id": 10, "name": "s10"}]
         mock_prober._probe_failed_streams = []
         # Only stream 10 is in scope — stream 40 is from a different group
+        mock_prober._last_probe_scope_kind = "scoped"
         mock_prober._last_probe_channel_stream_ids = {10, 20, 30}
 
         async def mock_probe(**kwargs):

--- a/backend/tests/unit/test_stream_probe_group_scope.py
+++ b/backend/tests/unit/test_stream_probe_group_scope.py
@@ -1,0 +1,182 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from stream_prober import StreamProber
+from tasks.stream_probe import StreamProbeTask
+
+
+def _task_prober(current_groups):
+    return SimpleNamespace(
+        _probing_in_progress=False,
+        _probe_progress_total=0,
+        _probe_progress_current=0,
+        _probe_progress_status="completed",
+        _probe_progress_current_stream="",
+        _probe_progress_success_count=0,
+        _probe_progress_failed_count=0,
+        _probe_progress_skipped_count=0,
+        _probe_progress_black_screen_count=0,
+        _probe_progress_low_fps_count=0,
+        _probe_success_streams=[],
+        _probe_failed_streams=[],
+        probe_timeout=30,
+        max_concurrent_probes=3,
+        client=SimpleNamespace(
+            get_channel_groups=AsyncMock(return_value=current_groups)
+        ),
+        probe_all_streams=AsyncMock(return_value={"status": "completed"}),
+        cancel_probe=MagicMock(),
+        _failure_breakdown=MagicMock(return_value=[]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("parameters", "expected_groups"),
+    [
+        pytest.param({}, None, id="unconfigured-probes-all"),
+        pytest.param({"channel_groups": []}, [], id="explicit-empty-probes-none"),
+        pytest.param({"channel_groups": [999]}, [], id="all-stale-probes-none"),
+        pytest.param(
+            {"channel_groups": [7, 999]},
+            ["Sports"],
+            id="mixed-probes-valid-only",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_scheduled_probe_preserves_resolved_group_scope(
+    parameters, expected_groups
+):
+    prober = _task_prober([{"id": 7, "name": "Sports"}])
+    task = StreamProbeTask()
+    task.set_prober(prober)
+    task.update_config(parameters)
+
+    result = await task.execute()
+
+    assert result.success is True
+    prober.probe_all_streams.assert_awaited_once_with(
+        channel_groups_override=expected_groups,
+        skip_m3u_refresh=False,
+        start_send_alerts=True,
+        allow_reorder_after_probe=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("groups", "expected_stream_ids", "expected_channel_fetches"),
+    [
+        pytest.param(None, {10, 20}, 1, id="unconfigured-probes-all"),
+        pytest.param([], set(), 0, id="explicit-empty-probes-none"),
+        pytest.param(["Deleted"], set(), 0, id="all-stale-probes-none"),
+        pytest.param(
+            ["Sports", "Deleted"], {10}, 1, id="mixed-probes-valid-only"
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_prober_filters_channel_streams_to_resolved_group_scope(
+    groups, expected_stream_ids, expected_channel_fetches
+):
+    client = AsyncMock()
+    client.get_channel_groups.return_value = [
+        {"id": 7, "name": "Sports"},
+        {"id": 8, "name": "News"},
+    ]
+    client.get_channels.return_value = {
+        "results": [
+            {
+                "id": 1,
+                "name": "Sports One",
+                "channel_group_id": 7,
+                "channel_number": 1,
+                "streams": [10],
+            },
+            {
+                "id": 2,
+                "name": "News One",
+                "channel_group_id": 8,
+                "channel_number": 2,
+                "streams": [20],
+            },
+        ],
+        "next": None,
+    }
+    prober = StreamProber(client=client)
+
+    stream_ids, _, _ = await prober._fetch_channel_stream_ids(groups)
+
+    assert stream_ids == expected_stream_ids
+    assert client.get_channels.await_count == expected_channel_fetches
+
+
+@pytest.mark.asyncio
+async def test_explicit_empty_probe_completes_without_metadata_or_reorder_work():
+    client = AsyncMock()
+    prober = StreamProber(client=client, auto_reorder_after_probe=True)
+    prober._persist_probe_history = lambda: None
+
+    with patch.object(
+        prober,
+        "_fetch_channel_stream_ids",
+        AsyncMock(return_value=(set(), {}, {})),
+    ) as fetch_channel_stream_ids, patch.object(
+        prober, "_fetch_all_streams", AsyncMock(return_value=[])
+    ) as fetch_all_streams, patch.object(
+        prober, "_create_probe_notification", AsyncMock()
+    ) as create_notification, patch.object(
+        prober, "_finalize_probe_notification", AsyncMock()
+    ), patch.object(
+        prober, "_auto_reorder_channels", AsyncMock()
+    ) as reorder, patch.object(
+        prober, "_save_probe_history", MagicMock()
+    ) as save_history:
+        result = await prober.probe_all_streams(channel_groups_override=[])
+
+    assert result == {"status": "completed", "probed": 0, "reordered_channels": 0}
+    fetch_channel_stream_ids.assert_not_awaited()
+    fetch_all_streams.assert_not_awaited()
+    create_notification.assert_not_awaited()
+    reorder.assert_not_awaited()
+    save_history.assert_called_once()
+    client.refresh_all_m3u_accounts.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("groups", "expected_channel_ids", "expected_channel_fetches"),
+    [
+        pytest.param([], [], 0, id="explicit-empty-reorders-none"),
+        pytest.param(["Deleted"], [], 0, id="all-stale-reorders-none"),
+        pytest.param(
+            ["Sports", "Deleted"], [1], 1, id="mixed-reorders-valid-only"
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_reorder_scope_never_widens_past_resolved_groups(
+    groups, expected_channel_ids, expected_channel_fetches
+):
+    client = AsyncMock()
+    client.get_channel_groups.return_value = [
+        {"id": 7, "name": "Sports"},
+        {"id": 8, "name": "News"},
+    ]
+    client.get_channels.return_value = {
+        "results": [
+            {"id": 1, "name": "Sports One", "channel_group_id": 7},
+            {"id": 2, "name": "News One", "channel_group_id": 8},
+        ],
+        "next": None,
+    }
+    client.get_channel.side_effect = lambda channel_id: {"streams": [channel_id]}
+    prober = StreamProber(client=client)
+
+    result = await prober._auto_reorder_channels(groups)
+
+    assert result == []
+    assert client.get_channel.await_args_list == [
+        call(channel_id) for channel_id in expected_channel_ids
+    ]
+    assert client.get_channels.await_count == expected_channel_fetches

--- a/backend/tests/unit/test_stream_probe_group_scope.py
+++ b/backend/tests/unit/test_stream_probe_group_scope.py
@@ -273,6 +273,71 @@ async def test_channel_pagination_failure_fails_without_writes_and_preserves_sco
     client.update_channel.assert_not_awaited()
 
 
+@pytest.mark.parametrize("failure_page", [1, 2])
+@pytest.mark.asyncio
+async def test_reorder_pagination_failure_fails_without_writes_and_preserves_scope(
+    failure_page,
+):
+    client = AsyncMock()
+    client.get_channel_groups.return_value = [{"id": 7, "name": "Sports"}]
+    probe_page = {
+        "results": [
+            {
+                "id": 1,
+                "name": "Sports One",
+                "channel_group_id": 7,
+                "streams": [10],
+            }
+        ],
+        "next": None,
+    }
+    reorder_page = {
+        "results": [
+            {"id": 1, "name": "Sports One", "channel_group_id": 7}
+        ],
+        "next": "page-2",
+    }
+    client.get_channels.side_effect = (
+        [probe_page, RuntimeError("reorder channels unavailable")]
+        if failure_page == 1
+        else [
+            probe_page,
+            reorder_page,
+            RuntimeError("reorder channels unavailable"),
+        ]
+    )
+    client.get_m3u_accounts.return_value = []
+    prober = StreamProber(
+        client=client,
+        auto_reorder_after_probe=True,
+        refresh_m3us_before_probe=False,
+    )
+    prober._persist_probe_history = lambda: None
+    prober._last_probe_scope_kind = "scoped"
+    prober._last_probe_channel_stream_ids = {88}
+    task = StreamProbeTask()
+    task.set_prober(prober)
+    task.update_config({"channel_groups": [7]})
+
+    with patch.object(
+        prober, "_fetch_all_streams", AsyncMock(return_value=[])
+    ), patch.object(
+        prober, "_create_probe_notification", AsyncMock()
+    ), patch.object(
+        prober, "_finalize_probe_notification", AsyncMock()
+    ):
+        result = await task.execute()
+
+    assert result.success is False
+    assert "reorder channels unavailable" in result.error
+    assert prober._probe_progress_status == "failed"
+    assert prober.get_probe_history()[0]["status"] == "failed"
+    assert prober._last_probe_scope_kind == "scoped"
+    assert prober._last_probe_channel_stream_ids == {88}
+    client.get_channel.assert_not_awaited()
+    client.update_channel.assert_not_awaited()
+
+
 @pytest.mark.parametrize("configured_ids", [[], [999]])
 @pytest.mark.asyncio
 async def test_full_scheduled_zero_scope_completes_before_refresh_or_metadata(

--- a/backend/tests/unit/test_stream_probe_group_scope.py
+++ b/backend/tests/unit/test_stream_probe_group_scope.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import pytest
 
 from stream_prober import StreamProber
+from models import StreamStats
+from tasks.failed_stream_reprobe import FailedStreamReprobeTask
 from tasks.stream_probe import StreamProbeTask
 
 
@@ -33,21 +35,22 @@ def _task_prober(current_groups):
 
 
 @pytest.mark.parametrize(
-    ("parameters", "expected_groups"),
+    ("parameters", "expected_groups", "expected_group_ids"),
     [
-        pytest.param({}, None, id="unconfigured-probes-all"),
-        pytest.param({"channel_groups": []}, [], id="explicit-empty-probes-none"),
-        pytest.param({"channel_groups": [999]}, [], id="all-stale-probes-none"),
+        pytest.param({}, None, None, id="unconfigured-probes-all"),
+        pytest.param({"channel_groups": []}, None, frozenset(), id="explicit-empty-probes-none"),
+        pytest.param({"channel_groups": [999]}, None, frozenset({999}), id="all-stale-probes-none"),
         pytest.param(
             {"channel_groups": [7, 999]},
-            ["Sports"],
+            None,
+            frozenset({7, 999}),
             id="mixed-probes-valid-only",
         ),
     ],
 )
 @pytest.mark.asyncio
 async def test_scheduled_probe_preserves_resolved_group_scope(
-    parameters, expected_groups
+    parameters, expected_groups, expected_group_ids
 ):
     prober = _task_prober([{"id": 7, "name": "Sports"}])
     task = StreamProbeTask()
@@ -59,6 +62,7 @@ async def test_scheduled_probe_preserves_resolved_group_scope(
     assert result.success is True
     prober.probe_all_streams.assert_awaited_once_with(
         channel_groups_override=expected_groups,
+        channel_group_ids_override=expected_group_ids,
         skip_m3u_refresh=False,
         start_send_alerts=True,
         allow_reorder_after_probe=True,
@@ -180,3 +184,315 @@ async def test_reorder_scope_never_widens_past_resolved_groups(
         call(channel_id) for channel_id in expected_channel_ids
     ]
     assert client.get_channels.await_count == expected_channel_fetches
+
+
+@pytest.mark.asyncio
+async def test_scheduled_group_lookup_failure_fails_task_and_probe_history():
+    client = AsyncMock()
+    client.get_channel_groups.side_effect = RuntimeError("groups unavailable")
+    prober = StreamProber(client=client, refresh_m3us_before_probe=True)
+    prober._persist_probe_history = lambda: None
+    prober._last_probe_scope_kind = "scoped"
+    prober._last_probe_channel_stream_ids = {88}
+    task = StreamProbeTask()
+    task.set_prober(prober)
+    task.update_config({"channel_groups": [7]})
+
+    with patch.object(
+        prober, "_fetch_all_streams", AsyncMock()
+    ) as fetch_all_streams, patch.object(
+        prober, "_create_probe_notification", AsyncMock()
+    ) as create_notification, patch.object(
+        prober, "_auto_reorder_channels", AsyncMock()
+    ) as reorder:
+        result = await task.execute()
+
+    assert result.success is False
+    assert "groups unavailable" in result.error
+    assert prober._probe_progress_status == "failed"
+    assert prober._probe_progress_current_stream == ""
+    assert prober.get_probe_history()[0]["status"] == "failed"
+    assert "groups unavailable" in prober.get_probe_history()[0]["error"]
+    assert prober._last_probe_scope_kind == "scoped"
+    assert prober._last_probe_channel_stream_ids == {88}
+    client.refresh_all_m3u_accounts.assert_not_awaited()
+    fetch_all_streams.assert_not_awaited()
+    create_notification.assert_not_awaited()
+    reorder.assert_not_awaited()
+
+
+@pytest.mark.parametrize("failure_page", [1, 2])
+@pytest.mark.asyncio
+async def test_channel_pagination_failure_fails_without_writes_and_preserves_scope(
+    failure_page,
+):
+    client = AsyncMock()
+    client.get_channel_groups.return_value = [{"id": 7, "name": "Sports"}]
+    first_page = {
+        "results": [
+            {
+                "id": 1,
+                "name": "Sports One",
+                "channel_group_id": 7,
+                "streams": [10],
+            }
+        ],
+        "next": "page-2",
+    }
+    client.get_channels.side_effect = (
+        RuntimeError("channels unavailable")
+        if failure_page == 1
+        else [first_page, RuntimeError("channels unavailable")]
+    )
+    prober = StreamProber(client=client, auto_reorder_after_probe=True)
+    prober._persist_probe_history = lambda: None
+    prober._last_probe_scope_kind = "scoped"
+    prober._last_probe_channel_stream_ids = {88}
+    task = StreamProbeTask()
+    task.set_prober(prober)
+    task.update_config({"channel_groups": [7]})
+
+    with patch.object(
+        prober, "_fetch_all_streams", AsyncMock()
+    ) as fetch_all_streams, patch.object(
+        prober, "_create_probe_notification", AsyncMock()
+    ) as create_notification, patch.object(
+        prober, "_auto_reorder_channels", AsyncMock()
+    ) as reorder:
+        result = await task.execute()
+
+    assert result.success is False
+    assert "channels unavailable" in result.error
+    assert prober._probe_progress_status == "failed"
+    assert prober.get_probe_history()[0]["status"] == "failed"
+    assert prober._last_probe_scope_kind == "scoped"
+    assert prober._last_probe_channel_stream_ids == {88}
+    fetch_all_streams.assert_not_awaited()
+    create_notification.assert_not_awaited()
+    reorder.assert_not_awaited()
+    client.update_channel.assert_not_awaited()
+
+
+@pytest.mark.parametrize("configured_ids", [[], [999]])
+@pytest.mark.asyncio
+async def test_full_scheduled_zero_scope_completes_before_refresh_or_metadata(
+    configured_ids,
+):
+    client = AsyncMock()
+    client.get_channel_groups.return_value = [{"id": 7, "name": "Sports"}]
+    prober = StreamProber(client=client, refresh_m3us_before_probe=True)
+    prober._persist_probe_history = lambda: None
+    task = StreamProbeTask()
+    task.set_prober(prober)
+    task.update_config({"channel_groups": configured_ids})
+
+    with patch.object(
+        prober, "_fetch_all_streams", AsyncMock()
+    ) as fetch_all_streams, patch.object(
+        prober, "_create_probe_notification", AsyncMock()
+    ) as create_notification, patch.object(
+        prober, "_auto_reorder_channels", AsyncMock()
+    ) as reorder:
+        result = await task.execute()
+
+    assert result.success is True
+    assert result.total_items == 0
+    assert prober._probe_progress_status == "completed"
+    assert prober._probe_progress_current_stream == ""
+    assert prober._probe_progress_total == 0
+    assert prober._last_probe_scope_kind == "scoped"
+    assert prober._last_probe_channel_stream_ids == set()
+    assert prober.get_probe_history()[0]["status"] == "completed"
+    client.refresh_all_m3u_accounts.assert_not_awaited()
+    client.get_channels.assert_not_awaited()
+    fetch_all_streams.assert_not_awaited()
+    create_notification.assert_not_awaited()
+    reorder.assert_not_awaited()
+
+
+@pytest.mark.parametrize("configured_ids", [[], [999]])
+@pytest.mark.asyncio
+async def test_zero_scope_then_failed_reprobe_does_not_widen(
+    configured_ids, test_session
+):
+    test_session.add(
+        StreamStats(
+            stream_id=40,
+            stream_name="outside",
+            probe_status="failed",
+            consecutive_failures=1,
+        )
+    )
+    test_session.commit()
+    client = AsyncMock()
+    client.get_channel_groups.return_value = [{"id": 7, "name": "Sports"}]
+    prober = StreamProber(client=client)
+    prober._persist_probe_history = lambda: None
+
+    prior = await prober.probe_all_streams(
+        channel_group_ids_override=frozenset(configured_ids),
+        skip_m3u_refresh=True,
+    )
+    assert prior["status"] == "completed"
+    assert prober._last_probe_scope_kind == "scoped"
+    assert prober._last_probe_channel_stream_ids == set()
+
+    prober.probe_all_streams = AsyncMock()
+    task = FailedStreamReprobeTask()
+    task.set_prober(prober)
+    with patch("tasks.failed_stream_reprobe.get_session", return_value=test_session):
+        result = await task.execute()
+
+    assert result.success is True
+    assert result.total_items == 0
+    prober.probe_all_streams.assert_not_awaited()
+    client.update_channel.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("group_ids", "channels", "expected_failed_ids", "expected_kind"),
+    [
+        (None, [{"channel_group_id": 7, "streams": [10]}], {10, 40}, "all"),
+        (frozenset({7}), [{"channel_group_id": 7, "streams": [10]}], {10}, "scoped"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_successful_prior_scope_controls_failed_reprobe(
+    group_ids, channels, expected_failed_ids, expected_kind, test_session
+):
+    for stream_id in (10, 40):
+        test_session.add(
+            StreamStats(
+                stream_id=stream_id,
+                stream_name=f"s{stream_id}",
+                probe_status="failed",
+                consecutive_failures=1,
+            )
+        )
+    test_session.commit()
+    client = AsyncMock()
+    client.get_channel_groups.return_value = [{"id": 7, "name": "Sports"}]
+    client.get_channels.return_value = {"results": channels, "next": None}
+    client.get_m3u_accounts.return_value = []
+    prober = StreamProber(client=client, parallel_probing_enabled=False)
+    prober._persist_probe_history = lambda: None
+
+    with patch.object(prober, "_fetch_all_streams", AsyncMock(return_value=[])), patch.object(
+        prober, "_create_probe_notification", AsyncMock()
+    ), patch.object(prober, "_finalize_probe_notification", AsyncMock()):
+        prior = await prober.probe_all_streams(
+            channel_group_ids_override=group_ids,
+            skip_m3u_refresh=True,
+        )
+
+    assert prior["status"] == "completed"
+    assert prober._last_probe_scope_kind == expected_kind
+    prober.probe_all_streams = AsyncMock(return_value={"status": "completed"})
+    task = FailedStreamReprobeTask()
+    task.set_prober(prober)
+    with patch("tasks.failed_stream_reprobe.get_session", return_value=test_session):
+        result = await task.execute()
+
+    assert result.success is True
+    assert set(prober.probe_all_streams.await_args.kwargs["stream_ids_filter"]) == expected_failed_ids
+
+
+@pytest.mark.asyncio
+async def test_scheduled_numeric_ids_ignore_stale_id_without_widening_duplicate_name():
+    client = AsyncMock()
+    client.get_channel_groups.return_value = [
+        {"id": 7, "name": "Sports"},
+        {"id": 8, "name": "Sports"},
+    ]
+    client.get_channels.return_value = {
+        "results": [
+            {"id": 1, "channel_group_id": 7, "streams": [10]},
+            {"id": 2, "channel_group_id": 8, "streams": [20]},
+        ],
+        "next": None,
+    }
+    client.get_m3u_accounts.return_value = []
+    prober = StreamProber(client=client, auto_reorder_after_probe=True)
+    prober._persist_probe_history = lambda: None
+
+    with patch.object(
+        prober,
+        "_fetch_all_streams",
+        AsyncMock(return_value=[]),
+    ), patch.object(
+        prober, "_create_probe_notification", AsyncMock()
+    ), patch.object(
+        prober, "_finalize_probe_notification", AsyncMock()
+    ), patch.object(
+        prober, "_auto_reorder_channels", AsyncMock(return_value=[])
+    ) as reorder:
+        result = await prober.probe_all_streams(
+            channel_group_ids_override=frozenset({7, 999}),
+            skip_m3u_refresh=True,
+        )
+
+    assert result["status"] == "completed"
+    assert prober._last_probe_channel_stream_ids == {10}
+    reorder.assert_awaited_once_with(
+        stream_to_channels={10: ["Channel 1"]},
+        channel_group_ids_override=frozenset({7}),
+    )
+    assert client.get_channel_groups.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_name_scope_fails_closed_before_refresh_or_metadata():
+    client = AsyncMock()
+    client.get_channel_groups.return_value = [
+        {"id": 7, "name": "Sports"},
+        {"id": 8, "name": "Sports"},
+    ]
+    prober = StreamProber(client=client, refresh_m3us_before_probe=True)
+    prober._persist_probe_history = lambda: None
+
+    with patch.object(
+        prober, "_fetch_all_streams", AsyncMock()
+    ) as fetch_all_streams, patch.object(
+        prober, "_auto_reorder_channels", AsyncMock()
+    ) as reorder:
+        result = await prober.probe_all_streams(channel_groups_override=["Sports"])
+
+    assert result["status"] == "failed"
+    assert "ambiguous" in result["error"].lower()
+    client.refresh_all_m3u_accounts.assert_not_awaited()
+    client.get_channels.assert_not_awaited()
+    fetch_all_streams.assert_not_awaited()
+    reorder.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_name_scope_does_not_substitute_replacement_created_after_resolution():
+    client = AsyncMock()
+    client.get_channel_groups.return_value = [{"id": 7, "name": "Sports"}]
+    client.get_channels.return_value = {
+        "results": [
+            {"id": 2, "name": "Replacement", "channel_group_id": 8, "streams": [20]}
+        ],
+        "next": None,
+    }
+    prober = StreamProber(client=client, refresh_m3us_before_probe=True)
+    prober._persist_probe_history = lambda: None
+
+    with patch.object(
+        prober, "_fetch_all_streams", AsyncMock()
+    ) as fetch_all_streams, patch.object(
+        prober, "_create_probe_notification", AsyncMock()
+    ) as create_notification, patch.object(
+        prober, "_auto_reorder_channels", AsyncMock()
+    ) as reorder:
+        result = await prober.probe_all_streams(
+            channel_groups_override=["Sports"],
+            skip_m3u_refresh=True,
+        )
+
+    assert result == {"status": "completed", "probed": 0, "reordered_channels": 0}
+    assert prober._last_probe_channel_stream_ids == set()
+    assert client.get_channel_groups.await_count == 1
+    fetch_all_streams.assert_not_awaited()
+    create_notification.assert_not_awaited()
+    reorder.assert_not_awaited()

--- a/backend/tests/unit/test_stream_probe_reorder_option.py
+++ b/backend/tests/unit/test_stream_probe_reorder_option.py
@@ -74,13 +74,15 @@ async def test_scheduled_probe_reorder_choice_is_invocation_local_and_group_scop
     assert second.success is True
     assert prober.probe_all_streams.await_args_list == [
         call(
-            channel_groups_override=["Sports"],
+            channel_groups_override=None,
+            channel_group_ids_override=frozenset({7}),
             skip_m3u_refresh=False,
             start_send_alerts=True,
             allow_reorder_after_probe=False,
         ),
         call(
             channel_groups_override=None,
+            channel_group_ids_override=None,
             skip_m3u_refresh=False,
             start_send_alerts=True,
             allow_reorder_after_probe=True,
@@ -111,6 +113,7 @@ async def test_probe_all_reorder_gate_preserves_metadata_and_channel_order(
     monkeypatch.setattr(stream_prober, "get_session", session_factory)
 
     client = AsyncMock()
+    client.get_channel_groups.return_value = [{"id": 7, "name": "Sports"}]
     client.get_m3u_accounts.return_value = []
     channel_order = [10, 20]
     prober = StreamProber(
@@ -120,8 +123,11 @@ async def test_probe_all_reorder_gate_preserves_metadata_and_channel_order(
     )
     prober._persist_probe_history = lambda: None
 
-    async def reorder(group_names, _stream_to_channels):
-        assert group_names == groups
+    async def reorder(*, stream_to_channels, channel_group_ids_override):
+        assert stream_to_channels == {20: ["Channel"]}
+        assert channel_group_ids_override == (
+            frozenset({7}) if groups is not None else None
+        )
         channel_order[:] = [20, 10]
         return [{"channel_id": 1}]
 
@@ -175,7 +181,11 @@ async def test_probe_all_reorder_gate_preserves_metadata_and_channel_order(
         result = await prober.probe_all_streams(**kwargs)
 
     assert result["status"] == "completed"
-    fetch_channel_stream_ids.assert_awaited_once_with(groups)
+    fetch_channel_stream_ids.assert_awaited_once_with(
+        channel_group_ids_override=(
+            frozenset({7}) if groups is not None else None
+        )
+    )
     assert channel_order == expected_order
     if expected_order == [20, 10]:
         reorder_mock.assert_awaited_once()

--- a/backend/tests/unit/test_stream_probe_task_smart_sort.py
+++ b/backend/tests/unit/test_stream_probe_task_smart_sort.py
@@ -72,6 +72,7 @@ async def test_scheduled_probe_uses_resolved_smart_sort_configuration(strategy):
     assert prober.stream_sort_point_rules == point_rules
     prober.probe_all_streams.assert_awaited_once_with(
         channel_groups_override=None,
+        channel_group_ids_override=None,
         skip_m3u_refresh=False,
         start_send_alerts=True,
         allow_reorder_after_probe=True,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0003",
+  "version": "0.18.2-0004",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What
- Preserve scheduled Stream Probe group IDs as one immutable invocation scope for metadata probing and reordering.
- Treat explicit-empty and all-stale selections as completed zero-work runs instead of widening to all groups.
- Fail visibly on incomplete group/channel pagination and perform no partial reorder writes.
- Keep failed-stream reprobes within the prior all/scoped/scoped-empty boundary.
- Advance the app version to `0.18.2-0004`.

## Scope
This PR contains only bead `enhancedchannelmanager-8gmk8.3`. Its prerequisite, PR #960, has merged and this PR now targets `dev`.

## Verification
- Focused probe/reprobe scope suite: 35 passed
- Backend gate: 12,275 passed, 3 skipped, 2 deselected; 80.99% coverage
- Frontend tests: 3,627 passed
- Frontend lint and TypeScript: passed
- Frontend production build: passed
- `mkdocs build --strict`: passed
- Final code review: no in-scope findings
- Final security re-check: resolved and accepted

## Deployment
- No database migration or infrastructure change
- Rollback: revert the three `8gmk8.3` commits