### PR TITLE
feat: detach proven stale Event Sync streams (60r8c)

### DIFF
--- a/backend/channel_pipeline_engine.py
+++ b/backend/channel_pipeline_engine.py
@@ -886,6 +886,25 @@ class ChannelPipelineEngine:
             if execution.mode == "dry_run":
                 return {"success": False, "error": "Cannot rollback a dry-run execution"}
 
+            if any("cleanup" in summary for summary in execution.get_event_sync_summary()):
+                from services.event_sync_cleanup import rollback_batch
+                modified = execution.get_modified_entities()
+                if execution.get_created_entities() or any(
+                    entity.get("type") != "channel" or set((entity.get("previous") or {}).keys()) != {"streams"}
+                    for entity in modified
+                ):
+                    return {"success": False, "error": "Cleanup rollback cannot safely restore mixed non-stream mutations"}
+                # End the reader transaction before private intent writes or HTTP.
+                session.close()
+                result = await rollback_batch(self.client, str(execution_id), expected_count=len(modified))
+                if result["success"]:
+                    execution = session.get(ChannelPipelineExecution, execution_id)
+                    execution.status = "rolled_back"
+                    execution.rolled_back_at = datetime.utcnow()
+                    execution.rolled_back_by = rolled_back_by
+                    session.commit()
+                return {**result, "execution_id": execution_id}
+
             # --- uc51o.5: unify on the snapshot when one exists ---------------
             # If this execution has a pre-run snapshot, the FULL restore is the
             # right revert (the legacy path cannot re-add streams the run
@@ -1127,6 +1146,10 @@ class ChannelPipelineEngine:
                     "success": False,
                     "error": "Execution already reverted",
                 }
+
+            if any("cleanup" in summary for summary in execution.get_event_sync_summary()):
+                session.close()
+                return await self.rollback_execution(execution_id, rolled_back_by=restored_by, confirm=True)
 
             snapshot = session.query(ChannelPipelineSnapshot).filter(
                 ChannelPipelineSnapshot.execution_id == execution_id
@@ -4518,6 +4541,7 @@ class ChannelPipelineEngine:
                 decisions=decisions,
                 effective_master_group_id=effective_master_group_id,
                 exclusions=exclusions,
+                rule_created_at=rule.created_at.isoformat() if isinstance(rule.created_at, datetime) else None,
             )
 
             # ti939.3.2: persist the run's ambiguous pairings as pending

--- a/backend/channel_pipeline_executor.py
+++ b/backend/channel_pipeline_executor.py
@@ -1714,6 +1714,27 @@ class ActionExecutor:
                 skipped=True
             )
 
+        cleanup_operation = (merge_provenance or {}).get("cleanup_operation")
+        if cleanup_operation and not exec_ctx.dry_run:
+            try:
+                from services.event_sync_cleanup import apply_change
+                if self._plan_only:
+                    outcome = await self.client.event_sync_change(cleanup_operation)
+                else:
+                    outcome = await apply_change(self.client, cleanup_operation, self._execution_id)
+                channel.update(outcome["channel"])
+                exec_ctx.current_channel_id = channel_id
+                return ActionResult(
+                    success=True, action_type="merge_stream", entity_type="channel",
+                    entity_id=channel_id, entity_name=channel_name,
+                    description=f"Added stream to channel '{channel_name}'",
+                    skipped=outcome.get("skipped", False), modified=not outcome.get("skipped", False),
+                    previous_state={"streams": outcome.get("before", current_streams)},
+                )
+            except Exception as error:
+                return ActionResult(success=False, action_type="merge_stream",
+                                    description="Event Sync attach failed", error=str(error))
+
         new_count = stream_count + 1
 
         def _track_m3u_count():
@@ -5008,7 +5029,8 @@ class ActionExecutor:
                                       exec_ctx: ExecutionContext,
                                       decisions=None,
                                       effective_master_group_id=None,
