### PR TITLE
v0.18.2-0023: fix Points grey screen and Emby button layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **Settings layout (bead `enhancedchannelmanager-9nd9o`, build 0.18.2-0023).** Keep Clear Emby Logos left aligned with its icon centered beside the text, and prevent selecting Smart Sort Points from scrolling the entire app offscreen when the hidden radio receives focus.
 - **ntfy settings header (bead `enhancedchannelmanager-dulo7`).** Show exactly `ntfy Notifications` without the notification icon in both administrator and non-administrator views.
 - **Desktop visual repairs now have a distinct dev build (bead `enhancedchannelmanager-0m06f.8.1`, PR #987, build 0.18.2-0021).** The merged desktop repairs address clipped controls and glyphs, overlapping labels, typography, spacing, and theme contrast across pages and dialogs. This follow-up advances the UI/image, backup-export, and OpenAPI version metadata together after PR #987 retained 0.18.2-0020. Phone-only repairs remain outside this delivery's scope.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -158,7 +158,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0022",
+    version="0.18.2-0023",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -132,7 +132,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0022"
+APP_VERSION = "0.18.2-0023"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/e2e/smart-sort-points.spec.ts
+++ b/e2e/smart-sort-points.spec.ts
@@ -166,6 +166,98 @@ test.afterAll(async () => {
   if (temporaryDirectory) await rm(temporaryDirectory, { recursive: true, force: true })
 })
 
+test('physical Points selection keeps the document and editor onscreen', async ({ page }, testInfo) => {
+  for (const [width, height] of [[1920, 1080], [1366, 768], [1100, 800], [1024, 768]]) {
+    await page.setViewportSize({ width, height })
+    await page.goto('about:blank')
+    await page.goto(`${appURL}/#settings/channel-defaults`)
+    const group = page.getByRole('radiogroup', { name: 'Smart Sort strategy' })
+    await expect(group.getByRole('radio', { name: 'Priority' })).toBeChecked()
+    await group.evaluate((element) => {
+      const container = element.closest('.settings-content')!
+      container.scrollTop += element.getBoundingClientRect().top - container.getBoundingClientRect().top - 180
+    })
+    const points = group.getByText('Points', { exact: true })
+    const box = await points.boundingBox()
+    expect(box).not.toBeNull()
+    expect(box!.y).toBeGreaterThanOrEqual(0)
+    expect(box!.y + box!.height).toBeLessThan(height)
+    // Locator clicks auto-scroll and can conceal the document focus-scroll bug.
+    await page.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2)
+    await expect(group.getByRole('radio', { name: 'Points' })).toBeChecked()
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
+    const geometry = await page.locator('.smart-sort-points-editor').evaluate((element) => {
+      const rect = element.getBoundingClientRect()
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        appTop: document.querySelector('.app')!.getBoundingClientRect().top,
+        hit: element.contains(document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2)),
+      }
+    })
+    expect(geometry.appTop).toBe(0)
+    expect(geometry.top).toBeGreaterThanOrEqual(0)
+    expect(geometry.bottom).toBeLessThanOrEqual(height)
+    expect(geometry.hit).toBe(true)
+    await page.screenshot({ path: testInfo.outputPath(`points-physical-${width}.png`), fullPage: false })
+  }
+})
+
+test('default settings survive the Priority to Points render transition', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (error) => errors.push(error.message))
+  const response = await page.request.get(`${appURL}/api/settings`)
+  expect(response.ok()).toBe(true)
+  expect(await response.json()).toMatchObject({
+    stream_sort_strategy: 'priority',
+    stream_sort_point_rules: [],
+  })
+
+  await page.goto(`${appURL}/#settings/channel-defaults`)
+  await expect(page.getByRole('radio', { name: 'Priority' })).toBeChecked()
+  await chooseStrategy(page, 'Points')
+  await expect(page.getByText('No point rules configured. Every stream will receive a score of 0.')).toBeVisible()
+  await page.getByRole('button', { name: 'Add rule' }).click()
+  await expect(pointRule(page, 0).getByLabel('Condition')).toContainText('Resolution')
+  await chooseStrategy(page, 'Priority')
+  await chooseStrategy(page, 'Points')
+  await expect(page.getByTestId('smart-sort-point-rule')).toHaveCount(1)
+  await chooseStrategy(page, 'Priority')
+  await page.getByRole('button', { name: /Reorder$/ }).click()
+  await expect(page.getByRole('button', { name: /Done$/ })).toBeVisible()
+  await chooseStrategy(page, 'Points')
+  await expect(page.getByTestId('smart-sort-point-rule')).toHaveCount(1)
+  expect(errors).toEqual([])
+})
+
+test('Clear Emby Logos stays left aligned with its icon level with the text', async ({ page }) => {
+  await page.goto(`${appURL}/#settings/integrations`)
+  const button = page.getByTestId('emby-clear-logos-btn')
+  await expect(button).toBeVisible()
+  // Inspect only: never invoke the destructive action, even in this harness.
+  for (const width of [1280, 390]) {
+    await page.setViewportSize({ width, height: 900 })
+    await expect(button).toHaveCSS('display', 'flex')
+    await expect(button).toHaveCSS('align-items', 'center')
+    await expect(button).toHaveCSS('margin-left', '0px')
+    const geometry = await button.evaluate((element) => {
+      const buttonRect = element.getBoundingClientRect()
+      const parentRect = element.parentElement!.getBoundingClientRect()
+      const iconRect = element.querySelector('.material-icons')!.getBoundingClientRect()
+      const range = document.createRange()
+      range.selectNodeContents(element)
+      range.setStartAfter(element.querySelector('.material-icons')!)
+      const textRect = range.getBoundingClientRect()
+      return {
+        leftOffset: buttonRect.left - parentRect.left,
+        centerOffset: (iconRect.top + iconRect.bottom - textRect.top - textRect.bottom) / 2,
+      }
+    })
+    expect(Math.abs(geometry.leftOffset)).toBeLessThan(1)
+    expect(Math.abs(geometry.centerOffset)).toBeLessThan(2)
+  }
+})
+
 test('GH971 complete YAML collection crosses real API and file SQLite on desktop and mobile', async ({ page }, testInfo) => {
   test.setTimeout(90_000)
   await page.goto(`${appURL}/#channel-pipeline`)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0022",
+  "version": "0.18.2-0023",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/tabs/SettingsTab.css
+++ b/frontend/src/components/tabs/SettingsTab.css
@@ -990,6 +990,8 @@
 }
 
 .smart-sort-strategy-option {
+  /* Keep hidden radio focus within the card's scroll container. */
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -1380,6 +1382,12 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 0.5rem;
+}
+
+.emby-clear-logos-actions > .btn-secondary {
+  /* Keep the shared icon-button layout inside .form-group-vertical. */
+  display: inline-flex;
+  margin-left: 0;
 }
 
 /* Clear Emby Logos type checkboxes (GH #475, bd-v9tp7) */

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -4515,7 +4515,7 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
               ))}
             </div>
 
-            <div className="integration-test-actions">
+            <div className="integration-test-actions emby-clear-logos-actions">
               <button
                 type="button"
                 className="btn-secondary"


### PR DESCRIPTION
## Summary
- Contain the hidden Smart Sort radio inside its strategy card so focusing Points cannot scroll the whole application offscreen.
- Left-align Clear Emby Logos and center its icon beside its text.
- Add physical-click browser regressions with viewport geometry assertions across four desktop sizes, plus Emby alignment coverage.
- Advance all three version touchpoints to 0.18.2-0023 and update the changelog.

Bead: enhancedchannelmanager-9nd9o

## Verification
- Reproduced the Points grey screen on the reported instance; browser-only CSS trial prevented it without saving settings.
- Regression failed before fix and passed after.
- Seven isolated Chromium tests passed, independently rerun.
- Full frontend suite: 3,709 tests passed.
- Lint, typecheck, production build, and 24 version consistency tests passed.
- Independent code review in progress; will finish before merge.

No live settings writes or logo deletion performed.