### PR TITLE
feat: add preferred-name alias mappings (u0ko6)

### DIFF
--- a/backend/alembic/versions/20260904_1200_0055_channel_name_mappings.py
+++ b/backend/alembic/versions/20260904_1200_0055_channel_name_mappings.py
@@ -1,0 +1,38 @@
+"""Add operator-defined literal channel aliases (u0ko6).
+
+Revision ID: 0055
+Revises: 0054
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0055"
+down_revision = "0054"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    tables = sa.inspect(op.get_bind()).get_table_names()
+    if "channel_name_mappings" not in tables:
+        op.create_table(
+            "channel_name_mappings",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("preferred_name", sa.String(255), nullable=False),
+        )
+    if "channel_name_aliases" not in tables:
+        op.create_table(
+            "channel_name_aliases",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("mapping_id", sa.Integer(), sa.ForeignKey("channel_name_mappings.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("name", sa.String(255), nullable=False),
+            sa.Column("match_key", sa.String(765), nullable=False, unique=True),
+        )
+    indexes = {index["name"] for index in sa.inspect(op.get_bind()).get_indexes("channel_name_aliases")}
+    if "ix_channel_name_aliases_mapping_id" not in indexes:
+        op.create_index("ix_channel_name_aliases_mapping_id", "channel_name_aliases", ["mapping_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("channel_name_aliases")
+    op.drop_table("channel_name_mappings")

--- a/backend/channel_pipeline_engine.py
+++ b/backend/channel_pipeline_engine.py
@@ -2692,7 +2692,7 @@ class ChannelPipelineEngine:
             # Fall back to DB: any enabled group means lookups should consult
             # the normalized indices even if no rule explicitly opts in.
             try:
-                from models import NormalizationRuleGroup
+                from models import NormalizationRuleGroup, ChannelNameMapping
                 session = get_session()
                 try:
                     has_enabled_group = session.query(
@@ -2700,9 +2700,10 @@ class ChannelPipelineEngine:
                     ).filter(
                         NormalizationRuleGroup.enabled == True  # noqa: E712 — SQLA needs ==
                     ).first() is not None
+                    has_name_mapping = session.query(ChannelNameMapping.id).first() is not None
                 finally:
                     session.close()
-                if has_enabled_group:
+                if has_enabled_group or has_name_mapping:
                     needs_norm = True
             except Exception as e:
                 logger.warning("[AUTO-CREATE-ENGINE] Failed to probe enabled normalization groups: %s", e)

--- a/backend/channel_pipeline_executor.py
+++ b/backend/channel_pipeline_executor.py
@@ -403,6 +403,7 @@ class ActionExecutor:
         self.existing_channels = existing_channels or []
         self.existing_groups = existing_groups or []
         self._normalization_engine = normalization_engine
+        self._preferred_names = dict(normalization_engine.get_name_mappings()) if normalization_engine else {}
         self._settings = settings
         # ``all_profile_ids`` carries a THREE-way availability signal, kept
         # DISTINCT (do NOT coerce ``None`` -> ``[]`` here):
@@ -996,9 +997,8 @@ class ActionExecutor:
         — so it fell back to the raw stream name everywhere except create_channel,
         which alone re-normalized its expanded name afterward.
 
-        When the rule has no normalization groups (or no engine), it falls back
-        to the raw stream name — unchanged from prior behavior, so the only rules
-        affected are those that actually opted into normalization.
+        Without selected groups, unmapped names remain raw. Literal mappings
+        resolve independently of the regex-group selection.
         """
         quality_str = None
         if stream_ctx.resolution_height:
@@ -1027,6 +1027,7 @@ class ActionExecutor:
                     "[AUTO-CREATE-EXEC] Failed to normalize {normalized_name} for '%s': %s",
                     stream_ctx.stream_name, e)
         normalized_name = normalized_name or stream_ctx.stream_name
+        normalized_name = self._preferred_names.get(stream_ctx.stream_name.casefold(), normalized_name)
 
         ctx = {
             TemplateVariables.STREAM_NAME: stream_ctx.stream_name,
@@ -1227,7 +1228,11 @@ class ActionExecutor:
 
         # Apply normalization engine if enabled (non-empty group IDs list)
         pre_norm_name = channel_name
-        if normalization_group_ids and self._normalization_engine:
+        preferred_name = self._preferred_names.get(stream_ctx.stream_name.casefold())
+        if preferred_name is not None:
+            channel_name = preferred_name
+            action_details.append(f"Preferred-name mapping: '{pre_norm_name}' -> '{channel_name}'")
+        elif normalization_group_ids and self._normalization_engine:
             logger.debug("[AUTO-CREATE-EXEC] Applying normalization groups %s to '%s'", normalization_group_ids, channel_name)
             try:
                 # bd-eio04.1: preserve_superscripts kwarg removed. The
@@ -1235,7 +1240,7 @@ class ActionExecutor:
                 # Test Rules — both strip letter-superscripts AND convert
                 # numeric superscripts (ESPN² -> ESPN2). Closes GH #104.
                 norm_result = self._normalization_engine.normalize(
-                    channel_name, group_ids=normalization_group_ids)
+                    channel_name, group_ids=normalization_group_ids, resolve_mapping=False)
                 if norm_result.normalized != channel_name:
                     logger.debug("[AUTO-CREATE-EXEC] Normalized channel name: '%s' -> '%s'", channel_name, norm_result.normalized)
                     for rule_id, before, after in norm_result.transformations:
@@ -1284,10 +1289,12 @@ class ActionExecutor:
         # channels unless the rule explicitly opts in.
         existing = self._find_channel_by_name(
             channel_name, scope_group_id=scope_group_id,
+            exact_only=preferred_name is not None,
+            resolve_mapping=False,
             block_manual=not allow_manual_channel_merge,
             # GH #645 / bead 0vao3: opt-in whitespace/case fold on the merge
             # lookup's comparison key (never on the stored name).
-            fold_key=fold_match_key,
+            fold_key=fold_match_key and preferred_name is None,
         )
         if existing is not None and allow_manual_channel_merge \
                 and self._is_manual_channel(existing):
@@ -2047,6 +2054,8 @@ class ActionExecutor:
         # streams via the word-prefix step). Set loose_name_match=True on the
         # action to restore the legacy cascade.
         loose_name_match = params.get("loose_name_match", False) is True
+        if target == "auto" and stream_ctx.stream_name.casefold() in self._preferred_names:
+            loose_name_match = False
         # enhancedchannelmanager-jnzst: SCORED-FUZZY path. When loose_name_match
         # is on AND a min_score is configured, channel resolution runs through
         # the unified scoring core (services.dedup_matcher.score_all) instead of
@@ -5865,7 +5874,8 @@ class ActionExecutor:
     def _find_channel_by_name(self, name: str, scope_group_id: Optional[int] = None,
                               exact_only: bool = False,
                               block_manual: bool = True,
-                              fold_key: bool = False) -> Optional[dict]:
+                              fold_key: bool = False,
+                              resolve_mapping: bool = True) -> Optional[dict]:
         """Find channel by exact name (case-insensitive).
 
         Also checks the base-name mapping so that a lookup for "USA Network"
@@ -5994,7 +6004,7 @@ class ActionExecutor:
         # (exact_only=False) where they prevent duplicate channels (GH-104).
         if not exact_only and self._normalization_engine is not None:
             try:
-                norm = self._normalization_engine.normalize(name)
+                norm = self._normalization_engine.normalize(name, resolve_mapping=resolve_mapping)
                 norm_lower = (norm.normalized or "").strip().lower()
             except Exception as e:
                 logger.warning("[AUTO-CREATE-EXEC] Normalization of lookup name '%s' failed: %s", name, e)

--- a/backend/models.py
+++ b/backend/models.py
@@ -13,6 +13,30 @@ from credential_sentinel import ALERT_METHOD_CREDENTIAL_KEYS
 logger = logging.getLogger(__name__)
 
 
+class ChannelNameMapping(Base):
+    """Reusable preferred spelling, independent of Dispatcharr channel IDs."""
+    __tablename__ = "channel_name_mappings"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    preferred_name = Column(String(255), nullable=False)
+    aliases = relationship(
+        "ChannelNameAlias", cascade="all, delete-orphan", order_by="ChannelNameAlias.id",
+    )
+
+    def to_dict(self):
+        return {"id": self.id, "preferred_name": self.preferred_name,
+                "aliases": [alias.name for alias in self.aliases]}
+
+
+class ChannelNameAlias(Base):
+    __tablename__ = "channel_name_aliases"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    mapping_id = Column(Integer, ForeignKey("channel_name_mappings.id", ondelete="CASCADE"), nullable=False, index=True)
+    name = Column(String(255), nullable=False)
+    match_key = Column(String(765), nullable=False, unique=True)
+
+
 class JournalEntry(Base):
     """
     Represents a single change entry in the journal.

--- a/backend/normalization_engine.py
+++ b/backend/normalization_engine.py
@@ -59,7 +59,7 @@ from dataclasses import dataclass, field
 from sqlalchemy.orm import Session
 
 import safe_regex  # bd-eio04.14: ReDoS-guarded wrapper for user-supplied regex
-from models import NormalizationRule, NormalizationRuleGroup, TagGroup, Tag
+from models import NormalizationRule, NormalizationRuleGroup, TagGroup, Tag, ChannelNameAlias, ChannelNameMapping
 
 logger = logging.getLogger(__name__)
 
@@ -799,6 +799,7 @@ class NormalizationEngine:
         self.db = db
         self._rules_cache: Optional[list] = None
         self._groups_cache: Optional[list] = None
+        self._mapping_cache: dict[str, str] | None = None
         # Per-instance memo for extract_core_name(for_matching=True) — see
         # extract_core_name (bd-xxzxe). Bounded by the request's unique names.
         self._core_name_match_cache: dict[str, str] = {}
@@ -807,6 +808,7 @@ class NormalizationEngine:
         """Clear cached rules to force reload from database."""
         self._rules_cache = None
         self._groups_cache = None
+        self._mapping_cache = None
         self._core_name_match_cache.clear()
         # Also clear tag group cache
         global _tag_group_cache
@@ -1357,7 +1359,20 @@ class NormalizationEngine:
             logger.warning("[NORMALIZE] Unknown else action type: %s", action_type)
             return text
 
