### PR TITLE
v0.18.2-0022: fix ntfy notifications header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **ntfy settings header (bead `enhancedchannelmanager-dulo7`).** Show exactly `ntfy Notifications` without the notification icon in both administrator and non-administrator views.
 - **Desktop visual repairs now have a distinct dev build (bead `enhancedchannelmanager-0m06f.8.1`, PR #987, build 0.18.2-0021).** The merged desktop repairs address clipped controls and glyphs, overlapping labels, typography, spacing, and theme contrast across pages and dialogs. This follow-up advances the UI/image, backup-export, and OpenAPI version metadata together after PR #987 retained 0.18.2-0020. Phone-only repairs remain outside this delivery's scope.
 
 - **Explicit broad Channel Pipeline schedules now run all enabled rules without requiring Run on Refresh (GitHub #975, build 0.18.2-0019).** Selecting the broad scope stores `run_all_rules: true` and applies equally to due schedules and Run Now. Existing parameterless schedules, including the built-in 60-second poll, remain refresh-only with their existing guards; no schedule is silently reclassified. Exact selected-rule scope remains separate and fail-closed.

--- a/backend/main.py
+++ b/backend/main.py
@@ -158,7 +158,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0021",
+    version="0.18.2-0022",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -132,7 +132,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0021"
+APP_VERSION = "0.18.2-0022"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0021",
+  "version": "0.18.2-0022",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/settings/AlertMethodsSection.test.tsx
+++ b/frontend/src/components/settings/AlertMethodsSection.test.tsx
@@ -72,6 +72,8 @@ describe('AlertMethodsSection', () => {
     await waitFor(() => {
       expect(screen.getByText(/no alert methods configured/i)).toBeInTheDocument();
     });
+    expect(screen.getByRole('heading', { level: 3, name: 'ntfy Notifications' }).parentElement)
+      .toHaveTextContent(/^ntfy Notifications$/);
   });
 
   it('renders a create-only ntfy form with password token input', async () => {
@@ -271,6 +273,8 @@ describe('AlertMethodsSection', () => {
 
     render(<AlertMethodsSection isAdmin={false} />);
 
+    expect(screen.getByRole('heading', { level: 3, name: 'ntfy Notifications' }).parentElement)
+      .toHaveTextContent(/^ntfy Notifications$/);
     expect(
       screen.getByText(/Only administrators can view or manage alert methods\./),
     ).toBeInTheDocument();

--- a/frontend/src/components/settings/AlertMethodsSection.tsx
+++ b/frontend/src/components/settings/AlertMethodsSection.tsx
@@ -163,8 +163,7 @@ export function AlertMethodsSection({ isAdmin }: AlertMethodsSectionProps) {
     return (
       <div className="settings-section alert-methods-section">
         <div className="settings-section-header">
-          <span className="material-icons">notifications_active</span>
-          <h3>Alert Methods</h3>
+          <h3>ntfy Notifications</h3>
         </div>
         <div className="alert-methods-empty empty-inline">
           <span className="material-icons">lock</span>
@@ -177,8 +176,7 @@ export function AlertMethodsSection({ isAdmin }: AlertMethodsSectionProps) {
   return (
     <div className="settings-section alert-methods-section">
       <div className="settings-section-header">
-        <span className="material-icons">notifications_active</span>
-        <h3>Alert Methods</h3>
+        <h3>ntfy Notifications</h3>
       </div>
       <p className="section-description">
         Send a test message or remove an alert method you no longer use.


### PR DESCRIPTION
## Summary
- Change both administrator and non-administrator section headers to exactly ntfy Notifications, removing the notifications_active icon text.
- Preserve existing ntfy behavior and add exact-header regression assertions.
- Increment all three version touchpoints from 0.18.2-0021 to 0.18.2-0022 and record the fix in CHANGELOG.md.

Bead: enhancedchannelmanager-dulo7

## Verification
- Full frontend suite: 261 files / 3,709 tests passed, independently rerun.
- ESLint, TypeScript, and production build passed.
- Version touchpoint consistency: 24 tests passed.
- Independent code review of 4ab11dee: no findings.
- Live browser verification not performed; component rendering tested with jsdom.

User authorized commit, push, merge, and version increment.