### PR TITLE
v0.18.2-0024: move Mapped channels into Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **Mapped channels moved to Settings > Channel Normalization (bead `enhancedchannelmanager-81sy8`, GitHub #775, build 0.18.2-0024).** The existing manager is now a headed, section-linked Settings section instead of an Operations sidebar destination. Old `#mapped-channels` bookmarks redirect to the new section. Mapping saves, API permissions, and the stream-selection **Add mapping** shortcut are unchanged.
+
 ### Added
 
 - **Stream probes now classify resolution-relative low bitrate (bead `enhancedchannelmanager-8gmk8.4`, GitHub #980, build 0.18.2-0020).** Fresh bitrate in bits/second is low only when strictly below `width * height * low_bitrate_threshold`, independent of FPS. The configurable positive finite threshold defaults to 1.0 bit/pixel/second. Inputs prefer fresh measured throughput, then video metadata, then overall format metadata, using current effective dimensions including opt-in resdet results. Missing or invalid inputs and failed probes clear the flag rather than reusing stale values. Classification remains visible independently of sorting; Priority deprioritization defaults off and follows the existing global health gate. Points mode uses explicit `low_bitrate` rules only, with no hidden bucket, injected rule, or automatic penalty. Existing numeric bitrate ranking and direct sorts are unchanged.

--- a/backend/main.py
+++ b/backend/main.py
@@ -158,7 +158,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0023",
+    version="0.18.2-0024",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -132,7 +132,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0023"
+APP_VERSION = "0.18.2-0024"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -150,8 +150,15 @@ If a channel name created before the bd-eio04.1 cutover still carries `²`, `³`
 
 ## Mapped Channels
 
-Use **Mapped channels** to add, review, edit or remove reusable preferred-name
-mappings. In Channel Manager, select streams on the right and choose **Add
+Use **Settings > Channel Normalization > Mapped channels** to add, review, edit
+or remove reusable preferred-name mappings. The **On this page** rail links to
+the section. Its bookmark is
+`#settings/normalization?section=settings-normalization-section-mapped-channels`;
+older `#mapped-channels` bookmarks redirect there. **Save mapping** and **Remove**
+persist immediately, independently of **Save Settings**. Mapping writes still
+require an administrator when authentication is enabled.
+
+In Channel Manager, select streams on the right and choose **Add
 mapping**, then **Existing** (a mapping, not a Dispatcharr channel) or **Add new**.
 Selected stream names prefill the alternatives; enter one literal name per line.
 

--- a/docs/u0ko6_alias_mapping_plan.md
+++ b/docs/u0ko6_alias_mapping_plan.md
@@ -4,6 +4,13 @@ Owner: project-engineer. GitHub: #775. Base: origin/dev `144334cf`.
 Status: frozen contract implemented locally; final bounded code and DBA reviews complete.
 This supplements, rather than replaces, the original request in the owning bead.
 
+> Superseding PO decision, 2026-09-08 (`enhancedchannelmanager-81sy8`): move
+> management into **Settings > Channel Normalization > Mapped channels** and
+> redirect shipped `#mapped-channels` bookmarks to
+> `#settings/normalization?section=settings-normalization-section-mapped-channels`.
+> Only the dedicated-tab policy below is superseded; mapping behavior and the
+> stream-selection shortcut are unchanged. Relocation is local and unshipped.
+
 ## Approved Behavior
 
 - Right-side stream selection offers Add mapping, with Existing / Add new.

--- a/docs/user_guide/settings/channel-normalization.md
+++ b/docs/user_guide/settings/channel-normalization.md
@@ -1,8 +1,9 @@
 # Channel Normalization
 
 Channel Normalization, under **Channel Processing** in the Settings
-navigation, holds two Settings-level toggles plus the full normalization
-rules engine. This article covers only the two toggles. Rule authoring,
+navigation, holds two Settings-level toggles, the full normalization
+rules engine, and **Mapped channels**. This article covers the toggles and mapping
+management. Rule authoring,
 condition/action types, testing, and the developer reference all live in
 the dedicated normalization guide linked below. That guide is the source of
 truth; this page exists so the two Settings-only toggles have a documented
@@ -33,6 +34,22 @@ channel names entirely.
 
 **Result:** Instead of removing country prefixes, normalization now keeps
 them with a consistent separator format.
+
+### Manage preferred-name mappings
+
+1. Go to **Settings > Channel Normalization**.
+2. Choose **Mapped channels** in the **On this page** rail, or scroll to that section.
+3. Use **Add mapping**, **Edit**, or **Remove** to manage literal aliases.
+4. Use **Save mapping** in the editor. Mapping changes save immediately and do
+   not require **Save Settings**. Mapping writes require an administrator when
+   authentication is enabled.
+
+The direct bookmark is
+`#settings/normalization?section=settings-normalization-section-mapped-channels`.
+Old `#mapped-channels` bookmarks redirect here; there is no separate Operations
+destination. The stream-selection **Add mapping** shortcut in Channel Manager
+is still available. See [Mapped Channels](https://github.com/MotWakorb/enhancedchannelmanager/blob/main/docs/normalization.md#mapped-channels)
+for matching rules and examples.
 
 ## Going deeper
 

--- a/e2e/channel-name-mappings.spec.ts
+++ b/e2e/channel-name-mappings.spec.ts
@@ -41,6 +41,8 @@ test('selected names -> persisted mapping -> Create grouping and management', as
         '/api/auth/status': { require_auth: false, setup_complete: true, dispatcharr_enabled: false },
         '/api/auth/setup-required': { required: false },
         '/api/settings': { configured: true, url: 'https://fixture.invalid', normalize_on_channel_create: false, show_hide_controls: true, default_channel_profile_ids: [] },
+        '/api/normalization/rules': { groups: [] },
+        '/api/tags/groups': { groups: [] },
         '/api/channels/logos': paginated([]),
         '/api/channels': paginated([]),
         '/api/channel-groups': [{ id: 5, name: 'Mapped output', channel_count: 0 }],
@@ -82,10 +84,18 @@ test('selected names -> persisted mapping -> Create grouping and management', as
     await expect(page.locator('.channels-pane .channel-item')).toContainText('Stars TV HD');
     await expect(page.locator('.channels-pane .channel-item .channel-streams-count')).toHaveAttribute('aria-label', /^2 streams;/);
     // Staging exercises App's grouping/assignment, but never commits to Dispatcharr.
-    await page.getByRole('link', { name: 'Mapped channels', exact: true }).click();
+    await expect(page.getByRole('link', { name: 'Mapped channels', exact: true })).toHaveCount(0);
+    await page.getByRole('link', { name: 'Settings', exact: true }).click();
     await page.getByRole('button', { name: 'Discard', exact: true }).click();
+    await page.getByRole('link', { name: 'Channel Normalization', exact: true }).click();
+    await page.getByRole('navigation', { name: 'On this page' }).getByRole('button', { name: 'Mapped channels', exact: true }).click();
+    await expect(page).toHaveURL(/#settings\/normalization\?section=settings-normalization-section-mapped-channels$/);
+    await expect(page.getByRole('heading', { name: 'Mapped channels', exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Edit Stars TV HD' })).toBeVisible();
+    await page.goto('/#mapped-channels');
+    await expect(page).toHaveURL(/#settings\/normalization\?section=settings-normalization-section-mapped-channels$/);
     await page.reload();
+    await expect(page.getByRole('heading', { name: 'Mapped channels', exact: true })).toBeInViewport();
     await expect(page.getByRole('button', { name: 'Edit Stars TV HD' })).toBeVisible();
     await page.getByRole('button', { name: 'Edit Stars TV HD' }).click();
     await expect(page.getByLabel('Alternative names (one per line)')).toHaveValue('Stars TV HD\nStars.TV\nStars-TV');

--- a/e2e/desktop-visual-repairs.spec.ts
+++ b/e2e/desktop-visual-repairs.spec.ts
@@ -775,13 +775,15 @@ for (const theme of ['dark', 'light', 'high-contrast']) {
     });
     test(`G05 mapped editor roles ${theme} ${viewport.width}`, async ({ page }, testInfo) => {
       await page.setViewportSize(viewport);
-      await openSynthetic(page, 'mapped-channels', theme, {
+      await openSynthetic(page, 'settings/normalization?section=settings-normalization-section-mapped-channels', theme, {
+        '/api/normalization/rules': { groups: [] },
+        '/api/tags/groups': { groups: [] },
         '/api/normalization/mappings': { mappings: [{ id: 1, preferred_name: 'BBC One', aliases: ['BBC ONE HD'] }] },
       });
       await page.getByRole('button', { name: 'Add mapping', exact: true }).click();
       await capture(page, testInfo, 'G05');
       await page.setViewportSize({ width: 1280, height: 900 });
-      await capture(page, testInfo, 'G05-standalone-1280');
+      await capture(page, testInfo, 'G05-settings-1280');
       await expect.soft(page.locator('.mapped-channels label').first()).toHaveCSS('font-size', '13px');
       await page.setViewportSize(viewport);
       await expect.soft(page.locator('.mapped-channels > p').first()).toHaveCSS('font-size', '13px');
@@ -792,12 +794,16 @@ for (const theme of ['dark', 'light', 'high-contrast']) {
         : route.fallback());
       await page.getByRole('button', { name: 'Save mapping', exact: true }).click();
       await expect(page.locator('.mapped-channels [role=alert]')).toBeVisible();
-      await capture(page, testInfo, 'G05-standalone-validation');
+      await capture(page, testInfo, 'G05-settings-validation');
       await expect(page.locator('.mapped-channels [role=alert]')).toHaveCSS('font-size', '13px');
       await expect.soft(page.locator('.mapped-channels h3')).toHaveCSS('font-size', '13px');
       await expect.soft(page.locator('.mapped-channels h3')).toHaveCSS('font-weight', '600');
       await page.goto('about:blank');
-      await openSynthetic(page, 'mapped-channels', theme, { '/api/normalization/mappings': { mappings: [] } });
+      await openSynthetic(page, 'settings/normalization?section=settings-normalization-section-mapped-channels', theme, {
+        '/api/normalization/rules': { groups: [] },
+        '/api/tags/groups': { groups: [] },
+        '/api/normalization/mappings': { mappings: [] },
+      });
       await expect(page.getByText('No mappings defined.', { exact: true })).toBeVisible();
       await page.getByRole('button', { name: 'Add mapping', exact: true }).click();
       await capture(page, testInfo, 'G05-empty-list-editor');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0023",
+  "version": "0.18.2-0024",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,6 @@ import {
   type TabId,
 } from './components';
 import { ChannelManagerTab } from './components/tabs/ChannelManagerTab';
-import { MappedChannels } from './components/MappedChannels';
 import { OperatorDashboard } from './components/tabs/OperatorDashboard';
 import { useChangeHistory, useEditMode, useHashRoute, useDedupOnDrop, useServerDataInvalidation } from './hooks';
 import { useAuth } from './hooks/useAuth';
@@ -3397,7 +3396,6 @@ function App() {
             />
             </ErrorBoundary>
           )}
-          {activeTab === 'mapped-channels' && <MappedChannels />}
           {activeTab === 'm3u-manager' && (
             <ErrorBoundary key="tab-m3u-manager" scopeLabel="M3U Manager tab" reloadMode="reset">
             <M3UManagerTab

--- a/frontend/src/components/TabNavigation.test.tsx
+++ b/frontend/src/components/TabNavigation.test.tsx
@@ -23,11 +23,11 @@ describe('grouped primary navigation', () => {
     ]);
     expect(within(nav).getAllByRole('link').map((link) => link.getAttribute('aria-label'))).toEqual([
       'Dashboard', 'M3U Manager', 'EPG Manager', 'Logo Manager', 'Channel Manager',
-      'Mapped channels',
       'Channel Pipeline', 'Guide', 'Stats', 'M3U Changes', 'Journal', 'Settings',
     ]);
     expect(within(nav).getByRole('link', { name: 'Stats' })).toHaveAttribute('aria-current', 'page');
     expect(within(nav).getByRole('link', { name: 'Guide' })).toHaveAttribute('href', '#guide');
+    expect(within(nav).queryByRole('link', { name: 'Mapped channels' })).not.toBeInTheDocument();
   });
 
   it('activates destinations by pointer and keyboard', async () => {

--- a/frontend/src/components/TabNavigation.tsx
+++ b/frontend/src/components/TabNavigation.tsx
@@ -5,7 +5,7 @@ import { GROUPS } from './navigationGroups';
 import { settingsSectionGroups, type SettingsPage } from './settingsSections';
 import './TabNavigation.css';
 
-export type TabId = 'dashboard' | 'm3u-manager' | 'epg-manager' | 'channel-manager' | 'mapped-channels' | 'guide' | 'logo-manager' | 'm3u-changes' | 'channel-pipeline' | 'journal' | 'stats' | 'settings';
+export type TabId = 'dashboard' | 'm3u-manager' | 'epg-manager' | 'channel-manager' | 'guide' | 'logo-manager' | 'm3u-changes' | 'channel-pipeline' | 'journal' | 'stats' | 'settings';
 
 interface TabNavigationProps {
   activeTab: TabId;

--- a/frontend/src/components/navigationGroups.ts
+++ b/frontend/src/components/navigationGroups.ts
@@ -27,7 +27,6 @@ export const GROUPS: NavigationGroup[] = [
     { id: 'epg-manager', label: 'EPG Manager', icon: 'schedule' },
     { id: 'logo-manager', label: 'Logo Manager', icon: 'image' },
     { id: 'channel-manager', label: 'Channel Manager', icon: 'tv' },
-    { id: 'mapped-channels', label: 'Mapped channels', icon: 'link' },
   ] },
   { label: 'Automation', destinations: [
     { id: 'channel-pipeline', label: 'Channel Pipeline', icon: 'auto_fix_high' },

--- a/frontend/src/components/routeHierarchy.ts
+++ b/frontend/src/components/routeHierarchy.ts
@@ -121,7 +121,6 @@ function route(
 
 export const ROUTE_HIERARCHY: Record<TabId, RouteHierarchy> = {
   dashboard: route('OVERVIEW', 'dashboard', 'Review ECM status and move directly to the workspace that needs attention.'),
-  'mapped-channels': route('OPERATIONS', 'mapped-channels', 'Define reusable preferred channel names and literal aliases.'),
   // No related-settings link, on the same reasoning that removed M3U Manager's
   // (see below, bead enhancedchannelmanager-hmr0e). Channel Defaults is a
   // standing Settings destination with its own navigation entry, so the header
@@ -175,7 +174,6 @@ export interface RouteHeaderPolicy {
 export const ROUTE_HEADER_POLICIES: Record<TabId, RouteHeaderPolicy> = {
   dashboard: { primaryAction: null, exception: 'Read-only operational summary; actions remain on destination pages.' },
   'channel-manager': { primaryAction: 'Edit Mode' },
-  'mapped-channels': { primaryAction: null, exception: 'Add and save remain mapping-form scoped.' },
   guide: { primaryAction: null, exception: 'Guide refresh, print, and temporal selectors remain one source-scoped control group.' },
   'm3u-manager': { primaryAction: 'Add M3U Account' },
   'epg-manager': { primaryAction: 'Add Standard EPG' },

--- a/frontend/src/components/routeTitles.ts
+++ b/frontend/src/components/routeTitles.ts
@@ -3,7 +3,6 @@ import type { TabId } from './TabNavigation';
 export const ROUTE_TITLES: Record<TabId, string> = {
   dashboard: 'Dashboard',
   'channel-manager': 'Channel Manager',
-  'mapped-channels': 'Mapped channels',
   guide: 'Guide',
   'm3u-manager': 'M3U Manager',
   'epg-manager': 'EPG Manager',

--- a/frontend/src/components/settingsSections.ts
+++ b/frontend/src/components/settingsSections.ts
@@ -101,7 +101,7 @@ const SECTION_DEFINITIONS = [
   {
     id: 'normalization', label: 'Channel Normalization', icon: 'auto_fix_high',
     group: 'Channel Processing',
-    description: 'Configure tag-based patterns for cleaning up channel names during bulk channel creation.',
+    description: 'Configure normalization rules and reusable preferred-name mappings for channel creation.',
   },
   {
     id: 'tag-engine', label: 'Tags', icon: 'label',

--- a/frontend/src/components/tabs/SettingsTab.sectionRail.test.tsx
+++ b/frontend/src/components/tabs/SettingsTab.sectionRail.test.tsx
@@ -23,6 +23,13 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('../../services/channelNameMappings', () => ({
+  getChannelNameMappings: vi.fn(),
+  saveChannelNameMapping: vi.fn(),
+  deleteChannelNameMapping: vi.fn(),
+}));
 
 vi.mock('../../services/api', () => ({
   getSettings: vi.fn(),
@@ -98,6 +105,7 @@ vi.mock('../DeleteOrphanedGroupsModal', () => ({
 }));
 
 import * as api from '../../services/api';
+import * as mappings from '../../services/channelNameMappings';
 import type { SettingsPage } from '../../hooks';
 import { SettingsTab } from './SettingsTab';
 
@@ -158,6 +166,49 @@ describe('Settings section rail — complete from first paint (bead b32co)', () 
       ['Email Recipients', 'settings-m3u-digest-section-email-recipients'],
       ['Discord Notification', 'settings-m3u-digest-section-discord-notification'],
     ]);
+  });
+
+  it('mounts the mapping manager with its own CRUD saves and a stable section anchor', async () => {
+    const user = userEvent.setup();
+    vi.mocked(mappings.getChannelNameMappings).mockResolvedValue({ mappings: [] });
+    vi.mocked(mappings.saveChannelNameMapping).mockResolvedValue({ id: 1, preferred_name: 'Stars TV', aliases: ['Stars.TV'] });
+    vi.mocked(mappings.deleteChannelNameMapping).mockResolvedValue(undefined);
+    const { container } = renderPage('normalization');
+    expect(screen.getByRole('heading', { name: 'Mapped channels' })).toBeInTheDocument();
+    await expectRail(container, [
+      ['Default Behavior', 'settings-normalization-section-default-behavior'],
+      ['Country Prefix Format', 'settings-normalization-section-country-prefix-format'],
+      ['Mapped channels', 'settings-normalization-section-mapped-channels'],
+    ]);
+    const manager = within(screen.getByRole('region', { name: 'Mapped channels' }));
+    await user.click(await manager.findByRole('button', { name: 'Add mapping' }));
+    await user.type(manager.getByLabelText('Preferred name'), 'Stars TV');
+    await user.type(manager.getByLabelText('Alternative names (one per line)'), 'Stars.TV');
+    await user.click(manager.getByRole('button', { name: 'Save mapping' }));
+    expect(mappings.saveChannelNameMapping).toHaveBeenCalledWith({ preferred_name: 'Stars TV', aliases: ['Stars.TV'] }, undefined);
+    await user.click(await manager.findByRole('button', { name: 'Edit Stars TV' }));
+    await user.click(manager.getByRole('button', { name: 'Save mapping' }));
+    expect(mappings.saveChannelNameMapping).toHaveBeenLastCalledWith({ preferred_name: 'Stars TV', aliases: ['Stars.TV'] }, 1);
+    await user.click(await manager.findByRole('button', { name: 'Remove Stars TV' }));
+    expect(mappings.deleteChannelNameMapping).toHaveBeenCalledWith(1);
+    expect(await manager.findByText('No mappings defined.')).toBeInTheDocument();
+    expect(api.saveSettings).not.toHaveBeenCalled();
+    expect(screen.queryByRole('status', { name: 'Unsaved settings' })).not.toBeInTheDocument();
+  });
+
+  it('keeps mapping API permission denials visible in Settings without saving', async () => {
+    const user = userEvent.setup();
+    vi.mocked(mappings.getChannelNameMappings).mockResolvedValue({ mappings: [] });
+    vi.mocked(mappings.saveChannelNameMapping).mockRejectedValue(new Error('Admin access required'));
+    renderPage('normalization');
+    const manager = within(screen.getByRole('region', { name: 'Mapped channels' }));
+    await user.click(await manager.findByRole('button', { name: 'Add mapping' }));
+    await user.type(manager.getByLabelText('Preferred name'), 'Stars TV');
+    await user.click(manager.getByRole('button', { name: 'Save mapping' }));
+    expect(await manager.findByRole('alert')).toHaveTextContent('Admin access required');
+    expect(manager.getByLabelText('Preferred name')).toHaveValue('Stars TV');
+    expect(manager.queryByText(/Mapping saved/)).not.toBeInTheDocument();
+    expect(api.saveSettings).not.toHaveBeenCalled();
   });
 
   it('lists every Authentication section while the auth fetch is still pending', async () => {

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -4,6 +4,7 @@ import * as channelPipelineApi from '../../services/channelPipelineApi';
 import { useNotifications } from '../../contexts/NotificationContext';
 import type { Theme, ProbeHistoryEntry, SortCriterion, SortEnabledMap, FailedStreamCategory, GracenoteConflictMode, StreamPreviewMode, StreamSortStrategy, StreamSortPointCriterion, StreamSortPointOperator, StreamSortPointRule } from '../../services/api';
 import { NormalizationEngineSection } from '../settings/NormalizationEngineSection';
+import { MappedChannels } from '../MappedChannels';
 import { TagEngineSection } from '../settings/TagEngineSection';
 import { AuthSettingsSection } from '../settings/AuthSettingsSection';
 import { UserManagementSection } from '../settings/UserManagementSection';
@@ -3660,6 +3661,14 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
 
       {/* Advanced Normalization Rules Engine */}
       <NormalizationEngineSection />
+
+      <div className="settings-section" data-section-id="settings-normalization-section-mapped-channels">
+        <div className="settings-section-header">
+          <span className="material-icons" aria-hidden="true">link</span>
+          <h3>Mapped channels</h3>
+        </div>
+        <MappedChannels />
+      </div>
 
       <div className="settings-actions">
         <div className="settings-actions-left" />

--- a/frontend/src/hooks/useHashRoute.test.ts
+++ b/frontend/src/hooks/useHashRoute.test.ts
@@ -4,6 +4,24 @@ import { useHashRoute, _parseHash, _buildHash, type RouteChangeGuardDetail } fro
 import { SETTINGS_PAGE_IDS } from '../components/settingsSections';
 
 describe('parseHash', () => {
+  it('redirects shipped mapping bookmarks to the Settings section', () => {
+    expect(_parseHash('#mapped-channels')).toEqual({
+      tab: 'settings', settingsPage: 'normalization', section: 'settings-normalization-section-mapped-channels',
+    });
+  });
+
+  it('replaces a mapping bookmark without adding history or dropping route state', () => {
+    window.history.replaceState({ ecmRouteIndex: 3, ecmRouteEpoch: 2 }, '', '#mapped-channels');
+    const length = window.history.length;
+    const { result, unmount } = renderHook(() => useHashRoute());
+    expect(result.current.activeTab).toBe('settings');
+    expect(result.current.settingsPage).toBe('normalization');
+    expect(window.location.hash).toBe('#settings/normalization?section=settings-normalization-section-mapped-channels');
+    expect(window.history.length).toBe(length);
+    expect(window.history.state).toEqual({ ecmRouteIndex: 3, ecmRouteEpoch: 2 });
+    unmount();
+    window.history.replaceState(null, '', '/');
+  });
   it('preserves supported section deep links on audited long pages', () => {
     expect(_parseHash('#stats?section=stats-section-watch-history')).toEqual({
       tab: 'stats', settingsPage: null, section: 'stats-section-watch-history',

--- a/frontend/src/hooks/useHashRoute.ts
+++ b/frontend/src/hooks/useHashRoute.ts
@@ -11,7 +11,7 @@ export type { SettingsPage };
 const VALID_TABS: Set<string> = new Set([
   'dashboard', 'm3u-manager', 'epg-manager', 'channel-manager', 'guide',
   'logo-manager', 'm3u-changes', 'channel-pipeline', 'journal',
-  'stats', 'settings', 'mapped-channels',
+  'stats', 'settings',
 ]);
 
 /**
@@ -139,6 +139,11 @@ function parseHash(hash: string): HashRoute {
     ? Number(hoursParam) : null;
   const sectionParam = new URLSearchParams(query).get('section');
   const section = sectionParam && /^[a-z0-9-]+$/.test(sectionParam) ? sectionParam : undefined;
+
+  // Preserve shipped bookmarks after moving the manager into Settings (81sy8).
+  if (path === 'mapped-channels') {
+    return { tab: 'settings', settingsPage: 'normalization', section: 'settings-normalization-section-mapped-channels' };
+  }
 
   // Check for settings/sub-page format
   if (path.startsWith('settings/')) {


### PR DESCRIPTION
## Summary
- Move mapping management to System > Settings > Channel Normalization > Mapped channels.
- Remove the standalone Operations destination, retain the stream-selection Add mapping shortcut, and redirect shipped mapped-channels bookmarks to the new Settings section.
- Preserve independent mapping CRUD and Save mapping behavior.
- Update current documentation, regression tests, and all three version touchpoints to 0.18.2-0024.

Bead: enhancedchannelmanager-81sy8. Relates to #775; that closed feature issue will receive a shipped-location update after publication.

## Verification
- Independently rerun: 3,713 frontend tests, lint, typecheck, production build, and isolated exact-build mapping browser workflow passed.
- Engineer checks: 24 version-consistency tests and strict MkDocs build passed.
- Browser coverage includes mapping creation/grouping/edit/removal, Settings navigation, legacy bookmark redirect/reload, and mobile access.
- Independent code review in progress; will complete before merge.

No live instance deployment or data changes performed.