-    def normalize(self, name: str, group_ids: list[int] | None = None) -> NormalizationResult:
+    def get_name_mappings(self) -> dict[str, str]:
+        """Snapshot the mappings for this normalization request or pipeline run."""
+        if self._mapping_cache is None:
+            self._mapping_cache = dict(self.db.query(
+                ChannelNameAlias.match_key, ChannelNameMapping.preferred_name,
+            ).join(ChannelNameMapping, ChannelNameAlias.mapping_id == ChannelNameMapping.id).all())
+        return self._mapping_cache
+
+    def resolve_preferred_name(self, name: str) -> str | None:
+        """Match original whole names only; no preprocessing or regex interpretation."""
+        return self.get_name_mappings().get(name.casefold())
+
+    def normalize(self, name: str, group_ids: list[int] | None = None, *,
+                  resolve_mapping: bool = True) -> NormalizationResult:
         """
         Apply enabled rules to normalize a stream name.
 
@@ -1369,6 +1384,8 @@ class NormalizationEngine:
             name: The stream name to normalize
             group_ids: Optional list of NormalizationRuleGroup IDs to apply.
                        None = all enabled groups (default behavior).
+            resolve_mapping: False when a caller already resolved ownership on
+                             the original name before applying a name template.
 
         Returns:
             NormalizationResult with original, normalized name, and applied rules.
@@ -1401,6 +1418,11 @@ class NormalizationEngine:
             rules_applied=[],
             transformations=[]
         )
+
+        preferred = self.resolve_preferred_name(name) if resolve_mapping else None
+        if preferred is not None:
+            result.normalized = preferred
+            return result
 
         current = name.strip()
 

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -369,6 +369,8 @@ _STANDARD_ARTIFACT_TABLES: dict[str, str] = {
     ),
     "normalization_rule_groups": "Normalization rule groups — operator-authored configuration.",
     "normalization_rules": "Normalization rules — operator-authored configuration.",
+    "channel_name_mappings": "Preferred channel names - operator-authored normalization configuration.",
+    "channel_name_aliases": "Literal aliases and comparison keys required to restore preferred-name mappings.",
     "tag_groups": "Tag groups — the normalization vocabulary, operator-authored configuration.",
     "tags": "Tags — the normalization vocabulary, operator-authored configuration.",
     "ffmpeg_profiles": "FFmpeg profiles — operator-authored configuration (name + config).",

--- a/backend/routers/normalization.py
+++ b/backend/routers/normalization.py
@@ -9,19 +9,25 @@ import json
 import logging
 import re
 import time
+from contextlib import contextmanager
+from threading import RLock
 from typing import List, Literal, Optional
 
 import yaml
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import NullPool
 
 import journal
 from auth import RequireAdminIfEnabled, ResolveIsMcpServicePrincipalIfEnabled
 from auth.routes import limiter
 from concurrency import run_cpu_bound
 from config import get_settings
-from database import get_session
+from database import get_database_url, get_session
 from dispatcharr_client import get_client
 from regex_lint import (
     lint_conditions_json,
@@ -32,6 +38,92 @@ from regex_lint import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/normalization", tags=["Normalization"])
+
+# Serialize local mapping CRUD; generic readers do not take this lock.
+_mapping_lock = RLock()
+
+
+@contextmanager
+def _mapping_write_session():
+    # A generic StaticPool session must not see or roll back a mapping's
+    # uncommitted writes. NullPool closes this private connection on exit.
+    engine = create_engine(get_database_url(), poolclass=NullPool)
+    try:
+        with Session(engine, autoflush=False) as session:
+            yield session
+    finally:
+        engine.dispose()
+
+
+class ChannelNameMappingRequest(BaseModel):
+    preferred_name: str = Field(min_length=1, max_length=255)
+    aliases: list[str] = Field(max_length=1000)
+
+    @field_validator("preferred_name", "aliases")
+    @classmethod
+    def validate_names(cls, value):
+        names = [value] if isinstance(value, str) else value
+        for name in names:
+            if not name.strip() or len(name) > 255 or any(ord(c) < 32 for c in name):
+                raise ValueError("Names must be non-blank, single-line text of at most 255 characters")
+        return value
+
+
+@router.get("/mappings")
+def get_channel_name_mappings():
+    from models import ChannelNameMapping
+    with _mapping_lock, get_session() as session:
+        return {"mappings": [m.to_dict() for m in session.query(ChannelNameMapping).order_by(ChannelNameMapping.id).all()]}
+
+
+def _save_channel_name_mapping(request: ChannelNameMappingRequest, mapping_id: int | None = None):
+    from models import ChannelNameAlias, ChannelNameMapping
+    with _mapping_lock, _mapping_write_session() as session:
+        if mapping_id is not None:
+            # First acquire SQLite's writer lock and delete the CURRENT set,
+            # not an ORM collection that another writer may have replaced.
+            session.query(ChannelNameAlias).filter_by(mapping_id=mapping_id).delete(synchronize_session=False)
+        mapping = session.get(ChannelNameMapping, mapping_id) if mapping_id is not None else ChannelNameMapping()
+        if mapping is None:
+            raise HTTPException(404, "Mapping not found")
+        # Reserve the preferred identity as well, making repeated resolution stable.
+        names = {}
+        for name in [request.preferred_name, *request.aliases]:
+            names.setdefault(name.casefold(), name)
+        try:
+            mapping.preferred_name = request.preferred_name
+            session.add(mapping)
+            session.flush()
+            mapping.aliases = [ChannelNameAlias(name=name, match_key=key) for key, name in names.items()]
+            session.flush()
+            result = mapping.to_dict()
+            session.commit()
+            return result
+        except IntegrityError:
+            session.rollback()
+            raise HTTPException(409, "An alias or preferred name is already owned by another mapping")
+
+
+@router.post("/mappings", status_code=201)
+def create_channel_name_mapping(request: ChannelNameMappingRequest, _admin=RequireAdminIfEnabled):
+    return _save_channel_name_mapping(request)
+
+
+@router.put("/mappings/{mapping_id}")
+def update_channel_name_mapping(mapping_id: int, request: ChannelNameMappingRequest, _admin=RequireAdminIfEnabled):
+    return _save_channel_name_mapping(request, mapping_id)
+
+
+@router.delete("/mappings/{mapping_id}", status_code=204)
+def delete_channel_name_mapping(mapping_id: int, _admin=RequireAdminIfEnabled):
+    from models import ChannelNameAlias, ChannelNameMapping
+    with _mapping_lock, _mapping_write_session() as session:
+        session.query(ChannelNameAlias).filter_by(mapping_id=mapping_id).delete(synchronize_session=False)
+        mapping = session.get(ChannelNameMapping, mapping_id)
+        if mapping is None:
+            raise HTTPException(404, "Mapping not found")
+        session.delete(mapping)
+        session.commit()
 
 
 # Request models
@@ -125,6 +217,15 @@ class TestRuleRequest(BaseModel):
 
 class TestRulesBatchRequest(BaseModel):
     texts: list[str]
+
+
+@router.post("/mappings/resolve")
+def resolve_channel_name_mappings(request: TestRulesBatchRequest):
+    from normalization_engine import get_normalization_engine
+    with get_session() as session:
+        engine = get_normalization_engine(session)
+        return {"results": [{"original": name, "preferred_name": engine.resolve_preferred_name(name)}
+                            for name in dict.fromkeys(request.texts)]}
 
 
 class ReorderRulesRequest(BaseModel):

--- a/backend/tests/fixtures/channel_name_mapping_server.py
+++ b/backend/tests/fixtures/channel_name_mapping_server.py
@@ -1,0 +1,31 @@
+"""Isolated real mapping API for the u0ko6 browser contract test.
+
+Only the normalization router is mounted. No application lifespan, schedulers,
+provider refreshes or Dispatcharr writes are started by this fixture.
+"""
+import socket
+
+from tests._config_harness import initialize_test_config, cleanup_test_config
+
+
+def main():
+    config_dir = initialize_test_config()
+    try:
+        import database
+        from fastapi import FastAPI
+        from routers.normalization import router
+        import uvicorn
+
+        database.init_db()
+        app = FastAPI()
+        app.include_router(router)
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            print(f"MAPPING_API_PORT={sock.getsockname()[1]}", flush=True)
+            uvicorn.Server(uvicorn.Config(app, log_level="warning")).run(sockets=[sock])
+    finally:
+        cleanup_test_config(config_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/integration/test_channel_name_mapping_migration.py
+++ b/backend/tests/integration/test_channel_name_mapping_migration.py
@@ -1,0 +1,38 @@
+"""u0ko6 upgrade/downgrade preserves existing data and owns aliases uniquely."""
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+
+import database
+
+
+def test_mapping_migration_round_trip(tmp_path):
+    url = f"sqlite:///{tmp_path / 'mappings.db'}"
+    cfg = Config(str(database.ALEMBIC_INI_PATH))
+    cfg.set_main_option("sqlalchemy.url", url)
+    command.upgrade(cfg, "0054")
+    engine = create_engine(url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("CREATE TABLE existing_fixture (value TEXT)"))
+            conn.execute(text("INSERT INTO existing_fixture VALUES ('keep')"))
+        command.upgrade(cfg, "0055")
+        with engine.begin() as conn:
+            conn.execute(text("INSERT INTO channel_name_mappings (id, preferred_name) VALUES (1, 'TVN'), (2, 'Other')"))
+            conn.execute(text("INSERT INTO channel_name_aliases (mapping_id, name, match_key) VALUES (1, 'TVN-HD', 'tvn-hd')"))
+        with pytest.raises(IntegrityError), engine.begin() as conn:
+            conn.execute(text("INSERT INTO channel_name_aliases (mapping_id, name, match_key) VALUES (2, 'tvn-hd', 'tvn-hd')"))
+        # Application startup also supports models getting ahead of Alembic.
+        command.stamp(cfg, "0054")
+        command.upgrade(cfg, "0055")
+        with engine.connect() as conn:
+            assert conn.execute(text("SELECT name FROM channel_name_aliases")).scalar_one() == "TVN-HD"
+        command.downgrade(cfg, "0054")
+        assert "channel_name_mappings" not in inspect(engine).get_table_names()
+        assert "channel_name_aliases" not in inspect(engine).get_table_names()
+        with engine.connect() as conn:
+            assert conn.execute(text("SELECT value FROM existing_fixture")).scalar_one() == "keep"
+    finally:
+        engine.dispose()

--- a/backend/tests/integration/test_event_sync_review_retention_index_migration.py
+++ b/backend/tests/integration/test_event_sync_review_retention_index_migration.py
@@ -8,6 +8,7 @@ from sqlalchemy import create_engine, inspect, text
 import pytest
 
 import database
+from models import ChannelNameMapping, ChannelNameAlias
 
 
 TABLE = "event_sync_reviews"
@@ -65,6 +66,8 @@ def test_migration_0052_adds_and_round_trips_retention_index(tmp_path):
                 "trigger_key VARCHAR(1000) NOT NULL PRIMARY KEY, "
                 "claimed_at DATETIME NOT NULL)"
             ))
+        ChannelNameMapping.__table__.create(engine)
+        ChannelNameAlias.__table__.create(engine)
         assert database._schema_matches_head(engine) is True
         database._bootstrap_alembic(engine)
     finally:

--- a/backend/tests/routers/test_channel_name_mappings.py
+++ b/backend/tests/routers/test_channel_name_mappings.py
@@ -70,9 +70,11 @@ async def test_persisted_crud_and_literal_matching(async_client, test_session):
     fresh = NormalizationEngine(test_session)
     assert fresh.resolve_preferred_name("tvn sd") == "TVN"
     assert fresh.resolve_preferred_name("TVN HD") is None
-    assert (await async_client.delete(f"/api/normalization/mappings/{ids[2]}")).status_code == 204
+    response = await async_client.delete(f"/api/normalization/mappings/{ids[2]}")
+    assert response.status_code == 204
     assert NormalizationEngine(test_session).resolve_preferred_name("TVN-HD") is None
-    assert (await async_client.delete(f"/api/normalization/mappings/{ids[2]}")).status_code == 404
+    response = await async_client.delete(f"/api/normalization/mappings/{ids[2]}")
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_channel_name_mappings.py
+++ b/backend/tests/routers/test_channel_name_mappings.py
@@ -1,0 +1,403 @@
+"""Frozen u0ko6 contract: persisted literal aliases, not regex rules."""
+import pytest
+
+from normalization_engine import NormalizationEngine
+from models import NormalizationRule, NormalizationRuleGroup
+
+
+@pytest.fixture(autouse=True)
+def isolated_tag_caches():
+    from normalization_engine import invalidate_tag_cache
+
+    invalidate_tag_cache()
+    yield
+    invalidate_tag_cache()
+
+
+@pytest.fixture
+def test_engine(tmp_path, monkeypatch):
+    import database
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import StaticPool
+
+    monkeypatch.setattr(database, "JOURNAL_DB_FILE", tmp_path / "mappings.db")
+    engine = create_engine(database.get_database_url(),
+                           connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    database.Base.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_persisted_crud_and_literal_matching(async_client, test_session):
+    examples = {
+        "Polonia": ["Polonia", "Polonia 1", "Polonia1", "Polonia.1"],
+        "Stars TV": ["Stars TV", "Stars.TV", "Stars-TV"],
+        "TVN": ["TVN", "TVN HD", "TVN-HD"],
+        "Literal HD": ["A.+[1](TV)?$", "Literal HD"],
+    }
+    ids = []
+    for preferred, aliases in examples.items():
+        response = await async_client.post("/api/normalization/mappings", json={
+            "preferred_name": preferred, "aliases": aliases,
+        })
+        assert response.status_code == 201, response.text
+        ids.append(response.json()["id"])
+    listed = await async_client.get("/api/normalization/mappings")
+    assert len(listed.json()["mappings"]) == 4
+
+    group = NormalizationRuleGroup(name="Destructive later pass", enabled=True)
+    test_session.add(group)
+    test_session.flush()
+    test_session.add(NormalizationRule(
+        group_id=group.id, name="Strip HD", enabled=True,
+        condition_type="contains", condition_value=" HD", action_type="remove",
+    ))
+    test_session.commit()
+    engine = NormalizationEngine(test_session)
+    for preferred, aliases in examples.items():
+        for alias in aliases:
+            assert engine.normalize(alias.swapcase()).normalized == preferred
+            assert engine.normalize(preferred).normalized == preferred
+    for negative in ["TVN24", "Polonia 2", "StarsXTV", "Axxx1TV", " TVN", "TVN\n"]:
+        assert engine.resolve_preferred_name(negative) is None
+    assert engine.normalize("Unmapped HD").normalized == "Unmapped"
+
+    response = await async_client.put(f"/api/normalization/mappings/{ids[2]}", json={
+        "preferred_name": "TVN", "aliases": ["TVN", "TVN-HD", "TVN SD"],
+    })
+    assert response.status_code == 200
+    fresh = NormalizationEngine(test_session)
+    assert fresh.resolve_preferred_name("tvn sd") == "TVN"
+    assert fresh.resolve_preferred_name("TVN HD") is None
+    assert (await async_client.delete(f"/api/normalization/mappings/{ids[2]}")).status_code == 204
+    assert NormalizationEngine(test_session).resolve_preferred_name("TVN-HD") is None
+    assert (await async_client.delete(f"/api/normalization/mappings/{ids[2]}")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_duplicate_aliases_deduplicated_and_conflicts_atomic(async_client):
+    created = await async_client.post("/api/normalization/mappings", json={
+        "preferred_name": "TVN", "aliases": ["TVN", "tvn", "TVN-HD", "TVN-HD"],
+    })
+    assert created.status_code == 201
+    assert created.json()["aliases"] == ["TVN", "TVN-HD"]
+    for preferred, aliases in [("Other", ["tvn-hd"]), ("tvn", []), ("Other", ["TVN"])]:
+        conflict = await async_client.post("/api/normalization/mappings", json={
+            "preferred_name": preferred, "aliases": aliases,
+        })
+        assert conflict.status_code == 409
+        assert "owned" in conflict.json()["detail"]
+    other = await async_client.post("/api/normalization/mappings", json={
+        "preferred_name": "Other", "aliases": ["Other.1"],
+    })
+    rejected = await async_client.put(f"/api/normalization/mappings/{other.json()['id']}", json={
+        "preferred_name": "Changed", "aliases": ["tvn-hd"],
+    })
+    assert rejected.status_code == 409
+    listed = (await async_client.get("/api/normalization/mappings")).json()["mappings"]
+    assert {item["preferred_name"] for item in listed} == {"TVN", "Other"}
+    assert next(item for item in listed if item["preferred_name"] == "Other")["aliases"] == ["Other", "Other.1"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [
+    {"preferred_name": "", "aliases": []},
+    {"preferred_name": "TVN", "aliases": [""]},
+    {"preferred_name": "TVN", "aliases": ["TVN\n"]},
+])
+async def test_invalid_mapping_is_visible_validation_error(async_client, payload):
+    response = await async_client.post("/api/normalization/mappings", json=payload)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_pipeline_repeated_runs_group_aliases_without_duplicate_attachments(async_client, test_session):
+    from unittest.mock import AsyncMock, MagicMock
+    from copy import deepcopy
+    from channel_pipeline_executor import ActionExecutor, ExecutionContext
+    from channel_pipeline_evaluator import StreamContext
+
+    await async_client.post("/api/normalization/mappings", json={
+        "preferred_name": "Stars TV HD", "aliases": ["Stars.TV", "Stars-TV"],
+    })
+    channels = []
+
+    async def create(data):
+        channel = {"id": len(channels) + 1, **deepcopy(data)}
+        channels.append(channel)
+        return deepcopy(channel)
+
+    async def update(channel_id, data):
+        channel = next(c for c in channels if c["id"] == channel_id)
+        channel.update(deepcopy(data))
+        return deepcopy(channel)
+
+    client = MagicMock()
+    client.create_channel = AsyncMock(side_effect=create)
+    client.update_channel = AsyncMock(side_effect=update)
+    client.get_channel = AsyncMock(side_effect=lambda channel_id: deepcopy(next(c for c in channels if c["id"] == channel_id)))
+    for _run in range(2):
+        executor = ActionExecutor(client, existing_channels=deepcopy(channels),
+                                  managed_channel_ids=[c["id"] for c in channels],
+                                  normalization_engine=NormalizationEngine(test_session))
+        for stream_id, name in [(1, "Stars.TV"), (2, "Stars-TV")]:
+            result = await executor.execute(
+                {"type": "create_channel", "if_exists": "merge", "group_id": 5},
+                StreamContext.from_dispatcharr_stream({"id": stream_id, "name": name, "m3u_account": stream_id}),
+                ExecutionContext(), normalization_group_ids=[],
+            )
+            assert result.success, result.error
+    assert len(channels) == 1
+    assert channels[0]["name"] == "Stars TV HD"
+    assert sorted(channels[0]["streams"]) == [1, 2]
+    assert client.create_channel.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("managed,scope,expected_streams", [
+    (True, 5, [1, 2]), (False, 5, [1]), (True, 6, [1]),
+])
+async def test_mapped_auto_merge_keeps_manual_and_group_protections(
+    async_client, test_session, managed, scope, expected_streams,
+):
+    from unittest.mock import AsyncMock, MagicMock
+    from channel_pipeline_executor import ActionExecutor, ExecutionContext
+    from channel_pipeline_evaluator import StreamContext
+
+    await async_client.post("/api/normalization/mappings", json={
+        "preferred_name": "TVN", "aliases": ["TVN-HD"],
+    })
+    channel = {"id": 1, "name": "TVN", "channel_group_id": 5, "streams": [1]}
+    client = MagicMock()
+    client.update_channel = AsyncMock(side_effect=lambda _id, data: channel.update(data))
+    client.get_channel = AsyncMock(return_value=channel)
+    executor = ActionExecutor(client, existing_channels=[channel],
+                              managed_channel_ids=[1] if managed else [],
+                              normalization_engine=NormalizationEngine(test_session))
+    for _run in range(2):
+        await executor.execute(
+            {"type": "merge_streams", "target": "auto"},
+            StreamContext.from_dispatcharr_stream({"id": 2, "name": "TVN-HD"}),
+            ExecutionContext(), rule_scope_group_id=scope, normalization_group_ids=[],
+        )
+    assert sorted(channel["streams"]) == expected_streams
+    assert client.update_channel.await_count == (1 if expected_streams == [1, 2] else 0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("groups", [False, True])
+@pytest.mark.parametrize("existing", [False, True])
+@pytest.mark.parametrize("original,pattern,replacement,expected", [
+    ("Stars.TV", r"\.", "-", "Stars TV HD"),
+    ("StarsXTV", "X", ".", "Stars.TV"),
+])
+async def test_create_mapping_ownership_precedes_transform(
+    async_client, test_session, groups, existing, original, pattern, replacement, expected,
+):
+    from unittest.mock import AsyncMock, MagicMock
+    from channel_pipeline_executor import ActionExecutor, ExecutionContext
+    from channel_pipeline_evaluator import StreamContext
+
+    await async_client.post("/api/normalization/mappings", json={
+        "preferred_name": "Stars TV HD", "aliases": ["Stars.TV"],
+    })
+    group = NormalizationRuleGroup(name="Selected", enabled=True)
+    test_session.add(group)
+    test_session.commit()
+    client = MagicMock()
+    client.create_channel = AsyncMock(side_effect=lambda data: {"id": 10, **data})
+    channel = {"id": 1, "name": "Stars TV HD", "streams": [1]}
+    client.get_channel = AsyncMock(return_value=channel)
+    client.update_channel = AsyncMock()
+    executor = ActionExecutor(client, existing_channels=[channel] if existing else [],
+                              managed_channel_ids=[1], normalization_engine=NormalizationEngine(test_session))
+    result = await executor.execute(
+        {"type": "create_channel", "if_exists": "merge", "name_transform_pattern": pattern,
+         "name_transform_replacement": replacement},
+        StreamContext.from_dispatcharr_stream({"id": 2, "name": original}),
+        ExecutionContext(), normalization_group_ids=[group.id] if groups else [],
+    )
+    assert result.success, result.error
+    if existing and original == "Stars.TV":
+        client.create_channel.assert_not_awaited()
+        client.update_channel.assert_awaited_once()
+    else:
+        assert client.create_channel.call_args.args[0]["name"] == expected
+        client.update_channel.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["create_channel", "merge_streams"])
+async def test_mapped_identity_does_not_fall_back_to_quality_stripped_channel(
+    async_client, test_session, action,
+):
+    from unittest.mock import AsyncMock, MagicMock
+    from channel_pipeline_executor import ActionExecutor, ExecutionContext
+    from channel_pipeline_evaluator import StreamContext
+    from models import Tag, TagGroup
+
+    await async_client.post("/api/normalization/mappings", json={
+        "preferred_name": "Stars TV HD", "aliases": ["Stars.TV"],
+    })
+    test_session.add(TagGroup(name="Quality Tags", tags=[Tag(value="HD")]))
+    group = NormalizationRuleGroup(name="Selected", enabled=True)
+    test_session.add(group)
+    test_session.commit()
+    channel = {"id": 1, "name": "Stars TV", "channel_group_id": 5, "streams": [1]}
+    client = MagicMock()
+    client.get_channel = AsyncMock(return_value=channel)
+    client.update_channel = AsyncMock()
+    client.create_channel = AsyncMock(side_effect=lambda data: {"id": 10, **data})
+    executor = ActionExecutor(client, existing_channels=[channel], managed_channel_ids=[1],
+                              normalization_engine=NormalizationEngine(test_session))
+    assert NormalizationEngine(test_session).extract_core_name("Stars TV HD", for_matching=True) == "Stars TV"
+    await executor.execute(
+        {"type": action, "if_exists": "merge", "target": "auto", "loose_name_match": True},
+        StreamContext.from_dispatcharr_stream({"id": 2, "name": "Stars.TV" if action == "create_channel" else "Stars TV HD"}),
+        ExecutionContext(), normalization_group_ids=[] if action == "create_channel" else [group.id],
+    )
+    client.update_channel.assert_not_awaited()
+    if action == "create_channel":
+        assert client.create_channel.call_args.args[0]["name"] == "Stars TV HD"
+
+
+@pytest.mark.parametrize("delete_second", [False, True])
+def test_overlapping_mapping_replacement_uses_current_state(test_engine, monkeypatch, delete_second):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Event, current_thread
+    from sqlalchemy import event, text
+    from sqlalchemy.orm import Session, sessionmaker
+    from routers import normalization as router
+
+    engine = test_engine
+    with engine.connect() as connection:
+        assert connection.execute(text("PRAGMA journal_mode=WAL")).scalar() == "wal"
+    factory = sessionmaker(bind=engine, autoflush=False)
+    monkeypatch.setattr(router, "get_session", factory)
+
+    def save(name, aliases, mapping_id=None):
+        return router._save_channel_name_mapping(
+            router.ChannelNameMappingRequest(preferred_name=name, aliases=aliases), mapping_id)
+
+    original = save("Old", ["Old alias"])
+    first_loaded, second_loaded, release_first, first_done, second_attempt = (Event() for _ in range(5))
+
+    def before_flush(session, context, instances):
+        second = current_thread().name.endswith("_1")
+        if session.info.get("waited"):
+            return
+        session.info["waited"] = True
+        if second:
+            second_loaded.set()
+            assert first_done.wait(10)
+        else:
+            first_loaded.set()
+            assert release_first.wait(10)
+
+    event.listen(Session, "before_flush", before_flush)
+
+    def first():
+        try:
+            return save("First", ["First x", "First y", "First z"], original["id"])
+        finally:
+            first_done.set()
+
+    def second():
+        second_attempt.set()
+        if delete_second:
+            return router.delete_channel_name_mapping(original["id"])
+        return save("Second", ["Final"], original["id"])
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            a = pool.submit(first)
+            assert first_loaded.wait(10)
+            b = pool.submit(second)
+            assert second_attempt.wait(10)
+            # Old code loads both stale collections; serialized code waits outside the session.
+            second_loaded.wait(0.2)
+            release_first.set()
+            assert a.result(timeout=10)["preferred_name"] == "First"
+            b.result(timeout=10)
+        monkeypatch.setattr(router, "get_session", factory)
+        mappings = router.get_channel_name_mappings()["mappings"]
+        if delete_second:
+            assert mappings == []
+        else:
+            assert mappings == [{"id": original["id"], "preferred_name": "Second",
+                                 "aliases": ["Second", "Final"]}]
+        with factory() as session:
+            assert NormalizationEngine(session).resolve_preferred_name("First y") is None
+            from models import ChannelNameAlias
+            assert session.query(ChannelNameAlias).count() == (0 if delete_second else 2)
+    finally:
+        release_first.set()
+        event.remove(Session, "before_flush", before_flush)
+        engine.dispose()
+
+
+@pytest.mark.parametrize("operation", ["create", "update", "delete"])
+def test_mapping_write_isolated_from_production_readers(tmp_path, monkeypatch, operation):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Event, current_thread
+    from sqlalchemy import event, text
+    from sqlalchemy.orm import Session
+    from sqlalchemy.pool import StaticPool
+    import database
+    from models import ChannelNameAlias, ChannelNameMapping
+    from routers import normalization as router
+
+    monkeypatch.setattr(database, "JOURNAL_DB_FILE", tmp_path / "production.db")
+    monkeypatch.setattr(database, "_engine", None)
+    monkeypatch.setattr(database, "_SessionLocal", None)
+    database.init_db()
+    ready, release = Event(), Event()
+
+    def save(name, aliases, mapping_id=None):
+        return router._save_channel_name_mapping(
+            router.ChannelNameMappingRequest(preferred_name=name, aliases=aliases), mapping_id)
+
+    old = save("Old", ["Old alias"])
+
+    def pause_writer(session, context):
+        if current_thread().name.startswith("mapping-writer"):
+            session.info["flush_count"] = session.info.get("flush_count", 0) + 1
+            if session.info["flush_count"] == (1 if operation == "delete" else 2):
+                ready.set()
+                assert release.wait(10)
+
+    event.listen(Session, "after_flush_postexec", pause_writer)
+    try:
+        with ThreadPoolExecutor(max_workers=1, thread_name_prefix="mapping-writer") as pool:
+            if operation == "delete":
+                writer = pool.submit(router.delete_channel_name_mapping, old["id"])
+            else:
+                writer = pool.submit(save, "Second", ["Final"], old["id"] if operation == "update" else None)
+            try:
+                assert ready.wait(10)
+                resolved = router.resolve_channel_name_mappings(
+                    router.TestRulesBatchRequest(texts=["Final", "Old alias"]))
+                with database.get_session() as session:
+                    assert isinstance(session.bind.pool, StaticPool)
+                    assert session.execute(text("PRAGMA journal_mode")).scalar() == "wal"
+                    snapshot = [m.to_dict() for m in session.query(ChannelNameMapping).all()]
+            finally:
+                release.set()
+            result = writer.result(timeout=10)
+        assert resolved["results"] == [
+            {"original": "Final", "preferred_name": None},
+            {"original": "Old alias", "preferred_name": "Old"},
+        ]
+        assert snapshot == [old]
+        expected = [] if operation == "delete" else ([old, result] if operation == "create" else [result])
+        assert router.get_channel_name_mappings()["mappings"] == expected
+        with database.get_session() as session:
+            assert session.query(ChannelNameAlias).count() == (0 if operation == "delete" else 4 if operation == "create" else 2)
+            assert NormalizationEngine(session).resolve_preferred_name("Final") == (None if operation == "delete" else "Second")
+        if operation != "delete":
+            assert result == {"id": result["id"], "preferred_name": "Second", "aliases": ["Second", "Final"]}
+    finally:
+        release.set()
+        event.remove(Session, "after_flush_postexec", pause_writer)
+        database.close_db()

--- a/backend/tests/test_admin_gate_inventory.py
+++ b/backend/tests/test_admin_gate_inventory.py
@@ -270,6 +270,11 @@ _CHANNEL_AUTOMATION = {
     ("POST", "/api/channels/{channel_id}/remove-stream"),
     ("POST", "/api/channels/{channel_id}/reorder-streams"),
     ("POST", "/api/normalization/apply-to-channels"),
+    # u0ko6: local naming configuration, same admin tier as channel automation.
+    # This does not add any MCP mapping tool or outbound write on save.
+    ("POST", "/api/normalization/mappings"),
+    ("PUT", "/api/normalization/mappings/{mapping_id}"),
+    ("DELETE", "/api/normalization/mappings/{mapping_id}"),
     ("POST", "/api/m3u/accounts/{account_id}/group-auto-sync-toggle"),
 }
 

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -139,6 +139,38 @@ If a channel name created before the bd-eio04.1 cutover still carries `²`, `³`
 | Ligature | `ﬁrst` | `ﬁrst` (preserved; NFC, not NFKC) |
 | Fullwidth digit | `ESPN１` | `ESPN１` (preserved; NFC) |
 
+## Mapped Channels
+
+Use **Mapped channels** to add, review, edit or remove reusable preferred-name
+mappings. In Channel Manager, select streams on the right and choose **Add
+mapping**, then **Existing** (a mapping, not a Dispatcharr channel) or **Add new**.
+Selected stream names prefill the alternatives; enter one literal name per line.
+
+Examples:
+
+| Preferred name | Alternative names |
+| --- | --- |
+| Polonia | Polonia, Polonia 1, Polonia1, Polonia.1 |
+| Stars TV | Stars TV, Stars.TV, Stars-TV |
+| TVN | TVN, TVN HD, TVN-HD |
+
+Matching is case-insensitive whole-name equality across providers. Punctuation
+is literal: `Stars.TV` does not match `StarsXTV`; `TVN` does not match `TVN24`.
+The preferred name matches itself. Repeated aliases within a mapping are
+deduplicated; names owned by another mapping are rejected with a visible error.
+
+Mappings take precedence over normalization rules for matched original names,
+including when Create's Normalization Rules toggle or Pipeline normalization
+groups are off. The preferred spelling is not stripped for quality grouping.
+Unmapped names still follow the existing normalization options. Existing Pipeline
+`if_exists` choices and manual-channel / target-group safeguards still apply;
+use the existing merge behavior when you want matching streams attached together.
+
+Saving does not assign streams immediately. Definitions are used by subsequent
+explicit Create / Pipeline runs and already-configured automation. Removing a
+mapping removes only the definition, not channels or attachments. This feature
+does not clean up existing duplicates or install refresh automation.
+
 ## Authoring rules
 
 ### Condition types
@@ -146,14 +178,14 @@ If a channel name created before the bd-eio04.1 cutover still carries `²`, `³`
 - **`contains`**: substring match, case-insensitive.
 - **`starts_with` / `ends_with`**: anchored substring, case-insensitive.
 - **`regex`**: Python regex via `safe_regex` (100 ms timeout, size-bounded). Patterns run against the post-policy input.
-- **`equals`**: exact string match.
+- For literal preferred-name aliases, use **Mapped channels**, not an `equals` condition (unsupported).
 - **Compound**: boolean combinations via the `conditions[]` JSON; useful when one rule needs to match multiple unrelated suffixes.
 
 ### Action types
 
 - **`replace`**: replace the matched portion with a literal string.
 - **`remove`**: replace the matched portion with the empty string.
-- **`set`**: overwrite the entire name with a literal (use sparingly; defeats composition).
+- For an authoritative preferred spelling, use **Mapped channels**, not a `set` action (unsupported).
 - **Conditional else-action**: the `else_action_value` branch fires when the condition does *not* match. Useful for "strip suffix if present, pass through otherwise."
 
 `action_value` and `else_action_value` are literal templates. They are **not** regexes and **not** linted for regex safety.

--- a/docs/u0ko6_alias_mapping_plan.md
+++ b/docs/u0ko6_alias_mapping_plan.md
@@ -1,0 +1,282 @@
+# enhancedchannelmanager-u0ko6: Frozen Alias Mapping Contract
+
+Owner: project-engineer. GitHub: #775. Base: origin/dev `144334cf`.
+Status: frozen contract implemented locally; final bounded code and DBA reviews complete.
+This supplements, rather than replaces, the original request in the owning bead.
+
+## Approved Behavior
+
+- Right-side stream selection offers Add mapping, with Existing / Add new.
+  Existing means a reusable preferred-name mapping, not a Dispatcharr channel ID.
+- Dedicated Mapped channels tab supports review, edit, add and remove.
+- Persist structured aliases. Match whole original names case-insensitively and
+  literally across providers. Reject conflicting ownership; no regex, fuzzy,
+  substring or provider-specific matching.
+- Preferred spelling is authoritative when a name matches, including subsequent
+  normalization and Create / Pipeline consumers. Unmapped behavior is preserved.
+- Saving defines mappings for subsequent explicit Create / Pipeline runs and
+  already-configured automation only. It performs no Dispatcharr mutation.
+  Removal leaves existing channels and attachments intact.
+- Examples: Polonia <- Polonia, Polonia 1, Polonia1, Polonia.1;
+  Stars TV <- Stars TV, Stars.TV, Stars-TV; TVN <- TVN, TVN HD, TVN-HD.
+- No duplicate cleanup, detaches, scheduler, EPG/TVG redesign, MCP tools,
+  import/export, unrelated refactors or dependencies.
+
+## Verification Boundary
+
+Tests first: literal positives/negatives (TVN24, Polonia 2, StarsXTV), regex
+metacharacters, duplicate/conflicting aliases, persisted CRUD, visible API
+errors, selection prefill, preferred spelling surviving normalization, Create
+grouping and repeated Pipeline execution without duplicate channels/attachments.
+Existing manual-channel and group safeguards remain in force. Text normalization
+tests alone are not downstream assignment evidence. Render the browser surface.
+Run targeted backend/frontend tests before canonical gates; report exact results
+and gaps. No live Dispatcharr writes.
+
+## Persistence / Review
+
+Prepare an additive Alembic migration for preferred-name mappings and uniquely
+owned case-folded literal aliases. Preferred names reserve their own identity.
+No existing data rewrite or automatic mapping seed. DBA review is required before
+completion. Downgrade removes mapping definitions only, not Dispatcharr data.
+
+Prepared migration: `0055`, predecessor `0054`,
+`backend/alembic/versions/20260904_1200_0055_channel_name_mappings.py`.
+`channel_name_mappings` holds integer ID and preferred spelling;
+`channel_name_aliases` holds ID, indexed mapping FK, literal name, and globally
+unique Python-casefold comparison key. CRUD reserves the preferred name in the
+alias table, deduplicates same-owner keys and rolls back conflicting writes.
+The migration supports the existing create-all-before-Alembic recovery path.
+Standard database backup table classification follows normalization configuration;
+there is no new import/export UI or MCP tool. API writes use the existing admin
+tier (including its existing MCP-principal semantics), recorded in the admin gate
+inventory. The initial independent DBA review found the concurrent replacement
+defect recorded in the remediation evidence below; full final DBA re-review passed
+as recorded in Final Review and Handoff below.
+
+## Delivery Boundary
+
+The user authorized commit, push and a PR against dev on feat/u0ko6-alias-mapping.
+The project-engineer owns the commit only; parent owns push, PR and bead status.
+HOLD merge; no merge or issue closure is authorized. The authorized PR must
+record `Closes #775` and verify GitHub #775 closure on merge; do not close now.
+Review blockers are contract failures, introduced regressions, security or data
+loss, not additional enhancements. Report unforeseen product decisions.
+
+## Local Verification Evidence
+
+Verified against the uncommitted isolated worktree, not a deployed instance:
+
+| Layer | Command | Result |
+| --- | --- | --- |
+| Backend API, literal matching, executor and migration | `scripts/backend-gate.sh --subset tests/routers/test_channel_name_mappings.py tests/integration/test_channel_name_mapping_migration.py` | 10 passed |
+| Backend canonical gate | `scripts/backend-gate.sh` | 12,855 passed; 3 documented skips; 2 deselected; 81.45% coverage |
+| Frontend lint | `npm run lint` in `frontend/` | Passed |
+| Frontend types | `npm run typecheck` in `frontend/` | Passed |
+| Frontend canonical suite | `npm run test:coverage` in `frontend/` | 259 files; 3,685 passed; 59.8% statement coverage |
+| Frontend build | `npm run build` in `frontend/` | Passed; existing large-chunk warning remains |
+| Browser/API seam | Command below | 1 Chromium test passed |
+| Diff whitespace | `git diff --check` | Passed |
+
+TDD evidence: initial API tests failed with 404 before the routes existed;
+the repeated-executor test created four channels before mapping integration;
+frontend preferred-name tests failed with raw names before resolver integration.
+The partial-response test failed before atomic response validation was repaired.
+
+The browser test uses the actual normalization router and file-backed SQLite on
+an ephemeral loopback port. It selects streams in the real pane, saves a mapping,
+stages one preferred-name channel with two attachments, discards the staged
+changes without committing, reloads the management tab, and removes the mapping.
+Desktop and 390px screenshots are under `test-results/`; the narrow layout uses
+the existing collapsed sidebar. Other browser API calls are fixture responses.
+Repeated Pipeline executor tests use a stateful fake Dispatcharr client and ECM's
+managed-channel ledger between executor instances; no live Dispatcharr write was
+performed. Auto-merge tests also pin manual-channel and target-group safeguards.
+
+### Independent Reproduction
+
+Workdir: `/tmp/opencode/ecm-u0ko6`. Node: `v24.13.0`. Dependencies were installed
+from each lockfile with `npm ci` in the root and frontend (no dependency edits).
+Do not use the initially bootstrapped shared frontend packages: their versions
+did not match this base. Python was the existing project venv, read-only:
+
+```sh
+export ECM_PYTHON=/home/lecaptainc/ecm/enhancedchannelmanager/.venv/bin/python
+export ECM_TEST_CONFIG_ROOT=/tmp/opencode/ecm-u0ko6/.test-config
+export TMPDIR=/tmp/opencode/ecm-u0ko6
+export PYTHONDONTWRITEBYTECODE=1
+scripts/backend-gate.sh
+E2E_START_SERVER=true E2E_EXACT_BUILD=true PLAYWRIGHT_HTML_OPEN=never npm run test:e2e -- e2e/channel-name-mappings.spec.ts --project=chromium --workers=1 --retries=0
+```
+
+Run the browser command with exclusive ownership of preview port 4173. Its API
+fixture owns a separate ephemeral port and unique database and is stopped before
+the command returns. No watcher or verification server was left running.
+
+Logs: `backend-gate-final.log`, `frontend-coverage-final.log`. Earlier failing
+gate logs remain as TDD/remediation evidence. `.npm-cache/`, `.test-config/`,
+`pytest-of-lecaptainc/`, and `ecm-debug-bundle-*.tar.gz` are local test/install
+scratch, not product changes and must not be staged. Generated `test-results/`,
+coverage and build artifacts are also not product changes.
+
+### Remaining Delivery Boundary
+
+Final bounded code review, full in-scope DBA re-review and parent verification are
+complete, with scope and provenance recorded in Final Review and Handoff below.
+Commit, push and a PR against dev are now authorized, with push and PR reserved
+for the parent. Merge remains on HOLD; publishing, live deployment/reporter
+verification and issue closure are not authorized. Preserve the closure-on-merge
+instructions for #775.
+
+## Four-Finding Remediation Evidence
+
+This records remediation of the confirmed review findings, not new acceptance
+conditions. The Approved Behavior and Verification Boundary remain frozen.
+Review sources: code reviewer `ses_f9028063bffejNsmS4pcADhkGG` and DBA
+`ses_f90280626ffeuW8xvpzTIV47Gr`.
+
+- Mapped Create identity now disables lookup re-normalization/core fallback and
+  folded fallback, retaining the existing exact-name indices, manual gate and
+  group gate. Mapped auto-merge disables the loose-name cascade. Tests first
+  reproduced attaching to managed `Stars TV` instead of `Stars TV HD` in both
+  Create and loose auto-merge.
+- Create ownership is resolved from the original stream name, not the template
+  or transform output. Subsequent rule normalization and lookup normalization
+  cannot acquire mapping ownership from a transformed name. Eight executor cases
+  cover mapped/unmapped originals, selected/no groups and existing/no preferred
+  channel. The existing-channel negative also failed before the lookup fix.
+- App Create numbering sorts resolved mapped names and legacy quality-stripped
+  unmapped base names, not internal identity prefixes. The actual App staging
+  callback regression failed with `ZDF=100, ABC=101` before the fix and now proves
+  `ABC=100`, natural `C-SPAN`, `C-SPAN 2`, `C-SPAN 10` order, then `ZDF=104`.
+  Group identity separation is unchanged.
+- The first remediation added a local lock before opening mapping CRUD sessions.
+  This serialized mapping CRUD but did not isolate generic StaticPool readers;
+  the remaining defect and final remediation are recorded below. Update and
+  delete first delete aliases by mapping ID from current database state, acquiring
+  SQLite's writer lock before reading the mapping; replacement and commit remain
+  one transaction. Isolated file-backed WAL/StaticPool/autoflush-false tests force
+  overlapping update/update and update/delete requests. Before the fix the update
+  test persisted exactly `First y, First z, Second, Final`; after the fix only the
+  final request's aliases remain, and delete leaves no alias rows. The retained
+  DBA probe was read, not modified or rerun (its barrier assumes the old interleave).
+
+Fresh verification against the uncommitted remediation worktree:
+
+| Layer | Result |
+| --- | --- |
+| Backend focused: mapping API/executor/concurrency, migration, executor unit tests, normalization router | 456 passed |
+| Frontend focused: App staging, normalization, mapped-channel component | 29 passed |
+| Backend canonical `scripts/backend-gate.sh` | 12,867 passed; 3 documented skips; 2 deselected; 81.46% coverage; 1,081.67s |
+| Frontend `npm run lint` / `npm run typecheck` | Both passed |
+| Frontend `npm run test:coverage` | 259 files; 3,686 passed; 59.8% statement coverage |
+| Frontend `npm run build` | Passed; existing large-chunk warning |
+| Existing exact-build Chromium browser/API test | 1 passed; 5.6s |
+
+Environment: same isolated worktree, Node 24.13.0, installed root/frontend
+lockfile dependencies and project Python venv documented above. Backend runs used
+the documented `ECM_TEST_CONFIG_ROOT`, `TMPDIR`, and `PYTHONDONTWRITEBYTECODE`.
+All verification commands returned synchronously; no live Dispatcharr writes.
+Logs `backend-gate-remediation.log`, `frontend-coverage-remediation.log` and
+`frontend-build-remediation.log` are scratch and must not be staged. Existing
+scratch/user work is preserved. Browser output remains under `test-results/`.
+No commits, pushes, PRs, merges, tracker changes or self-approval were performed.
+At that stage, parent gates, code re-review and full DBA re-review were outstanding;
+their final disposition is recorded below.
+
+## Final Bounded Remediation Evidence
+
+This round addresses the same mapping-integrity contract and the cache-sensitive
+Create regression test only. No acceptance criteria were added.
+
+- Mapping create/update/delete now use a short-lived private SQLite connection
+  through a `NullPool` engine and `Session(autoflush=False)`. The existing
+  `get_database_url()` helper and engine-wide PRAGMA listener are reused;
+  `database.py`, its production `StaticPool`, and migration `0055` are unchanged.
+  The session closes before the private engine is disposed, including failures.
+  The mapping lock and delete-current-alias-set replacement logic are retained.
+- Three regression cases call actual `init_db()`, pause create/update/delete
+  after flush and before commit, then call the actual resolve handler and an
+  ordinary `get_session()` reader while the writer is paused. Before the fix,
+  create/update exposed `Final -> Second` and delete hid `Old alias` before commit.
+  After the fix, both readers see the committed old set; after they close and
+  the writer resumes, the persisted set matches the successful requested result.
+  Existing overlapping replacement/delete and conflict rollback tests also pass.
+- Mapping tests now clear shared tag-ID and tag-value caches before and after
+  each case via `invalidate_tag_cache()`. The quality-stripping regression also
+  asserts that `Stars TV HD` actually extracts to `Stars TV` for matching.
+  In private scratch `/tmp/opencode/u0ko6-final-mutation`, changing only the Create
+  lookup to `exact_only=False` produced the intended failure: `update_channel`
+  was awaited once. Result: 1 failed, 18 passed, 5 deselected. The live tested
+  source was never mutated. Scratch is not part of the product diff.
+
+Final local results against the uncommitted worktree:
+
+| Layer | Result |
+| --- | --- |
+| Mapping API/executor/concurrency and migration subset | 25 passed |
+| Broader mapping, migration, executor unit and normalization router subset | 459 passed |
+| Canonical `scripts/backend-gate.sh` | 12,870 passed; 3 documented skips; 2 deselected; 82.12% coverage; 738.39s |
+| Diff whitespace | `git diff --check` passed |
+
+Reproduction commands from `/tmp/opencode/ecm-u0ko6`, using the same environment
+as the earlier evidence:
+
+```sh
+export ECM_PYTHON=/home/lecaptainc/ecm/enhancedchannelmanager/.venv/bin/python
+export ECM_TEST_CONFIG_ROOT=/tmp/opencode/ecm-u0ko6/.test-config
+export TMPDIR=/tmp/opencode/ecm-u0ko6
+export PYTHONDONTWRITEBYTECODE=1
+scripts/backend-gate.sh --subset tests/routers/test_channel_name_mappings.py tests/integration/test_channel_name_mapping_migration.py tests/unit/test_channel_pipeline_executor.py tests/routers/test_normalization.py
+scripts/backend-gate.sh
+git diff --check
+```
+
+The full gate was waited synchronously with 60-second heartbeat checks until
+exit 0; no background watcher or test process was left running. Its captured
+output is `/home/lecaptainc/.local/share/opencode/tool-output/tool_0701877b8001tgM94bCNkW0Z1s`.
+Frontend code was not changed or re-gated in this round; earlier frontend/browser
+results above remain historical evidence, not a fresh run. This internal plan is
+not an input to the published MkDocs site. Existing logs, caches, configuration,
+debug bundles and generated artifacts remain scratch and must not be staged.
+No commits, pushes, PRs, merges or tracker changes were made in that remediation
+round. The subsequent independent reviews and parent verification are recorded below.
+
+## Final Review and Handoff
+
+This documentation/bead-only handoff records the final reports supplied by the
+parent; it does not claim new test runs or independent re-review by this handoff
+editor. Earlier results above are chronological evidence, not pending gates.
+
+- Final bounded code review `ses_f8fe459a5ffeNM1Tb0LY6e3SSP` approved the
+  cache-test repair and private transaction boundary. The reviewer reran the
+  unsafe `exact_only=False` mutant and observed the expected failure; all six
+  boundary cases passed.
+- Final DBA review `ses_f8fe459d8ffetvARjcsgESc5W4` reported full in-scope PASS,
+  25 tests and no remaining findings. Scope included private write consumer
+  isolation for create/update/delete using actual `init_db()`, overlapping writes
+  and conflicts, Unicode ownership, FK/PRAGMA behavior, upgrade/downgrade/bootstrap,
+  and sentinel/index checks.
+
+| Verification owner | Final evidence |
+| --- | --- |
+| Parent, final backend tree | 459 focused backend tests passed |
+| Parent, final browser/API seam | Actual mapping API Chromium test: 1 passed |
+| Parent, documentation | Strict `mkdocs build --site-dir /tmp/opencode/ecm-u0ko6-docs-site` passed |
+| Parent, whitespace | `git diff --check` passed |
+| Parent, frontend | 3,686 tests, lint, typecheck, coverage and build passed; frontend unchanged by the last backend fix |
+| Engineer, final full backend; reviewer log-confirmed | 12,870 passed; 3 skipped; 2 deselected; 82.12% coverage |
+| Parent, earlier full backend | 12,867 passed before the last backend fix; final-tree parent verification was the 459-test focused run, not a fresh full backend run |
+
+Local implementation and handoff: `/tmp/opencode/ecm-u0ko6`, branch
+`feat/u0ko6-alias-mapping`, base/HEAD `144334cf`; code remains uncommitted.
+This document is the durable frozen-contract, implementation, review and
+verification handoff. Owning bead `enhancedchannelmanager-u0ko6` remains
+`in_progress`; its design/notes record this handoff without replacing the original
+description or acceptance criteria.
+
+The user subsequently authorized commit, push and a PR against dev, with the
+project-engineer limited to commit and the parent handling push and PR. Passing
+reports do not authorize merge: HOLD merge, with no publishing or status closure.
+The authorized PR must include `Closes #775` and verify GitHub #775 closure
+on merge; do not close either item now.

--- a/e2e/channel-name-mappings.spec.ts
+++ b/e2e/channel-name-mappings.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { resolve } from 'node:path';
+
+if (process.env.E2E_EXACT_BUILD !== 'true' || process.env.E2E_START_SERVER !== 'true' || !process.env.ECM_PYTHON) {
+  throw new Error('Mapping contract requires isolated exact build and ECM_PYTHON project interpreter');
+}
+
+test('selected names -> persisted mapping -> Create grouping and management', async ({ page }, testInfo) => {
+  page.setDefaultTimeout(5000);
+  const child = spawn(process.env.ECM_PYTHON!, ['-m', 'tests.fixtures.channel_name_mapping_server'], {
+    cwd: resolve('backend'),
+    env: { ...process.env, ECM_TEST_CONFIG_ROOT: resolve('.test-config'), PYTHONDONTWRITEBYTECODE: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let output = '';
+  let port = '';
+  child.stdout.on('data', chunk => { output += chunk; port = output.match(/MAPPING_API_PORT=(\d+)/)?.[1] ?? ''; });
+  child.stderr.on('data', chunk => { output += chunk; });
+  try {
+    await expect.poll(() => port || (child.exitCode !== null ? `exited: ${output}` : ''), { timeout: 20000 }).toMatch(/^\d+$/);
+    const backend = `http://127.0.0.1:${port}`;
+    await expect.poll(async () => {
+      try { return (await fetch(`${backend}/api/normalization/mappings`)).status; } catch { return 0; }
+    }).toBe(200);
+    const streams = ['Stars.TV', 'Stars-TV'].map((name, index) => ({
+      id: index + 1, name, channel_group_name: 'Provider', channel_group: null, m3u_account: index + 1,
+      url: `https://fixture.invalid/${index}`, stream_profile_id: null,
+    }));
+    const paginated = (results: unknown[]) => ({ count: results.length, next: null, previous: null, results });
+    await page.route('**/api/**', async route => {
+      const path = new URL(route.request().url()).pathname;
+      if (path.startsWith('/api/normalization/mappings') || path === '/api/normalization/normalize') {
+        const response = await route.fetch({ url: `${backend}${path}` });
+        await route.fulfill({ response });
+        return;
+      }
+      const data: Record<string, unknown> = {
+        '/api/profile-conflict-reviews': { reviews: [] },
+        '/api/auth/status': { require_auth: false, setup_complete: true, dispatcharr_enabled: false },
+        '/api/auth/setup-required': { required: false },
+        '/api/settings': { configured: true, url: 'https://fixture.invalid', normalize_on_channel_create: false, show_hide_controls: true, default_channel_profile_ids: [] },
+        '/api/channels/logos': paginated([]),
+        '/api/channels': paginated([]),
+        '/api/channel-groups': [{ id: 5, name: 'Mapped output', channel_count: 0 }],
+        '/api/stream-groups': [{ name: 'Provider', count: 2 }],
+        '/api/streams': paginated(streams),
+        '/api/notifications': { notifications: [], unread_count: 0 },
+      };
+      await route.fulfill({ json: data[path] ?? [] });
+    });
+    await page.goto('/#channel-manager');
+    await expect(page.locator('.streams-pane')).toBeVisible();
+    const close = page.getByRole('button', { name: 'Close', exact: true });
+    if (await close.isVisible()) await close.click();
+    // The selection is made in the real stream pane, not injected into the editor.
+    await page.getByRole('button', { name: 'edit Edit Mode' }).click();
+    await page.locator('.streams-pane').getByRole('button', { name: /^Other/ }).click();
+    await page.locator('.streams-pane').getByRole('button', { name: /Provider$/, exact: false }).click();
+    await page.getByRole('checkbox', { name: 'Select stream Stars.TV', exact: true }).click();
+    await page.getByRole('checkbox', { name: 'Select stream Stars-TV', exact: true }).click();
+    await page.locator('.streams-pane').getByRole('button', { name: 'Add mapping', exact: true }).click();
+    await expect(page.getByLabel('Alternative names (one per line)')).not.toBeEmpty();
+    await page.getByLabel('Preferred name', { exact: true }).fill('Stars TV HD');
+    await page.getByLabel('Alternative names (one per line)').fill('Stars.TV\nStars-TV');
+    await page.getByRole('button', { name: 'Save mapping', exact: true }).click();
+    await expect(page.getByRole('status').filter({ hasText: 'Mapping saved' })).toBeVisible();
+    await page.getByRole('button', { name: 'Close mapping editor' }).click();
+    await page.locator('.streams-pane').getByRole('button', { name: 'playlist_add Create', exact: true }).click();
+    await expect(page.locator('.bulk-create-modal')).toContainText('Stars TV HD');
+    await expect(page.locator('.bulk-create-modal')).toContainText('2 streams');
+    await page.locator('.bulk-create-modal input[type="number"]').fill('100');
+    await page.locator('.bulk-create-modal').getByText('Channel Group', { exact: true }).click();
+    await page.locator('.bulk-create-modal').getByRole('radio', { name: 'Create new group' }).check();
+    await page.getByPlaceholder('New group name').fill('Alias output');
+    await page.screenshot({ path: testInfo.outputPath('mapped-create-preview.png'), fullPage: true });
+    await page.locator('.bulk-create-modal').getByRole('button', { name: /Create 1 Channels/ }).click();
+    await expect(page.locator('.bulk-create-modal')).toHaveCount(0);
+    await page.locator('.channels-pane').getByRole('button', { name: /Alias output$/ }).click();
+    await expect(page.locator('.channels-pane .channel-item')).toHaveCount(1);
+    await expect(page.locator('.channels-pane .channel-item')).toContainText('Stars TV HD');
+    await expect(page.locator('.channels-pane .channel-item .channel-streams-count')).toHaveAttribute('aria-label', /^2 streams;/);
+    // Staging exercises App's grouping/assignment, but never commits to Dispatcharr.
+    await page.getByRole('link', { name: 'Mapped channels', exact: true }).click();
+    await page.getByRole('button', { name: 'Discard', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Edit Stars TV HD' })).toBeVisible();
+    await page.reload();
+    await expect(page.getByRole('button', { name: 'Edit Stars TV HD' })).toBeVisible();
+    await page.getByRole('button', { name: 'Edit Stars TV HD' }).click();
+    await expect(page.getByLabel('Alternative names (one per line)')).toHaveValue('Stars TV HD\nStars.TV\nStars-TV');
+    await page.screenshot({ path: testInfo.outputPath('mapped-channels-desktop.png'), fullPage: true });
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.getByRole('button', { name: 'Collapse navigation', exact: true }).click();
+    await page.getByLabel('Preferred name', { exact: true }).scrollIntoViewIfNeeded();
+    await expect(page.getByLabel('Preferred name', { exact: true })).toBeVisible();
+    await page.screenshot({ path: testInfo.outputPath('mapped-channels-mobile.png'), fullPage: true });
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+    await page.getByRole('button', { name: 'Remove Stars TV HD' }).click();
+    await expect(page.getByText('No mappings defined.')).toBeVisible();
+    const remaining = await (await fetch(`${backend}/api/normalization/mappings`)).json();
+    expect(remaining).toEqual({ mappings: [] });
+  } finally {
+    if (child.exitCode === null) {
+      const exited = once(child, 'exit');
+      child.kill('SIGTERM');
+      await exited;
+    }
+    await testInfo.attach('mapping-api.log', { body: output, contentType: 'text/plain' });
+  }
+});

--- a/frontend/src/App.bulkCreateStaging.test.tsx
+++ b/frontend/src/App.bulkCreateStaging.test.tsx
@@ -149,6 +149,35 @@ describe('App bulk-create staging', () => {
     });
   });
 
+  it('numbers mixed mapped and unmapped Create groups by visible natural name', async () => {
+    const names = ['ZDF alias', 'ABC', 'C-SPAN 10', 'C-SPAN 2', 'C-SPAN'];
+    const streams = names.map((name, index) => ({ ...makeStream(index), name }));
+    const resolution = new NameResolution(
+      new Map(names.map(name => [name, name === 'ZDF alias' ? 'ZDF' : name])),
+      false, new Set(['ZDF alias']),
+    );
+    render(<App />);
+    const editButton = await screen.findByRole('button', { name: /edit mode/i });
+    await waitFor(() => expect(editButton).toBeEnabled());
+    fireEvent.click(editButton);
+    await waitFor(() => expect(testState.channelManagerProps?.isEditMode).toBe(true));
+    await act(async () => {
+      await testState.channelManagerProps!.onBulkCreateFromGroup(
+        streams, 100, null, undefined, undefined, undefined, false, undefined,
+        false, undefined, undefined, undefined, undefined, undefined, undefined,
+        [], false, resolution,
+      );
+    });
+    await waitFor(() => {
+      const ledger = JSON.parse(sessionStorage.getItem(STAGED_LEDGER_STORAGE_KEY)!) as PersistedStagedLedger;
+      const channels = ledger.operations.filter(op => op.apiCall.type === 'createChannel')
+        .map(op => op.afterSnapshot[0]);
+      expect(channels.map(channel => [channel.name, channel.channel_number])).toEqual([
+        ['ABC', 100], ['C-SPAN', 101], ['C-SPAN 2', 102], ['C-SPAN 10', 103], ['ZDF', 104],
+      ]);
+    });
+  });
+
   it('stages and applies every one-stream channel through the real App callback', async () => {
     const count = 316;
     const streams = Array.from({ length: count }, (_, index) => makeStream(index));

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import {
   type TabId,
 } from './components';
 import { ChannelManagerTab } from './components/tabs/ChannelManagerTab';
+import { MappedChannels } from './components/MappedChannels';
 import { OperatorDashboard } from './components/tabs/OperatorDashboard';
 import { useChangeHistory, useEditMode, useHashRoute, useDedupOnDrop, useServerDataInvalidation } from './hooks';
 import { useAuth } from './hooks/useAuth';
@@ -2437,7 +2438,7 @@ function App() {
           // established that the resolution answers for every one of these.
           const normalizedName = nameResolution.nameFor(stream.name);
           // Strip quality suffixes for grouping (so HD/FHD/4K/SD variants merge together)
-          const groupingKey = api.stripQualitySuffixes(normalizedName);
+          const groupingKey = nameResolution.groupingKeyFor(stream.name);
           const existing = streamsByBaseName.get(groupingKey);
           if (existing) {
             existing.streams.push(stream);
@@ -2524,8 +2525,10 @@ function App() {
         // Use natural sort so "C-SPAN" comes before "C-SPAN 2" which comes before "C-SPAN 3"
         const sortedEntries = Array.from(streamsByBaseName.entries()).sort((a, b) => {
           // Natural sort comparison that handles trailing numbers properly
-          const nameA = a[0];
-          const nameB = b[0];
+          const nameA = nameResolution.isMapped(a[1].streams[0].name)
+            ? a[1].normalizedName : api.stripQualitySuffixes(a[1].normalizedName);
+          const nameB = nameResolution.isMapped(b[1].streams[0].name)
+            ? b[1].normalizedName : api.stripQualitySuffixes(b[1].normalizedName);
 
           // Extract base name and trailing number (if any)
           const matchA = nameA.match(/^(.+?)(\s*\d+)?$/);
@@ -2567,7 +2570,9 @@ function App() {
           };
 
           let channelName = normalizedName;
-          if (addChannelNumber && keepCountryPrefix) {
+          if (addChannelNumber && nameResolution.isMapped(groupedStreams[0].name)) {
+            channelName = `${channelNumber} ${numberSeparator} ${normalizedName}`;
+          } else if (addChannelNumber && keepCountryPrefix) {
             // Strip existing channel number before checking for country prefix
             const nameWithoutNumber = stripChannelNumber(normalizedName);
             const countryMatch = nameWithoutNumber.match(new RegExp(`^([A-Z]{2,6})\\s*[${countrySeparator ?? '|'}]\\s*(.+)$`));
@@ -3392,6 +3397,7 @@ function App() {
             />
             </ErrorBoundary>
           )}
+          {activeTab === 'mapped-channels' && <MappedChannels />}
           {activeTab === 'm3u-manager' && (
             <ErrorBoundary key="tab-m3u-manager" scopeLabel="M3U Manager tab" reloadMode="reset">
             <M3UManagerTab

--- a/frontend/src/components/MappedChannels.css
+++ b/frontend/src/components/MappedChannels.css
@@ -1,0 +1,33 @@
+.mapped-channels {
+  padding: 16px;
+  max-width: 960px;
+  overflow-wrap: anywhere;
+  overflow: auto;
+  min-height: 0;
+}
+
+.mapped-channels fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 1px solid var(--border-primary);
+  min-width: 0;
+}
+
+.mapped-channels input:not([type="radio"]),
+.mapped-channels textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.mapped-channels-actions,
+.mapped-channels-mode {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.mapped-channels-list article {
+  border-bottom: 1px solid var(--border-primary);
+  padding: 16px 0;
+}

--- a/frontend/src/components/MappedChannels.test.tsx
+++ b/frontend/src/components/MappedChannels.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '../test/mocks/server';
+import { MappedChannels } from './MappedChannels';
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('Mapped channels', () => {
+  it('prefills selected literal names and adds them to an existing mapping', async () => {
+    const user = userEvent.setup();
+    let saved: unknown;
+    server.use(
+      http.get('/api/normalization/mappings', () => HttpResponse.json({ mappings: [
+        { id: 8, preferred_name: 'Stars TV', aliases: ['Stars TV', 'Stars.TV'] },
+      ] })),
+      http.put('/api/normalization/mappings/8', async ({ request }) => {
+        saved = await request.json();
+        return HttpResponse.json({ id: 8, ...(saved as object) });
+      }),
+    );
+    render(<MappedChannels selectedNames={['Stars-TV', 'Stars.TV']} />);
+    expect(await screen.findByLabelText('Alternative names (one per line)')).toHaveValue('Stars-TV\nStars.TV');
+    await user.click(screen.getByRole('radio', { name: 'Existing' }));
+    await user.click(screen.getByRole('button', { name: 'Existing mapping' }));
+    await user.click(screen.getByRole('option', { name: 'Stars TV' }));
+    await user.click(screen.getByRole('button', { name: 'Save mapping' }));
+    await waitFor(() => expect(saved).toEqual({ preferred_name: 'Stars TV', aliases: ['Stars TV', 'Stars.TV', 'Stars-TV', 'Stars.TV'] }));
+    expect(await screen.findByRole('status')).toHaveTextContent('Mapping saved');
+  });
+
+  it('reviews, edits, adds, removes and keeps API errors visible', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/normalization/mappings', () => HttpResponse.json({ mappings: [
+        { id: 1, preferred_name: 'TVN', aliases: ['TVN', 'TVN-HD'] },
+      ] })),
+      http.put('/api/normalization/mappings/1', () => HttpResponse.json({ detail: 'Alias already owned' }, { status: 409 })),
+      http.delete('/api/normalization/mappings/1', () => new HttpResponse(null, { status: 204 })),
+      http.post('/api/normalization/mappings', () => HttpResponse.json({ id: 2, preferred_name: 'Polonia', aliases: ['Polonia'] }, { status: 201 })),
+    );
+    render(<MappedChannels />);
+    await user.click(await screen.findByRole('button', { name: 'Edit TVN' }));
+    expect(screen.getByLabelText('Preferred name')).toHaveValue('TVN');
+    await user.click(screen.getByRole('button', { name: 'Save mapping' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Alias already owned');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(screen.getByRole('button', { name: 'Remove TVN' }));
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Edit TVN' })).not.toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Add mapping' }));
+    await user.type(screen.getByLabelText('Preferred name'), 'Polonia');
+    await user.click(screen.getByRole('button', { name: 'Save mapping' }));
+    expect(await screen.findByRole('button', { name: 'Edit Polonia' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/MappedChannels.tsx
+++ b/frontend/src/components/MappedChannels.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useId, useState } from 'react';
+import { CustomSelect } from './CustomSelect';
+import { deleteChannelNameMapping, getChannelNameMappings, saveChannelNameMapping, type ChannelNameMapping } from '../services/channelNameMappings';
+import './MappedChannels.css';
+
+interface MappedChannelsProps {
+  selectedNames?: string[];
+}
+
+export function MappedChannels({ selectedNames }: MappedChannelsProps) {
+  const id = useId();
+  const [mappings, setMappings] = useState<ChannelNameMapping[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+  const [editing, setEditing] = useState(Boolean(selectedNames));
+  const [editingId, setEditingId] = useState<number>();
+  const [mode, setMode] = useState('new');
+  const [existingId, setExistingId] = useState('');
+  const [preferred, setPreferred] = useState(selectedNames?.[0] ?? '');
+  const [aliases, setAliases] = useState(selectedNames?.join('\n') ?? '');
+
+  useEffect(() => {
+    let active = true;
+    getChannelNameMappings().then(({ mappings: loaded }) => {
+      if (active) setMappings(loaded);
+    }).catch((err: unknown) => {
+      if (active) setError(err instanceof Error ? err.message : 'Failed to load mappings');
+    }).finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, []);
+
+  const edit = (mapping?: ChannelNameMapping) => {
+    setEditingId(mapping?.id);
+    setMode('new');
+    setPreferred(mapping?.preferred_name ?? selectedNames?.[0] ?? '');
+    setAliases(mapping?.aliases.join('\n') ?? selectedNames?.join('\n') ?? '');
+    setError('');
+    setMessage('');
+    setEditing(true);
+  };
+
+  const save = async () => {
+    setBusy(true);
+    setError('');
+    setMessage('');
+    const existing = mode === 'existing' ? mappings.find(m => String(m.id) === existingId) : undefined;
+    try {
+      const saved = await saveChannelNameMapping({
+        preferred_name: existing?.preferred_name ?? preferred,
+        aliases: [...(existing?.aliases ?? []), ...aliases.split('\n').filter(name => name !== '')],
+      }, existing?.id ?? editingId);
+      setMappings(current => [...current.filter(m => m.id !== saved.id), saved]);
+      setEditing(false);
+      setMessage('Mapping saved. Used by subsequent Create / Pipeline runs; no channels changed now.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save mapping');
+    } finally { setBusy(false); }
+  };
+
+  const remove = async (mapping: ChannelNameMapping) => {
+    setBusy(true);
+    setError('');
+    setMessage('');
+    try {
+      await deleteChannelNameMapping(mapping.id);
+      setMappings(current => current.filter(m => m.id !== mapping.id));
+      setMessage('Mapping removed. Existing channels and attachments are unchanged.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to remove mapping');
+    } finally { setBusy(false); }
+  };
+
+  return <section className="mapped-channels" aria-label="Mapped channels">
+    <p>Whole-name, case-insensitive literal aliases across providers. Saving applies to subsequent Create / Pipeline runs and configured automation, not existing channels.</p>
+    {error && <p role="alert" className="error-message">{error}</p>}
+    {message && <p role="status">{message}</p>}
+    {loading ? <p role="status">Loading mappings...</p> : <>
+      {!editing && <button className="btn-primary" onClick={() => edit()} disabled={busy}>Add mapping</button>}
+      {editing && <form onSubmit={event => { event.preventDefault(); void save(); }}>
+        <fieldset disabled={busy}>
+          <legend>{editingId ? 'Edit mapping' : 'Add mapping'}</legend>
+          {!editingId && <div className="mapped-channels-mode">
+            <label><input type="radio" name={`${id}-mode`} checked={mode === 'existing'} onChange={() => setMode('existing')} />Existing</label>
+            <label><input type="radio" name={`${id}-mode`} checked={mode === 'new'} onChange={() => setMode('new')} />Add new</label>
+          </div>}
+          {mode === 'existing' ? <CustomSelect ariaLabel="Existing mapping" value={existingId} onChange={setExistingId}
+            options={mappings.map(m => ({ value: String(m.id), label: m.preferred_name }))} /> : <>
+            <label htmlFor={`${id}-preferred`}>Preferred name</label>
+            <input className="form-input" id={`${id}-preferred`} required maxLength={255} value={preferred} onChange={e => setPreferred(e.target.value)} />
+          </>}
+          <label htmlFor={`${id}-aliases`}>Alternative names (one per line)</label>
+          <textarea className="form-input" id={`${id}-aliases`} rows={6} value={aliases} onChange={e => setAliases(e.target.value)} />
+          <p>The preferred name also matches itself. Existing adds these aliases without removing its current aliases.</p>
+          <div className="mapped-channels-actions">
+            <button className="btn-primary" type="submit" disabled={mode === 'existing' && !existingId}>Save mapping</button>
+            <button className="btn-secondary" type="button" onClick={() => setEditing(false)}>Cancel</button>
+          </div>
+        </fieldset>
+      </form>}
+      {!selectedNames && <div className="mapped-channels-list">
+        {mappings.length === 0 && <p>No mappings defined.</p>}
+        {mappings.map(mapping => <article key={mapping.id}>
+          <h3>{mapping.preferred_name}</h3>
+          <p>{mapping.aliases.join(', ')}</p>
+          <div className="mapped-channels-actions">
+            <button className="btn-secondary" aria-label={`Edit ${mapping.preferred_name}`} disabled={busy || editing} onClick={() => edit(mapping)}>Edit</button>
+            <button className="btn-secondary" aria-label={`Remove ${mapping.preferred_name}`} disabled={busy || editing} onClick={() => void remove(mapping)}>Remove</button>
+          </div>
+        </article>)}
+      </div>}
+    </>}
+  </section>;
+}

--- a/frontend/src/components/StreamsPane.tsx
+++ b/frontend/src/components/StreamsPane.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import type { Stream, StreamGroupInfo, M3UAccount, Channel, ChannelGroup, ChannelProfile, M3UGroupSetting } from '../types';
 import { useSelection, useExpandCollapse, useAddStreamDedup } from '../hooks';
-import { detectRegionalVariants, filterStreamsByTimezone, resolveCreateChannelNames, stripQualitySuffixes, type ResolvedCreateChannelNames, type TimezonePreference, type NumberSeparator, type PrefixOrder, type SortCriterion, type SortEnabledMap, type M3UAccountPriorities } from '../services/api';
+import { detectRegionalVariants, filterStreamsByTimezone, resolveCreateChannelNames, type ResolvedCreateChannelNames, type TimezonePreference, type NumberSeparator, type PrefixOrder, type SortCriterion, type SortEnabledMap, type M3UAccountPriorities } from '../services/api';
 import { naturalCompare } from '../utils/naturalSort';
 import { channelNumberInputError, parseChannelNumberInput } from '../utils/channelNumber';
 import { categorizeStreamGroups } from '../utils/streamGroupCategories';
@@ -12,6 +12,7 @@ import { useDropdown } from '../hooks/useDropdown';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import { CustomSelect } from './CustomSelect';
 import { StreamCreateMenu } from './StreamCreateMenu';
+import { MappedChannels } from './MappedChannels';
 import { PreviewStreamModal } from './PreviewStreamModal';
 import { ModalOverlay } from './ModalOverlay';
 import { useOwnedDialog } from '../hooks/useOwnedDialog';
@@ -593,6 +594,7 @@ export function StreamsPane({
   // the `streams` prop no longer contains the previously selected streams.
   // This cache ensures we can still resolve those IDs to full Stream objects.
   const selectedStreamsCacheRef = useRef<Map<number, Stream>>(new Map());
+  const [mappingNames, setMappingNames] = useState<string[] | null>(null);
   useEffect(() => {
     const cache = selectedStreamsCacheRef.current;
     // Add any currently visible selected streams to cache
@@ -1571,7 +1573,7 @@ export function StreamsPane({
         // groups is two entries rather than a collision. NUL is the joiner
         // because a group name may contain any printable separator, and
         // "A B" + "C" must not collide with "A" + "B C".
-        const groupingKey = `${bucket.key}\u0000${stripQualitySuffixes(resolvedName)}`;
+        const groupingKey = `${bucket.key}\u0000${createNameResolution.groupingKeyFor(stream.name)}`;
         const existing = channelMap.get(groupingKey);
         if (existing) {
           existing.streams.push(stream);
@@ -2176,6 +2178,12 @@ export function StreamsPane({
               {selectedCount} stream{selectedCount !== 1 ? 's' : ''}
               {selectedGroupNames.size > 0 && ` (${selectedGroupNames.size} group${selectedGroupNames.size !== 1 ? 's' : ''})`}
             </span>
+            <button className="create-channels-btn" onClick={() => setMappingNames(
+              Array.from(new Set(Array.from(selectedIds).flatMap(streamId => {
+                const stream = selectedStreamsCacheRef.current.get(streamId);
+                return stream ? [stream.name] : [];
+              })))
+            )}>Add mapping</button>
             {isEditMode && onBulkCreateFromGroup && (
               <button
                 className="create-channels-btn"
@@ -2225,6 +2233,10 @@ export function StreamsPane({
         )}
       </div>
 
+      {mappingNames && <div>
+        <button className="btn-secondary" onClick={() => setMappingNames(null)}>Close mapping editor</button>
+        <MappedChannels key={JSON.stringify(mappingNames)} selectedNames={mappingNames} />
+      </div>}
       <div className="streams-pane-filters">
         <div className="search-row">
           <div className="search-input-wrapper">

--- a/frontend/src/components/TabNavigation.test.tsx
+++ b/frontend/src/components/TabNavigation.test.tsx
@@ -23,6 +23,7 @@ describe('grouped primary navigation', () => {
     ]);
     expect(within(nav).getAllByRole('link').map((link) => link.getAttribute('aria-label'))).toEqual([
       'Dashboard', 'M3U Manager', 'EPG Manager', 'Logo Manager', 'Channel Manager',
+      'Mapped channels',
       'Channel Pipeline', 'Guide', 'Stats', 'M3U Changes', 'Journal', 'Settings',
     ]);
     expect(within(nav).getByRole('link', { name: 'Stats' })).toHaveAttribute('aria-current', 'page');

--- a/frontend/src/components/TabNavigation.tsx
+++ b/frontend/src/components/TabNavigation.tsx
@@ -5,7 +5,7 @@ import { GROUPS } from './navigationGroups';
 import { settingsSectionGroups, type SettingsPage } from './settingsSections';
 import './TabNavigation.css';
 
-export type TabId = 'dashboard' | 'm3u-manager' | 'epg-manager' | 'channel-manager' | 'guide' | 'logo-manager' | 'm3u-changes' | 'channel-pipeline' | 'journal' | 'stats' | 'settings';
+export type TabId = 'dashboard' | 'm3u-manager' | 'epg-manager' | 'channel-manager' | 'mapped-channels' | 'guide' | 'logo-manager' | 'm3u-changes' | 'channel-pipeline' | 'journal' | 'stats' | 'settings';
 
 interface TabNavigationProps {
   activeTab: TabId;

--- a/frontend/src/components/navigationGroups.ts
+++ b/frontend/src/components/navigationGroups.ts
@@ -27,6 +27,7 @@ export const GROUPS: NavigationGroup[] = [
     { id: 'epg-manager', label: 'EPG Manager', icon: 'schedule' },
     { id: 'logo-manager', label: 'Logo Manager', icon: 'image' },
     { id: 'channel-manager', label: 'Channel Manager', icon: 'tv' },
+    { id: 'mapped-channels', label: 'Mapped channels', icon: 'link' },
   ] },
   { label: 'Automation', destinations: [
     { id: 'channel-pipeline', label: 'Channel Pipeline', icon: 'auto_fix_high' },

--- a/frontend/src/components/routeHierarchy.ts
+++ b/frontend/src/components/routeHierarchy.ts
@@ -121,6 +121,7 @@ function route(
 
 export const ROUTE_HIERARCHY: Record<TabId, RouteHierarchy> = {
   dashboard: route('OVERVIEW', 'dashboard', 'Review ECM status and move directly to the workspace that needs attention.'),
+  'mapped-channels': route('OPERATIONS', 'mapped-channels', 'Define reusable preferred channel names and literal aliases.'),
   // No related-settings link, on the same reasoning that removed M3U Manager's
   // (see below, bead enhancedchannelmanager-hmr0e). Channel Defaults is a
   // standing Settings destination with its own navigation entry, so the header
@@ -174,6 +175,7 @@ export interface RouteHeaderPolicy {
 export const ROUTE_HEADER_POLICIES: Record<TabId, RouteHeaderPolicy> = {
   dashboard: { primaryAction: null, exception: 'Read-only operational summary; actions remain on destination pages.' },
   'channel-manager': { primaryAction: 'Edit Mode' },
+  'mapped-channels': { primaryAction: null, exception: 'Add and save remain mapping-form scoped.' },
   guide: { primaryAction: null, exception: 'Guide refresh, print, and temporal selectors remain one source-scoped control group.' },
   'm3u-manager': { primaryAction: 'Add M3U Account' },
   'epg-manager': { primaryAction: 'Add Standard EPG' },

--- a/frontend/src/components/routeTitles.ts
+++ b/frontend/src/components/routeTitles.ts
@@ -3,6 +3,7 @@ import type { TabId } from './TabNavigation';
 export const ROUTE_TITLES: Record<TabId, string> = {
   dashboard: 'Dashboard',
   'channel-manager': 'Channel Manager',
+  'mapped-channels': 'Mapped channels',
   guide: 'Guide',
   'm3u-manager': 'M3U Manager',
   'epg-manager': 'EPG Manager',

--- a/frontend/src/hooks/useHashRoute.ts
+++ b/frontend/src/hooks/useHashRoute.ts
@@ -11,7 +11,7 @@ export type { SettingsPage };
 const VALID_TABS: Set<string> = new Set([
   'dashboard', 'm3u-manager', 'epg-manager', 'channel-manager', 'guide',
   'logo-manager', 'm3u-changes', 'channel-pipeline', 'journal',
-  'stats', 'settings',
+  'stats', 'settings', 'mapped-channels',
 ]);
 
 /**

--- a/frontend/src/services/channelNameMappings.ts
+++ b/frontend/src/services/channelNameMappings.ts
@@ -1,0 +1,23 @@
+import { fetchJson } from './httpClient';
+
+export interface ChannelNameMapping {
+  id: number;
+  preferred_name: string;
+  aliases: string[];
+}
+
+const BASE = '/api/normalization/mappings';
+
+export function getChannelNameMappings(): Promise<{ mappings: ChannelNameMapping[] }> {
+  return fetchJson(BASE);
+}
+
+export function saveChannelNameMapping(mapping: Omit<ChannelNameMapping, 'id'>, id?: number): Promise<ChannelNameMapping> {
+  return fetchJson(id === undefined ? BASE : `${BASE}/${id}`, {
+    method: id === undefined ? 'POST' : 'PUT', body: JSON.stringify(mapping),
+  });
+}
+
+export function deleteChannelNameMapping(id: number): Promise<void> {
+  return fetchJson(`${BASE}/${id}`, { method: 'DELETE' });
+}

--- a/frontend/src/services/normalization.test.ts
+++ b/frontend/src/services/normalization.test.ts
@@ -359,7 +359,33 @@ describe('Normalization API', () => {
   });
 
   describe('resolveCreateChannelNames', () => {
-    it('does not call the backend and keeps the raw provider names when normalization is off', async () => {
+    it('does not accept a partial mapping response as a partial success', async () => {
+      server.use(http.post('/api/normalization/mappings/resolve', () => HttpResponse.json({ results: [
+        { original: 'Stars.TV', preferred_name: 'Stars TV' },
+      ] })));
+      const result = await resolveCreateChannelNames(['Stars.TV', 'TVN'], false);
+      expect(result.normalizationFailed).toBe(true);
+      expect(result.nameFor('Stars.TV')).toBe('Stars.TV');
+      expect(result.isMapped('Stars.TV')).toBe(false);
+    });
+    it.each([false, true])('uses authoritative mapped spelling and grouping with normalization=%s', async normalize => {
+      server.use(http.post('/api/normalization/normalize', async ({ request }) => {
+        const { texts } = await request.json() as { texts: string[] };
+        expect(texts).toEqual(['Stars TV']);
+        return HttpResponse.json({ results: texts.map(original => ({ original, normalized: original.replace(/ HD$/, '') })) });
+      }));
+      server.use(http.post('/api/normalization/mappings/resolve', () => HttpResponse.json({ results: [
+        { original: 'Stars.TV', preferred_name: 'Stars TV HD' },
+        { original: 'Stars-TV', preferred_name: 'Stars TV HD' },
+        { original: 'Stars TV', preferred_name: null },
+      ] })));
+      const result = await resolveCreateChannelNames(['Stars.TV', 'Stars-TV', 'Stars TV'], normalize);
+      expect(result.nameFor('Stars.TV')).toBe('Stars TV HD');
+      expect(result.normalizationFailed).toBe(false);
+      expect(result.groupingKeyFor('Stars.TV')).toBe(result.groupingKeyFor('Stars-TV'));
+      expect(result.groupingKeyFor('Stars.TV')).not.toBe(result.groupingKeyFor('Stars TV'));
+    });
+    it('does not run regex normalization and keeps unmapped names when normalization is off', async () => {
       let called = false;
       server.use(
         http.post('/api/normalization/normalize', async () => {

--- a/frontend/src/services/streamNormalization.ts
+++ b/frontend/src/services/streamNormalization.ts
@@ -7,6 +7,7 @@
  */
 
 import { logger } from '../utils/logger';
+import { fetchJson } from './httpClient';
 import {
   QUALITY_SUFFIXES,
   NETWORK_PREFIXES,
@@ -605,14 +606,13 @@ export class ResolvedCreateChannelNames {
   private readonly resolved: ReadonlyMap<string, string>;
 
   /**
-   * True only when normalization was REQUESTED and the backend call failed or
-   * came back incomplete, so the names are raw provider names the operator did
-   * not ask for. False when the operator turned normalization off — those raw
-   * names are the requested outcome, not a failure.
+   * A mapping lookup or requested regex normalization failed. Unmapped names
+   * fall back to raw provider names; validated mapping results retain their
+   * preferred spelling if the subsequent regex request fails.
    */
   readonly normalizationFailed: boolean;
 
-  constructor(resolved: ReadonlyMap<string, string>, normalizationFailed: boolean) {
+  constructor(resolved: ReadonlyMap<string, string>, normalizationFailed: boolean, private readonly mapped: ReadonlySet<string> = new Set()) {
     this.resolved = resolved;
     this.normalizationFailed = normalizationFailed;
   }
@@ -625,6 +625,15 @@ export class ResolvedCreateChannelNames {
   /** Whether this resolution answers for `streamName`. */
   has(streamName: string): boolean {
     return this.resolved.has(streamName);
+  }
+
+  isMapped(streamName: string): boolean {
+    return this.mapped.has(streamName);
+  }
+
+  groupingKeyFor(streamName: string): string {
+    const name = this.nameFor(streamName);
+    return this.isMapped(streamName) ? `mapped:${name}` : `unmapped:${stripQualitySuffixes(name)}`;
   }
 
   /** Whether this resolution answers for every one of `streamNames`. */
@@ -680,6 +689,7 @@ export async function resolveCreateChannelNames(
   streamNames: string[],
   normalize: boolean,
 ): Promise<ResolvedCreateChannelNames> {
+  const preferredNames = new Map<string, string>();
   const identity = (): Map<string, string> => {
     const map = new Map<string, string>();
     for (const name of streamNames) {
@@ -708,15 +718,37 @@ export async function resolveCreateChannelNames(
       );
       return new ResolvedCreateChannelNames(identity(), true);
     }
-    return new ResolvedCreateChannelNames(names, normalizationFailed);
+    for (const [original, preferred] of preferredNames) names.set(original, preferred);
+    return new ResolvedCreateChannelNames(names, normalizationFailed, new Set(preferredNames.keys()));
   };
 
-  if (!normalize || streamNames.length === 0) {
+  if (streamNames.length === 0) {
     return finish(identity(), false);
   }
 
   try {
-    return finish(await normalizeStreamNamesWithBackend(streamNames), false);
+    const requested = new Set(streamNames);
+    const response = await fetchJson<{ results: { original: string; preferred_name: string | null }[] }>(
+      '/api/normalization/mappings/resolve', { method: 'POST', body: JSON.stringify({ texts: [...requested] }) },
+    );
+    const seen = new Set<string>();
+    for (const result of response.results) {
+      if (!requested.has(result.original) || seen.has(result.original)
+        || (result.preferred_name !== null && typeof result.preferred_name !== 'string')) {
+        throw new Error('Invalid mapping resolution response');
+      }
+      seen.add(result.original);
+    }
+    if (seen.size !== requested.size) throw new Error('Incomplete mapping resolution response');
+    for (const result of response.results) {
+      if (result.preferred_name !== null) preferredNames.set(result.original, result.preferred_name);
+    }
+    const unmapped = [...requested].filter(name => !preferredNames.has(name));
+    const names = identity();
+    if (normalize && unmapped.length) {
+      for (const [name, normalized] of await normalizeStreamNamesWithBackend(unmapped)) names.set(name, normalized);
+    }
+    return finish(names, false);
   } catch (error) {
     // Carry on with the raw names rather than abandoning a create the
     // operator already confirmed — but say so, so the resulting names are

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -557,6 +557,10 @@ export function resetMockDataStore(): void {
 // =============================================================================
 
 export const handlers = [
+  http.post('/api/normalization/mappings/resolve', async ({ request }) => {
+    const { texts } = await request.json() as { texts: string[] };
+    return HttpResponse.json({ results: [...new Set(texts)].map(original => ({ original, preferred_name: null })) });
+  }),
   // -------------------------------------------------------------------------
   // Auth (no-auth mode — tests run with require_auth=false so no user is needed)
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes #775

Bead: enhancedchannelmanager-u0ko6

- Add selection-driven Add mapping (Existing / Add new) and a Mapped channels management tab.
- Persist whole-name, case-insensitive literal aliases with exclusive ownership and authoritative preferred names.
- Apply mappings through existing Create/Pipeline workflows only. Saving or deleting definitions does not mutate channel attachments.
- Preserve channel numbering and manual-channel/group safeguards; isolate mapping transactions from concurrent readers and writers.

## Frozen Scope
Preferred-name mappings, not channel-ID bindings. No fuzzy/substring matching, automatic duplicate cleanup, immediate assignment, new scheduler, or new dependencies. Contract and evidence: docs/u0ko6_alias_mapping_plan.md.

## Verification
- Final full backend suite: 12,870 passed, 3 documented skips, 2 deselected (engineer-run, terminal result confirmed during independent review).
- Parent final focused backend: 459 passed.
- Parent frontend: 3,686 passed; lint, typecheck, coverage and build passed.
- Parent real-API Chromium mapping flow and strict MkDocs build passed.
- Final independent bounded code and full in-scope DBA reviews found no remaining findings.
- git diff --check passed. CI against this commit remains to be verified.

## Migration
Additive Alembic 0055 adds mapping/alias tables; no existing data rewrite or seed. Upgrade, downgrade, bootstrap, ownership conflicts and concurrency were tested. Downgrade removes mapping definitions, not Dispatcharr channels or attachments.

## Delivery
Merge is ON HOLD pending explicit Product Owner instruction. After authorized merge into dev, explicitly verify and close GitHub #775 if the closing keyword does not apply on the non-default branch. Keep the bead in progress until merge.