-                                      exclusions=None) -> dict:
+                                      exclusions=None,
+                                      rule_created_at=None) -> dict:
         """Execute one event_sync rule's attach path (bead ti939.2.1).
 
         Phase 1B — the FIRST write path for event_sync. Resolves every
@@ -5138,6 +5160,32 @@ class ActionExecutor:
             "excluded_suppressed": 0,
         }
 
+        if config.get("detach_stale_streams") is True:
+            from services.event_sync_cleanup import UncertainMutationError, apply_change, plan_cleanup
+            cleanup = await plan_cleanup(self.client, rule_id, config)
+            summary["cleanup"] = cleanup
+            for operation in cleanup["operations"]:
+                row = next(r for r in cleanup["decisions"] if r["channel_id"] == operation["channel_id"]
+                           and r["stream_id"] == operation["stream_id"])
+                if exec_ctx.dry_run:
+                    continue
+                try:
+                    outcome = (await self.client.event_sync_change(operation) if self._plan_only
+                               else await apply_change(self.client, operation, self._execution_id))
+                    self._channel_by_id[operation["channel_id"]].update(outcome["channel"])
+                    row["decision"] = "would_detach" if self._plan_only else "detached"
+                    exec_ctx.modified_entities.append({"type": "channel", "id": operation["channel_id"],
+                                                       "previous": {"streams": outcome["before"]}})
+                    exec_ctx.merged_channel_ids.add(operation["channel_id"])
+                except Exception as error:
+                    row.update(decision="uncertain" if isinstance(error, UncertainMutationError) else "preserve",
+                               reason="mutation_outcome_uncertain" if isinstance(error, UncertainMutationError)
+                               else "cleanup_cancelled_before_mutation")
+                    cleanup["error"] = str(error)
+                    summary["attach_errors"] += 1
+                    break
+            cleanup.pop("operations")
+
         for r in resolution.resolved:
             summary["rejected_suppressed"] += r.rejected_suppressed
             summary["excluded_suppressed"] += r.excluded_suppressed
@@ -5262,6 +5310,9 @@ class ActionExecutor:
             provenance = {
                 "kind": "event_sync",
                 "rule_id": rule_id,
+                "rule_created_at": rule_created_at,
+                "channel_uuid": channel.get("uuid"),
+                "stream_account": r.stream.provider_id,
                 "secondary_stream_id": r.stream.stream_id,
                 "secondary_stream_name": r.stream.name,
                 "provider": r.stream.provider,
@@ -5278,6 +5329,17 @@ class ActionExecutor:
                 # queue-driven attach is auditable as such.
                 "attach_source": r.attach_source,
             }
+            if config.get("detach_stale_streams") is True and not already_attached:
+                from services.event_sync_cleanup import rule_identity
+                try:
+                    provenance["cleanup_operation"] = {
+                        **rule_identity(rule_id), "channel_id": master_channel_id,
+                        "channel_uuid": channel.get("uuid"), "stream_id": r.stream.stream_id,
+                        "stream_account": r.stream.provider_id, "action": "attach", "config": config,
+                    }
+                except Exception:
+                    summary["attach_errors"] += 1
+                    continue
             stream_ctx = StreamContext(
                 stream_id=r.stream.stream_id,
                 stream_name=r.stream.name,

--- a/backend/channel_pipeline_schema.py
+++ b/backend/channel_pipeline_schema.py
@@ -941,6 +941,7 @@ _EVENT_SYNC_ALLOWED_KEYS = frozenset({
     "include_master_group_streams",
     "assume_current_date",
     "demote_stale_dateless",
+    "detach_stale_streams",
     "parse_master_from_stream",
     # Unmatched-stream promotion (bead ti939.4.1) — the ONE sanctioned
     # exception to "ECM never creates channels". Opt-in; absent keys mean
@@ -1349,6 +1350,10 @@ def validate_event_sync_config(config: Any) -> list[str]:
     # every stored config that predates the key keeps manual-run-only
     # behavior unchanged. Filled in place like the other defaults so stored
     # configs are explicit.
+    if "detach_stale_streams" in config and type(config["detach_stale_streams"]) is not bool:
+        errors.append(_event_sync_error(
+            "detach_stale_streams", config["detach_stale_streams"], "a boolean (default false)",
+        ))
     auto_run = config.get("auto_run")
     if auto_run is None:
         config["auto_run"] = False

--- a/backend/routers/channel_pipeline.py
+++ b/backend/routers/channel_pipeline.py
@@ -1998,7 +1998,10 @@ async def commit_auto_creation_pipeline(request: CommitPipelinePlanRequest, _adm
             _mark_execution_failed(execution_id, exc)
             raise HTTPException(status_code=409, detail=f"pipeline state drifted: {exc}") from exc
         try:
-            _, remap = await replay_write_plan(engine.client, write_plan, read_set_validated=True)
+            replay_options = {"read_set_validated": True}
+            if any(write.event_sync for write in write_plan.writes):
+                replay_options["execution_id"] = execution_id
+            _, remap = await replay_write_plan(engine.client, write_plan, **replay_options)
         except PartialReplayError as exc:
             partial_replay = {
                 "failed_index": exc.failed_index,
@@ -2029,6 +2032,10 @@ async def commit_auto_creation_pipeline(request: CommitPipelinePlanRequest, _adm
         if planned_journal:
             journal.log_entries(entries=planned_journal)
         result = remapped(plan.payload["result"])
+        for summary in result.get("event_sync", []):
+            for decision in summary.get("cleanup", {}).get("decisions", []):
+                if decision["decision"] == "would_detach":
+                    decision["decision"] = "detached"
         review_counts: dict[int, dict] = {}
         from services.event_sync_review_store import enqueue_review_candidates
         for review in result.get("planned_review_candidates", []):
@@ -3443,6 +3450,7 @@ class EventSyncPreviewRequest(BaseModel):
 
     rule_id: Optional[int] = None
     event_sync_config: Optional[dict] = None
+    cleanup_rule_id: Optional[int] = Field(default=None, strict=True, gt=0)
 
     @model_validator(mode="after")
     def _exactly_one_source(self):
@@ -3451,6 +3459,10 @@ class EventSyncPreviewRequest(BaseModel):
                 "provide exactly one of rule_id (preview a saved rule) or "
                 "event_sync_config (preview before saving)"
             )
+        if self.cleanup_rule_id is not None and (
+            self.rule_id is not None or not (self.event_sync_config or {}).get("detach_stale_streams")
+        ):
+            raise ValueError("cleanup_rule_id requires an inline cleanup-enabled config")
         return self
 
 
@@ -3805,6 +3817,7 @@ async def preview_event_sync(
     )
 
     config = await _load_event_sync_preview_config(request)
+    preview_rule_id = request.rule_id if request.rule_id is not None else request.cleanup_rule_id
     master_group_id = config["master_group_id"]
     secondary_group_ids = config["secondary_group_ids"]
     client = get_client()
@@ -3818,16 +3831,16 @@ async def preview_event_sync(
     decisions = None
     pending_fps: frozenset = frozenset()
     exclusion_keys: frozenset = frozenset()
-    if request.rule_id is not None:
+    if preview_rule_id is not None:
         session = get_session()
         try:
-            decisions = load_review_decisions(session, request.rule_id)
-            pending_fps = load_pending_fingerprints(session, request.rule_id)
+            decisions = load_review_decisions(session, preview_rule_id)
+            pending_fps = load_pending_fingerprints(session, preview_rule_id)
             # ti939.3.5: operator never-attach exclusions feed the SAME
             # shared resolver, so the preview predicts exactly what a run
             # would suppress (excluded pairings report as
             # excluded_by_operator, never as would_attach).
-            exclusion_keys = load_exclusion_keys(session, request.rule_id)
+            exclusion_keys = load_exclusion_keys(session, preview_rule_id)
         except Exception as e:
             logger.warning(
                 "[EVENT-SYNC] preview: failed to load review-queue state "
@@ -3896,6 +3909,10 @@ async def preview_event_sync(
         config, client, effective_master_group_id, decisions=decisions,
         exclusions=exclusion_keys,
     )
+    if config.get("detach_stale_streams") is True:
+        from services.event_sync_cleanup import plan_cleanup
+        fetched["cleanup"] = await plan_cleanup(client, preview_rule_id, config)
+        fetched["cleanup"].pop("operations")
     resolution = fetched["resolution"]
     name_to_id = fetched["name_to_id"]
     group_names = fetched["group_names"]
@@ -4244,6 +4261,7 @@ async def preview_event_sync(
         # in (promotion_out is None otherwise → the two ** expansions are
         # empty and the payload is byte-identical to the pre-feature shape).
         **({"promotion": promotion_out} if promotion_out is not None else {}),
+        **({"cleanup": fetched["cleanup"]} if "cleanup" in fetched else {}),
         "preflight": preflight,
         "summary": {
             "secondary_streams": len(resolution.resolved),

--- a/backend/services/event_sync_cleanup.py
+++ b/backend/services/event_sync_cleanup.py
@@ -1,0 +1,491 @@
+"""Rule-owned, cross-account Event Sync detaches and their surgical inverse.
+
+HTTP is outside SQLite transactions. List PATCH has no upstream CAS: a fresh
+read narrows, but cannot eliminate, the race with external writers.
+"""
+from contextlib import contextmanager
+from datetime import datetime
+import json
+import logging
+from uuid import UUID
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import NullPool
+
+from database import get_database_url
+from config import get_settings
+from models import ChannelPipelineRule, JournalEntry
+from services import event_sync_staleness
+from services.event_sync_exclusion_store import load_exclusion_keys
+from services.event_sync_preflight import (
+    CHECK_GROUP_SETTINGS_FOUND, check_event_sync_group_settings, resolve_effective_master_group_id,
+)
+from services.event_sync_resolver import (
+    SecondaryStream, build_master_name_to_id, resolve_event_sync,
+)
+from services.event_sync_review_store import load_review_decisions
+
+logger = logging.getLogger(__name__)
+
+
+class UncertainMutationError(RuntimeError):
+    """PATCH started, but its outcome could not be confirmed."""
+
+
+@contextmanager
+def _session():
+    # StaticPool readers may roll back a shared DBAPI connection. Keep these
+    # durable intent transactions private (the mapping writer uses this pattern).
+    engine = create_engine(get_database_url(), poolclass=NullPool)
+    try:
+        with Session(engine, expire_on_commit=False) as session:
+            yield session
+    finally:
+        engine.dispose()
+
+
+def valid_id(value):
+    return type(value) is int and 0 < value <= 9223372036854775807
+
+
+def _uuid(value):
+    try:
+        return str(UUID(value)) if isinstance(value, str) else None
+    except ValueError:
+        return None
+
+
+def native_guard(channel: dict, stream: dict) -> str | None:
+    if channel.get("auto_created") is not True:
+        return "native_auto_created_required"
+    if not valid_id(channel.get("auto_created_by")):
+        return "native_owner_unknown"
+    if not valid_id(stream.get("m3u_account")):
+        return "stream_account_unknown"
+    if channel["auto_created_by"] == stream["m3u_account"]:
+        return "same_account_protected"
+    return None
+
+
+def _ids(channel):
+    raw = channel.get("streams")
+    if not isinstance(raw, list):
+        raise ValueError("channel memberships unavailable")
+    ids = [s.get("id") if isinstance(s, dict) else s for s in raw]
+    if any(not valid_id(s) for s in ids) or len(set(ids)) != len(ids):
+        raise ValueError("channel membership identity uncertain")
+    return ids
+
+
+def rule_identity(rule_id: int) -> dict:
+    if not valid_id(rule_id):
+        raise ValueError("rule identity unavailable")
+    with _session() as session:
+        rule = session.get(ChannelPipelineRule, rule_id)
+        if rule is None or not rule.is_event_sync() or not isinstance(rule.created_at, datetime):
+            raise ValueError("rule creation identity unavailable")
+        return {"rule_id": rule_id, "rule_created_at": rule.created_at.isoformat()}
+
+
+async def _pages(fetch, **kwargs):
+    rows = []
+    seen = set()
+    for page in range(1, 101):
+        response = await fetch(page=page, page_size=500, **kwargs)
+        if isinstance(response, list):
+            batch, more, count = response, False, len(response)
+        elif isinstance(response, dict) and isinstance(response.get("results"), list):
+            batch, more, count = response["results"], response.get("next"), response.get("count")
+            if "next" not in response or type(count) is not int or count < 0:
+                raise ValueError("incomplete page metadata")
+        else:
+            raise ValueError("malformed page")
+        for row in batch:
+            if not isinstance(row, dict) or not valid_id(row.get("id")) or row["id"] in seen:
+                raise ValueError("malformed or duplicate page identity")
+            seen.add(row["id"])
+        rows.extend(batch)
+        if len(rows) > 50000 or more and not batch:
+            raise ValueError("truncated or stalled pagination")
+        if not more:
+            if count != len(rows):
+                raise ValueError("incomplete page count")
+            return rows
+    raise ValueError("truncated pagination")
+
+
+def _history(channel_id):
+    # Existing idx_journal_entity narrows this read; no arbitrary 1000-row cap.
+    with _session() as session:
+        rows = session.query(JournalEntry).filter(
+            JournalEntry.category == "event_sync", JournalEntry.entity_id == channel_id,
+        ).order_by(JournalEntry.id).all()
+        return [(r.id, r.action_type, json.loads(r.before_value or "{}"),
+                 json.loads(r.after_value or "{}")) for r in rows]
+
+
+async def plan_cleanup(client, rule_id: int, config: dict) -> dict:
+    plan = {"decisions": [], "operations": [], "error": None}
+    if config.get("detach_stale_streams") is not True:
+        return plan
+    try:
+        identity = rule_identity(rule_id)
+        # The attach scorer deliberately falls back on settings failure. A
+        # destructive decision must instead load explicitly and fail closed.
+        aliases = get_settings().event_sync_team_aliases
+        if not isinstance(aliases, list) or any(
+            not isinstance(group, dict) or not isinstance(group.get("terms"), list)
+            or any(not isinstance(term, str) for term in group["terms"])
+            for group in aliases
+        ):
+            raise ValueError("team alias settings unavailable")
+        aliases = [group["terms"] for group in aliases]
+        with _session() as session:
+            decisions = load_review_decisions(session, rule_id)
+            exclusions = load_exclusion_keys(session, rule_id)
+        settings = await client.get_all_m3u_group_settings()
+        if not isinstance(settings, dict):
+            raise ValueError("group settings unavailable")
+        preflight = await check_event_sync_group_settings(client, config, all_settings=settings)
+        if any(failure["check"] == CHECK_GROUP_SETTINGS_FOUND for failure in preflight["failures"]):
+            plan["error"] = "configured_group_settings_unavailable"
+            return plan
+        group = resolve_effective_master_group_id(settings, config["master_group_id"])
+        channels = await _pages(client.get_channels, channel_group=group)
+        if any(ch.get("channel_group_id") != group for ch in channels):
+            raise ValueError("master group identity uncertain")
+        scopes = config.get("secondary") or [
+            {"group_id": gid, "m3u_account_id": None} for gid in config["secondary_group_ids"]
+        ]
+        if config.get("include_master_group_streams"):
+            scopes = [*scopes, {"group_id": config["master_group_id"], "m3u_account_id": None}]
+        accounts = await client.get_m3u_accounts()
+        if not isinstance(accounts, list) or any(not valid_id(a.get("id")) for a in accounts):
+            raise ValueError("accounts unavailable")
+        account_ids = {account["id"] for account in accounts}
+        stale = event_sync_staleness.previous_day_names(
+            [a["id"] for a in accounts], event_sync_staleness.local_midnight_utc(),
+        )
+        streams = {}
+        names = {}
+        for scope in scopes:
+            gid = scope["group_id"]
+            names[gid] = await client._channel_group_name_for_id(gid)
+            if not names[gid]:
+                raise ValueError("configured group unavailable")
+            rows = await _pages(client.get_streams, channel_group_name=names[gid],
+                                m3u_account=scope.get("m3u_account_id"))
+            for row in rows:
+                if not isinstance(row.get("name"), str) or not row["name"]:
+                    raise ValueError("stream name unavailable")
+                if row.get("channel_group") != gid:
+                    raise ValueError("stream group identity uncertain")
+                if scope.get("m3u_account_id") is not None and row.get("m3u_account") != scope["m3u_account_id"]:
+                    raise ValueError("stream scope identity uncertain")
+                if row["id"] in streams and streams[row["id"]] != row:
+                    raise ValueError("stream identity changed during pagination")
+                streams[row["id"]] = row
+        master_names = await build_master_name_to_id(
+            channels, client, bool(config.get("parse_master_from_stream")),
+        )
+        for channel in channels:
+            cid = channel["id"]
+            history = _history(cid)
+            pending = any(after.get("state") in {"intent", "uncertain"} for _, _, _, after in history)
+            for sid in _ids(channel):
+                row = {"channel_id": cid, "channel_name": channel.get("name"),
+                       "stream_id": sid, "decision": "preserve", "reason": "ownership_unknown_or_expired"}
+                plan["decisions"].append(row)
+                fetched = await client.get_streams_by_ids([sid])
+                if not isinstance(fetched, list) or len(fetched) != 1 or fetched[0].get("id") != sid:
+                    row["reason"] = "stream_identity_unavailable"
+                    continue
+                stream = fetched[0]
+                reason = native_guard(channel, stream)
+                if reason:
+                    row["reason"] = reason
+                    continue
+                if channel["auto_created_by"] not in account_ids or stream["m3u_account"] not in account_ids:
+                    row["reason"] = "account_identity_unavailable"
+                    continue
+                uuid = _uuid(channel.get("uuid"))
+                if not uuid:
+                    row["reason"] = "channel_identity_unknown"
+                    continue
+                if pending:
+                    row["reason"] = "uncertain_prior_mutation"
+                    continue
+                proof = None
+                for _, action, before, after in history:
+                    operation = after.get("operation", {})
+                    if operation.get("stream_id") == sid:
+                        if after.get("state") == "cancelled":
+                            continue
+                        proof = None
+                        preimage = before.get("stream_ids") if isinstance(before, dict) else None
+                        if (not isinstance(preimage, list) or any(not valid_id(s) for s in preimage)
+                                or len(set(preimage)) != len(preimage)):
+                            row["reason"] = "ownership_preimage_missing_or_invalid"
+                            continue
+                        if (action == "merge_stream" and after.get("state") == "confirmed"
+                                and after.get("version") == 1 and sid not in preimage
+                                and sid in after.get("stream_ids", [])):
+                            proof = operation
+                if (not proof or any(proof.get(k) != v for k, v in identity.items())
+                        or proof.get("channel_uuid") != uuid
+                        or proof.get("stream_account") != stream.get("m3u_account")):
+                    continue
+                gid = stream.get("channel_group")
+                if not valid_id(gid) or not isinstance(stream.get("name"), str):
+                    row["reason"] = "stream_identity_unknown"
+                    continue
+                secondary = SecondaryStream(
+                    name=stream["name"], group_id=gid, stream_id=sid,
+                    provider_id=stream["m3u_account"],
+                    name_seen_before_today=event_sync_staleness.name_seen_before_today(
+                        stale, stream["m3u_account"], names.get(gid), stream["name"],
+                    ),
+                )
+                resolved = resolve_event_sync(config, sorted(master_names), [secondary],
+                                              decisions=decisions, exclusions=exclusions, team_aliases=aliases)
+                own_names = [name for name, mid in master_names.items() if mid == cid]
+                if (not own_names or any(name in resolved.unparsed_master_names for name in own_names)
+                        or len(resolved.resolved) != 1):
+                    row["reason"] = "master_identity_or_matching_unavailable"
+                    continue
+                result = resolved.resolved[0]
+                if result.disposition in {"ambiguous", "parse_failed"}:
+                    row["reason"] = "matching_" + result.disposition
+                    continue
+                if result.disposition not in {"would_attach", "unmatched", "excluded_by_operator"}:
+                    row["reason"] = "matching_unknown"
+                    continue
+                in_scope = any(gid == s["group_id"] and s.get("m3u_account_id") in
+                               (None, stream["m3u_account"]) for s in scopes)
+                if in_scope and (sid not in streams or any(
+                    streams[sid].get(key) != stream.get(key) for key in ("name", "channel_group", "m3u_account")
+                )):
+                    row["reason"] = "stream_changed_or_missing_from_scope_read"
+                    continue
+                if (in_scope and result.best is not None
+                        and master_names.get(result.best.master_name) == cid):
+                    row["reason"] = "still_matches"
+                    continue
+                row.update(decision="would_detach", reason="no_longer_matches_current_rule")
+                plan["operations"].append({**identity, "channel_id": cid, "channel_uuid": uuid,
+                                           "stream_id": sid, "stream_account": stream["m3u_account"],
+                                           "stream_group": gid,
+                                           "action": "detach", "config": config,
+                                           "channel_name": channel.get("name"), "stream_name": stream["name"],
+                                           "owner_account": channel["auto_created_by"], "master_group": group,
+                                           "master_identity_name": next(name for name, mid in master_names.items() if mid == cid)})
+    except Exception as error:
+        logger.warning("[EVENT-SYNC] Cleanup evaluation incomplete: %s", error)
+        plan["operations"] = []
+        plan["error"] = "incomplete_cleanup_evaluation"
+        for row in plan["decisions"]:
+            row.update(decision="preserve", reason="incomplete_cleanup_evaluation")
+    return plan
+
+
+def write_intent(operation: dict, batch_id: str, channel: dict, before: list, after: list) -> int:
+    with _session() as session:
+        session.execute(text("BEGIN IMMEDIATE"))
+        if not str(batch_id).startswith("undo:"):
+            from channel_pipeline_schema import validate_event_sync_config
+            rule = session.get(ChannelPipelineRule, operation["rule_id"])
+            current = rule.get_event_sync_config() if rule is not None else None
+            expected = json.loads(json.dumps(operation["config"]))
+            if (rule is None or not rule.enabled or current is None
+                    or rule.created_at.isoformat() != operation["rule_created_at"]
+                    or validate_event_sync_config(current) or validate_event_sync_config(expected)
+                    or current != expected):
+                raise ValueError("rule configuration or identity changed before intent")
+        pending = session.query(JournalEntry).filter(
+            JournalEntry.category == "event_sync", JournalEntry.entity_id == channel["id"],
+        ).all()
+        if any(json.loads(row.after_value or "{}").get("state") in {"intent", "uncertain"} for row in pending):
+            raise RuntimeError("uncertain prior Event Sync mutation blocks further writes")
+        entry = JournalEntry(
+            category="event_sync", action_type="merge_stream" if operation["action"] == "attach" else "detach_stream",
+            entity_id=channel["id"], entity_name=channel.get("name") or str(channel["id"]),
+            description=f"Event Sync {operation['action']} stream {operation['stream_id']}: intent",
+            before_value=json.dumps({"stream_ids": before}),
+            after_value=json.dumps({"version": 1, "state": "intent", "operation": operation, "stream_ids": after}),
+            batch_id=str(batch_id), user_initiated=False, mutation_source="auto_creation",
+        )
+        session.add(entry)
+        session.commit()
+        return entry.id
+
+
+def _outcome(entry_id: int, state: str):
+    with _session() as session:
+        entry = session.get(JournalEntry, entry_id)
+        if entry is None:
+            raise RuntimeError("cleanup intent disappeared")
+        data = json.loads(entry.after_value)
+        data["state"] = state
+        entry.after_value = json.dumps(data)
+        entry.description = f"Event Sync {data['operation']['action']} stream {data['operation']['stream_id']}: {state}"
+        session.commit()
+
+
+async def apply_change(client, operation: dict, batch_id: str) -> dict:
+    if not batch_id or any(not valid_id(operation.get(k)) for k in ("rule_id", "channel_id", "stream_id", "stream_account")):
+        raise ValueError("mutation identity unavailable")
+    if any(operation.get(k) != v for k, v in rule_identity(operation["rule_id"]).items()):
+        raise ValueError("rule identity changed")
+    if operation["action"] == "detach":
+        plan = await plan_cleanup(client, operation["rule_id"], operation["config"])
+        if operation not in plan["operations"]:
+            raise ValueError("cleanup decision changed or incomplete")
+    elif operation["action"] != "attach":
+        raise ValueError("unknown Event Sync operation")
+    channel = await client.get_channel(operation["channel_id"])
+    if (not valid_id(channel.get("id")) or channel["id"] != operation["channel_id"]
+            or _uuid(channel.get("uuid")) != operation.get("channel_uuid") or not _uuid(channel.get("uuid"))):
+        raise ValueError("channel identity changed")
+    streams = await client.get_streams_by_ids([operation["stream_id"]])
+    if (not isinstance(streams, list) or len(streams) != 1 or not valid_id(streams[0].get("id"))
+            or not valid_id(streams[0].get("m3u_account")) or streams[0].get("id") != operation["stream_id"]
+            or streams[0].get("m3u_account") != operation["stream_account"]):
+        raise ValueError("stream identity changed")
+    if operation["action"] == "detach" and native_guard(channel, streams[0]):
+        raise ValueError("native attachment protected")
+    if operation["action"] == "detach" and (
+        channel.get("name") != operation["channel_name"]
+        or channel.get("auto_created_by") != operation["owner_account"]
+        or channel.get("channel_group_id") != operation["master_group"]
+        or streams[0].get("name") != operation["stream_name"]
+        or streams[0].get("channel_group") != operation["stream_group"]
+    ):
+        raise ValueError("matching inputs changed immediately before mutation")
+    if operation["action"] == "detach" and operation["config"].get("parse_master_from_stream"):
+        current_identity = await build_master_name_to_id([channel], client, True)
+        if current_identity.get(operation["master_identity_name"]) != channel["id"]:
+            raise ValueError("master matching identity changed")
+    before = _ids(channel)
+    sid = operation["stream_id"]
+    after = ([s for s in before if s != sid] if operation["action"] == "detach"
+             else before if sid in before else [*before, sid])
+    if before == after:
+        return {"skipped": True, "channel": channel}
+    entry_id = write_intent(operation, batch_id, channel, before, after)
+    patch_started = False
+    try:
+        fresh = await client.get_channel(channel["id"])
+        if any(fresh.get(key) != channel.get(key) for key in (
+            "id", "uuid", "name", "channel_group_id", "auto_created", "auto_created_by",
+        )):
+            _outcome(entry_id, "cancelled")
+            raise ValueError("channel identity changed after intent")
+        fresh_streams = await client.get_streams_by_ids([sid])
+        if (not isinstance(fresh_streams, list) or len(fresh_streams) != 1
+                or not valid_id(fresh_streams[0].get("id")) or fresh_streams[0]["id"] != sid
+                or not valid_id(fresh_streams[0].get("m3u_account"))
+                or fresh_streams[0]["m3u_account"] != operation["stream_account"]):
+            raise ValueError("stream identity changed after intent")
+        if operation["action"] == "detach" and (
+            native_guard(fresh, fresh_streams[0]) or fresh_streams[0].get("name") != operation["stream_name"]
+            or fresh_streams[0].get("channel_group") != operation["stream_group"]
+        ):
+            raise ValueError("stream authority or matching identity changed after intent")
+        if operation["action"] == "detach" and operation["config"].get("parse_master_from_stream"):
+            fresh_identity = await build_master_name_to_id([fresh], client, True)
+            if fresh_identity.get(operation["master_identity_name"]) != channel["id"]:
+                raise ValueError("master matching identity changed after intent")
+        before = _ids(fresh)
+        after = ([s for s in before if s != sid] if operation["action"] == "detach"
+                 else before if sid in before else [*before, sid])
+        if before == after:
+            _outcome(entry_id, "cancelled")
+            return {"skipped": True, "channel": fresh, "before": before}
+        with _session() as session:
+            intent = session.get(JournalEntry, entry_id)
+            if intent is None:
+                raise RuntimeError("intent unavailable")
+            data = json.loads(intent.after_value)
+            data["stream_ids"] = after
+            intent.before_value = json.dumps({"stream_ids": before})
+            intent.after_value = json.dumps(data)
+            session.commit()
+        patch_started = True
+        await client.update_channel(channel["id"], {"streams": after})
+        actual = await client.get_channel(channel["id"])
+        if _uuid(actual.get("uuid")) != operation["channel_uuid"] or _ids(actual) != after:
+            raise RuntimeError("upstream outcome not confirmed")
+        _outcome(entry_id, "confirmed")
+    except Exception as error:
+        # The already-committed intent remains blocking even if this update fails.
+        try:
+            _outcome(entry_id, "uncertain" if patch_started else "cancelled")
+        except Exception:
+            logger.exception("[EVENT-SYNC] Could not record uncertain intent outcome")
+        if patch_started:
+            raise UncertainMutationError("Event Sync mutation outcome uncertain; further cleanup blocked") from error
+        raise RuntimeError("Event Sync mutation cancelled before PATCH; reevaluate cleanup") from error
+    return {"skipped": False, "channel": actual, "journal_id": entry_id, "before": before}
+
+
+async def rollback_batch(client, batch_id: str, expected_count: int | None = None) -> dict:
+    try:
+        with _session() as session:
+            rows = session.query(JournalEntry).filter(
+                JournalEntry.category == "event_sync", JournalEntry.batch_id == str(batch_id),
+            ).order_by(JournalEntry.id.desc()).all()
+            entries = [(r.id, json.loads(r.after_value or "{}")) for r in rows]
+        entries = [(rid, data) for rid, data in entries if data.get("version") == 1]
+    except Exception:
+        logger.exception("[EVENT-SYNC] Recovery history unavailable")
+        return {"success": False, "error": "cleanup_history_unavailable"}
+    if expected_count is not None and len(entries) != expected_count:
+        return {"success": False, "error": "cleanup_history_incomplete_or_expired"}
+    if not entries:
+        return {"success": False, "error": "cleanup_history_missing_or_expired"}
+    touched = 0
+    for rid, data in entries:
+        if data.get("state") == "reverted":
+            continue
+        if data.get("state") != "confirmed":
+            return {"success": False, "error": "uncertain_cleanup_outcome", "entities_restored": touched}
+        try:
+            op = data["operation"]
+            if any(not valid_id(op.get(k)) for k in ("channel_id", "stream_id", "stream_account", "rule_id")):
+                raise ValueError("malformed recovery identity")
+            channel = await client.get_channel(op["channel_id"])
+            if (not valid_id(channel.get("id")) or channel["id"] != op["channel_id"]
+                    or not _uuid(channel.get("uuid")) or _uuid(channel.get("uuid")) != op["channel_uuid"]):
+                raise ValueError("channel identity changed")
+            streams = await client.get_streams_by_ids([op["stream_id"]])
+            if (len(streams) != 1 or not valid_id(streams[0].get("id")) or not valid_id(streams[0].get("m3u_account"))
+                    or streams[0].get("id") != op["stream_id"] or streams[0].get("m3u_account") != op["stream_account"]):
+                raise ValueError("stream identity unavailable")
+            before = _ids(channel)
+            sid = op["stream_id"]
+            if op["action"] == "attach":
+                if native_guard(channel, streams[0]):
+                    raise ValueError("native attachment protected")
+                after = [s for s in before if s != sid]
+            elif op["action"] == "detach":
+                after = before if sid in before else [*before, sid]
+            else:
+                raise ValueError("unknown recovery action")
+            # Persist inverse intent in a separate batch so retry never inverts
+            # an inverse. Uncertain inverse blocks retry, rather than guessing.
+            undo = {**op, "action": "detach" if op["action"] == "attach" else "attach"}
+            undo_id = write_intent(undo, f"undo:{batch_id}:{rid}", channel, before, after)
+            _outcome(rid, "uncertain")
+            if after != before:
+                await client.update_channel(channel["id"], {"streams": after})
+                actual = await client.get_channel(channel["id"])
+                if _uuid(actual.get("uuid")) != op["channel_uuid"] or _ids(actual) != after:
+                    raise ValueError("inverse outcome uncertain")
+                touched += 1
+            _outcome(undo_id, "reverted")
+            _outcome(rid, "reverted")
+        except Exception:
+            logger.exception("[EVENT-SYNC] Surgical cleanup rollback failed")
+            return {"success": False, "error": "cleanup_rollback_failed", "entities_restored": touched}
+    return {"success": True, "surgical_unmerge": True, "entities_removed": 0, "entities_restored": touched}

--- a/backend/services/event_sync_resolver.py
+++ b/backend/services/event_sync_resolver.py
@@ -702,6 +702,7 @@ def resolve_event_sync(
     decisions: ReviewDecisions | None = None,
     exclusions: frozenset[tuple[int, str, str]] | None = None,
     attached_stream_ids: set[int] | frozenset[int] | None = None,
+    team_aliases=None,
 ) -> EventSyncResolution:
     """Resolve every secondary stream against the master channel names.
 
