### PR TITLE
feat: show execution rule names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- **Channel Pipeline Execution Details now identifies the rule scope for every historical run (bead `enhancedchannelmanager-zr9l2`, GitHub #795, build 0012).** Single-rule runs show the rule name snapshotted when execution started, so later renames or deletion do not change or break history. Selected runs list every persisted rule name in execution order, while run-all and legacy rows display the explicit full-pipeline scope instead of a blank or arbitrary rule.
+
 - **Channel Pipeline rules can explicitly remove stream-profile and channel-profile assignments for after-season cleanup (bead `enhancedchannelmanager-o8bzu`, build 0011).** Both actions default to fail-closed **Selected** targeting and require explicit profile IDs; only choosing **All** clears any stream profile or every channel-profile membership. Dry runs report the intended removals without writing, and channel-profile removal uses the standard RuleBuilder and executor paths.
 
 - **Channel Pipeline now identifies enabled rules outside their inclusive UTC active date window as Inactive (bead `enhancedchannelmanager-ftgqb`, build 0010).** Rule status and selected-run eligibility refresh automatically at UTC midnight without reloading the page, while disabled rules remain Disabled.

--- a/backend/main.py
+++ b/backend/main.py
@@ -157,7 +157,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0011",
+    version="0.18.2-0012",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -131,7 +131,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0011"
+APP_VERSION = "0.18.2-0012"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0011",
+  "version": "0.18.2-0012",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.test.tsx
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.test.tsx
@@ -891,6 +891,61 @@ describe('ChannelPipelineTab', () => {
   });
 
   describe('execution history', () => {
+    it('shows persisted rule names and explicit multi-rule/full-pipeline scopes from history fixtures', async () => {
+      const user = userEvent.setup();
+      mockDataStore.channelPipelineRules.push(
+        createMockChannelPipelineRule({ id: 41, name: 'Renamed Sports Rule' }),
+      );
+      mockDataStore.channelPipelineExecutions.push(
+        createMockChannelPipelineExecution({
+          id: 101,
+          rule_id: 41,
+          rule_name: 'Original Sports Rule',
+          run_scope: 'single',
+        }),
+        createMockChannelPipelineExecution({
+          id: 102,
+          run_scope: 'selected',
+          selected_rule_ids: [4, 9],
+          selected_rule_integrity: 'valid',
+          selected_rule_outcomes: [
+            { rule_id: 4, rule_name: 'First Rule', rule_kind: 'standard', status: 'completed' },
+            { rule_id: 9, rule_name: 'Second Rule', rule_kind: 'event_sync', status: 'completed' },
+          ],
+        }),
+        createMockChannelPipelineExecution({
+          id: 103,
+          rule_id: null,
+          rule_name: 'Deleted Rule Snapshot',
+          run_scope: 'single',
+        }),
+        createMockChannelPipelineExecution({
+          id: 104,
+          rule_id: null,
+          rule_name: null,
+          run_scope: 'all',
+        }),
+      );
+
+      renderWithProviders(<ChannelPipelineTab />);
+      const historyRows = await screen.findAllByTestId('execution-item');
+
+      const expectedScopes = [
+        'Original Sports Rule',
+        'Selected Rules: First Rule, Second Rule',
+        'Deleted Rule Snapshot',
+        'Full Pipeline (all enabled rules)',
+      ];
+      for (const [index, expectedScope] of expectedScopes.entries()) {
+        await user.click(within(historyRows[index]).getByRole('button', { name: /view details/i }));
+        const dialog = within(screen.getByRole('dialog', { name: 'Execution Details' }));
+        expect(dialog.getByText('Rule Name:').closest('.detail-row')).toHaveTextContent(expectedScope);
+        await user.click(dialog.getByRole('button', { name: 'Close' }));
+      }
+
+      expect(screen.queryByText('Renamed Sports Rule')).toBeInTheDocument();
+    });
+
     it('labels selected-rule history and names its scope', async () => {
       mockDataStore.channelPipelineExecutions.push(
         createMockChannelPipelineExecution({

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
@@ -82,6 +82,22 @@ const selectedOutcomeSummary = (outcome: SelectedRuleOutcome) => {
   return `${outcome.rule_name}: ${status}, ${count}, ${errors}`;
 };
 
+const executionRuleScope = (execution: ChannelPipelineExecution) => {
+  if (execution.run_scope === 'selected') {
+    if (execution.selected_rule_integrity === 'corrupt') {
+      return 'Selected Rules (data corrupt)';
+    }
+    const names = (execution.selected_rule_outcomes ?? []).map(outcome => outcome.rule_name);
+    return names.length > 0
+      ? `Selected Rules: ${names.join(', ')}`
+      : `Selected Rules (${execution.selected_rule_ids?.length ?? 0})`;
+  }
+  if (execution.run_scope === 'single' || execution.rule_name) {
+    return execution.rule_name || 'Rule no longer exists';
+  }
+  return 'Full Pipeline (all enabled rules)';
+};
+
 /**
  * Aggregated event_sync run counters across an execution's per-rule summaries
  * (enhancedchannelmanager-7wuhd). One execution can span several event_sync
@@ -2108,6 +2124,10 @@ export function ChannelPipelineTab() {
               <div className="detail-row">
                 <span className="detail-label">Mode:</span>
                 <span>{details.mode === 'dry_run' ? 'Dry Run' : 'Execute'}</span>
+              </div>
+              <div className="detail-row">
+                <span className="detail-label">Rule Name:</span>
+                <span>{executionRuleScope(details)}</span>
               </div>
               <div className="detail-row">
                 <span className="detail-label">Started:</span>

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -169,6 +169,8 @@ export function createMockChannelPipelineExecution(overrides: Partial<MockChanne
   const id = overrides.id ?? nextId()
   return {
     id,
+    rule_id: overrides.rule_id ?? null,
+    rule_name: overrides.rule_name ?? null,
     mode: overrides.mode ?? 'execute',
     triggered_by: overrides.triggered_by ?? 'manual',
     started_at: overrides.started_at ?? new Date().toISOString(),
@@ -351,6 +353,8 @@ interface MockChannelPipelineRule {
 
 interface MockChannelPipelineExecution {
   id: number
+  rule_id: number | null
+  rule_name: string | null
   mode: 'execute' | 'dry_run'
   triggered_by: 'manual' | 'scheduled' | 'm3u_refresh'
   started_at: string

--- a/frontend/src/types/channelPipeline.ts
+++ b/frontend/src/types/channelPipeline.ts
@@ -448,6 +448,9 @@ export type ExecutionLogFilterCategory =
  */
 export interface ChannelPipelineExecution {
   id: number;
+  /** Source rule identity snapshotted when a single-rule execution starts. */
+  rule_id?: number | null;
+  rule_name?: string | null;
   mode: ExecutionMode;
   triggered_by: ExecutionTrigger;
   scheduled_task_id?: string;


### PR DESCRIPTION
## Summary
- show persisted execution-time rule names in Execution History
- render ordered selected-rule and explicit full-pipeline scopes
- cover renamed, deleted, multi-rule, and full-pipeline histories

## Verification
- frontend component tests: 95 passed
- frontend full suite with coverage: 3,670 passed
- backend full suite: 12,644 passed, 3 skipped, 2 deselected
- frontend lint, typecheck, and production build passed
- bounded code review: Approved, no findings

Closes #795.
Tracks enhancedchannelmanager-zr9l2.