### PR TITLE
chore: bump desktop repairs to 0.18.2-0021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **Desktop visual repairs now have a distinct dev build (bead `enhancedchannelmanager-0m06f.8.1`, PR #987, build 0.18.2-0021).** The merged desktop repairs address clipped controls and glyphs, overlapping labels, typography, spacing, and theme contrast across pages and dialogs. This follow-up advances the UI/image, backup-export, and OpenAPI version metadata together after PR #987 retained 0.18.2-0020. Phone-only repairs remain outside this delivery's scope.
+
 - **Explicit broad Channel Pipeline schedules now run all enabled rules without requiring Run on Refresh (GitHub #975, build 0.18.2-0019).** Selecting the broad scope stores `run_all_rules: true` and applies equally to due schedules and Run Now. Existing parameterless schedules, including the built-in 60-second poll, remain refresh-only with their existing guards; no schedule is silently reclassified. Exact selected-rule scope remains separate and fail-closed.
 
 - **Channel Group / Is conditions now use a searchable group selector that saves integer IDs (GitHub #856, build 0.18.2-0019).** The editor displays group names without submitting them as invalid string values. Matching still uses the stream's assigned channel group, not its provider stream group.

--- a/backend/main.py
+++ b/backend/main.py
@@ -158,7 +158,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0020",
+    version="0.18.2-0021",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -132,7 +132,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0020"
+APP_VERSION = "0.18.2-0021"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -33,6 +33,8 @@ bd update <id> --description "Detailed description of changes made"
 
 **Not every change does.** A change containing only approved root machine-generated `.beads` state carries no build to advance. Every other path requires a bump.
 
+**Bump on every delivery**, including UI/CSS repairs and corrective follow-ups; a previous delivery's bump does not cover the next one. Before committing, compare against current `origin/dev` and increment its zero-padded `BUILD` suffix for the same target release. Do not reuse a build number. This is a manual checklist requirement, not an advancement gate; the inert machine-state exception above remains unchanged.
+
 The rule is mechanical and you can apply it from what you edited, without running anything:
 
 | Every file you changed | What to do |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0020",
+  "version": "0.18.2-0021",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Correct the missing build increment in desktop visual repair PR #987 (epic enhancedchannelmanager-0m06f.8.1).

- Advance frontend/image, OpenAPI, and backup-export informational versions together from 0.18.2-0020 to 0.18.2-0021.
- Record the desktop repairs and correction in the changelog.
- Explicitly require a fresh build number for each delivery in the existing shipping checklist, including UI/CSS repairs and corrective follow-ups.
- Preserve the documented inert machine-state exception and existing lockfile-version conventions. No runtime logic, dependencies, or backup schema changes.

## Validation
- Parent independently ran version touchpoint consistency tests: 24 passed.
- Engineer verified Python compilation, frontend TypeScript and production build; existing chunk-size warning only.
- Diff whitespace checks passed.

The 192 Playwright and 3,709 frontend test results for the desktop fixes belong to PR #987; they were not rerun for this metadata-only correction.