@@ -841,6 +842,7 @@ def resolve_event_sync(
             threshold=threshold,
             now=now,
             assume_current_date=assume_current_date,
+            **({"team_aliases": team_aliases} if team_aliases is not None else {}),
         )
         for stream, result in zip(streams, results):
             rs = _resolve_stream(

--- a/backend/services/pipeline_write_plan.py
+++ b/backend/services/pipeline_write_plan.py
@@ -30,6 +30,7 @@ class PlannedWrite:
     method: str
     args: list[Any]
     kwargs: dict[str, Any]
+    event_sync: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -109,6 +110,27 @@ class PlanningDispatcharrClient:
         if channel_id in self._shadow_channels:
             return copy.deepcopy(self._shadow_channels[channel_id])
         return await self._client.get_channel(channel_id)
+
+    async def event_sync_change(self, operation: dict) -> dict:
+        """Record the semantic operation; only real replay writes its intent."""
+        channel_id = operation["channel_id"]
+        current = await self.get_channel(channel_id)
+        from services.event_sync_cleanup import _ids
+        before = _ids(current)
+        sid = operation["stream_id"]
+        after = ([s for s in before if s != sid] if operation["action"] == "detach"
+                 else before if sid in before else [*before, sid])
+        if after == before:
+            return {"skipped": True, "channel": current, "before": before}
+        self.plan.channel_preconditions.setdefault(str(channel_id), {
+            key: copy.deepcopy(current.get(key)) for key in
+            ("id", "uuid", "name", "streams", "channel_group_id", "auto_created", "auto_created_by")
+        })
+        current["streams"] = after
+        self._shadow_channels[channel_id] = copy.deepcopy(current)
+        self.plan.writes.append(PlannedWrite("update_channel", [channel_id, {"streams": after}], {},
+                                            event_sync=copy.deepcopy(operation)))
+        return {"skipped": False, "channel": current, "before": before}
 
     async def _channel_before(self, channel_id: int) -> dict[str, Any]:
         if channel_id in self._shadow_channels:
@@ -223,7 +245,7 @@ async def validate_read_set(client, plan: PipelineWritePlan) -> None:
 
 
 async def replay_write_plan(
-    client, plan: PipelineWritePlan, *, read_set_validated: bool = False
+    client, plan: PipelineWritePlan, *, read_set_validated: bool = False, execution_id: int | None = None
 ) -> tuple[list[Any], dict[int, int]]:
     """Validate first, then replay only recorded writes with temp-ID remapping."""
     if not read_set_validated:
@@ -248,7 +270,11 @@ async def replay_write_plan(
         for write in plan.writes:
             args = mapped(write.args)
             kwargs = mapped(write.kwargs)
-            result = await getattr(client, write.method)(*args, **kwargs)
+            if write.event_sync:
+                from services.event_sync_cleanup import apply_change
+                result = await apply_change(client, write.event_sync, execution_id)
+            else:
+                result = await getattr(client, write.method)(*args, **kwargs)
             if write.method.startswith("create_"):
                 real_id = result.get("id") if isinstance(result, dict) else None
                 if real_id is None:
@@ -259,9 +285,16 @@ async def replay_write_plan(
             completed.append((write, args, result))
     except Exception as exc:
         compensation_errors: list[str] = []
+        if any(write.event_sync for write in plan.writes):
+            from services.event_sync_cleanup import rollback_batch
+            recovery = await rollback_batch(client, str(execution_id))
+            if not recovery["success"]:
+                compensation_errors.append(recovery["error"])
         # Best effort for reversible writes. Deletes and profile membership are
         # explicitly not recreated because upstream cannot preserve their IDs.
         for done, args, result in reversed(completed):
+            if done.event_sync:
+                continue
             try:
                 if done.method == "create_channel":
                     await client.delete_channel(result["id"])
@@ -270,6 +303,11 @@ async def replay_write_plan(
                 elif done.method == "update_channel" and args[0] > 0:
                     before = plan.channel_preconditions.get(str(args[0]))
                     if before:
+                        if any(write.event_sync and write.event_sync["channel_id"] == args[0] for write in plan.writes):
+                            compensation_errors.append(
+                                f"update_channel:{args[0]} overlaps Event Sync recovery; full preimage refused"
+                            )
+                            continue
                         await client.update_channel(args[0], {
                             key: value for key, value in before.items() if key != "id"
                         })
@@ -308,6 +346,9 @@ def journal_entries_for_plan(
         for channel_id, value in plan.channel_preconditions.items()
     }
     for write in plan.writes:
+        if write.event_sync:
+            # Already durably journaled at real replay, not reconstructed.
+            continue
         method = write.method
         if method.startswith("create_"):
             entity_id = remap.get(next_temp, next_temp)

--- a/backend/tests/fixtures/event_sync_cleanup_server.py
+++ b/backend/tests/fixtures/event_sync_cleanup_server.py
@@ -1,0 +1,77 @@
+"""60r8c isolated browser fixture: real router/SQLite, stateful fake upstream.
+
+No application lifespan, scheduler, provider refresh or live Dispatcharr client.
+The fixture run endpoint deliberately invokes the executor synchronously.
+"""
+import asyncio
+import copy
+from datetime import datetime
+import socket
+
+from tests._config_harness import initialize_test_config, cleanup_test_config
+
+
+def main():
+    config_dir = initialize_test_config()
+    try:
+        import database
+        from fastapi import FastAPI
+        import uvicorn
+        from channel_pipeline_executor import ActionExecutor, ExecutionContext
+        from models import ChannelPipelineRule, ChannelPipelineExecution
+        from routers import channel_pipeline
+        from services.event_sync_resolver import SecondaryStream
+        from tests.services.test_event_sync_cleanup import Upstream, CONFIG, NEW, attach
+
+        database.init_db()
+        upstream = Upstream()
+        channel_pipeline.get_client = lambda: upstream
+        with database.get_session() as session:
+            rule = ChannelPipelineRule(id=7, name="Cleanup fixture", conditions='[{"type":"always"}]',
+                                       actions='[{"type":"skip"}]', created_at=datetime(2026, 9, 5))
+            rule.set_event_sync_config(CONFIG)
+            session.add(rule)
+            session.commit()
+        asyncio.run(attach(upstream))
+        upstream.channel["name"] = NEW
+        with database.get_session() as session:
+            session.get(ChannelPipelineRule, 7).set_event_sync_config({**CONFIG, "detach_stale_streams": False})
+            session.commit()
+        app = FastAPI()
+
+        @app.post("/fixture/run")
+        async def run():
+            with database.get_session() as session:
+                config = session.get(ChannelPipelineRule, 7).get_event_sync_config()
+            executor = ActionExecutor(upstream, existing_channels=[copy.deepcopy(upstream.channel)],
+                                      existing_groups=[], execution_id=2)
+            context = ExecutionContext(dry_run=False)
+            summary = await executor.execute_event_sync_rule(
+                7, "Cleanup fixture", config,
+                [SecondaryStream(name=NEW, group_id=20, stream_id=3, provider_id=18)], context,
+            )
+            with database.get_session() as session:
+                execution = ChannelPipelineExecution(id=2, rule_id=7, rule_name="Cleanup fixture",
+                    mode="execute", status="completed", started_at=datetime.utcnow(), completed_at=datetime.utcnow(),
+                    is_event_sync=True)
+                execution.set_event_sync_summary([summary])
+                execution.set_modified_entities(context.modified_entities)
+                session.add(execution)
+                session.commit()
+            return {"streams": upstream.channel["streams"], "summary": summary}
+
+        @app.get("/fixture/state")
+        async def state():
+            return {"streams": upstream.channel["streams"], "writes": len(upstream.writes)}
+
+        app.include_router(channel_pipeline.router, prefix="/api/channel-pipeline")
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            print(f"CLEANUP_API_PORT={sock.getsockname()[1]}", flush=True)
+            uvicorn.Server(uvicorn.Config(app, log_level="warning")).run(sockets=[sock])
+    finally:
+        cleanup_test_config(config_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/services/test_event_sync_cleanup.py
+++ b/backend/tests/services/test_event_sync_cleanup.py
@@ -1,0 +1,630 @@
+"""60r8c: file-backed SQLite and stateful upstream, never a live server."""
+import copy
+import json
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from models import ChannelPipelineRule, JournalEntry
+from services import event_sync_cleanup as cleanup
+
+
+OLD = "Peacock 14: Mercury vs. Aces @ 11 Jul 06:00 PM ET"
+NEW = "Peacock 11: IMSA CTMP Qualifying @ 12 Jul 03:55 PM ET"
+CONFIG = {"master_group_id": 10, "secondary_group_ids": [20],
+          "detach_stale_streams": True}
+
+
+class Upstream:
+    def __init__(self):
+        self.channel = {"id": 100, "uuid": str(uuid4()), "name": OLD,
+                        "channel_group_id": 10, "auto_created": True,
+                        "auto_created_by": 17, "streams": [1]}
+        self.streams = {
+            1: {"id": 1, "name": OLD, "m3u_account": 17, "channel_group": 10},
+            2: {"id": 2, "name": OLD, "m3u_account": 18, "channel_group": 20},
+            3: {"id": 3, "name": NEW, "m3u_account": 18, "channel_group": 20},
+        }
+        self.writes = []
+        self.fail = False
+        self.malformed = False
+
+    async def get_channel(self, cid):
+        assert cid == 100
+        return copy.deepcopy(self.channel)
+
+    async def get_channels(self, **kwargs):
+        return {"results": [copy.deepcopy(self.channel)], "next": None, "count": 1}
+
+    async def get_streams(self, **kwargs):
+        if self.malformed:
+            return {"next": None}
+        rows = [s for s in self.streams.values() if s["channel_group"] == 20]
+        return {"results": copy.deepcopy(rows), "next": None, "count": len(rows)}
+
+    async def get_streams_by_ids(self, ids):
+        return [copy.deepcopy(self.streams[i]) for i in ids if i in self.streams]
+
+    async def _channel_group_name_for_id(self, gid):
+        return str(gid)
+
+    async def get_all_m3u_group_settings(self):
+        return {10: {"auto_channel_sync": True}, 20: {"auto_channel_sync": False}}
+
+    async def get_m3u_accounts(self):
+        return [{"id": 17}, {"id": 18}]
+
+    async def update_channel(self, cid, payload):
+        assert set(payload) == {"streams"}
+        self.writes.append(copy.deepcopy(payload))
+        self.channel.update(copy.deepcopy(payload))
+        if self.fail:
+            raise TimeoutError("response lost after upstream applied write")
+        return copy.deepcopy(self.channel)
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    url = f"sqlite:///{tmp_path / 'cleanup.db'}"
+    engine = create_engine(url)
+    ChannelPipelineRule.__table__.create(engine)
+    JournalEntry.__table__.create(engine)
+    monkeypatch.setattr(cleanup, "get_database_url", lambda: url)
+    with Session(engine) as session:
+        rule = ChannelPipelineRule(id=7, name="Events", conditions="[]", actions="[]",
+                                   event_sync_config=json.dumps(CONFIG), created_at=datetime(2026, 9, 5))
+        session.add(rule)
+        session.commit()
+    monkeypatch.setattr(cleanup, "load_review_decisions", lambda *args: None)
+    monkeypatch.setattr(cleanup, "load_exclusion_keys", lambda *args: frozenset())
+    monkeypatch.setattr(cleanup.event_sync_staleness, "previous_day_names", lambda *args: {})
+    yield engine
+    engine.dispose()
+
+
+async def attach(upstream, batch="1", sid=2):
+    proof = cleanup.rule_identity(7)
+    operation = {**proof, "channel_id": 100, "channel_uuid": upstream.channel["uuid"],
+                 "stream_id": sid, "stream_account": upstream.streams[sid]["m3u_account"],
+                 "action": "attach", "config": CONFIG}
+    await cleanup.apply_change(upstream, operation, batch)
+
+
+@pytest.mark.asyncio
+async def test_rename_zero_replacement_and_surgical_rollback(db):
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.channel["name"] = NEW
+    plan = await cleanup.plan_cleanup(upstream, 7, CONFIG)
+    assert [(r["stream_id"], r["decision"]) for r in plan["decisions"]] == [(1, "preserve"), (2, "would_detach")]
+    assert len(upstream.writes) == 1  # preview did not mutate
+    await cleanup.apply_change(upstream, plan["operations"][0], "2")
+    assert upstream.channel["streams"] == [1]
+    assert not (await cleanup.plan_cleanup(upstream, 7, CONFIG))["operations"]
+    await attach(upstream, "2", 3)
+    upstream.channel["streams"].append(99)  # unrelated current membership
+    result = await cleanup.rollback_batch(upstream, "2")
+    assert result["success"] is True
+    assert upstream.channel["streams"] == [1, 99, 2]
+    with Session(db) as session:
+        states = [json.loads(r.after_value)["state"] for r in session.query(JournalEntry)]
+        assert "reverted" in states
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field,value,reason", [
+    ("auto_created", False, "native"), ("auto_created", 1, "native"),
+    ("auto_created_by", None, "owner"), ("auto_created_by", True, "owner"),
+    ("auto_created_by", 18, "same_account"), ("uuid", "bad", "identity"),
+])
+async def test_native_authority_preserves_unknown_and_same_account(db, field, value, reason):
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.channel.update({"name": NEW, field: value})
+    plan = await cleanup.plan_cleanup(upstream, 7, CONFIG)
+    assert not plan["operations"]
+    assert any(reason in r["reason"] for r in plan["decisions"])
+
+
+@pytest.mark.asyncio
+async def test_noop_manual_and_expired_proof_are_not_adopted(db):
+    upstream = Upstream()
+    upstream.channel["streams"].append(2)
+    await attach(upstream)
+    assert not upstream.writes
+    upstream.channel["name"] = NEW
+    plan = await cleanup.plan_cleanup(upstream, 7, CONFIG)
+    assert not plan["operations"]
+    assert any("ownership" in r["reason"] for r in plan["decisions"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["malformed", "parse", "rule_reused", "expired", "other_rule", "account", "missing"])
+async def test_uncertainty_preserves_and_explains(db, failure):
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.channel["name"] = NEW
+    if failure == "malformed":
+        upstream.malformed = True
+    elif failure == "parse":
+        upstream.channel["name"] = "NO EVENT"
+    elif failure == "account":
+        upstream.streams[2]["m3u_account"] = None
+    elif failure == "missing":
+        del upstream.streams[2]
+    else:
+        with Session(db) as session:
+            if failure == "rule_reused":
+                session.get(ChannelPipelineRule, 7).created_at = datetime(2026, 9, 6)
+            elif failure == "expired":
+                session.query(JournalEntry).delete()
+            else:
+                row = session.query(JournalEntry).one()
+                data = json.loads(row.after_value)
+                data["operation"]["rule_id"] = 8
+                row.after_value = json.dumps(data)
+            session.commit()
+    plan = await cleanup.plan_cleanup(upstream, 7, CONFIG)
+    assert not plan["operations"]
+    assert plan["decisions"] or plan["error"]
+
+
+@pytest.mark.asyncio
+async def test_intent_failure_and_uncertain_http_never_false_success(db, monkeypatch):
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.channel["name"] = NEW
+    operation = (await cleanup.plan_cleanup(upstream, 7, CONFIG))["operations"][0]
+    original = cleanup.write_intent
+    monkeypatch.setattr(cleanup, "write_intent", lambda *args: (_ for _ in ()).throw(RuntimeError("disk full")))
+    with pytest.raises(RuntimeError, match="disk full"):
+        await cleanup.apply_change(upstream, operation, "2")
+    assert upstream.channel["streams"] == [1, 2]
+    monkeypatch.setattr(cleanup, "write_intent", original)
+    upstream.fail = True
+    with pytest.raises(RuntimeError, match="uncertain"):
+        await cleanup.apply_change(upstream, operation, "2")
+    assert (await cleanup.rollback_batch(upstream, "2"))["success"] is False
+    assert not (await cleanup.plan_cleanup(upstream, 7, CONFIG))["operations"]
+
+
+@pytest.mark.asyncio
+async def test_off_does_not_read_or_mutate(db):
+    assert await cleanup.plan_cleanup(None, 7, {}) == {"decisions": [], "operations": [], "error": None}
+
+
+def test_recorded_channel_shape_is_not_a_singular_parent():
+    # Captured 0.28.2 shape: test_channels_importer.py:361-396; representative IDs.
+    recorded = json.loads('''{"id":12411,"channel_number":50.0,
+      "name":"FloRacing 24/7 (FloRacing 247)","channel_group_id":3195,
+      "streams":[],"uuid":"08f14609-a078-4af9-9af1-81b1c7d3fff3",
+      "auto_created":true,"auto_created_by":17,"auto_created_by_name":"Infinity",
+      "source_stream":{"id":39491,"name":"FloRacing 24/7 (FloRacing 247)",
+      "account_id":17,"account_name":"Infinity"}}''')
+    assert cleanup.native_guard(recorded, {"m3u_account": 17}) == "same_account_protected"
+    assert cleanup.native_guard(recorded, {"m3u_account": 18}) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prepared", [False, True])
+async def test_executor_lifecycle_normal_and_prepared(db, prepared):
+    from channel_pipeline_executor import ActionExecutor, ExecutionContext
+    from services.event_sync_resolver import SecondaryStream
+    from services.pipeline_write_plan import PlanningDispatcharrClient, replay_write_plan
+
+    upstream = Upstream()
+
+    async def run(batch, sid):
+        client = PlanningDispatcharrClient(upstream) if prepared else upstream
+        executor = ActionExecutor(client, existing_channels=[copy.deepcopy(upstream.channel)],
+                                  existing_groups=[], execution_id=int(batch), plan_only=prepared)
+        stream = upstream.streams[sid]
+        context = ExecutionContext(dry_run=False)
+        summary = await executor.execute_event_sync_rule(
+            7, "Events", CONFIG, [SecondaryStream(name=stream["name"], group_id=20,
+                                                 stream_id=sid, provider_id=18)], context,
+        )
+        if prepared:
+            before = len(upstream.writes)
+            assert upstream.channel["streams"] == ([1] if batch == "1" else [1, 2])
+            with Session(db) as session:
+                assert session.query(JournalEntry).count() == (0 if batch == "1" else 1)
+            await replay_write_plan(upstream, client.plan, execution_id=int(batch))
+            assert len(upstream.writes) > before
+        return summary
+
+    await run("1", 2)
+    assert upstream.channel["streams"] == [1, 2]
+    upstream.channel["name"] = NEW
+    summary = await run("2", 3)
+    assert upstream.channel["streams"] == [1, 3]
+    assert summary["cleanup"]["decisions"][1]["decision"] == ("would_detach" if prepared else "detached")
+    upstream.channel["streams"].append(99)
+    assert (await cleanup.rollback_batch(upstream, "2"))["success"]
+    assert upstream.channel["streams"] == [1, 99, 2]
+
+
+def test_option_validation_is_strict_and_default_absent():
+    from channel_pipeline_schema import validate_event_sync_config
+    config = {"master_group_id": 10, "secondary_group_ids": [20]}
+    assert not validate_event_sync_config(config)
+    assert not config.get("detach_stale_streams", False)
+    assert not validate_event_sync_config(dict(CONFIG))
+    assert validate_event_sync_config({**CONFIG, "detach_stale_streams": "true"})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("snapshot", [False, True])
+@pytest.mark.parametrize("expired", [False, True])
+async def test_engine_rollback_uses_surgical_journal_even_with_snapshot(db, monkeypatch, snapshot, expired):
+    import channel_pipeline_engine as module
+    from models import ChannelPipelineExecution, ChannelPipelineSnapshot
+    ChannelPipelineExecution.__table__.create(db)
+    ChannelPipelineSnapshot.__table__.create(db)
+    monkeypatch.setattr(module, "get_session", lambda: Session(db))
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.channel["name"] = NEW
+    plan = await cleanup.plan_cleanup(upstream, 7, CONFIG)
+    await cleanup.apply_change(upstream, plan["operations"][0], "2")
+    await attach(upstream, "2", 3)
+    with Session(db) as session:
+        execution = ChannelPipelineExecution(id=2, started_at=datetime.utcnow(), status="completed")
+        execution.set_modified_entities([
+            {"type": "channel", "id": 100, "previous": {"streams": [1, 2]}},
+            {"type": "channel", "id": 100, "previous": {"streams": [1]}},
+        ])
+        execution.set_event_sync_summary([{"cleanup": {"decisions": []}}])
+        session.add(execution)
+        if snapshot:
+            snap = ChannelPipelineSnapshot(execution_id=2, channel_count=1)
+            snap.set_channels_data({"channels": [{**upstream.channel, "stream_ids": [1, 2]}]})
+            session.add(snap)
+        if expired:
+            session.query(JournalEntry).filter(JournalEntry.batch_id == "2").delete()
+        session.commit()
+    upstream.channel["streams"].append(99)
+    result = await module.ChannelPipelineEngine(upstream).rollback_execution(2, confirm=True)
+    assert result["success"] is not expired
+    assert upstream.channel["streams"] == ([1, 3, 99] if expired else [1, 99, 2])
+    with Session(db) as session:
+        assert session.get(ChannelPipelineExecution, 2).status == ("completed" if expired else "rolled_back")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["group", "settings", "missing_group_settings", "aliases", "reviews", "staleness", "truncated", "duplicate", "count_bool"])
+async def test_failed_dependencies_and_incomplete_pages_cannot_authorize_detach(db, monkeypatch, failure):
+    from unittest.mock import AsyncMock
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.channel["name"] = NEW
+    if failure == "group":
+        upstream._channel_group_name_for_id = AsyncMock(return_value=None)
+    elif failure == "settings":
+        upstream.get_all_m3u_group_settings = AsyncMock(side_effect=RuntimeError("unavailable"))
+    elif failure == "missing_group_settings":
+        upstream.get_all_m3u_group_settings = AsyncMock(return_value={})
+    elif failure in {"aliases", "reviews", "staleness"}:
+        def fail(*args):
+            raise RuntimeError("unavailable")
+        if failure == "aliases":
+            monkeypatch.setattr(cleanup, "get_settings", fail)
+        elif failure == "reviews":
+            monkeypatch.setattr(cleanup, "load_review_decisions", fail)
+        else:
+            monkeypatch.setattr(cleanup.event_sync_staleness, "previous_day_names", fail)
+    else:
+        rows = [upstream.streams[2]]
+        response = {"count": 2, "results": rows, "next": None}
+        if failure == "duplicate":
+            response["results"] = rows * 2
+        elif failure == "count_bool":
+            response["count"] = True
+        upstream.get_streams = AsyncMock(return_value=response)
+    plan = await cleanup.plan_cleanup(upstream, 7, CONFIG)
+    assert not plan["operations"]
+    assert plan["error"]
+    assert len(upstream.writes) == 1
+
+
+@pytest.mark.asyncio
+async def test_fresh_read_after_intent_preserves_new_unrelated_membership(db, monkeypatch):
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.channel["name"] = NEW
+    op = (await cleanup.plan_cleanup(upstream, 7, CONFIG))["operations"][0]
+    original = cleanup.write_intent
+    def interleave(*args):
+        rid = original(*args)
+        upstream.channel["streams"].insert(1, 99)
+        return rid
+    monkeypatch.setattr(cleanup, "write_intent", interleave)
+    await cleanup.apply_change(upstream, op, "2")
+    assert upstream.channel["streams"] == [1, 99]
+
+
+@pytest.mark.asyncio
+async def test_prepared_partial_failure_surgically_compensates_confirmed_detach(db):
+    from services.pipeline_write_plan import PlanningDispatcharrClient, PlannedWrite, replay_write_plan, PartialReplayError
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.channel["name"] = NEW
+    operation = (await cleanup.plan_cleanup(upstream, 7, CONFIG))["operations"][0]
+    planned = PlanningDispatcharrClient(upstream)
+    await planned.event_sync_change(operation)
+    planned.plan.writes.append(PlannedWrite("missing_method", [], {}))
+    with pytest.raises(PartialReplayError) as error:
+        await replay_write_plan(upstream, planned.plan, execution_id=2)
+    assert not error.value.compensation_errors
+    assert upstream.channel["streams"] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_attached_master_group_stream_is_explicitly_scored_not_dropped(db):
+    upstream = Upstream()
+    upstream.streams[2]["channel_group"] = 10
+    await attach(upstream)
+    upstream.channel["name"] = NEW
+    from unittest.mock import AsyncMock
+    upstream.get_streams = AsyncMock(return_value={"results": [upstream.streams[2]], "next": None, "count": 1})
+    config = {**CONFIG, "secondary_group_ids": [], "include_master_group_streams": True}
+    plan = await cleanup.plan_cleanup(upstream, 7, config)
+    assert len(plan["operations"]) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("inline", [False, True])
+async def test_real_preview_router_returns_cleanup_without_mutation(db, monkeypatch, inline):
+    from routers import channel_pipeline as router
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.channel["name"] = NEW
+    monkeypatch.setattr(router, "get_client", lambda: upstream)
+    monkeypatch.setattr(router, "get_session", lambda: Session(db))
+    before = len(upstream.writes)
+    request = (router.EventSyncPreviewRequest(event_sync_config=CONFIG, cleanup_rule_id=7)
+               if inline else router.EventSyncPreviewRequest(rule_id=7))
+    result = await router.preview_event_sync(request)
+    assert result["cleanup"]["decisions"][1]["decision"] == "would_detach"
+    assert len(upstream.writes) == before
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response_lost", [False, True])
+async def test_prepared_commit_persists_confirmed_cleanup_and_rollback(db, monkeypatch, response_lost):
+    from unittest.mock import AsyncMock
+    from types import SimpleNamespace
+    from channel_pipeline_executor import ActionExecutor, ExecutionContext
+    from models import ChannelPipelineExecution, ChannelPipelineSnapshot
+    from routers import channel_pipeline as router
+    from services.event_sync_resolver import SecondaryStream
+    from services.pipeline_write_plan import PlanningDispatcharrClient
+    from services import mutation_plan_store as store
+    import channel_pipeline_engine as engine_module
+
+    ChannelPipelineExecution.__table__.create(db)
+    ChannelPipelineSnapshot.__table__.create(db)
+    monkeypatch.setattr(router, "get_session", lambda: Session(db))
+    monkeypatch.setattr(engine_module, "get_session", lambda: Session(db))
+    monkeypatch.setattr(store, "mutation_plan_store", store.MutationPlanStore())
+    upstream = Upstream()
+    await attach(upstream, "prior")
+    upstream.channel["name"] = NEW
+    with Session(db) as session:
+        rule = session.get(ChannelPipelineRule, 7)
+        session.expunge(rule)
+    engine = SimpleNamespace(client=upstream, _load_rules=AsyncMock(return_value=[rule]),
+                             _update_rule_stats=AsyncMock())
+    monkeypatch.setattr(router, "_ensure_engine", AsyncMock(return_value=engine))
+
+    async def compute(request):
+        client = PlanningDispatcharrClient(upstream)
+        executor = ActionExecutor(client, existing_channels=[copy.deepcopy(upstream.channel)],
+                                  existing_groups=[], plan_only=True)
+        context = ExecutionContext(dry_run=False)
+        summary = await executor.execute_event_sync_rule(7, "Events", CONFIG,
+            [SecondaryStream(name=NEW, group_id=20, stream_id=3, provider_id=18)], context)
+        return {"request": request.model_dump(exclude={"dry_run"}), "snapshot": [],
+                "write_plan": client.plan.as_dict(), "result": {
+                    "event_sync": [summary], "modified_entities": context.modified_entities,
+                    "created_entities": [], "execution_log": [],
+                }}
+    monkeypatch.setattr(router, "_compute_pipeline_plan_payload", compute)
+    prepared = await router._materialize_pipeline_plan(router.RunPipelineRequest(rule_ids=[7]))
+    assert upstream.channel["streams"] == [1, 2]
+    if response_lost:
+        from fastapi import HTTPException
+        upstream.fail = True
+        with pytest.raises(HTTPException) as error:
+            await router.commit_auto_creation_pipeline(router.CommitPipelinePlanRequest(
+                plan_id=prepared["plan_id"], plan_hash=prepared["plan_hash"], phase="execute"), _admin=None)
+        assert error.value.status_code == 502
+        assert "uncertain_cleanup_outcome" in error.value.detail["compensation_errors"]
+        assert upstream.channel["streams"] == [1]
+        with Session(db) as session:
+            execution = session.query(ChannelPipelineExecution).one()
+            assert execution.status == "failed"
+            assert "PartialReplayError" in execution.error_message
+            assert not execution.get_event_sync_summary()
+            entry = session.query(JournalEntry).filter_by(batch_id=str(execution.id)).one()
+            assert json.loads(entry.after_value)["state"] == "uncertain"
+        return
+    response = await router.commit_auto_creation_pipeline(router.CommitPipelinePlanRequest(
+        plan_id=prepared["plan_id"], plan_hash=prepared["plan_hash"], phase="execute"), _admin=None)
+    execution_id = json.loads(response.body)["execution_id"]
+    assert upstream.channel["streams"] == [1, 3]
+    with Session(db) as session:
+        summary = session.get(ChannelPipelineExecution, execution_id).get_event_sync_summary()[0]
+        assert summary["cleanup"]["decisions"][1]["decision"] == "detached"
+        entries = session.query(JournalEntry).filter(JournalEntry.batch_id == str(execution_id)).all()
+        assert {r.action_type for r in entries} == {"merge_stream", "detach_stream"}
+        assert all(json.loads(r.after_value)["state"] == "confirmed" for r in entries)
+    upstream.channel["streams"].append(99)
+    result = await engine_module.ChannelPipelineEngine(upstream).rollback_execution(execution_id, confirm=True)
+    assert result["success"]
+    assert upstream.channel["streams"] == [1, 99, 2]
+
+
+@pytest.mark.asyncio
+async def test_partial_rollback_does_not_claim_success_when_detached_entity_disappears(db):
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.channel["name"] = NEW
+    await cleanup.apply_change(upstream, (await cleanup.plan_cleanup(upstream, 7, CONFIG))["operations"][0], "2")
+    await attach(upstream, "2", 3)
+    del upstream.streams[2]
+    upstream.channel["streams"].append(99)
+    result = await cleanup.rollback_batch(upstream, "2", expected_count=2)
+    assert result["success"] is False
+    assert result["entities_restored"] == 1
+    assert upstream.channel["streams"] == [1, 99]
+
+
+@pytest.mark.asyncio
+async def test_corrupt_history_is_preserved_not_adopted(db):
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.channel["name"] = NEW
+    with Session(db) as session:
+        session.query(JournalEntry).one().after_value = "{broken"
+        session.commit()
+    assert not (await cleanup.plan_cleanup(upstream, 7, CONFIG))["operations"]
+    assert (await cleanup.rollback_batch(upstream, "1"))["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_matching_and_attach_cap_do_not_prove_staleness(db):
+    upstream = Upstream()
+    await attach(upstream)
+    plan = await cleanup.plan_cleanup(upstream, 7, {**CONFIG, "max_attach_per_run": 1})
+    assert not plan["operations"]
+    assert plan["decisions"][1]["reason"] == "still_matches"
+    upstream.channel["name"] = "Peacock 11: IMSA CTMP Qualifying @ 11 Jul 03:55 PM ET"
+    upstream.streams[2]["name"] = "IMSA TV 03 : IMSA VPRC at CTMP R2 @ 11 Jul 03:55 PM ET"
+    plan = await cleanup.plan_cleanup(upstream, 7, CONFIG)
+    assert not plan["operations"]
+    assert plan["decisions"][1]["reason"] == "matching_ambiguous"
+
+
+def test_cleanup_preview_identity_rejects_malformed_ids():
+    from pydantic import ValidationError
+    from routers.channel_pipeline import EventSyncPreviewRequest
+    for bad in [True, 0, -1, "7", 7.0]:
+        with pytest.raises(ValidationError):
+            EventSyncPreviewRequest(event_sync_config=CONFIG, cleanup_rule_id=bad)
+
+
+@pytest.mark.asyncio
+async def test_last_read_rechecks_order_derived_matching_identity_without_using_it_as_parent(db, monkeypatch):
+    upstream = Upstream()
+    await attach(upstream)
+    config = {**CONFIG, "parse_master_from_stream": True}
+    with Session(db) as session:
+        session.get(ChannelPipelineRule, 7).set_event_sync_config(config)
+        session.commit()
+    upstream.streams[1]["name"] = NEW
+    operation = (await cleanup.plan_cleanup(upstream, 7, config))["operations"][0]
+    original = cleanup.write_intent
+    def reorder_after_intent(*args):
+        entry_id = original(*args)
+        upstream.channel["streams"] = [2, 1]
+        return entry_id
+    monkeypatch.setattr(cleanup, "write_intent", reorder_after_intent)
+    with pytest.raises(RuntimeError, match="cancelled"):
+        await cleanup.apply_change(upstream, operation, "2")
+    assert upstream.channel["streams"] == [2, 1]
+    assert len(upstream.writes) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prepared", [False, True])
+async def test_group_drift_after_durable_intent_cancels_detach(db, monkeypatch, prepared):
+    from services.pipeline_write_plan import PlanningDispatcharrClient, replay_write_plan, PartialReplayError
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.streams[2]["channel_group"] = 30
+    operation = (await cleanup.plan_cleanup(upstream, 7, CONFIG))["operations"][0]
+    planned = PlanningDispatcharrClient(upstream)
+    if prepared:
+        await planned.event_sync_change(operation)
+    original = cleanup.write_intent
+
+    def drift(*args):
+        entry_id = original(*args)
+        upstream.streams[2]["channel_group"] = 20
+        return entry_id
+
+    monkeypatch.setattr(cleanup, "write_intent", drift)
+    with pytest.raises((RuntimeError, PartialReplayError), match="replay failed" if prepared else "cancelled"):
+        if prepared:
+            await replay_write_plan(upstream, planned.plan, execution_id=2)
+        else:
+            await cleanup.apply_change(upstream, operation, "2")
+    assert upstream.channel["streams"] == [1, 2]
+    assert len(upstream.writes) == 1
+    with Session(db) as session:
+        row = session.query(JournalEntry).filter_by(batch_id="2").one()
+        assert json.loads(row.after_value)["state"] == "cancelled"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prepared", [False, True])
+@pytest.mark.parametrize("preimage", [None, "{}", '{"stream_ids":null}',
+    '{"stream_ids":[true]}', '{"stream_ids":[1,1]}', '{"stream_ids":[0]}',
+    '{"stream_ids":["1"]}', '{broken', '{"stream_ids":[1]}'])
+async def test_ownership_requires_valid_explicit_preimage(db, prepared, preimage):
+    from services.pipeline_write_plan import PlanningDispatcharrClient, replay_write_plan, PartialReplayError
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.channel["name"] = NEW
+    operation = (await cleanup.plan_cleanup(upstream, 7, CONFIG))["operations"][0]
+    planned = PlanningDispatcharrClient(upstream)
+    if prepared:
+        await planned.event_sync_change(operation)
+    with Session(db) as session:
+        session.query(JournalEntry).one().before_value = preimage
+        session.commit()
+    plan = await cleanup.plan_cleanup(upstream, 7, CONFIG)
+    valid = preimage == '{"stream_ids":[1]}'
+    assert bool(plan["operations"]) is valid
+    if not valid:
+        assert plan["error"] or all(r["reason"] for r in plan["decisions"])
+        with pytest.raises((ValueError, PartialReplayError), match="replay failed" if prepared else "decision changed"):
+            if prepared:
+                await replay_write_plan(upstream, planned.plan, execution_id=2)
+            else:
+                await cleanup.apply_change(upstream, operation, "2")
+        assert upstream.channel["streams"] == [1, 2]
+        assert len(upstream.writes) == 1
+    else:
+        if prepared:
+            await replay_write_plan(upstream, planned.plan, execution_id=2)
+        else:
+            await cleanup.apply_change(upstream, operation, "2")
+        assert upstream.channel["streams"] == [1]
+
+
+@pytest.mark.asyncio
+async def test_executor_response_lost_history_does_not_claim_preserved(db):
+    from channel_pipeline_executor import ActionExecutor, ExecutionContext
+    from models import ChannelPipelineExecution
+    ChannelPipelineExecution.__table__.create(db)
+    upstream = Upstream()
+    await attach(upstream)
+    upstream.channel["name"] = NEW
+    upstream.fail = True
+    executor = ActionExecutor(upstream, existing_channels=[copy.deepcopy(upstream.channel)],
+                              existing_groups=[], execution_id=2)
+    summary = await executor.execute_event_sync_rule(7, "Events", CONFIG, [], ExecutionContext(dry_run=False))
+    assert upstream.channel["streams"] == [1]
+    with Session(db) as session:
+        execution = ChannelPipelineExecution(id=2, started_at=datetime.utcnow(), status="completed_with_errors")
+        execution.set_event_sync_summary([summary])
+        session.add(execution)
+        session.commit()
+        persisted = session.get(ChannelPipelineExecution, 2).get_event_sync_summary()[0]
+        assert persisted["cleanup"]["decisions"][1]["decision"] == "uncertain"
+        assert persisted["cleanup"]["error"]

--- a/backend/tests/unit/test_channel_pipeline_engine.py
+++ b/backend/tests/unit/test_channel_pipeline_engine.py
@@ -1543,8 +1543,8 @@ class TestEventSyncStreamReorderWiring:
         async def _fake_event_sync(rule_id, rule_name, config,
                                    secondary_streams, exec_ctx,
                                    decisions=None,
-                                   effective_master_group_id=None,
-                                   exclusions=None):
+                                    effective_master_group_id=None,
+                                    exclusions=None, rule_created_at=None):
             for cid in merged_ids:
                 exec_ctx.merged_channel_ids.add(cid)
             return dict(summary_template)

--- a/backend/tests/unit/test_selected_pipeline_lifecycle.py
+++ b/backend/tests/unit/test_selected_pipeline_lifecycle.py
@@ -39,6 +39,7 @@ def _rule(rule_id, name, *, event_sync=False, priority=0):
     return SimpleNamespace(
         id=rule_id,
         name=name,
+        created_at=datetime(2026, 9, 5),
         priority=priority,
         is_event_sync=lambda: event_sync,
         get_event_sync_config=lambda: config if event_sync else None,

--- a/docs/60r8c_stale_event_streams_plan.md
+++ b/docs/60r8c_stale_event_streams_plan.md
@@ -1,0 +1,433 @@
+# enhancedchannelmanager-60r8c: Frozen Stale Attachment Contract
+
+Owner: project-engineer. GitHub: #725. Base: `08bbde8b`.
+Status: local reviewed implementation; bounded current-run code, DBA and security
+reviews completed for the diff from `08bbde8b`. Parent final independent gates
+passed. Ruff remains unavailable. Delivery authorized; commit-only handoff in progress.
+Authority: PO implementation brief and bead notes, 2026-09-05, followed by explicit
+commit, push and merge authorization. Project-engineer owns commit only; parent
+owns push, PR, merge and in_progress status. No closure or live upstream writes
+are authorized in this commit-only handoff.
+
+## Approved Behavior
+
+The per-rule Event Sync cleanup option is absent/off by default. Cleanup is
+limited to attachments proven made by this current rule, with future provenance
+bound to rule creation identity, channel UUID and stream account where available.
+Already-attached no-ops do not adopt ownership. Old rule IDs alone, expired or
+corrupt history, restored/reused identities and uncertain ownership preserve the
+attachment with an explanation in preview and persisted history.
+
+The approved first version is cross-account only: require channel
+`auto_created` exactly true, valid authoritative `auto_created_by`, and a valid
+candidate `m3u_account` different from that owner. Preserve every same-account
+or unknown case with reasons. Attachment order, names and `source_stream` are
+not parent authority. Dispatcharr native parent attachments are protected.
+
+## Frozen Acceptance Matrix
+
+These are requirements, not claims of implemented guarantees. Tests must prove
+the production seams as well as pure decisions before status changes.
+
+| Scenario | Required outcome | Proof layer |
+| --- | --- | --- |
+| Option absent or off | Existing behavior unchanged | Configuration and execution |
+| Native channel renamed in place | Remove this-rule stale cross-account attachment; keep current matches and every owner-account stream | Stateful fake upstream with real SQLite |
+| Complete successful evaluation, zero replacements | Stale removal remains possible | Execution lifecycle |
+| Manual, preexisting, other-rule membership | Preserve; no ownership adoption | Provenance lifecycle |
+| Old proof, rule reuse, expired/corrupt history, uncertain identity | Preserve and explain | SQLite, preview and history |
+| Same-account or missing/malformed native/account metadata | Preserve and explain | Adversarial authority tests |
+| Truncation, malformed pages, missing groups, read/dependency failure | No detach | Fetch-to-execution integration |
+| Ambiguous/failed parsing or unavailable master | Preserve | Existing scorer integration |
+| Already-attached filtered out of resolver; attachment cap reached | Neither absence nor cap proves stale; evaluate eligible owned attachments explicitly | Planner/scorer integration |
+| Repeat successful run | Idempotent | Stateful execution |
+| Attach and detach, then rollback | Surgical inverse preserves unrelated current memberships, with snapshot present or expired | Real SQLite and stateful upstream |
+| Journal prewrite failure | No removal | Failure injection |
+| Missing entities, uncertain HTTP, partial rollback | Explicit uncertainty/failure; no false success, further cleanup blocked on uncertain mutation | Failure/recovery lifecycle |
+| Preview | Same decisions as execute, zero upstream mutations | Router and browser/API seam |
+| History | Visible would-detach, detach and skip reasons | Persist/serialize/render |
+
+## Implementation Boundary
+
+Reuse the existing scorer, Event Sync phases, JSON configuration and journal
+where feasible. A small shared planner is acceptable for preview/execute parity.
+Durable recoverable detach intent must commit before upstream mutation, with
+confirmed outcome afterward; journal failure must not degrade to warning-only
+removal. Do not hold SQLite transactions across HTTP. Transaction writes need
+private connections rather than shared StaticPool DBAPI transactions. Review
+schema, query and transaction changes with DBA; review authority and malformed
+identities with security. Add an index migration only with concrete query evidence.
+
+Freshly reread and revalidate before a streams-only PATCH; preserve unrelated
+current membership and order. Dispatcharr's list-replacement API has no CAS:
+this cannot be claimed atomic against concurrent external writers. Document the
+remaining read/PATCH race rather than inventing an upstream API guarantee.
+
+Explicit exclusions: same-account cleanup, protected-anchor UI, order/name/source
+heuristics, general cleanup engine, retention extension, ownership backfill,
+new scheduler, new dependency, matching redesign and unrelated changes.
+Review may block contract failures, introduced regressions, security or data loss;
+it must not silently expand this freeze. Material scope decisions return to PO.
+
+## Sources and Evidence
+
+- Researcher upstream evidence supplied by the parent (not independently reverified yet):
+  [Dispatcharr 0.28.2 channel fields](https://github.com/Dispatcharr/Dispatcharr/blob/v0.28.2/apps/channels/models.py#L365-L376),
+  [native auto-sync map](https://github.com/Dispatcharr/Dispatcharr/blob/v0.28.2/apps/m3u/tasks.py#L2294-L2314)
+  and orphan cleanup at lines 3019-3042. Native ownership is account-based;
+  no singular origin FK. The PO reports the same targeted predicates in
+  0.28.0/.1 and 0.29/.30; ECM's tested series is 0.28, not a broader guarantee.
+- Available recorded channel response: `backend/tests/dbas/test_channels_importer.py`
+  (PO identifies lines 353-387 as captured from 0.28.2). At least one new test
+  must parse this actual shape. Survey other supported fixtures before coding.
+- `backend/tests/fixtures/dispatcharr_stream_provider_channel_number.json` has
+  no explicit capture provenance according to the PO. Treat it as a shape fixture,
+  not independently verified live evidence. No live distribution/capture or
+  production mutation is authorized by this plan.
+- Investigation pointers to reread before implementation: resolver first-stream
+  name extraction and already-attached filtering; executor merge journal and
+  no-op branches; engine fetch completeness, dependency fallbacks, summary and
+  surgical rollback; journal buffering and cleanup retention. These pointers
+  are inherited evidence, not proof that remedies already exist.
+
+## Verification and Handoff
+
+Write regression tests first, demonstrate red, then implement. Use real SQLite
+and a stateful fake upstream lifecycle, plus recorded-shape parsing and a rendered
+browser flow on the exact build. No live Dispatcharr writes. Run targeted tests,
+`scripts/backend-gate.sh`, frontend lint/typecheck/test:coverage/build,
+isolated-port exact-build Playwright and strict MkDocs. Install root/frontend
+lockfile dependencies independently in this worktree, without changing locks.
+
+Backend environment: `ECM_PYTHON=/home/lecaptainc/ecm/enhancedchannelmanager/.venv/bin/python`,
+`ECM_TEST_CONFIG_ROOT=/tmp/opencode/ecm-60r8c/.test-config`,
+`TMPDIR=/tmp/opencode/ecm-60r8c`, `PYTHONDONTWRITEBYTECODE=1`.
+Own resources exclusively; do not concurrently clean/reset a running proof.
+All waits remain foreground and synchronous through terminal gate results.
+Final report names exact files, commands/results, evidence limitations, remaining
+resources and review gaps. Parent independently verifies; no self-review signoff.
+
+## Intake Findings and Pending Boundary
+
+Verified in this worktree at `08bbde8b`, before tests or product edits:
+
+- The merge/no-op, resolver filtering, fetch fallbacks, buffered journal and
+  surgical rollback paths identified by the PO exist as described. The source
+  modules are top-level `backend/channel_pipeline_engine.py` and
+  `backend/channel_pipeline_executor.py`, not a `channel_pipeline/` package.
+- The channel fixture's capture comment explicitly identifies Dispatcharr 0.28.2
+  and 2026-07-27, with representative names/IDs and verbatim structure. Its
+  `streams` is empty while `source_stream` is populated; do not manufacture a
+  native-parent relation from that derived field. The stream shape fixture has
+  integer `m3u_account` and `channel_group`, without a capture-provenance comment.
+- Filename survey under `backend/tests/fixtures/` found additional recorded
+  OpenAPI, settings, EPG, DVR, recording, account and profile fixtures. This is
+  a fixture inventory, not a live field-value distribution or validation of
+  every fixture's content. The recorded OpenAPI and account fixtures have not
+  yet been inspected for this feature.
+- A second execution surface needs an explicit scope disposition:
+  `backend/routers/channel_pipeline.py:1765-1803` runs the real engine against
+  `PlanningDispatcharrClient` with `plan_only=True`. The commit route at
+  lines 1957-2030 stores snapshot-based evidence, replays generic writes and
+  rebuilds journal entries afterward. This is not the ordinary executor's
+  per-merge journal lifecycle.
+- `backend/services/pipeline_write_plan.py:225-284` compensates completed
+  channel updates with their full preimage after replay failure. Its journal
+  reconstruction at lines 288-356 uses category `auto_creation`, does not carry
+  Event Sync rule provenance, and represents stream removals as `remove_stream`.
+  Routing new cleanup through this mechanism unchanged would not meet the
+  frozen durable-detach and surgical-recovery requirements. This conclusion is
+  source-traced, not yet demonstrated by a regression test.
+
+PO decision, 2026-09-05 continuation: **Support both paths (Recommended)**.
+Include narrowly scoped Event Sync provenance and surgical compensation in
+prepared execution so normal and prepared runs honor identical cleanup guarantees.
+Planning/dry-run performs no real mutation or durable intent write. Persist intent
+at real replay, not fake planning. Partial-write recovery remains surgical. Other
+pipeline semantics remain unchanged; no generic prepared-pipeline rewrite.
+This decision was approved before tests. Local implementation and verification
+are recorded below; the approved behavior and exclusions remain the boundary.
+
+At implementation intake, independent DBA and security review required parent
+dispatch. Those reviews are now completed as recorded in Final Delivery State;
+the implementation evidence below is not self-review signoff.
+
+## Local Implementation
+
+- `detach_stale_streams` is a strict per-rule boolean, absent/off by default.
+  Existing attach behavior remains selected when off. Future ordinary merge
+  provenance carries rule creation time, channel UUID and stream account where
+  available; it is not silently promoted to confirmed durable ownership proof.
+- `services/event_sync_cleanup.py` shares cleanup planning across preview,
+  normal execution and prepared planning/replay. It explicitly evaluates owned
+  attached streams through the existing resolver, including master-group streams
+  that the ordinary attach path filters out. Attach caps are not stale evidence.
+- Cleanup reads validate pagination, IDs, configured-group presence, dependencies,
+  rule creation identity, channel UUID, native owner and candidate account. The
+  native guard protects every same-account attachment. Current-rule matching can
+  remove stale cross-account attachments with zero replacements.
+- Cleanup-enabled attaches and detaches use existing journal JSON with a
+  versioned operation and `intent`, `confirmed`, `cancelled`, `uncertain` or
+  `reverted` state. A private NullPool connection commits intent before PATCH;
+  no database transaction spans HTTP. The final reread checks channel, stream,
+  native authority and order-derived matching identity, and rebases membership
+  against unrelated current IDs. A known pre-PATCH cancellation is distinct from
+  an uncertain PATCH outcome. An unresolved intent prevents further writes on
+  that channel. Retention is not extended and old ownership is not backfilled.
+- Prepared planning records semantic Event Sync operations without writing
+  intents or mutating real upstream state. Real replay commits intents and
+  confirms outcomes. The existing generic journal reconstruction skips these
+  already-journaled operations. Confirmed Event Sync writes use surgical
+  compensation; unrelated generic replay behavior is not redesigned.
+- Engine rollback uses the journal's inverse against current memberships with
+  or without a snapshot. Missing/partial history, missing entities and partial
+  rollback do not report success. Mixed non-stream rollback and overlapping
+  generic prepared compensation refuse a whole-preimage restore instead of
+  overwriting unrelated current memberships; this is an explicit recovery
+  limitation, not a claim of automatic mixed-run recovery.
+- The editor persists the option, marks the cleanup risk, and includes saved-rule
+  context (`cleanup_rule_id`) for inline cleanup previews. Preview and execution
+  details render would-detach, detached and preserve reasons. No protected-anchor
+  UI, scheduler, dependency, schema migration or retention extension was added.
+
+## Verification Evidence
+
+Verified on the uncommitted isolated worktree at base `08bbde8b`, not deployed:
+
+| Layer | Command | Final result |
+| --- | --- | --- |
+| Cleanup logic, SQLite lifecycle, executor, preview router, prepared commit and rollback | `scripts/backend-gate.sh --subset tests/services/test_event_sync_cleanup.py` | 45 passed |
+| Canonical backend gate | `scripts/backend-gate.sh` | 12,915 passed; 3 documented skips; 2 deselected; 82.33% coverage; 756.33 seconds |
+| Frontend lint | `npm run lint` in `frontend/` | Passed |
+| Frontend types | `npm run typecheck` in `frontend/` | Passed |
+| Frontend coverage | `npm run test:coverage` in `frontend/` | 259 files, 3,688 passed; 59.82% statements |
+| Frontend build | `npm run build` in `frontend/` | Passed; existing large-chunk warning |
+| Exact-build browser | Command below | 1 Chromium test passed; desktop and 390px screenshots inspected |
+| Documentation | `python -m mkdocs build --strict --site-dir /tmp/opencode/ecm-60r8c/.60r8c-docs-site` | Passed; internal handoff notes are excluded by existing MkDocs configuration |
+| Diff whitespace | `git diff --check` | Passed |
+| Python Ruff | Project interpreter `-m ruff check` on the new Python files | Unavailable: venv has no Ruff module; no environment/dependency changes made to install it |
+
+TDD evidence: missing implementation initially failed collection; the executor
+rename regression then failed with `[1, 2, 3]` instead of `[1, 3]`; prepared replay
+and option validation failed before wiring. Frontend tests failed for the absent
+toggle and cleanup results. Disabling the same-account guard deliberately caused
+two tests to fail, including an actual would-detach of the protected account;
+the guard was restored before final gates. Browser inspection exposed missing
+group-settings authority; its regression was demonstrated red before the fix.
+The last-read/order-derived matching-identity regression also failed before its
+guard. Final backend and frontend gates were rerun after those fixes.
+
+The browser test uses the actual rule CRUD and preview/history routers with
+file-backed SQLite. A dedicated fixture endpoint invokes the actual executor
+synchronously against a stateful fake upstream, then persists the history row;
+it does not exercise the production queue/scheduler. Backend tests separately
+exercise prepared commit/journaling/rollback, using a real executor-generated
+plan and a scoped planning-traversal adapter. The native response test parses
+the relevant JSON field subset from the recorded 0.28.2 channel response. The
+stateful lifecycle data and provider-group settings are synthetic, not a newly
+captured live distribution. No live Dispatcharr write or production check ran.
+
+The first browser fixtures had incomplete unrelated API stubs and a missing
+router prefix; those were corrected without application changes. A teardown
+race was fixed by awaiting the actual execution-details response and draining
+route handlers before stopping the fixture. Every verification command returned
+synchronously; no background gate watcher was armed.
+
+### Reproduction
+
+Workdir `/tmp/opencode/ecm-60r8c`; Node installed independently from the root
+and frontend lockfiles using `npm ci`, with the Node 24.13.0 installation on PATH.
+Locks and shared node dependencies were not modified. Backend environment is
+the one recorded above. Reuse it for the browser fixture too:
+
+```sh
+export PATH=/home/lecaptainc/.local/share/fnm/node-versions/v24.13.0/installation/bin:$PATH
+export ECM_PYTHON=/home/lecaptainc/ecm/enhancedchannelmanager/.venv/bin/python
+export ECM_TEST_CONFIG_ROOT=/tmp/opencode/ecm-60r8c/.test-config
+export TMPDIR=/tmp/opencode/ecm-60r8c
+export PYTHONDONTWRITEBYTECODE=1
+scripts/backend-gate.sh
+E2E_START_SERVER=true E2E_EXACT_BUILD=true PLAYWRIGHT_HTML_OPEN=never npm run test:e2e -- e2e/event-sync-cleanup.spec.ts --project=chromium --workers=1 --retries=0
+```
+
+The browser owns preview port 4173 exclusively and its API fixture binds a
+separate ephemeral loopback port. Both stop before the test command returns.
+Run frontend gates sequentially in `frontend/`. All final gate logs are retained
+at the worktree root: `backend-gate-60r8c.log`, `frontend-gates-60r8c.log`,
+`browser-gate-60r8c.log`, `docs-gate-60r8c.log`. Screenshots and the browser API log are under
+`test-results/` and the Playwright report.
+
+### Exact Product File Manifest
+
+```text
+backend/channel_pipeline_engine.py
+backend/channel_pipeline_executor.py
+backend/channel_pipeline_schema.py
+backend/routers/channel_pipeline.py
+backend/services/event_sync_cleanup.py
+backend/services/event_sync_resolver.py
+backend/services/pipeline_write_plan.py
+backend/tests/fixtures/event_sync_cleanup_server.py
+backend/tests/services/test_event_sync_cleanup.py
+backend/tests/unit/test_channel_pipeline_engine.py
+backend/tests/unit/test_selected_pipeline_lifecycle.py
+docs/60r8c_stale_event_streams_plan.md
+docs/event_sync.md
+e2e/event-sync-cleanup.spec.ts
+frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
+frontend/src/components/channelPipeline/EventSyncPreviewPanel.test.tsx
+frontend/src/components/channelPipeline/EventSyncPreviewPanel.tsx
+frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
+frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
+frontend/src/types/channelPipeline.ts
+frontend/src/types/eventSync.ts
+```
+
+### Remaining Resources and Review
+
+Do not stage generated resources: root/frontend `node_modules`, `.npm-cache/`,
+`.test-config/`, `.60r8c-docs-site/`, `pytest-of-lecaptainc/`, `node-compile-cache/`,
+`playwright-transform-cache-3000/`, `ecm-debug-bundle-*.tar.gz`, logs, coverage,
+frontend build output and browser reports. They are dedicated to this worktree.
+No live server, watcher, container or upstream resource is needed for handoff.
+
+Independent parent verification and bounded code, DBA transaction/query and
+security authority reviews are completed; see Final Delivery State. Ruff was not
+run successfully. The upstream
+no-CAS concurrency limitation remains; neither passing tests nor this report
+claim atomicity against external writers. No commit, push, PR, merge, deployment
+or issue-status change was performed. The parent retains the in-progress bead.
+
+## Four-Defect Remediation Evidence
+
+2026-09-05, fresh project-engineer remediation in `/tmp/opencode/ecm-60r8c`.
+This section records only the four demonstrated introduced defects supplied by
+the parent. It does not change the approved scope, acceptance matrix, exclusions,
+or no-CAS limitation. Prior verification above predates these fixes.
+
+### Changes This Run
+
+- Unknown PATCH outcome: `UncertainMutationError` distinguishes a started PATCH
+  whose outcome is unknown from a known pre-PATCH cancellation. The ordinary
+  executor persists `uncertain`, not `preserve`, for response loss. The shared
+  preview/history renderer counts uncertain rows separately and no longer claims
+  that uncertain attachments were preserved. Prepared commit's existing failure
+  path is pinned: HTTP 502, failed execution, uncertain journal and recovery
+  error, no fabricated successful cleanup summary.
+- E2E collection: replace the spec's import-time throw with a static Playwright
+  skip annotation using the same three prerequisites. Unsupported modes collect
+  without aborting and skip before page/fixture setup or mutations. No general
+  E2E configuration or framework change.
+- Stream group drift: planned detach inputs now include `stream_group`. Both
+  immediate and post-durable-intent reads compare it. A return from out-of-scope
+  group 30 to matching group 20 cancels before PATCH on normal and prepared paths.
+- Missing ownership preimage: ownership requires an explicit list of unique,
+  positive, signed-64-bit integer IDs. Missing/NULL membership, booleans, strings,
+  zero and duplicate IDs cannot establish ownership. Missing/invalid preimages
+  explain preservation; invalid JSON still fails closed. Prepared replay
+  revalidates this proof and refuses previously planned detaches after corruption.
+
+Product/test files edited this run, relative to the worktree:
+
+```text
+backend/channel_pipeline_executor.py
+backend/services/event_sync_cleanup.py
+backend/tests/services/test_event_sync_cleanup.py
+e2e/event-sync-cleanup.spec.ts
+frontend/src/components/channelPipeline/EventSyncPreviewPanel.test.tsx
+frontend/src/components/channelPipeline/EventSyncPreviewPanel.tsx
+frontend/src/types/eventSync.ts
+docs/60r8c_stale_event_streams_plan.md
+```
+
+### Regression And Gate Results
+
+Tests were added before product fixes. Red evidence demonstrated both group-drift
+paths proceeding instead of cancelling, NULL/empty preimages authorizing detach,
+response-lost history claiming `preserve`, and the renderer claiming uncertain
+attachments were preserved. Non-isolated `--list` failed with the top-level throw.
+The initial backend test run also exposed two prepared-error assertions matching
+the underlying error instead of the existing `PartialReplayError` wrapper; those
+test expectations were corrected, not product behavior.
+
+| Check | Command | Terminal result this run |
+| --- | --- | --- |
+| All cleanup feature tests | `scripts/backend-gate.sh --subset tests/services/test_event_sync_cleanup.py` | 67 passed |
+| Preview/history and editor tests | `npm exec vitest run src/components/channelPipeline/EventSyncPreviewPanel.test.tsx src/components/channelPipeline/EventSyncRuleEditor.test.tsx` in frontend | 108 passed |
+| Canonical backend | `scripts/backend-gate.sh` | 12,937 passed, 3 documented skips, 2 deselected; 82.36% coverage; 752.29 seconds |
+| Frontend lint | `npm run lint` in frontend | Passed |
+| Frontend types | `npm run typecheck` in frontend | Passed |
+| Frontend coverage | `npm run test:coverage` in frontend | 259 files, 3,689 passed; 59.82% statements |
+| Frontend build | `npm run build` in frontend | Passed; existing large-chunk warning |
+| Exact browser positive control | Exact-build command in Reproduction above | 1 Chromium test passed, no retries; 5.2 seconds |
+| Diff whitespace | `git diff --check` | Passed before this evidence append |
+| Python Ruff | Project interpreter `-m ruff check` on the three changed Python files | Unavailable: no Ruff module; no dependencies installed |
+
+Collection proof used private scratch config
+`.test-config/remediation-playwright.cjs`: only this spec, list reporter, private
+output directory, no web server. With `ECM_PYTHON` and `E2E_EXACT_BUILD` unset,
+`E2E_BASE_URL=http://127.0.0.1:49199`, both external mode (`E2E_START_SERVER`
+unset) and dev mode (`E2E_START_SERVER=true`) returned one collected test using
+`npm run test:e2e -- --config=.test-config/remediation-playwright.cjs --list`.
+Executing the external-mode private configuration with `--workers=1 --retries=0`
+returned one skipped test without starting fixtures or connecting to that URL.
+The exact positive control used the repository configuration, not this private
+collection config.
+
+Environment remained the project Python 3.12.3 interpreter and backend variables
+recorded above, plus Node 24.13.0 on PATH and the existing independent root/frontend
+lockfile dependencies. No dependency or lockfile changes. Each gate waited in the
+foreground until its terminal result; no concurrent cleanup or background watcher.
+Backend tests use isolated temporary SQLite and fake upstream state. Browser
+preview and fixture servers terminated with the successful test command.
+
+Full backend and frontend coverage command output is retained by the tool runner
+at `/home/lecaptainc/.local/share/opencode/tool-output/tool_072b0feef001gRSA9yA9AQLkWj`
+and `/home/lecaptainc/.local/share/opencode/tool-output/tool_072b2365a001FjETDHZLEPZ9F9`.
+Scratch config, generated test/build/coverage artifacts and logs are not product
+changes. No commits, push, PR, merge, git-status command, issue-status changes,
+live Dispatcharr writes, other-worktree mutations or resource cleanup performed.
+Parent-owned code/DBA/security delta reviews are now completed as recorded below;
+this remediation section is regression and gate evidence, not self-signoff.
+The remediation-time strict docs result is recorded below.
+
+Strict documentation gate: project interpreter `-m mkdocs build --strict
+--site-dir /tmp/opencode/ecm-60r8c/.60r8c-docs-site` passed in 1.08 seconds.
+Existing MkDocs configuration excludes internal handoff notes from the site.
+
+## Final Delivery State
+
+2026-09-05 handoff, based on the parent's supplied final review and independent
+verification results. Review was bounded to code from the current run, the diff
+from `08bbde8b`: exactly four initial findings, fixed in one remediation round,
+followed by delta-only final review. No remaining findings, broader review scope,
+new goalposts or acceptance changes.
+
+| Final review | Session | Bounded result |
+| --- | --- | --- |
+| Code | `ses_f8d3aaeb2ffe8ECvavrblv2IN0` | Approved: uncertain-status reporting and E2E collection fixes |
+| DBA | `ses_f8d3aaea2ffeerf9ZO54QHPk3Q` | Pass: 67 independently run real-SQLite tests |
+| Security | `ses_f8d3aae92ffeWl4JjB06Zku0Dm` | SEC1 pass: 63 independent cases |
+
+Parent final independent verification supersedes the earlier gate snapshots:
+
+| Gate | Parent final result |
+| --- | --- |
+| Full `scripts/backend-gate.sh` | 12,937 passed; 3 skips; 2 deselected; 82.36% coverage |
+| Frontend coverage, lint, typecheck and build | 3,689 tests passed; all listed gates passed |
+| Actual exact-build Chromium E2E | 1 passed; 5.3 seconds |
+| `git diff --check` | Passed before this docs-only handoff; no product changes after verification |
+
+These are parent-supplied results, not test reruns by this docs-only handoff.
+Ruff remains unavailable as previously documented; no dependency installation
+and no new blocker. The no-CAS limitation and existing evidence limitations remain.
+
+Delivery proceeds on `feat/60r8c-stale-event-streams` in
+`/tmp/opencode/ecm-60r8c` under explicit PO commit, push and merge authorization.
+Project-engineer performs the commit only; parent owns push, PR and merge.
+Scope stays frozen to normal
+and prepared execution, cross-account cleanup only. Bead `60r8c` remains
+`in_progress`, preserving its original description, acceptance criteria and prior
+notes. GitHub #725 remains open pending eventual merge; this commit-only handoff
+does not authorize deployment or closure. The unrelated closed
+parent `u0ko6` / #775 and its successful #982 post-merge result are not changed.

--- a/docs/event_sync.md
+++ b/docs/event_sync.md
@@ -19,6 +19,45 @@
 
 ## Overview
 
+### Optional Stale Attachment Cleanup
+
+Under **Behavior**, **Detach stale streams attached by this rule** is off by
+default (`detach_stale_streams` absent or false). It applies to normal manual,
+already-configured automatic and prepared runs; preview remains read-only.
+Cleanup can remove an old attachment after a native channel is renamed in place,
+including when no replacement matches.
+
+Only confirmed attachments owned by the current rule's creation identity are
+eligible. The channel UUID and stream account must still agree with the journal.
+The channel must be native auto-created with a known `auto_created_by` account,
+and the stream must belong to a different account. Every same-account stream is
+protected, not merely the first stream. `source_stream`, order and names are
+not native-parent authority. Existing matching criteria still decide staleness.
+
+Manual/preexisting attachments, other-rule attachments, missing or expired
+ownership history, malformed identities, failed dependencies and incomplete
+reads are preserved. Unparsed or ambiguous matching is not proof of staleness.
+Preview and execution details display would-detach, detached and preserve reasons.
+When editing a saved rule, inline cleanup preview carries `cleanup_rule_id` so
+it can evaluate the draft with that saved rule's ownership and review context.
+Unsaved rules cannot claim historical ownership.
+
+New cleanup-enabled writes commit a journal intent before PATCH and confirm its
+outcome afterward, on private SQLite connections. Prepared planning only records
+the operation; real replay writes the intent. A failed intent prevents the write.
+Uncertain HTTP outcomes block subsequent cleanup rather than being reported as
+success. Rollback uses surgical membership inverses, with or without a snapshot;
+missing/expired recovery evidence or partial failures do not mark a run rolled
+back. Mixed non-stream rollback and overlapping generic prepared compensation
+are refused rather than restoring full preimages over unrelated current streams.
+
+History created before durable ownership evidence existed is not backfilled or
+adopted. Retention is unchanged: when proof expires, cleanup preserves the stream.
+Avoid simultaneous manual edits or native sync while running: Dispatcharr replaces
+the full stream list and offers no compare-and-swap. Fresh rereads preserve
+unrelated memberships observed before PATCH, but cannot make that API atomic
+against concurrent external writers.
+
 Operators with multiple IPTV providers get N duplicate channels per
 sports/PPV event, one per provider's auto-sync event group, because the
 same real-world event is named differently by every provider (slot

--- a/e2e/event-sync-cleanup.spec.ts
+++ b/e2e/event-sync-cleanup.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { resolve } from 'node:path';
+
+test.skip(process.env.E2E_EXACT_BUILD !== 'true' || process.env.E2E_START_SERVER !== 'true' || !process.env.ECM_PYTHON,
+  'Cleanup contract requires isolated exact build and project interpreter');
+
+test('cleanup opt-in persists, preview is read-only, executor history explains detaches', async ({ page }, testInfo) => {
+  const child = spawn(process.env.ECM_PYTHON!, ['-m', 'tests.fixtures.event_sync_cleanup_server'], {
+    cwd: resolve('backend'), env: { ...process.env, PYTHONDONTWRITEBYTECODE: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let output = '';
+  let port = '';
+  child.stdout.on('data', chunk => { output += chunk; port = output.match(/CLEANUP_API_PORT=(\d+)/)?.[1] ?? ''; });
+  child.stderr.on('data', chunk => { output += chunk; });
+  try {
+    await expect.poll(() => port || (child.exitCode !== null ? `exited: ${output}` : ''), { timeout: 20000 }).toMatch(/^\d+$/);
+    const backend = `http://127.0.0.1:${port}`;
+    await expect.poll(async () => {
+      try { return (await fetch(`${backend}/fixture/state`)).status; } catch { return 0; }
+    }).toBe(200);
+    await page.route('**/api/**', async route => {
+      const url = new URL(route.request().url());
+      const path = url.pathname;
+      if (/^\/api\/channel-pipeline\/(rules|event-sync-preview|executions|schema)/.test(path)) {
+        const response = await route.fetch({ url: `${backend}${path}${url.search}` });
+        await route.fulfill({ response });
+        return;
+      }
+      const data: Record<string, unknown> = {
+        '/api/profile-conflict-reviews': { reviews: [] },
+        '/api/event-sync-reviews': { reviews: [], total: 0 },
+        '/api/event-sync-exclusions': { exclusions: [], total: 0 },
+        '/api/auth/status': { require_auth: false, setup_complete: true, dispatcharr_enabled: false },
+        '/api/auth/setup-required': { required: false },
+        '/api/settings': { configured: true, url: 'https://fixture.invalid' },
+        '/api/notifications': { notifications: [], unread_count: 0 },
+        '/api/channel-groups': [{ id: 10, name: 'Master' }, { id: 20, name: 'Secondary' }],
+        '/api/providers/group-settings/by-provider': [],
+        '/api/channel-pipeline/circuit-breaker': { tripped: false },
+      };
+      await route.fulfill({ json: data[path] ?? [] });
+    });
+    await page.goto('/#channel-pipeline');
+    await expect(page.getByRole('button', { name: 'Edit', exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.getByTestId('event-sync-step-3').click();
+    const toggle = page.getByTestId('event-sync-detach-stale-streams');
+    await expect(toggle).not.toBeChecked();
+    await toggle.check();
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(page.getByTestId('event-sync-editor')).toHaveCount(0);
+    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.getByTestId('event-sync-step-3').click();
+    await expect(toggle).toBeChecked();
+    await page.getByRole('button', { name: 'Preview matches', exact: false }).click();
+    await expect(page.getByRole('region', { name: 'Stale attachment cleanup' })).toContainText('would detach stream 2');
+    expect(await (await fetch(`${backend}/fixture/state`)).json()).toEqual({ streams: [1, 2], writes: 1 });
+    await page.screenshot({ path: testInfo.outputPath('cleanup-preview-desktop.png'), fullPage: true });
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.getByRole('region', { name: 'Stale attachment cleanup' }).scrollIntoViewIfNeeded();
+    await expect(page.getByRole('region', { name: 'Stale attachment cleanup' })).toBeVisible();
+    await page.screenshot({ path: testInfo.outputPath('cleanup-preview-mobile.png'), fullPage: true });
+    const result = await (await fetch(`${backend}/fixture/run`, { method: 'POST' })).json();
+    expect(result.streams).toEqual([1, 3]);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.reload();
+    const detailsLoaded = page.waitForResponse(response =>
+      new URL(response.url()).pathname === '/api/channel-pipeline/executions/2' && response.status() === 200);
+    await page.locator('.execution-section').getByRole('button', { name: /details/i }).click();
+    await detailsLoaded;
+    await expect(page.getByRole('region', { name: 'Stale attachment cleanup' })).toContainText('detached stream 2');
+    await expect(page.getByRole('region', { name: 'Stale attachment cleanup' })).toContainText('same account protected');
+  } finally {
+    await page.unrouteAll({ behavior: 'wait' });
+    if (child.exitCode === null) {
+      const exited = once(child, 'exit');
+      child.kill('SIGTERM');
+      await exited;
+    }
+    await testInfo.attach('cleanup-api.log', { body: output, contentType: 'text/plain' });
+  }
+});

--- a/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
+++ b/frontend/src/components/channelPipeline/ChannelPipelineTab.tsx
@@ -24,6 +24,7 @@ import { useChannelPipelineRules } from '../../hooks/useChannelPipelineRules';
 import { useChannelPipelineExecution } from '../../hooks/useChannelPipelineExecution';
 import { RuleBuilder } from './RuleBuilder';
 import { EventSyncRuleEditor } from './EventSyncRuleEditor';
+import { EventSyncCleanupResults } from './EventSyncPreviewPanel';
 import { EventSyncReviewQueue } from './EventSyncReviewQueue';
 import { EventSyncExclusionsPanel } from './EventSyncExclusionsPanel';
 import { BulkRuleSettingsModal } from './BulkRuleSettingsModal';
@@ -1838,6 +1839,10 @@ export function ChannelPipelineTab() {
                     where they match. Attaches are journaled and reversible via
                     rollback.
                   </p>
+                  {showEventSyncRunConfirm.rule.event_sync_config?.detach_stale_streams && (
+                    <p>This rule also removes proven stale cross-account attachments made by this rule,
+                      even without replacements. Same-account and uncertain attachments are preserved.</p>
+                  )}
                   {showEventSyncRunConfirm.rule.event_sync_config
                     ?.refresh_providers_before_run && (
                     <p data-testid="event-sync-run-refresh-note">
@@ -2115,6 +2120,8 @@ export function ChannelPipelineTab() {
             </div>
             <div className="modal-body">
               {/* Summary Section */}
+              {(details.event_sync_summary ?? []).map(summary => summary.cleanup &&
+                <EventSyncCleanupResults key={summary.rule_id} cleanup={summary.cleanup} />)}
               <div className="detail-row">
                 <span className="detail-label">Status:</span>
                 <span className={getStatusBadgeClass(details.status)}>

--- a/frontend/src/components/channelPipeline/EventSyncPreviewPanel.test.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncPreviewPanel.test.tsx
@@ -9,8 +9,19 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { EventSyncPreviewPanel } from './EventSyncPreviewPanel';
+import { EventSyncPreviewPanel, EventSyncCleanupResults } from './EventSyncPreviewPanel';
 import type { EventSyncPreviewResponse } from '../../types/eventSync';
+
+it('renders uncertain history without claiming the attachment was preserved', () => {
+  render(<EventSyncCleanupResults cleanup={{ error: 'mutation_outcome_uncertain', decisions: [
+    { channel_id: 100, channel_name: 'Events', stream_id: 2, decision: 'uncertain', reason: 'mutation_outcome_uncertain' },
+  ] }} />);
+  const region = screen.getByRole('region', { name: 'Stale attachment cleanup' });
+  expect(region).toHaveTextContent('1 uncertain');
+  expect(region).toHaveTextContent('0 preserved');
+  expect(region).toHaveTextContent('uncertain stream 2');
+  expect(region).not.toHaveTextContent('Uncertain attachments preserved');
+});
 
 function buildPreview(overrides: Partial<EventSyncPreviewResponse> = {}): EventSyncPreviewResponse {
   return {
@@ -94,6 +105,17 @@ function buildPreview(overrides: Partial<EventSyncPreviewResponse> = {}): EventS
 }
 
 describe('EventSyncPreviewPanel', () => {
+  it('shows would-detach and preserve reasons without mutation controls', () => {
+    render(<EventSyncPreviewPanel preview={buildPreview({ cleanup: {
+      error: null, decisions: [
+        { channel_id: 7, channel_name: 'Event', stream_id: 101, decision: 'would_detach', reason: 'no_longer_matches_current_rule' },
+        { channel_id: 7, channel_name: 'Event', stream_id: 102, decision: 'preserve', reason: 'same_account_protected' },
+      ],
+    } })} loading={false} error={null} onRunPreview={vi.fn()} />);
+    expect(screen.getByText(/would detach.*101/i)).toBeInTheDocument();
+    expect(screen.getByText(/same account protected/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^detach/i })).not.toBeInTheDocument();
+  });
   it('renders the band as a text label with an icon, never color alone', () => {
     render(
       <EventSyncPreviewPanel

--- a/frontend/src/components/channelPipeline/EventSyncPreviewPanel.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncPreviewPanel.tsx
@@ -16,6 +16,7 @@ import { useState } from 'react';
 import type {
   EventSyncPreviewResponse,
   EventSyncStreamRow,
+  EventSyncCleanupSummary,
 } from '../../types/eventSync';
 import {
   BAND_META,
@@ -28,6 +29,23 @@ import './EventSyncPreviewPanel.css';
 
 /** Cards rendered before the "Show more" affordance kicks in. */
 const CARDS_PER_PAGE = 50;
+
+export function EventSyncCleanupResults({ cleanup }: { cleanup: EventSyncCleanupSummary }) {
+  const [limit, setLimit] = useState(CARDS_PER_PAGE);
+  return <section className="event-sync-section" aria-label="Stale attachment cleanup">
+    <h4>Stale attachment cleanup</h4>
+    {cleanup.error && <p role="alert">Cleanup incomplete: {cleanup.error.split('_').join(' ')}. See individual outcomes below.</p>}
+    <p>{cleanup.decisions.filter(r => r.decision === 'would_detach').length} would detach;{' '}
+      {cleanup.decisions.filter(r => r.decision === 'detached').length} detached;{' '}
+      {cleanup.decisions.filter(r => r.decision === 'preserve').length} preserved;{' '}
+      {cleanup.decisions.filter(r => r.decision === 'uncertain').length} uncertain</p>
+    <ul>{cleanup.decisions.slice(0, limit).map(row => <li key={`${row.channel_id}:${row.stream_id}`}>
+      {row.decision.split('_').join(' ')} stream {row.stream_id} on {row.channel_name}: {row.reason.split('_').join(' ')}
+    </li>)}</ul>
+    {limit < cleanup.decisions.length && <button type="button" className="btn-secondary"
+      onClick={() => setLimit(limit + CARDS_PER_PAGE)}>Show more cleanup decisions</button>}
+  </section>;
+}
 
 /**
  * S5 (bead sf8dj): the caution behind each provenance chip — why this
@@ -346,6 +364,7 @@ export function EventSyncPreviewPanel({
             stale ? ' event-sync-preview-results--stale' : ''
           }`}
         >
+          {preview.cleanup && <EventSyncCleanupResults cleanup={preview.cleanup} />}
           {/* Pre-flight failures never block the preview — surface them loudly.
               Warnings (bead 2ey2y) are advisory: rendered in the same block,
               same teaching shape, without flipping ok. */}

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.test.tsx
@@ -425,6 +425,22 @@ describe('EventSyncRuleEditor', () => {
   });
 
   describe('stale-dateless demote guard (bead jqwfq)', () => {
+    it('keeps stale attachment cleanup off by default and saves explicit opt-in', async () => {
+      const user = userEvent.setup();
+      seedGroups();
+      stubGroupSettings({ 1: true, 2: false });
+      const onSave = vi.fn();
+      render(<EventSyncRuleEditor rule={EXISTING_RULE} onSave={onSave} onCancel={vi.fn()} />);
+      await user.click(screen.getByRole('button', { name: /3.*Behavior/ }));
+      const toggle = screen.getByTestId('event-sync-detach-stale-streams');
+      expect(toggle).not.toBeChecked();
+      await user.click(toggle);
+      expect(screen.getByText('Stale attachment cleanup', { selector: '.badge' })).toBeInTheDocument();
+      expect(screen.queryByText(/No risk flags set/)).not.toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+      expect(onSave.mock.calls[0][0].event_sync_config.detach_stale_streams).toBe(true);
+    });
     it('defaults ON, is disabled without the date assumption, and omits the key', async () => {
       const user = userEvent.setup();
       seedGroups();

--- a/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
+++ b/frontend/src/components/channelPipeline/EventSyncRuleEditor.tsx
@@ -343,6 +343,7 @@ export function EventSyncRuleEditor({
   // Phase 2 opt-in (ti939.3.1): unattended auto-run on the refresh
   // watermark. Default OFF — the backend treats an absent key as false.
   const [autoRun, setAutoRun] = useState(config?.auto_run ?? false);
+  const [detachStaleStreams, setDetachStaleStreams] = useState(config?.detach_stale_streams ?? false);
   // bead y8yby: refresh the rule's M3U providers before a MANUAL run (live Run
   // AND dry-run Test). Default OFF — the backend treats an absent key as false.
   // With it on, Test is no longer zero-write (it triggers a real refresh).
@@ -664,6 +665,9 @@ export function EventSyncRuleEditor({
     if (autoRun || config?.auto_run != null) {
       built.auto_run = autoRun;
     }
+    if (detachStaleStreams || config?.detach_stale_streams != null) {
+      built.detach_stale_streams = detachStaleStreams;
+    }
     // bead y8yby: emit refresh_providers_before_run when checked, and preserve
     // an explicit stored value (the backend validator fills the key on save).
     // A legacy config without the key stays without it while the box is
@@ -814,7 +818,9 @@ export function EventSyncRuleEditor({
     setPreviewLoading(true);
     setPreviewError(null);
     try {
-      const response = await previewEventSync({ event_sync_config: builtConfig });
+      const response = await previewEventSync({ event_sync_config: builtConfig,
+        ...(builtConfig.detach_stale_streams && rule?.id ? { cleanup_rule_id: rule.id } : {}),
+      });
       setPreview(response);
     } catch (err) {
       setPreviewError(err instanceof Error ? err.message : 'Preview failed');
@@ -946,6 +952,7 @@ export function EventSyncRuleEditor({
       thresholdText !== (config?.attach_threshold ?? EVENT_ATTACH_FLOOR).toFixed(2) ||
       enforceTimeWindow !== (config?.enforce_time_window ?? true) ||
       autoRun !== (config?.auto_run ?? false) ||
+      detachStaleStreams !== (config?.detach_stale_streams ?? false) ||
       refreshProvidersBeforeRun !== (config?.refresh_providers_before_run ?? false) ||
       includeMasterGroupStreams !== (config?.include_master_group_streams ?? false) ||
       assumeCurrentDate !== (config?.assume_current_date ?? false) ||
@@ -960,7 +967,7 @@ export function EventSyncRuleEditor({
   }, [
     name, description, enabled, activeFrom, activeUntil, masterScope, secondaryScopes, selectedPatternIds,
     customShared, groupOverrides, timeWindowText, thresholdText, enforceTimeWindow,
-    autoRun, refreshProvidersBeforeRun, includeMasterGroupStreams, assumeCurrentDate,
+    autoRun, detachStaleStreams, refreshProvidersBeforeRun, includeMasterGroupStreams, assumeCurrentDate,
     demoteStaleDateless, parseMasterFromStream, promoteUnmatched,
     promoteTargetGroupId, dummyEpgProfileId, config, rule,
     initial, customSharedMeta, streamSortField, streamSortOrder,
@@ -1059,6 +1066,7 @@ export function EventSyncRuleEditor({
           <> <strong>Refreshes this rule&apos;s M3U providers before each
           manual Run/Test</strong> (so Test is no longer zero-write).</>
         )}
+        {detachStaleStreams && <> <strong>Detaches proven stale cross-account attachments made by this rule.</strong></>}
         {includeMasterGroupStreams && secCount > 0 && (
           <> Also matches the master group&apos;s own streams.</>
         )}
@@ -1086,6 +1094,7 @@ export function EventSyncRuleEditor({
     currentTimeWindow,
     currentThreshold,
     autoRun,
+    detachStaleStreams,
     refreshProvidersBeforeRun,
     assumeCurrentDate,
     demoteStaleDateless,
@@ -1235,6 +1244,8 @@ export function EventSyncRuleEditor({
       const chips: ReactNode[] = [];
       if (autoRun)
         chips.push(<span key="ar" className="badge badge-sm badge-warning">Auto-run</span>);
+      if (detachStaleStreams)
+        chips.push(<span key="cleanup" className="badge badge-sm badge-warning">Stale attachment cleanup</span>);
       if (refreshProvidersBeforeRun)
         chips.push(<span key="rp" className="badge badge-sm badge-warning">Refresh before run</span>);
       if (!enforceTimeWindow)
@@ -1863,6 +1874,21 @@ export function EventSyncRuleEditor({
                 <span className="event-sync-phase-num">3</span> Behavior
               </h2>
 
+              <div className="form-group">
+                <label className="checkbox-option">
+                  <input type="checkbox" checked={detachStaleStreams}
+                    onChange={e => setDetachStaleStreams(e.target.checked)} disabled={isLoading}
+                    data-testid="event-sync-detach-stale-streams" />
+                  <span>Detach stale streams attached by this rule</span>
+                </label>
+                <span className="form-hint">
+                  Off by default. Removes only proven rule-owned stale attachments from a different
+                  provider account than the native channel owner, even with no replacement.
+                  Same-account, manual, preexisting and uncertain attachments are preserved with reasons.
+                  Preview first; removals are journaled for surgical rollback. Avoid concurrent edits
+                  in Dispatcharr while running: its stream-list API has no compare-and-swap.
+                </span>
+              </div>
               {/* Automation subgroup (S2). */}
               <details className="modal-subgroup">
                 <summary>

--- a/frontend/src/types/channelPipeline.ts
+++ b/frontend/src/types/channelPipeline.ts
@@ -4,7 +4,7 @@
  * These types mirror the backend schema and are used throughout the frontend
  * for type safety when working with channel pipeline rules, conditions, and actions.
  */
-import type { EventSyncConfig } from './eventSync';
+import type { EventSyncConfig, EventSyncCleanupSummary } from './eventSync';
 
 // =============================================================================
 // Condition Types
@@ -558,6 +558,7 @@ export interface SelectedRuleOutcome {
  * matches the Event Sync preview panel + debug-bundle taxonomy.
  */
 export interface EventSyncExecutionSummary {
+  cleanup?: EventSyncCleanupSummary;
   rule_id: number | null;
   rule_name?: string | null;
   /** Secondary-provider streams evaluated against the master channels. */

--- a/frontend/src/types/eventSync.ts
+++ b/frontend/src/types/eventSync.ts
@@ -37,6 +37,8 @@ export interface EventSyncGroupScope {
 }
 
 export interface EventSyncConfig {
+  /** Off by default; only proven rule-owned cross-account stale attachments. */
+  detach_stale_streams?: boolean;
   /**
    * bead 3p2af / 38dzi: canonical provider-scoped shape. The editor (P4)
    * reads and writes these nested scopes; the backend validator derives the
@@ -393,7 +395,14 @@ export interface EventSyncParseFailureGroup {
   stream_names: string[];
 }
 
+export interface EventSyncCleanupSummary {
+  error: string | null;
+  decisions: { channel_id: number; channel_name: string; stream_id: number;
+    decision: 'preserve' | 'would_detach' | 'detached' | 'uncertain'; reason: string }[];
+}
+
 export interface EventSyncPreviewResponse {
+  cleanup?: EventSyncCleanupSummary;
   preflight: EventSyncPreflight;
   summary: EventSyncPreviewSummary;
   streams: EventSyncStreamRow[];
@@ -409,7 +418,7 @@ export interface EventSyncPreviewResponse {
 /** Request body: exactly one of rule_id / event_sync_config. */
 export type EventSyncPreviewRequest =
   | { rule_id: number }
-  | { event_sync_config: EventSyncConfig };
+  | { event_sync_config: EventSyncConfig; cleanup_rule_id?: number };
 
 // =============================================================================
 // Review queue (bead ti939.3.2) — /api/event-sync-reviews


### PR DESCRIPTION
## Summary
Closes #725

Bead: enhancedchannelmanager-60r8c

Add an off-by-default Event Sync option to detach proven stale attachments owned by the current rule, limited to streams from a different provider account than the native auto-sync owner. Same-account, manual, other-rule and uncertain attachments are preserved with explanations. Complete evaluation may remove stale attachments without replacement streams.

## Frozen Scope
Normal execution and prepared plan/replay share the approved cleanup guarantees. Durable journal intent precedes mutation; surgical rollback preserves unrelated current membership. Unknown PATCH outcomes are reported as uncertain, not preserved. Missing ownership preimages and changed matching inputs fail closed.

No same-account cleanup, heuristic parent selection, ownership backfill, new scheduler, dependencies, schema migration or unrelated redesign. Dispatcharr has no CAS; final rereads do not eliminate the external read/PATCH race. Mixed non-stream recovery refuses unsafe whole-preimage restoration rather than claiming automatic recovery.

## Verification
- Independent parent backend: 12,937 passed, 3 documented skips, 2 deselected; 82.36% coverage.
- Independent parent frontend: 3,689 passed; lint, typecheck, coverage and build passed.
- Independent exact-build Chromium flow passed; real ECM routers and SQLite with stateful fake upstream, no live Dispatcharr writes.
- Strict MkDocs and whitespace checks passed. Ruff unavailable in supplied Python environment.
- Code, DBA and security reviews covered only this run against 08bbde8b. Four introduced findings fixed in one round; bounded final rechecks found no remaining issues.
- CI on this immutable head remains to be verified.

Contract and detailed evidence: docs/60r8c_stale_event_streams_plan.md.

## Delivery
Product Owner authorized commit, push and merge. Merge only after final CI passes, then explicitly close #725 if the non-default dev merge does not close it automatically. Verify exact-merge workflows and publication before closing the bead.