### PR TITLE
fix: enforce patched MCP libuuid floor (s0nem)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Security
 
+- **The MCP image now requires Alpine libuuid 2.42.3-r1 or newer (bead `enhancedchannelmanager-s0nem`, build 0.18.2-0018).** The explicit package floor invalidates the cached OS-upgrade layer and refuses vulnerable older packages, including revision r0, which Alpine lists as affected by CVE-2026-78408. The reviewed base digest, OpenSSL floors, non-root user, and existing image scan gates are retained.
+
 - **Removed the unpatched `ecdsa` runtime dependency by replacing `python-jose` with PyJWT for ECM's existing HS256-only tokens (bead `enhancedchannelmanager-tm9ma`, build 0169).** This resolves Dependabot alert #1 / [GHSA-wj6h-64fc-37mp](https://github.com/advisories/GHSA-wj6h-64fc-37mp) without changing access, refresh, password-reset, expiry, claim-validation, or revocation behavior. The separate `josepy` dependency remains for ACME certificate management.
 
 ### Fixed

--- a/backend/main.py
+++ b/backend/main.py
@@ -158,7 +158,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0017",
+    version="0.18.2-0018",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -132,7 +132,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0017"
+APP_VERSION = "0.18.2-0018"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/tests/unit/test_mcp_supply_chain_gate.py
+++ b/backend/tests/unit/test_mcp_supply_chain_gate.py
@@ -81,6 +81,29 @@ def test_policy_rejects_comment_only_mcp_openssl_package_floors(tmp_path):
     assert sum("OpenSSL package floor" in failure for failure in failures) == 2, failures
 
 
+@pytest.mark.parametrize(
+    "replacement",
+    ["", "'libuuid>=2.42.1-r0'", "'libuuid>=2.42.3-r0'", "libuuid"],
+)
+def test_policy_enforces_fixed_mcp_libuuid_package_floor(tmp_path, replacement):
+    gate = _load_gate()
+    _copy_policy_files(gate, tmp_path)
+    dockerfile = tmp_path / "mcp-server/Dockerfile"
+    contents = dockerfile.read_text(encoding="utf-8")
+    required = "'libuuid>=2.42.3-r1'"
+    assert required in contents
+    assert gate.check_repository(tmp_path) == []
+    dockerfile.write_text(
+        f"# Retain reviewed floor {required}\n"
+        + contents.replace(required, replacement, 1),
+        encoding="utf-8",
+    )
+
+    failures = gate.check_repository(tmp_path)
+
+    assert any("libuuid package floor" in failure for failure in failures), failures
+
+
 def test_policy_rejects_a_different_digest_pinned_mcp_base(tmp_path):
     gate = _load_gate()
     _copy_policy_files(gate, tmp_path)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0017",
+  "version": "0.18.2-0018",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -5,10 +5,12 @@ WORKDIR /app
 # Apply Alpine security updates that may have landed after the pinned base
 # manifest was published. The digest makes the input reviewable; this upgrade
 # step closes fixed OS advisories until the next intentional digest refresh.
+# Alpine v3.24 secdb requires libuuid 2.42.3-r1 for CVE-2026-78408.
 RUN apk upgrade --no-cache \
     && apk add --no-cache \
         'libcrypto3>=3.5.8-r0' \
         'libssl3>=3.5.8-r0' \
+        'libuuid>=2.42.3-r1' \
     && addgroup -g 1000 appgroup \
     && adduser -D -u 1000 -G appgroup appuser
 

--- a/sbom/dev/ecm.spdx.json
+++ b/sbom/dev/ecm.spdx.json
@@ -2,10 +2,10 @@
   "spdxVersion": "SPDX-2.3",
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
-  "name": "ecm-0.18.2-0017",
-  "documentNamespace": "https://github.com/motwakorb/enhancedchannelmanager/sbom/v0.18.2-0017/ecm-b0acd99f555847b1b8fcc484e9cab6697b5943b9896589da0669055dd418071f",
+  "name": "ecm-0.18.2-0018",
+  "documentNamespace": "https://github.com/motwakorb/enhancedchannelmanager/sbom/v0.18.2-0018/ecm-9d1159e849472174e63fc686759fc9a7d35a1c4c66bbec2cf5bb80cb4070b1ca",
   "creationInfo": {
-    "created": "2026-09-04T18:56:05Z",
+    "created": "2026-09-05T20:12:47Z",
     "creators": [
       "Tool: scripts/generate_sbom.py-6"
     ],
@@ -18,7 +18,7 @@
     {
       "SPDXID": "SPDXRef-Package-ecm",
       "name": "enhanced-channel-manager",
-      "versionInfo": "0.18.2-0017",
+      "versionInfo": "0.18.2-0018",
       "downloadLocation": "NOASSERTION",
       "filesAnalyzed": false,
       "supplier": "NOASSERTION",

--- a/sbom/dev/index.json
+++ b/sbom/dev/index.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
-  "version": "0.18.2-0017",
-  "created": "2026-09-04T18:56:05Z",
+  "version": "0.18.2-0018",
+  "created": "2026-09-05T20:12:47Z",
   "kind": "source-manifest",
   "channel": "dev",
   "permanent": false,
@@ -27,7 +27,7 @@
     "Dockerfile": "sha256:ab00a994d742aeb87d3bb28bce7d1d7d1a3fd5c14ca85ee74425c05a37af4472",
     "backend/requirements.txt": "sha256:d1dcc0302cbbe2714a411404d7aad01eb3448cabb5e9f33e1625332bed287599",
     "frontend/package-lock.json": "sha256:c1c0ac5f168feadf122bd32c1b8e714916b0a513d3c212a9e518afd10ebc7140",
-    "mcp-server/Dockerfile": "sha256:c475206aed271a9593e0dfa530c0f33dbe5f911d648871c9311d055b210ab2d2",
+    "mcp-server/Dockerfile": "sha256:58e90f5183dbf0e42069e3b752690a3f049721c1baa18f33f36aa9819433781c",
     "mcp-server/requirements.txt": "sha256:c226a10129c51750977051f1d5efe54f1e9177f4ed240400ab3a89c56a6f1a37",
     "sbom/native-dependencies.json": "sha256:530f7498262e5c38541513e01ca12b4f6964b61b80273f75ec8956ff5e17a82a"
   },
@@ -60,7 +60,7 @@
           ]
         ]
       },
