### PR TITLE
feat: trigger stream probes from EPG events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- **EPG events can trigger a bounded probe of every stream on their channel when the title matches an operator-supplied regular expression (bead `enhancedchannelmanager-8gmk8.1`, GitHub #901, build 0013).** The disabled-by-default EPG Event Probe task uses the schedule cadence as its timing control, evaluates only currently active programs, resolves standard and dummy EPG channel links, and records schedule/event/channel trigger keys so duplicate evaluations do not start repeated probes. Malformed expressions are rejected before schedule persistence, and each schedule can suppress stream reordering without changing the global setting.
+
 - **Channel Pipeline Execution Details now identifies the rule scope for every historical run (bead `enhancedchannelmanager-zr9l2`, GitHub #795, build 0012).** Single-rule runs show the rule name snapshotted when execution started, so later renames or deletion do not change or break history. Selected runs list every persisted rule name in execution order, while run-all and legacy rows display the explicit full-pipeline scope instead of a blank or arbitrary rule.
 
 - **Channel Pipeline rules can explicitly remove stream-profile and channel-profile assignments for after-season cleanup (bead `enhancedchannelmanager-o8bzu`, build 0011).** Both actions default to fail-closed **Selected** targeting and require explicit profile IDs; only choosing **All** clears any stream profile or every channel-profile membership. Dry runs report the intended removals without writing, and channel-profile removal uses the standard RuleBuilder and executor paths.

--- a/backend/alembic/versions/20260903_1200_0054_epg_event_probe_claims.py
+++ b/backend/alembic/versions/20260903_1200_0054_epg_event_probe_claims.py
@@ -1,0 +1,34 @@
+"""add durable EPG event probe claims
+
+Revision ID: 0054
+Revises: 0053
+Create Date: 2026-09-03 12:00:00.000000
+
+Bead: enhancedchannelmanager-8gmk8.1.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision: str = "0054"
+down_revision: Union[str, Sequence[str], None] = "0053"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    if "epg_event_probe_claims" not in inspect(op.get_bind()).get_table_names():
+        op.create_table(
+            "epg_event_probe_claims",
+            sa.Column("trigger_key", sa.String(length=1000), nullable=False),
+            sa.Column("claimed_at", sa.DateTime(), nullable=False),
+            sa.PrimaryKeyConstraint("trigger_key"),
+        )
+
+
+def downgrade() -> None:
+    if "epg_event_probe_claims" in inspect(op.get_bind()).get_table_names():
+        op.drop_table("epg_event_probe_claims")

--- a/backend/main.py
+++ b/backend/main.py
@@ -157,7 +157,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0012",
+    version="0.18.2-0013",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",
@@ -1644,6 +1644,13 @@ async def startup_event():
                     logger.info("[MAIN] Connected StreamProber to StreamProbeTask")
                 else:
                     logger.warning("[MAIN] StreamProbeTask not found in registry")
+
+                epg_event_probe_task = registry.get_task_instance("epg_event_probe")
+                if epg_event_probe_task:
+                    epg_event_probe_task.set_prober(prober)
+                    logger.info("[MAIN] Connected StreamProber to EPGEventProbeTask")
+                else:
+                    logger.warning("[MAIN] EPGEventProbeTask not found in registry")
 
                 failed_reprobe_task = registry.get_task_instance("failed_stream_reprobe")
                 if failed_reprobe_task:

--- a/backend/models.py
+++ b/backend/models.py
@@ -535,6 +535,14 @@ class TaskExecution(Base):
         return f"<TaskExecution(id={self.id}, task_id={self.task_id}, status={self.status})>"
 
 
+class EPGEventProbeClaim(Base):
+    """Durable ownership of one EPG event/channel probe trigger."""
+    __tablename__ = "epg_event_probe_claims"
+
+    trigger_key = Column(String(1000), primary_key=True)
+    claimed_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
 class Notification(Base):
     """
     Persistent notification storage.

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -509,6 +509,10 @@ _STANDARD_ARTIFACT_EXCLUDED: dict[str, str] = {
     "pending_merges": "The merge review queue — transient, regenerates on the next run.",
     "pending_merge_journal": "Merge review action history, keyed by actor_token_id.",
     "event_sync_reviews": "The event-sync review queue — transient, regenerates.",
+    "epg_event_probe_claims": (
+        "Probe-trigger idempotency history tied to live EPG events and channel ids; "
+        "a restored instance evaluates its current guide state independently."
+    ),
     "profile_conflict_reviews": (
         "The channel-profile conflict review queue — transient workflow state; "
         "conflicts are detected again from live M3U group settings."

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -131,7 +131,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0012"
+APP_VERSION = "0.18.2-0013"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -2405,7 +2405,12 @@ async def _restart_background_services(settings: DispatcharrSettings) -> dict:
             try:
                 from task_registry import get_registry
                 registry = get_registry()
-                for tid in ("stream_probe", "failed_stream_reprobe", "black_screen_scan"):
+                for tid in (
+                    "stream_probe",
+                    "epg_event_probe",
+                    "failed_stream_reprobe",
+                    "black_screen_scan",
+                ):
                     task_instance = registry.get_task_instance(tid)
                     if task_instance:
                         task_instance.set_prober(new_prober)

--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -3188,7 +3188,12 @@ class StreamProber:
         finally:
             self._probing_in_progress = False
 
-    async def probe_streams_by_ids(self, stream_ids: list[int], start_send_alerts: bool = True):
+    async def probe_streams_by_ids(
+        self,
+        stream_ids: list[int],
+        start_send_alerts: bool = True,
+        allow_reorder_after_probe: bool = True,
+    ):
         """Probe a specific list of stream IDs in the background (on-demand bulk probe).
 
         This is the async backing for POST /api/stream-stats/probe/bulk. It reuses
@@ -3210,6 +3215,8 @@ class StreamProber:
             start_send_alerts: Whether the info-level "probe started" notification
                 should dispatch an external alert (gated value — see
                 ``probe_all_streams``; GH #462).
+            allow_reorder_after_probe: Whether this invocation may apply the global
+                auto-reorder setting. False leaves channel order unchanged.
 
         Returns:
             Dict envelope: {status, probed, total, success, failed} or
@@ -3325,7 +3332,11 @@ class StreamProber:
             # that actually contain a probed stream — matching the prior bulk
             # endpoint's scope so opted-in users don't lose that behavior.
             reordered_channels = []
-            if self.auto_reorder_after_probe and not self._probe_cancelled:
+            if (
+                self.auto_reorder_after_probe
+                and allow_reorder_after_probe
+                and not self._probe_cancelled
+            ):
                 self._probe_progress_status = "reordering"
                 self._probe_progress_current_stream = "Reordering streams..."
                 try:

--- a/backend/tasks/__init__.py
+++ b/backend/tasks/__init__.py
@@ -11,6 +11,7 @@ from tasks.m3u_change_monitor import M3UChangeMonitorTask
 from tasks.cleanup import CleanupTask
 from tasks.journal_noise_purge import JournalNoisePurgeTask
 from tasks.stream_probe import StreamProbeTask
+from tasks.epg_event_probe import EPGEventProbeTask
 from tasks.failed_stream_reprobe import FailedStreamReprobeTask
 from tasks.struck_stream_cleanup import StruckStreamCleanupTask
 from tasks.popularity_calculation import PopularityCalculationTask
@@ -30,6 +31,7 @@ __all__ = [
     "CleanupTask",
     "JournalNoisePurgeTask",
     "StreamProbeTask",
+    "EPGEventProbeTask",
     "FailedStreamReprobeTask",
     "StruckStreamCleanupTask",
     "PopularityCalculationTask",

--- a/backend/tasks/epg_event_probe.py
+++ b/backend/tasks/epg_event_probe.py
@@ -1,18 +1,21 @@
 """Probe channel streams when a matching EPG event becomes active."""
 
-import json
 import logging
 from datetime import datetime, timezone
 from typing import Callable, Optional
 
 import safe_regex
 from database import get_session
-from models import TaskExecution
+from models import EPGEventProbeClaim
+from sqlalchemy.exc import IntegrityError
 from task_registry import register_task
 from task_scheduler import ScheduleConfig, ScheduleType, TaskResult, TaskScheduler
 
 
 logger = logging.getLogger(__name__)
+
+
+_MAX_EPG_DATA_ROWS = 50_000
 
 
 @register_task
@@ -49,7 +52,8 @@ class EPGEventProbeTask(TaskScheduler):
         schedule_config: Optional[ScheduleConfig] = None,
         *,
         now_fn: Optional[Callable[[], datetime]] = None,
-        seen_keys_loader: Optional[Callable[[datetime], set[str]]] = None,
+        claim_trigger: Optional[Callable[[str], bool]] = None,
+        release_claims: Optional[Callable[[list[str]], None]] = None,
     ):
         super().__init__(schedule_config or ScheduleConfig(
             schedule_type=ScheduleType.MANUAL
@@ -60,8 +64,8 @@ class EPGEventProbeTask(TaskScheduler):
         self._allow_reorder_after_probe = True
         self._invocation_schedule_id: Optional[int] = None
         self._now_fn = now_fn or (lambda: datetime.now(timezone.utc))
-        self._seen_keys_loader = seen_keys_loader or self._load_seen_trigger_keys
-        self._processed_trigger_keys: set[str] = set()
+        self._claim_trigger = claim_trigger or self._claim_trigger_key
+        self._release_claims = release_claims or self._release_trigger_claims
 
     def set_prober(self, prober) -> None:
         self._prober = prober
@@ -140,26 +144,27 @@ class EPGEventProbeTask(TaskScheduler):
             parsed = parsed.replace(tzinfo=timezone.utc)
         return parsed.astimezone(timezone.utc)
 
-    def _load_seen_trigger_keys(self, since: datetime) -> set[str]:
-        seen: set[str] = set()
+    def _claim_trigger_key(self, trigger_key: str) -> bool:
         session = get_session()
         try:
-            rows = session.query(TaskExecution.details).filter(
-                TaskExecution.task_id == self.task_id,
-                TaskExecution.started_at >= since.replace(tzinfo=None),
-                TaskExecution.details.isnot(None),
-            ).all()
-            for (details_json,) in rows:
-                try:
-                    details = json.loads(details_json)
-                except (TypeError, ValueError):
-                    continue
-                keys = details.get("trigger_keys") if isinstance(details, dict) else None
-                if isinstance(keys, list):
-                    seen.update(key for key in keys if isinstance(key, str))
+            session.add(EPGEventProbeClaim(trigger_key=trigger_key))
+            session.commit()
+            return True
+        except IntegrityError:
+            session.rollback()
+            return False
         finally:
             session.close()
-        return seen
+
+    def _release_trigger_claims(self, trigger_keys: list[str]) -> None:
+        session = get_session()
+        try:
+            session.query(EPGEventProbeClaim).filter(
+                EPGEventProbeClaim.trigger_key.in_(trigger_keys)
+            ).delete(synchronize_session=False)
+            session.commit()
+        finally:
+            session.close()
 
     async def _all_channels(self) -> list[dict]:
         channels: list[dict] = []
@@ -222,47 +227,64 @@ class EPGEventProbeTask(TaskScheduler):
             )
 
         channels = await self._all_channels()
-        epg_ids_by_tvg: dict[str, set[int]] = {}
-        for tvg_id in {program["tvg_id"] for program, _ in active_matches}:
-            epg_rows = await self._prober.client.get_epg_data(search=tvg_id)
-            epg_ids_by_tvg[tvg_id] = {
-                row["id"]
-                for row in epg_rows
-                if row.get("tvg_id") == tvg_id and isinstance(row.get("id"), int)
-            }
+        epg_rows = await self._prober.client.get_epg_data(
+            max_results=_MAX_EPG_DATA_ROWS + 1
+        )
+        if len(epg_rows) > _MAX_EPG_DATA_ROWS:
+            raise RuntimeError(
+                f"EPG data pagination exceeded the {_MAX_EPG_DATA_ROWS}-row safety limit"
+            )
+        epg_tvg_by_id = {
+            row["id"]: row["tvg_id"]
+            for row in epg_rows
+            if isinstance(row.get("id"), int)
+            and isinstance(row.get("tvg_id"), str)
+        }
+        channels_by_tvg: dict[str, list[dict]] = {}
+        for channel in channels:
+            epg_data_id = channel.get("epg_data_id")
+            if epg_data_id is not None:
+                tvg_id = epg_tvg_by_id.get(epg_data_id)
+                if tvg_id is not None:
+                    channels_by_tvg.setdefault(tvg_id, []).append(channel)
+                continue
+            tvg_id = channel.get("tvg_id")
+            channel_uuid = channel.get("uuid")
+            if isinstance(tvg_id, str):
+                channels_by_tvg.setdefault(tvg_id, []).append(channel)
+            if isinstance(channel_uuid, str) and channel_uuid != tvg_id:
+                channels_by_tvg.setdefault(channel_uuid, []).append(channel)
 
-        earliest_start = min(start for _, start in active_matches)
-        seen_keys = self._seen_keys_loader(earliest_start) | self._processed_trigger_keys
-        trigger_keys: list[str] = []
-        matched_channel_ids: list[int] = []
-        stream_ids: list[int] = []
-
+        candidates: list[tuple[str, int, list[int]]] = []
         for program, start in active_matches:
             tvg_id = program["tvg_id"]
-            for channel in channels:
-                epg_data_id = channel.get("epg_data_id")
-                channel_matches = (
-                    epg_data_id in epg_ids_by_tvg[tvg_id]
-                    if epg_data_id is not None
-                    else channel.get("tvg_id") == tvg_id
-                    or channel.get("uuid") == tvg_id
-                )
-                if not channel_matches or not isinstance(channel.get("id"), int):
+            for channel in channels_by_tvg.get(tvg_id, []):
+                channel_id = channel.get("id")
+                if not isinstance(channel_id, int):
                     continue
                 event_identity = program.get("id", start.isoformat())
                 trigger_key = (
                     f"{self._invocation_schedule_id or 'manual'}:"
-                    f"{event_identity}:{start.isoformat()}:{tvg_id}:{channel['id']}"
+                    f"{event_identity}:{start.isoformat()}:{tvg_id}:{channel_id}"
                 )
-                if trigger_key in seen_keys:
-                    continue
-                full_channel = await self._prober.client.get_channel(channel["id"])
-                matched_channel_ids.append(channel["id"])
-                trigger_keys.append(trigger_key)
-                seen_keys.add(trigger_key)
-                for stream_id in full_channel.get("streams", []):
-                    if isinstance(stream_id, int) and stream_id not in stream_ids:
-                        stream_ids.append(stream_id)
+                full_channel = await self._prober.client.get_channel(channel_id)
+                candidates.append(
+                    (trigger_key, channel_id, full_channel.get("streams", []))
+                )
+
+        trigger_keys: list[str] = []
+        matched_channel_ids: list[int] = []
+        stream_ids: list[int] = []
+        stream_id_set: set[int] = set()
+        for trigger_key, channel_id, channel_stream_ids in candidates:
+            if not self._claim_trigger(trigger_key):
+                continue
+            matched_channel_ids.append(channel_id)
+            trigger_keys.append(trigger_key)
+            for stream_id in channel_stream_ids:
+                if isinstance(stream_id, int) and stream_id not in stream_id_set:
+                    stream_id_set.add(stream_id)
+                    stream_ids.append(stream_id)
 
         if not trigger_keys:
             return TaskResult(
@@ -273,7 +295,6 @@ class EPGEventProbeTask(TaskScheduler):
             )
 
         if not stream_ids:
-            self._processed_trigger_keys.update(trigger_keys)
             return TaskResult(
                 success=True,
                 message="Matching EPG channels have no streams",
@@ -291,6 +312,7 @@ class EPGEventProbeTask(TaskScheduler):
             allow_reorder_after_probe=self._allow_reorder_after_probe,
         )
         if probe_result.get("status") == "already_running":
+            self._release_claims(trigger_keys)
             return TaskResult(
                 success=False,
                 message="A stream probe is already in progress",
@@ -299,7 +321,6 @@ class EPGEventProbeTask(TaskScheduler):
                 completed_at=datetime.utcnow(),
             )
 
-        self._processed_trigger_keys.update(trigger_keys)
         failed_count = int(probe_result.get("failed", 0))
         success_count = int(probe_result.get("success", 0))
         total = int(probe_result.get("total", len(stream_ids)))

--- a/backend/tasks/epg_event_probe.py
+++ b/backend/tasks/epg_event_probe.py
@@ -1,0 +1,323 @@
+"""Probe channel streams when a matching EPG event becomes active."""
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+import safe_regex
+from database import get_session
+from models import TaskExecution
+from task_registry import register_task
+from task_scheduler import ScheduleConfig, ScheduleType, TaskResult, TaskScheduler
+
+
+logger = logging.getLogger(__name__)
+
+
+@register_task
+class EPGEventProbeTask(TaskScheduler):
+    """Evaluate active guide entries and probe each matching channel once."""
+
+    task_id = "epg_event_probe"
+    task_name = "EPG Event Probe"
+    task_description = "Probe every stream on a channel when a matching EPG event starts"
+    default_enabled = False
+    persist_config = False
+    schedule_parameter_schema = {
+        "description": "Probe channels while matching EPG events are active",
+        "parameters": [
+            {
+                "name": "title_pattern",
+                "type": "string",
+                "label": "Title match expression",
+                "description": "Regular expression matched against active EPG titles",
+                "required": True,
+            },
+            {
+                "name": "allow_reorder_after_probe",
+                "type": "boolean",
+                "label": "Allow stream reordering",
+                "description": "Allow the global auto-reorder setting after this event probe",
+                "default": True,
+            },
+        ],
+    }
+
+    def __init__(
+        self,
+        schedule_config: Optional[ScheduleConfig] = None,
+        *,
+        now_fn: Optional[Callable[[], datetime]] = None,
+        seen_keys_loader: Optional[Callable[[datetime], set[str]]] = None,
+    ):
+        super().__init__(schedule_config or ScheduleConfig(
+            schedule_type=ScheduleType.MANUAL
+        ))
+        self._prober = None
+        self._title_pattern: Optional[str] = None
+        self._compiled_title_pattern = None
+        self._allow_reorder_after_probe = True
+        self._invocation_schedule_id: Optional[int] = None
+        self._now_fn = now_fn or (lambda: datetime.now(timezone.utc))
+        self._seen_keys_loader = seen_keys_loader or self._load_seen_trigger_keys
+        self._processed_trigger_keys: set[str] = set()
+
+    def set_prober(self, prober) -> None:
+        self._prober = prober
+
+    def get_config(self) -> dict:
+        return {
+            "title_pattern": self._title_pattern,
+            "allow_reorder_after_probe": self._allow_reorder_after_probe,
+        }
+
+    @classmethod
+    def validate_schedule_parameters(cls, parameters: Optional[dict]) -> None:
+        if not isinstance(parameters, dict):
+            raise ValueError("EPG event probe parameters must be an object")
+        title_pattern = parameters.get("title_pattern")
+        if not isinstance(title_pattern, str) or not title_pattern.strip():
+            raise ValueError("title_pattern must be a non-empty string")
+        try:
+            safe_regex.compile(title_pattern)
+        except safe_regex.SafeRegexError as error:
+            raise ValueError("title_pattern must be a valid regex") from error
+        if (
+            "allow_reorder_after_probe" in parameters
+            and type(parameters["allow_reorder_after_probe"]) is not bool
+        ):
+            raise ValueError("allow_reorder_after_probe must be a boolean")
+
+    validate_run_parameters = validate_schedule_parameters
+
+    def prepare_invocation_parameters(
+        self,
+        triggered_by: str,
+        schedule_id: Optional[int],
+        parameters: Optional[dict],
+    ) -> Optional[dict]:
+        del triggered_by
+        self._invocation_schedule_id = schedule_id
+        return parameters
+
+    def update_config(self, config: dict) -> None:
+        self.validate_schedule_parameters(config)
+        self._title_pattern = config["title_pattern"]
+        self._compiled_title_pattern = safe_regex.compile(self._title_pattern)
+        self._allow_reorder_after_probe = config.get(
+            "allow_reorder_after_probe", True
+        )
+
+    def restore_invocation_config(self, config: dict) -> None:
+        self._title_pattern = config.get("title_pattern")
+        self._compiled_title_pattern = (
+            safe_regex.compile(self._title_pattern)
+            if self._title_pattern
+            else None
+        )
+        self._allow_reorder_after_probe = config.get(
+            "allow_reorder_after_probe", True
+        )
+        self._invocation_schedule_id = None
+
+    async def validate_config(self) -> tuple[bool, str]:
+        if self._prober is None:
+            return False, "StreamProber not initialized"
+        if self._compiled_title_pattern is None:
+            return False, "Title match expression is not configured"
+        return True, ""
+
+    @staticmethod
+    def _parse_grid_time(value) -> Optional[datetime]:
+        if not isinstance(value, str):
+            return None
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    def _load_seen_trigger_keys(self, since: datetime) -> set[str]:
+        seen: set[str] = set()
+        session = get_session()
+        try:
+            rows = session.query(TaskExecution.details).filter(
+                TaskExecution.task_id == self.task_id,
+                TaskExecution.started_at >= since.replace(tzinfo=None),
+                TaskExecution.details.isnot(None),
+            ).all()
+            for (details_json,) in rows:
+                try:
+                    details = json.loads(details_json)
+                except (TypeError, ValueError):
+                    continue
+                keys = details.get("trigger_keys") if isinstance(details, dict) else None
+                if isinstance(keys, list):
+                    seen.update(key for key in keys if isinstance(key, str))
+        finally:
+            session.close()
+        return seen
+
+    async def _all_channels(self) -> list[dict]:
+        channels: list[dict] = []
+        page = 1
+        while True:
+            response = await self._prober.client.get_channels(page=page, page_size=500)
+            channels.extend(response.get("results", []))
+            if not response.get("next"):
+                return channels
+            page += 1
+            if page > 50:
+                raise RuntimeError("Channel pagination exceeded the 50-page safety limit")
+
+    async def execute(self) -> TaskResult:
+        started_at = datetime.utcnow()
+        if not self._enabled:
+            return TaskResult(
+                success=True,
+                message="EPG event probe is disabled",
+                started_at=started_at,
+                completed_at=datetime.utcnow(),
+            )
+        if self._prober is None or self._compiled_title_pattern is None:
+            return TaskResult(
+                success=False,
+                message="EPG event probe is not configured",
+                error="CONFIG_INVALID",
+                started_at=started_at,
+                completed_at=datetime.utcnow(),
+            )
+
+        now = self._now_fn()
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        now = now.astimezone(timezone.utc)
+        programs = await self._prober.client.get_epg_grid()
+        active_matches = []
+        for program in programs:
+            start = self._parse_grid_time(program.get("start_time"))
+            end = self._parse_grid_time(program.get("end_time"))
+            title = program.get("title")
+            tvg_id = program.get("tvg_id")
+            if (
+                start is not None
+                and end is not None
+                and start <= now < end
+                and isinstance(title, str)
+                and isinstance(tvg_id, str)
+                and tvg_id
+                and safe_regex.search(self._compiled_title_pattern, title) is not None
+            ):
+                active_matches.append((program, start))
+
+        if not active_matches:
+            return TaskResult(
+                success=True,
+                message="No active EPG titles matched",
+                started_at=started_at,
+                completed_at=datetime.utcnow(),
+            )
+
+        channels = await self._all_channels()
+        epg_ids_by_tvg: dict[str, set[int]] = {}
+        for tvg_id in {program["tvg_id"] for program, _ in active_matches}:
+            epg_rows = await self._prober.client.get_epg_data(search=tvg_id)
+            epg_ids_by_tvg[tvg_id] = {
+                row["id"]
+                for row in epg_rows
+                if row.get("tvg_id") == tvg_id and isinstance(row.get("id"), int)
+            }
+
+        earliest_start = min(start for _, start in active_matches)
+        seen_keys = self._seen_keys_loader(earliest_start) | self._processed_trigger_keys
+        trigger_keys: list[str] = []
+        matched_channel_ids: list[int] = []
+        stream_ids: list[int] = []
+
+        for program, start in active_matches:
+            tvg_id = program["tvg_id"]
+            for channel in channels:
+                epg_data_id = channel.get("epg_data_id")
+                channel_matches = (
+                    epg_data_id in epg_ids_by_tvg[tvg_id]
+                    if epg_data_id is not None
+                    else channel.get("tvg_id") == tvg_id
+                    or channel.get("uuid") == tvg_id
+                )
+                if not channel_matches or not isinstance(channel.get("id"), int):
+                    continue
+                event_identity = program.get("id", start.isoformat())
+                trigger_key = (
+                    f"{self._invocation_schedule_id or 'manual'}:"
+                    f"{event_identity}:{start.isoformat()}:{tvg_id}:{channel['id']}"
+                )
+                if trigger_key in seen_keys:
+                    continue
+                full_channel = await self._prober.client.get_channel(channel["id"])
+                matched_channel_ids.append(channel["id"])
+                trigger_keys.append(trigger_key)
+                seen_keys.add(trigger_key)
+                for stream_id in full_channel.get("streams", []):
+                    if isinstance(stream_id, int) and stream_id not in stream_ids:
+                        stream_ids.append(stream_id)
+
+        if not trigger_keys:
+            return TaskResult(
+                success=True,
+                message="Matching EPG events were already evaluated",
+                started_at=started_at,
+                completed_at=datetime.utcnow(),
+            )
+
+        if not stream_ids:
+            self._processed_trigger_keys.update(trigger_keys)
+            return TaskResult(
+                success=True,
+                message="Matching EPG channels have no streams",
+                started_at=started_at,
+                completed_at=datetime.utcnow(),
+                details={
+                    "trigger_keys": trigger_keys,
+                    "matched_channels": matched_channel_ids,
+                },
+            )
+
+        probe_result = await self._prober.probe_streams_by_ids(
+            stream_ids,
+            start_send_alerts=self._send_alerts,
+            allow_reorder_after_probe=self._allow_reorder_after_probe,
+        )
+        if probe_result.get("status") == "already_running":
+            return TaskResult(
+                success=False,
+                message="A stream probe is already in progress",
+                error="ALREADY_RUNNING",
+                started_at=started_at,
+                completed_at=datetime.utcnow(),
+            )
+
+        self._processed_trigger_keys.update(trigger_keys)
+        failed_count = int(probe_result.get("failed", 0))
+        success_count = int(probe_result.get("success", 0))
+        total = int(probe_result.get("total", len(stream_ids)))
+        succeeded = probe_result.get("status") == "completed"
+        return TaskResult(
+            success=succeeded,
+            message=(
+                f"EPG event probe processed {len(matched_channel_ids)} channel(s) "
+                f"and {total} stream(s)"
+            ),
+            error=None if succeeded else probe_result.get("error", "PROBE_FAILED"),
+            started_at=started_at,
+            completed_at=datetime.utcnow(),
+            total_items=total,
+            success_count=success_count,
+            failed_count=failed_count,
+            details={
+                "trigger_keys": trigger_keys,
+                "matched_channels": matched_channel_ids,
+            },
+        )

--- a/backend/tests/fixtures/dispatcharr_epg_grid_recorded.json
+++ b/backend/tests/fixtures/dispatcharr_epg_grid_recorded.json
@@ -1,0 +1,28 @@
+{
+  "capture": {
+    "source": "GET /api/epg/grid/ from a disposable Dispatcharr 0.29.0 container seeded with one synthetic ProgramData row",
+    "fixture_kind": "shape-preserving redacted HTTP capture",
+    "literal_raw_capture": false,
+    "captured_at": "2026-09-03",
+    "redaction": "Synthetic identifiers and text were normalized after capture; field names, scalar types, nullability, envelope, and timestamp format are unchanged"
+  },
+  "response": {
+    "data": [
+      {
+        "id": 1,
+        "start_time": "2026-09-03T16:12:23.807787Z",
+        "end_time": "2026-09-03T17:12:23.807787Z",
+        "title": "Recorded Fixture Event",
+        "sub_title": null,
+        "description": "Synthetic event recorded through the real grid endpoint",
+        "tvg_id": "fixture.channel",
+        "season": null,
+        "episode": null,
+        "is_new": false,
+        "is_live": true,
+        "is_premiere": false,
+        "is_finale": false
+      }
+    ]
+  }
+}

--- a/backend/tests/integration/test_api_tasks.py
+++ b/backend/tests/integration/test_api_tasks.py
@@ -279,6 +279,34 @@ class TestTaskSchedules:
                 assert data["parameters"]["channel_groups"] == ["Sports", "News"]
 
     @pytest.mark.asyncio
+    async def test_epg_probe_rejects_invalid_regex_before_persisting_schedule(
+        self, async_client, test_session
+    ):
+        from models import TaskSchedule
+        from tasks.epg_event_probe import EPGEventProbeTask
+        from tests.fixtures.factories import create_scheduled_task
+
+        create_scheduled_task(test_session, task_id="epg_event_probe")
+
+        with patch("task_registry.get_registry") as mock_registry:
+            mock_registry.return_value.get_task_class.return_value = EPGEventProbeTask
+            response = await async_client.post(
+                "/api/tasks/epg_event_probe/schedules",
+                json={
+                    "name": "Invalid EPG Probe",
+                    "schedule_type": "interval",
+                    "interval_seconds": 60,
+                    "parameters": {"title_pattern": "["},
+                },
+            )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == "title_pattern must be a valid regex"
+        assert test_session.query(TaskSchedule).filter(
+            TaskSchedule.task_id == "epg_event_probe"
+        ).count() == 0
+
+    @pytest.mark.asyncio
     async def test_update_task_schedule(self, async_client, test_session):
         """PATCH /api/tasks/{task_id}/schedules/{schedule_id} updates schedule."""
         from tests.fixtures.factories import create_task_schedule

--- a/backend/tests/integration/test_epg_event_probe_claim_migration.py
+++ b/backend/tests/integration/test_epg_event_probe_claim_migration.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+import pytest
+
+import database
+
+
+TABLE = "epg_event_probe_claims"
+
+
+def _config(db_url: str) -> Config:
+    config = Config(str(Path(database.ALEMBIC_INI_PATH)))
+    config.set_main_option("sqlalchemy.url", db_url)
+    return config
+
+
+@pytest.mark.integration
+def test_migration_0054_adds_unique_claims_and_round_trips(tmp_path):
+    db_url = f"sqlite:///{tmp_path / 'epg_event_probe_claims.db'}"
+    config = _config(db_url)
+    command.upgrade(config, "0053")
+
+    engine = create_engine(db_url)
+    try:
+        assert TABLE not in inspect(engine).get_table_names()
+    finally:
+        engine.dispose()
+
+    command.upgrade(config, "0054")
+    engine = create_engine(db_url)
+    try:
+        with engine.begin() as connection:
+            connection.execute(text(
+                f"INSERT INTO {TABLE} (trigger_key, claimed_at) "
+                "VALUES ('schedule:event:channel', CURRENT_TIMESTAMP)"
+            ))
+        with pytest.raises(IntegrityError):
+            with engine.begin() as connection:
+                connection.execute(text(
+                    f"INSERT INTO {TABLE} (trigger_key, claimed_at) "
+                    "VALUES ('schedule:event:channel', CURRENT_TIMESTAMP)"
+                ))
+    finally:
+        engine.dispose()
+
+    command.downgrade(config, "0053")
+    engine = create_engine(db_url)
+    try:
+        assert TABLE not in inspect(engine).get_table_names()
+    finally:
+        engine.dispose()

--- a/backend/tests/integration/test_event_sync_review_retention_index_migration.py
+++ b/backend/tests/integration/test_event_sync_review_retention_index_migration.py
@@ -55,10 +55,15 @@ def test_migration_0052_adds_and_round_trips_retention_index(tmp_path):
                 "(1, 7, :stream_hash, 'event|2026-09-02T00:00:00+00:00', "
                 "'rejected', 1, 2, '{}')"
             ), {"stream_hash": "a" * 64})
-            # 0053 is a column migration. Add its model-visible shape by hand
-            # so this test can continue isolating 0052's index-only replay.
+            # Add newer model-visible shapes by hand so this test can continue
+            # isolating 0052's index-only replay.
             conn.execute(text(
                 "ALTER TABLE auto_creation_rules ADD COLUMN required_provider_ids TEXT"
+            ))
+            conn.execute(text(
+                "CREATE TABLE epg_event_probe_claims ("
+                "trigger_key VARCHAR(1000) NOT NULL PRIMARY KEY, "
+                "claimed_at DATETIME NOT NULL)"
             ))
         assert database._schema_matches_head(engine) is True
         database._bootstrap_alembic(engine)

--- a/backend/tests/routers/test_settings.py
+++ b/backend/tests/routers/test_settings.py
@@ -956,7 +956,7 @@ class TestUpdateSettingsRebuildsBackgroundServices:
         mock_old_prober.stop.assert_called_once()
         mock_set_tracker.assert_called_once()
         mock_set_prober.assert_called_once_with(new_prober_instance)
-        assert mock_task_instance.set_prober.call_count == 3
+        assert mock_task_instance.set_prober.call_count == 4
         mock_task_instance.set_prober.assert_called_with(new_prober_instance)
 
     @pytest.mark.asyncio
@@ -1003,7 +1003,7 @@ class TestUpdateSettingsRebuildsBackgroundServices:
         assert response.json()["status"] == "saved"
         mock_set_tracker.assert_called_once()
         mock_set_prober.assert_called_once_with(new_prober_instance)
-        assert mock_task_instance.set_prober.call_count == 3
+        assert mock_task_instance.set_prober.call_count == 4
 
     @pytest.mark.asyncio
     async def test_rebuild_failure_does_not_break_the_save(self, async_client, caplog):

--- a/backend/tests/unit/test_dispatcharr_epg_grid_fixture.py
+++ b/backend/tests/unit/test_dispatcharr_epg_grid_fixture.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from config import DispatcharrSettings
+from dispatcharr_client import DispatcharrClient
+
+
+FIXTURE = Path(__file__).parents[1] / "fixtures" / "dispatcharr_epg_grid_recorded.json"
+
+
+@pytest.mark.asyncio
+async def test_get_epg_grid_parses_recorded_dispatcharr_response():
+    recorded = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    response = MagicMock()
+    response.json.return_value = recorded["response"]
+    response.raise_for_status.return_value = None
+    client = DispatcharrClient(DispatcharrSettings(url="http://dispatcharr.test"))
+    client._request = AsyncMock(return_value=response)
+
+    try:
+        programs = await client.get_epg_grid()
+    finally:
+        await client.close()
+
+    assert recorded["capture"]["source"].startswith("GET /api/epg/grid/")
+    assert programs == recorded["response"]["data"]
+    assert programs[0]["tvg_id"] == "fixture.channel"
+    assert programs[0]["start_time"].endswith("Z")

--- a/backend/tests/unit/test_epg_event_probe.py
+++ b/backend/tests/unit/test_epg_event_probe.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -6,7 +7,6 @@ import pytest
 from sqlalchemy.orm import sessionmaker
 
 import tasks.epg_event_probe as epg_event_probe
-from models import TaskExecution
 from tasks.epg_event_probe import EPGEventProbeTask
 
 
@@ -24,7 +24,25 @@ def _event(**overrides):
     }
 
 
-def _task(*, events=None, channels=None, epg_data=None, seen_keys_loader=lambda _: set()):
+def _task(
+    *,
+    events=None,
+    channels=None,
+    epg_data=None,
+    claim_trigger=None,
+    release_claims=None,
+    persistent_claims=False,
+):
+    if not persistent_claims and claim_trigger is None:
+        claimed = set()
+
+        def claim_trigger(key):
+            if key in claimed:
+                return False
+            claimed.add(key)
+            return True
+
+        release_claims = lambda keys: claimed.difference_update(keys)
     client = SimpleNamespace(
         get_epg_grid=AsyncMock(return_value=list(events or [])),
         get_epg_data=AsyncMock(return_value=list(epg_data or [])),
@@ -49,7 +67,8 @@ def _task(*, events=None, channels=None, epg_data=None, seen_keys_loader=lambda 
     )
     task = EPGEventProbeTask(
         now_fn=lambda: NOW,
-        seen_keys_loader=seen_keys_loader,
+        claim_trigger=claim_trigger,
+        release_claims=release_claims,
     )
     task.set_prober(prober)
     task._enabled = True
@@ -90,7 +109,7 @@ async def test_matching_active_event_probes_every_stream_on_resolved_channel_onc
         start_send_alerts=True,
         allow_reorder_after_probe=False,
     )
-    client.get_epg_data.assert_awaited_once_with(search="sports.example")
+    client.get_epg_data.assert_awaited_once_with(max_results=50001)
     assert len(result.details["trigger_keys"]) == 1
     assert result.details["matched_channels"] == [42]
 
@@ -143,6 +162,14 @@ def test_malformed_title_expression_is_rejected_at_configuration_boundary():
 
 @pytest.mark.asyncio
 async def test_duplicate_schedule_evaluation_does_not_probe_same_event_channel_twice():
+    claimed = set()
+
+    def claim_trigger(key):
+        if key in claimed:
+            return False
+        claimed.add(key)
+        return True
+
     task, prober, _ = _task(
         events=[_event()],
         channels=[{
@@ -151,6 +178,8 @@ async def test_duplicate_schedule_evaluation_does_not_probe_same_event_channel_t
             "tvg_id": "sports.example",
             "streams": [10, 11],
         }],
+        claim_trigger=claim_trigger,
+        release_claims=lambda keys: claimed.difference_update(keys),
     )
 
     first = await task.execute()
@@ -162,37 +191,92 @@ async def test_duplicate_schedule_evaluation_does_not_probe_same_event_channel_t
 
 
 @pytest.mark.asyncio
-async def test_duplicate_suppression_survives_task_restart(test_engine, monkeypatch):
+async def test_interrupted_probe_claim_survives_task_restart(test_engine, monkeypatch):
     session_factory = sessionmaker(bind=test_engine, expire_on_commit=False)
     monkeypatch.setattr(epg_event_probe, "get_session", session_factory)
-    session = session_factory()
-    session.add(TaskExecution(
-        task_id="epg_event_probe",
-        started_at=datetime(2026, 9, 3, 16, 1),
-        completed_at=datetime(2026, 9, 3, 16, 2),
-        status="completed",
-        success=True,
-        details=(
-            '{"trigger_keys":["17:501:2026-09-03T16:00:00+00:00:'
-            'sports.example:42"]}'
-        ),
-    ))
-    session.commit()
-    session.close()
+    channels = [{
+        "id": 42,
+        "uuid": "channel-uuid",
+        "tvg_id": "sports.example",
+        "streams": [10, 11],
+    }]
+    interrupted, interrupted_prober, _ = _task(
+        events=[_event()],
+        channels=channels,
+        persistent_claims=True,
+    )
+    interrupted_prober.probe_streams_by_ids.side_effect = KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        await interrupted.execute()
+
+    restarted, restarted_prober, _ = _task(
+        events=[_event()], channels=channels, persistent_claims=True
+    )
+    result = await restarted.execute()
+
+    assert result.total_items == 0
+    restarted_prober.probe_streams_by_ids.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tasks_atomically_claim_event_channel_once(test_engine, monkeypatch):
+    session_factory = sessionmaker(bind=test_engine, expire_on_commit=False)
+    monkeypatch.setattr(epg_event_probe, "get_session", session_factory)
+    channels = [{
+        "id": 42,
+        "uuid": "channel-uuid",
+        "tvg_id": "sports.example",
+        "streams": [10, 11],
+    }]
+    first, first_prober, _ = _task(
+        events=[_event()], channels=channels, persistent_claims=True
+    )
+    second, second_prober, _ = _task(
+        events=[_event()], channels=channels, persistent_claims=True
+    )
+
+    results = await asyncio.gather(first.execute(), second.execute())
+
+    assert sorted(result.total_items for result in results) == [0, 2]
+    assert (
+        first_prober.probe_streams_by_ids.await_count
+        + second_prober.probe_streams_by_ids.await_count
+    ) == 1
+
+
+@pytest.mark.asyncio
+async def test_already_running_refusal_releases_claim_for_retry():
+    claimed = set()
+
+    def claim_trigger(key):
+        if key in claimed:
+            return False
+        claimed.add(key)
+        return True
+
     task, prober, _ = _task(
         events=[_event()],
         channels=[{
             "id": 42,
             "uuid": "channel-uuid",
             "tvg_id": "sports.example",
-            "streams": [10, 11],
+            "streams": [10],
         }],
-        seen_keys_loader=None,
+        claim_trigger=claim_trigger,
+        release_claims=lambda keys: claimed.difference_update(keys),
     )
-    result = await task.execute()
+    prober.probe_streams_by_ids.side_effect = [
+        {"status": "already_running"},
+        {"status": "completed", "total": 1, "success": 1, "failed": 0},
+    ]
 
-    assert result.total_items == 0
-    prober.probe_streams_by_ids.assert_not_awaited()
+    first = await task.execute()
+    second = await task.execute()
+
+    assert first.error == "ALREADY_RUNNING"
+    assert second.success is True
+    assert prober.probe_streams_by_ids.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -211,3 +295,70 @@ async def test_channel_uuid_resolves_dummy_epg_event_without_epg_data_lookup():
     await task.execute()
 
     prober.probe_streams_by_ids.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_broad_match_resolves_with_one_epg_fetch_and_one_channel_index_pass():
+    class CountingChannel(dict):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.resolution_reads = 0
+
+        def get(self, key, default=None):
+            if key in {"epg_data_id", "tvg_id", "uuid"}:
+                self.resolution_reads += 1
+            return super().get(key, default)
+
+    channels = [
+        CountingChannel(id=1, epg_data_id=88, tvg_id="wrong", streams=[30, 10]),
+        CountingChannel(
+            id=2, epg_data_id=None, tvg_id="sports.example", streams=[10, 20]
+        ),
+        CountingChannel(
+            id=3,
+            epg_data_id=None,
+            tvg_id=None,
+            uuid="news.example",
+            streams=[20, 40],
+        ),
+    ]
+    claimed = set()
+    task, prober, client = _task(
+        events=[
+            _event(id=501, tvg_id="sports.example"),
+            _event(id=502, tvg_id="sports.example"),
+            _event(id=503, tvg_id="news.example"),
+        ],
+        channels=channels,
+        epg_data=[{"id": 88, "tvg_id": "sports.example"}],
+        claim_trigger=lambda key: key not in claimed and not claimed.add(key),
+        release_claims=lambda keys: claimed.difference_update(keys),
+    )
+
+    await task.execute()
+
+    client.get_epg_data.assert_awaited_once_with(max_results=50001)
+    assert [channel.resolution_reads for channel in channels] == [1, 3, 3]
+    prober.probe_streams_by_ids.assert_awaited_once_with(
+        [30, 10, 20, 40],
+        start_send_alerts=True,
+        allow_reorder_after_probe=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_epg_identity_listing_over_existing_ceiling_fails_closed():
+    task, prober, client = _task(
+        events=[_event()],
+        channels=[{"id": 42, "epg_data_id": 88, "streams": [10]}],
+        epg_data=[{"id": index, "tvg_id": f"channel-{index}"} for index in range(50001)],
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="EPG data pagination exceeded the 50000-row safety limit",
+    ):
+        await task.execute()
+
+    client.get_epg_data.assert_awaited_once_with(max_results=50001)
+    prober.probe_streams_by_ids.assert_not_awaited()

--- a/backend/tests/unit/test_epg_event_probe.py
+++ b/backend/tests/unit/test_epg_event_probe.py
@@ -1,0 +1,213 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+import tasks.epg_event_probe as epg_event_probe
+from models import TaskExecution
+from tasks.epg_event_probe import EPGEventProbeTask
+
+
+NOW = datetime(2026, 9, 3, 16, 30, tzinfo=timezone.utc)
+
+
+def _event(**overrides):
+    return {
+        "id": 501,
+        "start_time": "2026-09-03T16:00:00Z",
+        "end_time": "2026-09-03T17:00:00Z",
+        "title": "Premier League Live",
+        "tvg_id": "sports.example",
+        **overrides,
+    }
+
+
+def _task(*, events=None, channels=None, epg_data=None, seen_keys_loader=lambda _: set()):
+    client = SimpleNamespace(
+        get_epg_grid=AsyncMock(return_value=list(events or [])),
+        get_epg_data=AsyncMock(return_value=list(epg_data or [])),
+        get_channels=AsyncMock(return_value={
+            "results": list(channels or []),
+            "next": None,
+        }),
+        get_channel=AsyncMock(side_effect=lambda channel_id: next(
+            channel for channel in (channels or []) if channel["id"] == channel_id
+        )),
+    )
+    prober = SimpleNamespace(
+        client=client,
+        _probing_in_progress=False,
+        probe_streams_by_ids=AsyncMock(return_value={
+            "status": "completed",
+            "probed": 2,
+            "total": 2,
+            "success": 2,
+            "failed": 0,
+        }),
+    )
+    task = EPGEventProbeTask(
+        now_fn=lambda: NOW,
+        seen_keys_loader=seen_keys_loader,
+    )
+    task.set_prober(prober)
+    task._enabled = True
+    task.prepare_invocation_parameters(
+        "scheduled",
+        17,
+        {"title_pattern": "Premier League", "allow_reorder_after_probe": False},
+    )
+    task.update_config({
+        "title_pattern": "Premier League",
+        "allow_reorder_after_probe": False,
+    })
+    return task, prober, client
+
+
+@pytest.mark.asyncio
+async def test_matching_active_event_probes_every_stream_on_resolved_channel_once():
+    channel = {
+        "id": 42,
+        "uuid": "channel-uuid",
+        "name": "Sports",
+        "tvg_id": None,
+        "epg_data_id": 88,
+        "streams": [10, 11, 10],
+    }
+    task, prober, client = _task(
+        events=[_event()],
+        channels=[channel],
+        epg_data=[{"id": 88, "tvg_id": "sports.example"}],
+    )
+
+    result = await task.execute()
+
+    assert result.success is True
+    assert result.total_items == 2
+    prober.probe_streams_by_ids.assert_awaited_once_with(
+        [10, 11],
+        start_send_alerts=True,
+        allow_reorder_after_probe=False,
+    )
+    client.get_epg_data.assert_awaited_once_with(search="sports.example")
+    assert len(result.details["trigger_keys"]) == 1
+    assert result.details["matched_channels"] == [42]
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        [_event(title="Post-match analysis")],
+        [],
+        [_event(start_time="2026-09-03T16:31:00Z")],
+        [_event(end_time="2026-09-03T16:30:00Z")],
+    ],
+    ids=["non-matching", "missing-epg", "not-started", "ended"],
+)
+@pytest.mark.asyncio
+async def test_non_triggering_event_states_do_not_probe(events):
+    task, prober, _ = _task(
+        events=events,
+        channels=[{
+            "id": 42,
+            "uuid": "channel-uuid",
+            "tvg_id": "sports.example",
+            "streams": [10],
+        }],
+    )
+
+    result = await task.execute()
+
+    assert result.success is True
+    assert result.total_items == 0
+    prober.probe_streams_by_ids.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_disabled_trigger_does_not_read_epg_or_probe():
+    task, prober, client = _task(events=[_event()])
+    task._enabled = False
+
+    result = await task.execute()
+
+    assert result.success is True
+    client.get_epg_grid.assert_not_awaited()
+    prober.probe_streams_by_ids.assert_not_awaited()
+
+
+def test_malformed_title_expression_is_rejected_at_configuration_boundary():
+    with pytest.raises(ValueError, match="title_pattern must be a valid regex"):
+        EPGEventProbeTask.validate_schedule_parameters({"title_pattern": "["})
+
+
+@pytest.mark.asyncio
+async def test_duplicate_schedule_evaluation_does_not_probe_same_event_channel_twice():
+    task, prober, _ = _task(
+        events=[_event()],
+        channels=[{
+            "id": 42,
+            "uuid": "channel-uuid",
+            "tvg_id": "sports.example",
+            "streams": [10, 11],
+        }],
+    )
+
+    first = await task.execute()
+    second = await task.execute()
+
+    assert first.total_items == 2
+    assert second.total_items == 0
+    prober.probe_streams_by_ids.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_suppression_survives_task_restart(test_engine, monkeypatch):
+    session_factory = sessionmaker(bind=test_engine, expire_on_commit=False)
+    monkeypatch.setattr(epg_event_probe, "get_session", session_factory)
+    session = session_factory()
+    session.add(TaskExecution(
+        task_id="epg_event_probe",
+        started_at=datetime(2026, 9, 3, 16, 1),
+        completed_at=datetime(2026, 9, 3, 16, 2),
+        status="completed",
+        success=True,
+        details=(
+            '{"trigger_keys":["17:501:2026-09-03T16:00:00+00:00:'
+            'sports.example:42"]}'
+        ),
+    ))
+    session.commit()
+    session.close()
+    task, prober, _ = _task(
+        events=[_event()],
+        channels=[{
+            "id": 42,
+            "uuid": "channel-uuid",
+            "tvg_id": "sports.example",
+            "streams": [10, 11],
+        }],
+        seen_keys_loader=None,
+    )
+    result = await task.execute()
+
+    assert result.total_items == 0
+    prober.probe_streams_by_ids.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_channel_uuid_resolves_dummy_epg_event_without_epg_data_lookup():
+    task, prober, client = _task(
+        events=[_event(tvg_id="channel-uuid")],
+        channels=[{
+            "id": 42,
+            "uuid": "channel-uuid",
+            "tvg_id": None,
+            "epg_data_id": None,
+            "streams": [10],
+        }],
+    )
+
+    await task.execute()
+
+    prober.probe_streams_by_ids.assert_awaited_once()

--- a/backend/tests/unit/test_stream_prober_bulk.py
+++ b/backend/tests/unit/test_stream_prober_bulk.py
@@ -135,6 +135,23 @@ async def test_bulk_run_skips_reorder_when_setting_off():
     reorder_mock.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_bulk_run_invocation_can_suppress_global_reorder():
+    client = AsyncMock()
+    prober = _make_prober(client, auto_reorder_after_probe=True)
+    streams = [{"id": 10, "url": "http://example.com/10", "name": "Stream 10"}]
+    reorder_mock = AsyncMock()
+
+    with patch.object(prober, "_fetch_all_streams", AsyncMock(return_value=streams)), \
+         patch.object(prober, "probe_stream", AsyncMock(return_value={"probe_status": "success"})), \
+         patch.object(prober, "_auto_reorder_channels_for_streams", reorder_mock):
+        await prober.probe_streams_by_ids(
+            [10], allow_reorder_after_probe=False
+        )
+
+    reorder_mock.assert_not_awaited()
+
+
 @pytest.mark.parametrize("strategy", ["priority", "points"])
 @pytest.mark.asyncio
 async def test_probe_completion_reorder_uses_configured_smart_sort(strategy):

--- a/docs/dispatcharr_api.md
+++ b/docs/dispatcharr_api.md
@@ -27,11 +27,12 @@ Three of ECM's Dispatcharr integration bugs (`q6xjl`, `lsa0s`, and the settings-
 
 1. Fetch the live schema: `GET /api/schema/?format=json` (see above — do not fetch the bare route).
 2. Check the `paths` object in the response for the exact path you intend to call, and inspect its `get`/`post`/`patch`/`delete` keys for the request/response shape.
-3. If you cannot reach a live instance, use the recorded fixtures below — they are literal slices of a real 0.28.2 response, not hand-written examples:
+3. If you cannot reach a live instance, use the recorded fixtures below. Most are literal slices of a real 0.28.2 response; fixtures captured from another version or shape-preserving redactions say so in their metadata:
    - `backend/tests/fixtures/dispatcharr_openapi_recorded.json` — a slice of the `/api/schema/?format=json` document (the `/api/core/settings/` and `/api/core/settings/{id}/` path items, plus the `User` component schema).
    - `backend/tests/fixtures/dispatcharr_core_settings_recorded.json` — the shape of `GET /api/core/settings/` (a bare list, non-contiguous integer ids).
    - `backend/tests/fixtures/dispatcharr_dvr_recurring_rules_recorded.json` — the shape of `GET /api/channels/recurring-rules/` and the dead-endpoint capture for the old `/api/dvr/rules/` guess.
    - `backend/tests/fixtures/dispatcharr_recordings_recorded.json` — `GET`/`POST`/`DELETE` on `/api/channels/recordings/`, captured on **0.29.0** (the others are 0.28.2). The only fixture here with populated rows *and* a refused request: it records the `400 "End time must be in the future."` a past-dated create earns, and the destination writing its own key into `custom_properties` between the 201 and the next GET.
+   - `backend/tests/fixtures/dispatcharr_epg_grid_recorded.json` — the `{"data": [...]}` response shape from `GET /api/epg/grid/`, captured on **0.29.0** with one synthetic program and then value-redacted without changing fields or scalar types.
    - `backend/tests/fixtures/dispatcharr_openapi_paths_manifest.json` — **every** path and method the live 0.28.2 document exposes (all 224), with bodies stripped. Use it to answer "does this path exist, and does it allow this method?" without a live instance; use the fixtures above when you need the *shape* of a response.
 4. A path that "sounds right" by analogy to another resource is a guess, not a fact — Dispatcharr's namespacing is not fully consistent (see the DVR rules case below), and a wrong guess here has shipped a JSON-parse failure, a 404 on every apply, and a silently-empty backup category.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0012",
+  "version": "0.18.2-0013",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/ScheduleEditor.tsx
+++ b/frontend/src/components/ScheduleEditor.tsx
@@ -487,6 +487,7 @@ export function ScheduleEditor({ schedule, onSave, onCancel, saving, taskId, par
           <h4 className="section-title">Task Parameters</h4>
           {parameterSchema.map((param) => {
             const descriptionId = `schedule-parameter-${param.name}-description`;
+            const inputId = `schedule-parameter-${param.name}`;
             const source = param.source || param.name;
             const sourceState = parameterSourceStatus?.[source];
             const rawSelectedValues = parameters[param.name];
@@ -501,12 +502,15 @@ export function ScheduleEditor({ schedule, onSave, onCancel, saving, taskId, par
                   Timeout and Max Concurrent are optional overrides for the global settings in Settings → Maintenance.
                 </p>
               )}
-              <label>{param.label}</label>
+              {param.type !== 'boolean' && (
+                <label htmlFor={inputId}>{param.label}</label>
+              )}
               <p id={descriptionId} className="param-description">{param.description}</p>
 
               {/* Number input */}
               {param.type === 'number' && (
                 <input
+                  id={inputId}
                   type="number"
                   value={(parameters[param.name] as number) ?? param.default ?? 0}
                   onChange={(e) => updateParameter(param.name, parseInt(e.target.value) || 0)}
@@ -519,6 +523,7 @@ export function ScheduleEditor({ schedule, onSave, onCancel, saving, taskId, par
               {/* String input */}
               {param.type === 'string' && (
                 <input
+                  id={inputId}
                   type="text"
                   value={(parameters[param.name] as string) ?? param.default ?? ''}
                   onChange={(e) => updateParameter(param.name, e.target.value)}
@@ -530,6 +535,7 @@ export function ScheduleEditor({ schedule, onSave, onCancel, saving, taskId, par
               {param.type === 'boolean' && (
                 <label className="checkbox-label">
                   <input
+                    id={inputId}
                     type="checkbox"
                     checked={(parameters[param.name] as boolean) ?? param.default ?? false}
                     onChange={(e) => updateParameter(param.name, e.target.checked)}

--- a/frontend/src/components/TaskEditorModal.test.tsx
+++ b/frontend/src/components/TaskEditorModal.test.tsx
@@ -110,9 +110,53 @@ function makeStreamProbeTask(): TaskStatus {
   };
 }
 
+function makeEpgEventProbeTask(): TaskStatus {
+  return {
+    ...makeCleanupTask(),
+    task_id: 'epg_event_probe',
+    task_name: 'EPG Event Probe',
+    task_description: 'Probe streams when matching EPG events start',
+    enabled: false,
+    config: {},
+  };
+}
+
 describe('TaskEditorModal — bd-ia28g retention fields', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('renders and persists the EPG event probe title expression and reorder choice', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.getTaskParameterSchema).mockResolvedValue({
+      task_id: 'epg_event_probe',
+      description: 'EPG event probe parameters',
+      parameters: [
+        { name: 'title_pattern', type: 'string', label: 'Title match expression', description: 'Regular expression matched against active EPG titles', required: true },
+        { name: 'allow_reorder_after_probe', type: 'boolean', label: 'Allow stream reordering', description: 'Reorder after probing', default: true },
+      ],
+    });
+    const createSchedule = vi.spyOn(api, 'createTaskSchedule').mockResolvedValue(undefined as never);
+
+    render(<TaskEditorModal task={makeEpgEventProbeTask()} onClose={vi.fn()} onSaved={vi.fn()} openAddSchedule />);
+    const dialog = await screen.findByRole('dialog', { name: 'Add Schedule' });
+    const expression = within(dialog).getByRole('textbox', { name: 'Title match expression' });
+    const save = within(dialog).getByRole('button', { name: /add schedule/i });
+    expect(save).toBeDisabled();
+
+    await user.type(expression, 'Premier League');
+    await user.click(within(dialog).getByRole('checkbox', { name: 'Allow stream reordering' }));
+    await user.click(save);
+
+    await waitFor(() => expect(createSchedule).toHaveBeenCalledWith(
+      'epg_event_probe',
+      expect.objectContaining({
+        parameters: {
+          title_pattern: 'Premier League',
+          allow_reorder_after_probe: false,
+        },
+      }),
+    ));
   });
 
   it('blocks every parent dismissal affordance while the task save is unresolved', async () => {


### PR DESCRIPTION
## Summary
- add an enabled schedule type that probes all streams on channels whose EPG title regex matches an active event
- reject malformed regexes and durably claim each schedule/event/channel trigger before probing to prevent duplicate storms
- bound and index EPG/channel resolution while preserving per-invocation reorder behavior
- add migration 0054, a recorded Dispatcharr EPG fixture, backend/API/migration tests, and UI schedule coverage

## Frozen Scope
- trigger at the first scheduler evaluation where `start <= now < end`
- no lead/lag controls, alternate EPG fields, scheduler redesign, history redesign, or unrelated probe features

## Verification
- focused claim/migration/acceptance suite: 29 passed
- canonical backend: 12,662 passed, 3 skipped, 2 deselected; 81.32% coverage
- full frontend: 3,671 passed with coverage
- frontend typecheck, lint, and production build passed
- strict MkDocs and diff integrity passed
- bounded code review: Approved
- bounded DBA migration/data-integrity review: Approved

Closes #901.
Tracks enhancedchannelmanager-8gmk8.1.