-      "sha256": "2cb439e79a5f19a20003bf58144c96bbbfac41ecea667884547f764f0e929fb2"
+      "sha256": "7f19066abf9f2bfa2d8b4dfee8a3c2afcaca1c668adf6d6561003e65ed576bd3"
     },
     {
       "path": "mcp.spdx.json",
@@ -71,7 +71,7 @@
         "packages": [],
         "relationships": []
       },
-      "sha256": "50b9f75a1058c08acd8be1f0ee43bcb18c34d599300b87e3cc1061a99ef91d09"
+      "sha256": "776343252180f473e61d3755ac700f0ce7bca95f7d0f383dc157d78f4608d878"
     }
   ]
 }

--- a/sbom/dev/mcp.spdx.json
+++ b/sbom/dev/mcp.spdx.json
@@ -2,10 +2,10 @@
   "spdxVersion": "SPDX-2.3",
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
-  "name": "mcp-0.18.2-0017",
-  "documentNamespace": "https://github.com/motwakorb/enhancedchannelmanager/sbom/v0.18.2-0017/mcp-11f880ab2fba405b5a3ae1e14d70af2e5883e8f61e9a0b5aa2007183d06df651",
+  "name": "mcp-0.18.2-0018",
+  "documentNamespace": "https://github.com/motwakorb/enhancedchannelmanager/sbom/v0.18.2-0018/mcp-b495dcfd2dfd50816fc72fb7438b77be25da1adf7b8726f7c9819e45260a4977",
   "creationInfo": {
-    "created": "2026-09-04T18:56:05Z",
+    "created": "2026-09-05T20:12:47Z",
     "creators": [
       "Tool: scripts/generate_sbom.py-6"
     ],
@@ -18,7 +18,7 @@
     {
       "SPDXID": "SPDXRef-Package-mcp",
       "name": "enhanced-channel-manager-mcp",
-      "versionInfo": "0.18.2-0017",
+      "versionInfo": "0.18.2-0018",
       "downloadLocation": "NOASSERTION",
       "filesAnalyzed": false,
       "supplier": "NOASSERTION",

--- a/scripts/check_mcp_supply_chain.py
+++ b/scripts/check_mcp_supply_chain.py
@@ -90,6 +90,11 @@ def check_repository(root: Path) -> list[str]:
                 "MCP image must enforce the reviewed OpenSSL package floor: "
                 f"missing '{required}' from executable apk add arguments"
             )
+    if not _has_apk_add_argument(mcp_dockerfile, "libuuid>=2.42.3-r1"):
+        failures.append(
+            "MCP image must enforce the reviewed libuuid package floor: "
+            "missing 'libuuid>=2.42.3-r1' from executable apk add arguments"
+        )
 
     if "pip-audit -r mcp-server/requirements.txt" not in build:
         failures.append("MCP dependency audit is absent from the publication workflow")


### PR DESCRIPTION
## Summary
Separate PO-authorized security fix for enhancedchannelmanager-s0nem, unblocking #983 without changing its feature scope.

Enforce libuuid>=2.42.3-r1 in the MCP image and existing supply-chain policy. Alpine v3.24 security data lists CVE-2026-78408 in r1, stricter than the r0 currently reported by Trivy. Base digest, OpenSSL floors, non-root identity, requirements and scan gates remain unchanged. Includes required 0.18.2-0018 build metadata and regenerated dev SBOMs.

## Verification
- Parent:196 policy/SBOM/dependency/version tests passed;755 MCP tests passed,72.52%coverage.
- Parent SBOM verify and audit --all passed.
- No-cache AMD64 image installed libuuid2.42.3-r1; independent Trivy OS/Python HIGH/CRITICAL rescan:zero findings.
- Scanner negative control detected all seven libuuid CVEs in the pinned base.
- Bounded independent code/security review approved, no findings.
- ARM64 build/scan pending CI. Existing unrelated Ruff findings left untouched.

Official evidence:https://secdb.alpinelinux.org/v3.24/main.json

## Delivery
Merge separately after CI, then refresh #983 against dev and verify its checks. No Event Sync feature changes in this PR.