### PR TITLE
v0.18.2-0026: remove redundant internal work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- **Removed redundant internal work (beads `enhancedchannelmanager-hym4q`, `hym4q.2` through `hym4q.5`, `v4h9e`, and `pi9k2`; build 0.18.2-0026).** Settings no longer requests an unused stream count, and Add Stream and drag-drop deduplication share one candidate API client/type family. Network-suffix normalization skips an unreachable regex branch; normalized-name conditions reuse the existing normalization helper with regression coverage for fallback, diagnostics, and inversion. Existing matching behavior is preserved. Retired the unused channel-side profile-membership importer path; membership restoration remains driven by profile rows, with regression coverage for defensive field stripping and supported reporting behavior.
+
 - **Mapped channels moved to Settings > Channel Normalization (bead `enhancedchannelmanager-81sy8`, GitHub #775, build 0.18.2-0024).** The existing manager is now a headed, section-linked Settings section instead of an Operations sidebar destination. Old `#mapped-channels` bookmarks redirect to the new section. Mapping saves, API permissions, and the stream-selection **Add mapping** shortcut are unchanged.
 
 ### Added

--- a/backend/channel_pipeline_evaluator.py
+++ b/backend/channel_pipeline_evaluator.py
@@ -689,15 +689,7 @@ class ConditionEvaluator:
 
         # Normalize the stream name
         stream_name = context.stream_name
-        if self._normalization_engine:
-            try:
-                result = self._normalization_engine.normalize(stream_name)
-                normalized = result.normalized
-            except Exception as e:
-                logger.warning("[AUTO-CREATE-EVAL] Normalization failed for '%s': %s", stream_name, e)
-                normalized = stream_name
-        else:
-            normalized = stream_name
+        normalized = self._normalize_stream_name(context)
 
         # Check if normalized name matches any channel in the group (case-insensitive)
         matched = normalized.lower() in group_names

--- a/backend/dbas/importers/channels.py
+++ b/backend/dbas/importers/channels.py
@@ -1,11 +1,10 @@
-"""The channels restore importer — channel-row create + profile reattach + streams.
+"""The channels restore importer — channel-row create + streams.
 
 Bead ``enhancedchannelmanager-4vouz`` (split 2/4) created the channel-row +
 profile-reattach layer; bead ``enhancedchannelmanager-0i2vt.14`` (the INTEGRATION
 umbrella) extends it with the stream layer. This module restores the CHANNEL
 entity category from a Dispatcharr export archive: it creates each archived
-channel row, reattaches each channel to its archived channel-profile memberships,
-AND re-attaches each channel's archived embedded streams to the destination.
+channel row and re-attaches its archived embedded streams to the destination.
 
 THE STREAM LAYER (``0i2vt.14`` integration — wires the three sibling splits).
 For each restored channel, the archived embedded ``streams`` are matched against
@@ -68,15 +67,8 @@ the producer/consumer seam, applied to the importer/reattach seam.
   these fields are DROPPED from the create payload. (A later logo/epg bead
   reattaches them; this importer must not invent or forward a stale id.)
 
-Channel-profile membership reattach. Channels belong to channel profiles. After a
-channel is created, each archived membership is reattached via
-``client.update_profile_channel(dest_profile_id, dest_channel_id, {"enabled": ...})``.
-The destination profile id is resolved through the IdRemapTable
-(:data:`EntityType.CHANNEL_PROFILE`, populated by ``0i2vt.12``). If the profile
-is NOT in the remap (the channel-profiles importer did not run, or did not
-restore that profile), the membership is handled as ``DEPENDENCY_UNRESOLVED`` and
-recorded under the :data:`EntityType.CHANNEL_PROFILE` category — never crashing,
-never guessing a profile id.
+Channel-profile membership restoration is owned by
+``dbas/channel_reattach.py`` and driven by archived PROFILE rows, not channels.
 
 Collision taxonomy. A channel whose ``(name, channel_number)`` already exists on
 the destination is skipped ``ALREADY_EXISTS_IDENTICAL`` (never overwritten); its
@@ -104,8 +96,7 @@ Opt-in. The category does nothing unless the operator selected it (``selected``)
 
 Integration with the restore contracts (bead ``kxuj2``): results land in the
 shared :class:`~dbas.restore_contracts.RestoreReport`
-(:data:`EntityType.CHANNEL` category, plus :data:`EntityType.CHANNEL_PROFILE` for
-unresolved memberships), created channels register source->dest in the
+(:data:`EntityType.CHANNEL` category), created channels register source->dest in the
 :class:`~dbas.restore_contracts.IdRemapTable`, and every created channel is
 recorded in the :class:`~dbas.restore_contracts.RollbackLedger` so a later
 failure compensates by deleting it. This importer imports the contracts module
@@ -183,9 +174,9 @@ _SOURCE_PROVENANCE_KEYS = frozenset(
 _DERIVED_ECHO_PREFIX = "effective_"
 
 # Embedded/derived keys that are NOT part of a channel create payload. ``streams``
-# is the stream-attachment SEAM owned by bead 0i2vt.14 — this importer strips it
-# and never attaches a stream. ``profile_memberships`` is consumed separately by
-# the profile-reattach step (post-create), not sent in the create body.
+# is stripped from create and attached separately by the stream layer below.
+# ``profile_memberships`` is stripped defensively in case a GET ever echoes it;
+# no producer supplies it and it is not consumed. Memberships use profile rows.
 # ARCHIVE_EPG_TVG_ID_KEY is the EPG link's natural key that the backup producer
 # resolves off the source's guide row (bead …-dfkbn); it is ARCHIVE metadata
 # consumed by the post-create reattach pass (dbas/channel_reattach.py), not a
@@ -311,7 +302,7 @@ async def import_channels(
     created_source_ids: set[int] | None = None,
     matched_existing_channels: dict[int, dict] | None = None,
 ) -> None:
-    """Restore the CHANNEL category: create channel rows + reattach profiles.
+    """Restore the CHANNEL category: create channel rows + attach streams.
 
     Args:
         archive_channels: The channel records from the export archive. Each is a
@@ -321,12 +312,11 @@ async def import_channels(
         selected: The per-category opt-in flag. When ``False`` the entire category
             is skipped (no creates) — every channel recorded EXCLUDED_BY_OPERATOR.
         report: The shared :class:`RestoreReport`; channel results land in the
-            ``EntityType.CHANNEL`` category, unresolved profile memberships in
-            ``EntityType.CHANNEL_PROFILE``.
+            ``EntityType.CHANNEL`` category and stream results in ``EntityType.STREAM``.
         ledger: The shared :class:`RollbackLedger`; each created channel is
             recorded for compensating deletes.
         remap: The shared :class:`IdRemapTable`. READ to resolve channel FK
-            references (channel_group / stream_profile) and channel-profile ids;
+            references (channel_group / stream_profile);
             WRITTEN with each created channel's source->dest id (under
             ``EntityType.CHANNEL``) so the stream-attachment bead and the profile
             reattach can resolve channels.
@@ -416,11 +406,6 @@ async def import_channels(
     except Exception as exc:
         logger.warning("[DBAS-CHANNELS] Could not list existing channels: %s", exc)
 
-    # Channels created/resolved this run, paired with their archive record, so the
-    # profile-reattach pass (post-create) can resolve each channel's dest id.
-    # Each tuple: (archive_channel, destination_channel_id).
-    reattach_queue: list[tuple[dict, int]] = []
-
     # Per-channel stream-attach plans, built during the create loop and resolved
     # after the batched custom-stream fallback runs. Each is a _ChannelStreamPlan
     # carrying the channel's dest id + one ordered slot per archived stream.
@@ -485,7 +470,6 @@ async def import_channels(
                 if matched_existing_channels is not None:
                     matched_existing_channels[source_key] = dict(existing)
                 if not is_dry_run:
-                    reattach_queue.append((archive_channel, int(existing_id)))
                     _plan_streams(
                         stream_plans,
                         archive_channel,
@@ -561,7 +545,6 @@ async def import_channels(
                 if created_source_ids is not None:
                     created_source_ids.add(source_key)
             ledger.record_created(EntityType.CHANNEL, dest_id, label)
-            reattach_queue.append((archive_channel, dest_id))
             _plan_streams(
                 stream_plans,
                 archive_channel,
@@ -572,10 +555,7 @@ async def import_channels(
             )
         logger.info("[DBAS-CHANNELS] Restored channel '%s' (id=%s).", label, dest_id)
 
-    # Profile reattach pass — runs AFTER all channels are created so every channel
-    # has a destination id. Dry-run reattaches nothing.
     if not is_dry_run:
-        await _reattach_profiles(reattach_queue, client=client, report=report, remap=remap)
         # Stream layer: synthesize orphans (batched, one fallback state) + attach
         # the matched + synthesized stream ids to each channel in archived order.
         await _attach_streams(
@@ -817,94 +797,6 @@ async def _attach_streams(
                 plan.dest_channel_id,
                 FailureReason.UPSTREAM_API_ERROR.value,
             )
-
-
-async def _reattach_profiles(
-    reattach_queue: list[tuple[dict, int]],
-    *,
-    client: DispatcharrClient,
-    report: RestoreReport,
-    remap: IdRemapTable,
-) -> None:
-    """Reattach each restored channel to its archived channel-profile memberships.
-
-    For each membership, resolve the destination profile id through the
-    IdRemapTable (``EntityType.CHANNEL_PROFILE``). An unresolved profile means
-    the membership is NOT applied (no guessed id). A reattach upstream error is
-    recorded ``UPSTREAM_API_ERROR``.
-
-    THE ONE PRODUCER ON THIS PASS THAT CARRIES BOTH HALVES of bead ``…-4mkoe``,
-    and by volume the loudest: a membership is a LINK INTO the CHANNEL_PROFILE
-    category, and it is recorded under that category rather than under CHANNEL
-    for exactly that reason. With profiles DESELECTED every membership of every
-    channel is unresolvable by construction — the absence is what the operator
-    asked for, it would recur on every unattended cycle forever, and it is
-    recorded ``DEPENDENCY_DESELECTED`` and never counted as a shortfall. With
-    profiles SELECTED, the same row means a profile the run WAS asked to deliver
-    is not there, which is a real loss. The decision is
-    ``RestoreReport.record_dependency_unresolved``'s, not this function's.
-    """
-    for archive_channel, dest_channel_id in reattach_queue:
-        label = _channel_label(archive_channel)
-        for membership in _profile_memberships(archive_channel):
-            source_profile_id = membership.get("profile_id")
-            if source_profile_id is None:
-                continue
-            dest_profile_id = remap.resolve(
-                EntityType.CHANNEL_PROFILE, int(source_profile_id)
-            )
-            if dest_profile_id is None:
-                reason = report.record_dependency_unresolved(
-                    recorded_under=EntityType.CHANNEL_PROFILE,
-                    dependency=EntityType.CHANNEL_PROFILE,
-                    label=label,
-                    remap=remap,
-                    is_dry_run=False,
-                    source_export_id=int(source_profile_id),
-                )
-                logger.info(
-                    "[DBAS-CHANNELS] Channel '%s' profile membership skipped "
-                    "(%s) — profile (source id %s) is not on the destination.",
-                    label,
-                    reason.value,
-                    source_profile_id,
-                )
-                continue
-            enabled = bool(membership.get("enabled", True))
-            try:
-                await client.update_profile_channel(
-                    dest_profile_id, dest_channel_id, {"enabled": enabled}
-                )
-            except Exception as exc:
-                prof_cat = report.category(EntityType.CHANNEL_PROFILE)
-                prof_cat.failed += 1
-                prof_cat.failure_details.append(
-                    FailureDetail(
-                        reason=FailureReason.UPSTREAM_API_ERROR,
-                        label=label,
-                        message=_sanitize_failure(exc),
-                        source_export_id=int(source_profile_id),
-                    )
-                )
-                logger.warning(
-                    "[DBAS-CHANNELS] Failed to reattach channel '%s' to profile "
-                    "(dest id %s): %s",
-                    label,
-                    dest_profile_id,
-                    exc,
-                )
-
-
-def _profile_memberships(archive_channel: dict) -> list[dict]:
-    """Extract the channel's archived profile memberships as a list of dicts.
-
-    Accepts the canonical ``profile_memberships`` list (``{profile_id, enabled}``
-    records). Returns an empty list when the archive carries no memberships.
-    """
-    memberships = archive_channel.get("profile_memberships")
-    if not isinstance(memberships, list):
-        return []
-    return [m for m in memberships if isinstance(m, dict)]
 
 
 def _skip(

--- a/backend/main.py
+++ b/backend/main.py
@@ -158,7 +158,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0025",
+    version="0.18.2-0026",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -132,7 +132,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0025"
+APP_VERSION = "0.18.2-0026"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/stream_normalization.py
+++ b/backend/stream_normalization.py
@@ -286,12 +286,6 @@ def strip_network_suffix(name: str, custom_suffixes: Optional[list[str]] = None)
         if m:
             result = m.group(1).strip().rstrip("-|: ")
             continue
-        # Pattern 4: Bare suffix with just space
-        bare_space = re.compile(rf"^(.{{3,}})\s+{escaped}\s*$", re.IGNORECASE)  # nosemgrep: no-bare-re-on-dynamic-pattern
-        m = bare_space.match(result)
-        if m:
-            result = m.group(1).strip().rstrip("-|: ")
-            continue
 
     return result
 

--- a/backend/tests/dbas/test_4mkoe_deselected_vs_failed_dependency.py
+++ b/backend/tests/dbas/test_4mkoe_deselected_vs_failed_dependency.py
@@ -25,7 +25,9 @@ this restore records under that category rather than under the entity's own. So:
     a skip is faithful when it is recorded UNDER the same category as the
     dependency it could not resolve, AND that category was deselected.
 
-Both halves of that conjunction are asserted below, per producer.
+Both halves of that conjunction are asserted below. Profile memberships use
+profile rows (pi9k2): deselection gates the live pass off, while a refused PATCH
+is a category failure. Neither case manufactures a dependency skip.
 
 WHY EVERY OUTCOME TEST HERE IS MULTI-CYCLE. Both halves fail on a second cycle in
 opposite directions: a shortfall that is honest once and then silent (``…-ukjx5``)
@@ -38,8 +40,8 @@ places carry this, and every assertion below names which one it reads:
 * ``EntityCategoryReport.skip_details`` -> ``SkipDetail.reason`` ->
   :class:`~dbas.restore_contracts.SkipReason` — the per-entity CLASSIFICATION,
   and the named drill-down. NOT a failure: none of these rows errored.
-* ``failure_details`` / :class:`~dbas.restore_contracts.FailureReason` — NOT used
-  here at all, and asserted empty where it matters. A skip is not a failure.
+* ``failure_details`` / :class:`~dbas.restore_contracts.FailureReason` — used for
+  a refused membership PATCH, but empty for dependency skips. A skip is not a failure.
 * ``RestoreReport.entities_blocked_by_dependency`` — a TOP-LEVEL ``int``
   aggregate, and the only one of the three the outcome decision reads (through
   :data:`RestoreReport.DELIVERY_SHORTFALL_FIELDS`).
@@ -114,9 +116,7 @@ def _dependency_reasons(
 class _StatefulDest:
     """A destination that remembers what it was given, across cycles.
 
-    Enough of the client surface for the channel + groups/profiles importers.
-    Deliberately NOT a fault injector: both halves of this bead reach a report
-    with ZERO category failures, which is the whole reason the loss was invisible.
+    Client surface for the importers and supported profile-row reattach pass.
     """
 
     def __init__(self) -> None:
@@ -126,6 +126,7 @@ class _StatefulDest:
         self.stream_profiles: list[dict] = []
         self.user_agents: list[dict] = []
         self.memberships: list[tuple[int, int, bool]] = []
+        self.reject_memberships = False
         self._next_id = 5000
 
     def _mint(self) -> int:
@@ -152,6 +153,11 @@ class _StatefulDest:
                 row = dict(payload) if isinstance(payload, dict) else {"name": payload}
                 row["id"] = self._mint()
                 store.append(row)
+                if store is self.channel_profiles:
+                    row["channels"] = [c["id"] for c in self.channels]
+                elif store is self.channels:
+                    for profile in self.channel_profiles:
+                        profile.setdefault("channels", []).append(row["id"])
                 return row
 
             return _create
@@ -167,6 +173,15 @@ class _StatefulDest:
         client.create_user_agent = AsyncMock(side_effect=_creator(self.user_agents))
 
         async def _update_profile_channel(profile_id, channel_id, data):
+            if self.reject_memberships:
+                raise RuntimeError("destination refused membership PATCH")
+            profile = next(p for p in self.channel_profiles if p["id"] == profile_id)
+            enabled = set(profile.get("channels", []))
+            if data["enabled"]:
+                enabled.add(channel_id)
+            else:
+                enabled.discard(channel_id)
+            profile["channels"] = sorted(enabled)
             self.memberships.append(
                 (int(profile_id), int(channel_id), bool(data.get("enabled", True)))
             )
@@ -204,7 +219,7 @@ def _membership_plan(*, profiles_selected: bool) -> ImportPlan:
             PlanCategory(
                 entity_type=EntityType.CHANNEL_PROFILE,
                 selected=profiles_selected,
-                entities=[{"id": 11, "name": "Restricted"}],
+                entities=[{"id": 11, "name": "Restricted", "channels": []}],
             ),
             PlanCategory(
                 entity_type=EntityType.CHANNEL,
@@ -214,7 +229,6 @@ def _membership_plan(*, profiles_selected: bool) -> ImportPlan:
                         "id": 1,
                         "name": "CNN",
                         "channel_number": 5,
-                        "profile_memberships": [{"profile_id": 11, "enabled": True}],
                     }
                 ],
             ),
@@ -270,12 +284,13 @@ async def test_a_deselected_upstream_is_named_on_no_cycle(tmp_path):
     assert dest.memberships == []
 
     for cycle, report in enumerate(reports, start=1):
-        # The profile ROW itself is EXCLUDED_BY_OPERATOR (its own importer's
-        # verdict, unchanged); the MEMBERSHIP into it is the row this bead
-        # reclassifies, so the assertion is on the dependency reasons only.
-        assert _dependency_reasons(report, EntityType.CHANNEL_PROFILE) == [
-            SkipReason.DEPENDENCY_DESELECTED
+        # The live pass is gated off, not a producer of dependency skips.
+        assert _reasons(report, EntityType.CHANNEL_PROFILE) == [
+            SkipReason.EXCLUDED_BY_OPERATOR
         ], cycle
+        assert all(not c.failure_details for c in report.categories), cycle
+        assert report.profile_membership_drift == 0, cycle
+        assert not any("channel selection could not be re-applied" in n for n in report.notes), cycle
         assert report.entities_blocked_by_dependency == 0, cycle
         assert report.delivery_shortfalls() == {}, cycle
         assert report.outcome == RestoreOutcome.SUCCESS, cycle
@@ -314,7 +329,7 @@ async def test_a_dependency_that_was_in_scope_and_absent_is_named_on_every_cycle
 
 @pytest.mark.asyncio
 async def test_the_two_halves_are_distinguished_inside_one_run(tmp_path):
-    """Both producers in ONE cycle: one clause, counting only the genuine half.
+    """Deselected profiles and a genuine dependency loss in the same run.
 
     A rule that fires per-run rather than per-skip would report 2 or 0 here.
     """
@@ -322,44 +337,62 @@ async def test_the_two_halves_are_distinguished_inside_one_run(tmp_path):
     plan.categories.extend(_degraded_user_agent_plan().categories)
     dest = _StatefulDest()
 
-    report = await _cycle(plan, dest, tmp_path)
-
-    assert _dependency_reasons(report, EntityType.CHANNEL_PROFILE) == [
-        SkipReason.DEPENDENCY_DESELECTED
-    ]
-    assert _dependency_reasons(report, EntityType.STREAM_PROFILE) == [
-        SkipReason.DEPENDENCY_UNRESOLVED
-    ]
-    assert report.entities_blocked_by_dependency == 1
-    assert report.outcome == RestoreOutcome.COMPLETED_WITH_FAILURES
+    for _ in range(2):
+        report = await _cycle(plan, dest, tmp_path)
+        assert dest.memberships == []
+        assert dest.stream_profiles == []
+        assert _reasons(report, EntityType.CHANNEL_PROFILE) == [
+            SkipReason.EXCLUDED_BY_OPERATOR
+        ]
+        assert _dependency_reasons(report, EntityType.STREAM_PROFILE) == [
+            SkipReason.DEPENDENCY_UNRESOLVED
+        ]
+        assert all(not c.failure_details for c in report.categories)
+        assert not any("channel selection could not be re-applied" in n for n in report.notes)
+        assert report.entities_blocked_by_dependency == 1
+        assert report.delivery_shortfalls() == {"entities_blocked_by_dependency": 1}
+        assert report.outcome == RestoreOutcome.COMPLETED_WITH_FAILURES
+        assert "1 archived item(s) were not restored" in DbasRestoreTask._summary_message(report, True)
 
 
 @pytest.mark.asyncio
 async def test_a_membership_whose_profile_was_in_scope_is_the_genuine_half(tmp_path):
-    """The SAME producer, the other way. Selection is what separates them — not
-    which line of code recorded the skip.
-
-    The channel references profile 11 and the archive's SELECTED profile slice
-    carries only profile 12, so the membership is lost from a category the
-    operator asked for.
-    """
+    """A refused live profile-row PATCH is a category failure, not a dependency skip."""
     plan = _membership_plan(profiles_selected=True)
-    plan.category(EntityType.CHANNEL_PROFILE).entities = [{"id": 12, "name": "Other"}]
     dest = _StatefulDest()
+    dest.reject_memberships = True
 
     reports = [await _cycle(plan, dest, tmp_path) for _ in range(2)]
 
     for cycle, report in enumerate(reports, start=1):
-        assert (
-            SkipReason.DEPENDENCY_UNRESOLVED
-            in _reasons(report, EntityType.CHANNEL_PROFILE)
-        ), cycle
-        assert (
-            SkipReason.DEPENDENCY_DESELECTED
-            not in _reasons(report, EntityType.CHANNEL_PROFILE)
-        ), cycle
-        assert report.entities_blocked_by_dependency == 1, cycle
+        cat = report.category(EntityType.CHANNEL_PROFILE)
+        assert cat.failed == 1, cycle
+        assert len(cat.failure_details) == 1, cycle
+        detail = cat.failure_details[0]
+        assert detail.reason == FailureReason.UPSTREAM_API_ERROR, cycle
+        assert (detail.label, detail.source_export_id) == ("Restricted", 11), cycle
+        assert "CNN" in detail.message and "disabled" in detail.message, cycle
+        assert _dependency_reasons(report, EntityType.CHANNEL_PROFILE) == [], cycle
+        assert report.entities_blocked_by_dependency == 0, cycle
+        assert report.delivery_shortfalls() == {}, cycle
         assert report.outcome == RestoreOutcome.COMPLETED_WITH_FAILURES, cycle
+        assert "failed 1" in DbasRestoreTask._summary_message(report, True), cycle
+    assert dest.memberships == []
+    assert dest.channel_profiles[0]["channels"] == [dest.channels[0]["id"]]
+
+    # Repair the destination refusal: the same real pass now writes the archived
+    # restriction, then reasserts it without reporting recurring drift.
+    dest.reject_memberships = False
+    for cycle in range(2):
+        report = await _cycle(plan, dest, tmp_path)
+        assert dest.channel_profiles[0]["channels"] == []
+        assert dest.memberships[-1] == (
+            dest.channel_profiles[0]["id"], dest.channels[0]["id"], False
+        )
+        assert all(not c.failure_details for c in report.categories)
+        assert report.profile_membership_drift == (1 if cycle == 0 else 0)
+        assert report.delivery_shortfalls() == {}
+        assert report.outcome == RestoreOutcome.SUCCESS
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/dbas/test_channels_importer.py
+++ b/backend/tests/dbas/test_channels_importer.py
@@ -1,7 +1,7 @@
 """Tests for the channels restore importer
 (enhancedchannelmanager-4vouz — split 2/4 of 0i2vt.14).
 
-Scope under test (TIGHT — channel-row create + profile membership reattach):
+Scope under test (TIGHT — channel-row create):
 
 1. Create channels. For each archived channel, strip archive-only / non-writable
    keys (id/pk and the FK-id fields that are remapped) and create via
@@ -12,12 +12,8 @@ Scope under test (TIGHT — channel-row create + profile membership reattach):
    .12). They are resolved through the IdRemapTable to a destination id before
    create. If a referenced FK is NOT in the remap, the channel is skipped
    DEPENDENCY_UNRESOLVED (never sent upstream with a stale archive id).
-3. Profile reattach. After channels are created, each restored channel is
-   reattached to its archived channel-profile memberships via
-   ``client.update_profile_channel``. The destination profile id is resolved
-   through the IdRemapTable (EntityType.CHANNEL_PROFILE). A profile not in the
-   remap is skipped DEPENDENCY_UNRESOLVED (dependency not yet restored) — never
-   crashes, never guesses a profile id.
+3. Defensive stripping: channel-side membership echoes cause no writes or
+   reporting. The live profile-row pass is covered by the restore tests.
 4. Opt-in: nothing happens unless the operator selected the category.
 5. Dry-run: no creates, no ledger entries; reports would_create.
 6. Name/number collision taxonomy: an existing identical channel is skipped
@@ -464,109 +460,40 @@ async def test_streams_stripped_from_create_payload():
 
 
 # ---------------------------------------------------------------------------
-# Profile reattach
+# Defensive membership stripping
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_profile_reattach_happy_path():
-    """After create, each restored channel is reattached to its archived
-    channel-profile membership. The destination profile id is resolved through the
-    IdRemapTable (EntityType.CHANNEL_PROFILE) and update_profile_channel is called
-    with the destination profile id + destination channel id."""
-    client = _client()
+@pytest.mark.parametrize("existing", [False, True])
+@pytest.mark.parametrize("profile_resolved", [False, True])
+async def test_channel_membership_echo_is_stripped_without_writes_or_reporting(
+    existing, profile_resolved
+):
+    """Unexpected channel-side metadata is ignored; profile rows own membership."""
+    client = _client(existing_channels=(
+        [{"id": 501, "name": "CNN", "channel_number": 5}] if existing else []
+    ))
     report = _report()
-    ledger = _ledger()
-    # source profile 1 -> dest profile 101
-    remap = _remap(channel_profile={1: 101})
-
+    remap = _remap(channel_profile={1: 101} if profile_resolved else {})
     await import_channels(
-        archive_channels=[
-            {
-                "id": 5,
-                "name": "CNN",
-                "profile_memberships": [{"profile_id": 1, "enabled": True}],
-            }
-        ],
-        client=client,
-        selected=True,
-        report=report,
-        ledger=ledger,
-        remap=remap,
+        archive_channels=[{
+            "id": 5, "name": "CNN", "channel_number": 5,
+            "profile_memberships": [{"profile_id": 1, "enabled": False}],
+        }],
+        client=client, selected=True, report=report, ledger=_ledger(), remap=remap,
     )
-
-    # channel created with dest id 501
-    dest_channel_id = remap.resolve(EntityType.CHANNEL, 5)
-    assert dest_channel_id == 501
-    client.update_profile_channel.assert_awaited_once()
-    call = client.update_profile_channel.await_args
-    # update_profile_channel(profile_id, channel_id, data)
-    assert call.args[0] == 101  # destination profile id (resolved via remap)
-    assert call.args[1] == 501  # destination channel id
-    assert call.args[2] == {"enabled": True}
-
-
-@pytest.mark.asyncio
-async def test_profile_not_in_remap_skips_dependency_unresolved():
-    """A channel-profile membership whose profile is NOT in the remap (the
-    channel-profiles importer .12 has not run, or did not restore that profile) is
-    handled as DEPENDENCY_UNRESOLVED — no update_profile_channel call, no crash,
-    no guessed profile id. The channel itself still created successfully."""
-    client = _client()
-    report = _report()
-    ledger = _ledger()
-    remap = _remap()  # no channel_profile mappings
-
-    await import_channels(
-        archive_channels=[
-            {
-                "id": 5,
-                "name": "CNN",
-                "profile_memberships": [{"profile_id": 1, "enabled": True}],
-            }
-        ],
-        client=client,
-        selected=True,
-        report=report,
-        ledger=ledger,
-        remap=remap,
-    )
-
-    # channel created
-    assert report.category(EntityType.CHANNEL).created == 1
-    # but profile reattach was NOT issued (dependency unresolved)
+    if existing:
+        client.create_channel.assert_not_awaited()
+        assert report.category(EntityType.CHANNEL).skipped == 1
+    else:
+        client.create_channel.assert_awaited_once_with({"name": "CNN", "channel_number": 5})
+        assert report.category(EntityType.CHANNEL).created == 1
+    assert remap.resolve(EntityType.CHANNEL, 5) == 501
     client.update_profile_channel.assert_not_awaited()
-    # the unresolved membership is reported under CHANNEL_PROFILE as a skip
-    prof_cat = report.category(EntityType.CHANNEL_PROFILE)
-    assert prof_cat.skipped == 1
-    assert prof_cat.skip_details[0].reason == SkipReason.DEPENDENCY_UNRESOLVED
-
-
-@pytest.mark.asyncio
-async def test_profile_reattach_skipped_in_dry_run():
-    """Dry-run reattaches nothing — update_profile_channel is never called."""
-    client = _client()
-    report = _report(is_dry_run=True)
-    ledger = _ledger()
-    remap = _remap(channel_profile={1: 101})
-
-    await import_channels(
-        archive_channels=[
-            {
-                "id": 5,
-                "name": "CNN",
-                "profile_memberships": [{"profile_id": 1, "enabled": True}],
-            }
-        ],
-        client=client,
-        selected=True,
-        report=report,
-        ledger=ledger,
-        remap=remap,
-        is_dry_run=True,
-    )
-
-    client.update_profile_channel.assert_not_awaited()
+    assert EntityType.CHANNEL_PROFILE not in {c.entity_type for c in report.categories}
+    assert report.entities_blocked_by_dependency == 0
+    assert report.delivery_shortfalls() == {}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_channel_pipeline_evaluator.py
+++ b/backend/tests/unit/test_channel_pipeline_evaluator.py
@@ -5,6 +5,10 @@ Tests condition evaluation against stream contexts.
 """
 import json
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+import pytest
 
 from channel_pipeline_evaluator import (
     ConditionEvaluator,
@@ -12,6 +16,143 @@ from channel_pipeline_evaluator import (
     EvaluationResult,
     evaluate_conditions,
 )
+
+
+@pytest.mark.parametrize("kind,inverted,global_check", [
+    ("normalized_name_in_group", False, False),
+    ("normalized_name_not_in_group", True, False),
+    ("normalized_name_exists", False, True),
+    ("normalized_name_not_exists", True, True),
+])
+@pytest.mark.parametrize("engine_mode", ["absent", "normalize", "raise", "empty"])
+@pytest.mark.parametrize("stream_name", ["CNN", "Other"])
+@pytest.mark.parametrize("case_sensitive", [False, True])
+def test_normalized_name_dispatch_contract(
+    kind, inverted, global_check, engine_mode, stream_name, case_sensitive, caplog,
+):
+    engine = None if engine_mode == "absent" else Mock()
+    if engine is not None:
+        if engine_mode == "raise":
+            engine.normalize.side_effect = RuntimeError("engine unavailable")
+        else:
+            engine.normalize.side_effect = lambda name: SimpleNamespace(
+                normalized="" if engine_mode == "empty" else name.lower()
+            )
+    evaluator = ConditionEvaluator(
+        existing_channels=[{"id": 1, "name": "106 | cnn", "channel_group_id": 7}],
+        existing_groups=[{"id": 7, "name": "News"}],
+        normalization_engine=engine,
+    )
+    if engine is not None:
+        assert engine.normalize.call_args_list == [call("cnn")]
+    if engine_mode == "raise":
+        assert caplog.messages == [
+            "[AUTO-CREATE-EVAL] Normalization failed for channel 'cnn': engine unavailable"
+        ]
+    else:
+        assert caplog.messages == []
+    caplog.clear()
+    result = evaluator.evaluate(
+        {"type": kind, "value": 7, "case_sensitive": case_sensitive},
+        StreamContext(1, stream_name, normalized_name="ignored cached name"),
+    )
+    normalized = ("" if engine_mode == "empty" else stream_name.lower()
+                  if engine_mode == "normalize" else stream_name)
+    matched = stream_name == "CNN" and engine_mode != "empty"
+    assert result.matched is (matched != inverted)
+    assert result.condition_type == kind
+    if global_check:
+        phrase = "found" if matched else "not found"
+        if inverted:
+            # Pin the existing diagnostic, including its replacement order.
+            phrase = "confirmed absent" if matched else "not confirmed absent"
+        ending = f"{phrase} across all groups (2 names)"
+    else:
+        phrase = ("NOT in" if matched else "confirmed not in") if inverted else (
+            "matches" if matched else "no match in"
+        )
+        ending = f"{phrase} group 7 (2 channels)"
+    assert result.details == f"'{stream_name}' \u2192 '{normalized}' {ending}"
+    if engine is not None:
+        assert engine.normalize.call_args_list == [call("cnn"), call(stream_name)]
+    assert caplog.messages == ([
+        f"[AUTO-CREATE-EVAL] Normalization failed for '{stream_name}': engine unavailable"
+    ] if engine_mode == "raise" else [])
+
+
+@pytest.mark.parametrize("kind,inverted,global_check", [
+    ("normalized_name_in_group", False, False),
+    ("normalized_name_not_in_group", True, False),
+    ("normalized_name_exists", False, True),
+    ("normalized_name_not_exists", True, True),
+])
+@pytest.mark.parametrize("value", [{}, {"value": None}, {"value": 0}, {"value": 7}, {"value": 99}])
+@pytest.mark.parametrize("channels", [
+    [], [{"id": 1, "name": "cnn"}],
+    [{"id": 1, "name": "cnn", "channel_group_id": None}],
+    [{"id": 1, "name": "cnn", "channel_group_id": 0}],
+])
+def test_normalized_name_empty_groups_return_before_normalizing(
+    kind, inverted, global_check, value, channels, caplog,
+):
+    engine = Mock()
+    engine.normalize.side_effect = RuntimeError("must not be called")
+    evaluator = ConditionEvaluator(channels, [{"id": 7, "name": "Empty"}], engine)
+    result = evaluator.evaluate({"type": kind, **value}, StreamContext(1, "CNN"))
+    assert result == EvaluationResult(
+        inverted, kind,
+        "No channels exist in any group" if global_check else (
+            f"Group {value['value']} has no channels" if value.get("value")
+            else "No group ID specified"
+        ),
+    )
+    engine.normalize.assert_not_called()
+    assert caplog.messages == []
+
+
+def test_normalized_channel_names_are_indexed_by_constructor():
+    engine = Mock()
+    engine.normalize.side_effect = lambda name: SimpleNamespace(normalized=name.removesuffix(" HD"))
+    evaluator = ConditionEvaluator(
+        [{"id": 1, "name": "106 | CNN HD", "channel_group": {"id": 7}}],
+        normalization_engine=engine,
+    )
+    result = evaluator.evaluate(
+        {"type": "normalized_name_in_group", "value": 7, "negate": True}, StreamContext(1, "cnn"),
+    )
+    assert result == EvaluationResult(
+        False, "not(normalized_name_in_group)",
+        "Negated: 'cnn' \u2192 'cnn' matches group 7 (3 channels)",
+    )
+    assert engine.normalize.call_args_list == [call("CNN HD"), call("cnn")]
+
+
+def test_unknown_condition_dispatch_warns(caplog):
+    result = ConditionEvaluator().evaluate({"type": "future_condition"}, StreamContext(1, "CNN"))
+    assert result == EvaluationResult(False, "future_condition", "Unknown condition type: future_condition")
+    assert caplog.messages == ["[AUTO-CREATE-EVAL] Unknown condition type: future_condition"]
+
+
+def test_unhandled_enum_dispatch_warns(monkeypatch, caplog):
+    import channel_pipeline_evaluator as module
+    from channel_pipeline_schema import ConditionType
+
+    # No current enum member is unhandled; model a future member at the enum seam.
+    enum = Mock(wraps=ConditionType, return_value=object())
+    monkeypatch.setattr(module, "ConditionType", enum)
+    result = ConditionEvaluator().evaluate({"type": "future_condition"}, StreamContext(1, "CNN"))
+    assert result == EvaluationResult(False, "future_condition", "Unhandled condition type")
+    assert caplog.messages == ["[AUTO-CREATE-EVAL] Unhandled condition type: future_condition"]
+
+
+@pytest.mark.parametrize("condition,context,matched,details", [
+    ({"type": "tvg_id_matches", "value": "^$"}, StreamContext(1, "CNN", tvg_id=None), True, "'' matches /^$/"),
+    ({"type": "stream_group_contains", "value": "news"}, StreamContext(1, "CNN", group_name="US News"), True, "'US News' contains 'news'"),
+    ({"type": "stream_group_contains", "value": "news", "case_sensitive": True}, StreamContext(1, "CNN", group_name="US News"), False, "'US News' does not contain 'news'"),
+    ({"type": "stream_group_contains", "value": "news"}, StreamContext(1, "CNN"), False, "'' does not contain 'news'"),
+])
+def test_optional_metadata_dispatch(condition, context, matched, details):
+    assert ConditionEvaluator().evaluate(condition, context) == EvaluationResult(matched, condition["type"], details)
 
 
 class TestStreamContext:

--- a/backend/tests/unit/test_stream_normalization.py
+++ b/backend/tests/unit/test_stream_normalization.py
@@ -1,4 +1,8 @@
 """Tests for stream_normalization module."""
+from unittest.mock import patch
+
+import pytest
+import stream_normalization
 from stream_normalization import (
     normalize_unicode_to_ascii,
     strip_quality_suffixes,
@@ -15,6 +19,42 @@ from stream_normalization import (
     enrich_stream,
     DEFAULT_QUALITY_PRIORITY,
 )
+
+
+@pytest.mark.parametrize("name,custom,expected", [
+    ("CNN LIVE", None, "CNN"),
+    ("CNN\u00a0LIVE", None, "CNN"),
+    ("CNN\nLIVE", None, "CNN"),
+    ("CN\nN LIVE", None, "CN\nN LIVE"),
+    ("CNN\t | : - LIVE", None, "CNN\t"),
+    ("CNN live\n", None, "CNN"),
+    ("LIVE", None, "LIVE"),
+    ("", None, ""),
+    ("A LIVE", None, "A LIVE"),
+    ("AB LIVE", None, "AB LIVE"),
+    ("AB  LIVE", None, "AB"),
+    ("(LIVE)", None, ""),
+    ("A [ LIVE ]", None, "A"),
+    ("CNN ( LIVE )", None, "CNN"),
+    ("CNN [LIVE]", None, "CNN"),
+    ("CNN A+B.*", ["A+B.*"], "CNN"),
+    ("CNN AAABxyz", ["A+B.*"], "CNN AAABxyz"),
+    ("CNN [A+B.*]", ["A+B.*"], "CNN"),
+    ("CNN LIVE LIVE", None, "CNN LIVE"),
+    ("CNN LIVE BACKUP", None, "CNN"),
+    ("CNN BACKUP LIVE", None, "CNN BACKUP"),
+    ("CNN AAA BBB", ["AAA", "BBB"], "CNN AAA"),
+    ("CNN AAA BBB", ["BBB", "AAA"], "CNN"),
+])
+def test_network_suffix_boundaries_and_order(name, custom, expected):
+    assert strip_network_suffix(name, custom) == expected
+
+
+def test_network_suffix_compile_api_calls():
+    # Count API invocations, not regex-cache misses or wall-clock performance.
+    with patch.object(stream_normalization.re, "compile", wraps=stream_normalization.re.compile) as compile_mock:
+        assert strip_network_suffix("Unrelated channel") == "Unrelated channel"
+    assert compile_mock.call_count == 3 * len(stream_normalization.NETWORK_SUFFIXES)
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0025",
+  "version": "0.18.2-0026",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/tabs/SettingsTab.publicBaseUrl.test.tsx
+++ b/frontend/src/components/tabs/SettingsTab.publicBaseUrl.test.tsx
@@ -242,6 +242,8 @@ describe('SettingsTab public base URL (bead qsqfv)', () => {
     vi.mocked(api.listAlertMethods).mockResolvedValue([]);
     vi.mocked(api.getM3UAccounts).mockResolvedValue([]);
     vi.mocked(api.getStreams).mockResolvedValue({ count: 0, next: null, previous: null, results: [] });
+    vi.mocked(api.getProbeHistory).mockResolvedValue([]);
+    vi.mocked(api.getProbeProgress).mockResolvedValue({ in_progress: false } as Awaited<ReturnType<typeof api.getProbeProgress>>);
   });
 
   it('loads the stored value and reports it as configured', async () => {
@@ -255,6 +257,40 @@ describe('SettingsTab public base URL (bead qsqfv)', () => {
       expect(screen.getByLabelText('Public Base URL')).toHaveValue('https://ecm.example.com');
     });
     expect(publicBaseUrlBadge()).toHaveTextContent('Configured');
+  });
+
+  it.each([false, true])('mounts and remounts without a discarded stream lookup (loader failures: %s)', async (failLoads) => {
+    vi.mocked(api.getSettings).mockResolvedValue(makeSettings({
+      public_base_url: 'https://ecm.example.com',
+    }));
+    if (failLoads) {
+      vi.mocked(api.getProbeHistory).mockRejectedValue(new Error('history unavailable'));
+      vi.mocked(api.getProbeProgress).mockRejectedValue(new Error('progress unavailable'));
+      vi.mocked(api.getM3UAccounts).mockRejectedValue(new Error('accounts unavailable'));
+    }
+
+    let firstPayload: Parameters<typeof api.saveSettings>[0] | undefined;
+    for (let mount = 1; mount <= 2; mount++) {
+      const view = renderEmailPage();
+      await waitFor(() => expect(screen.getByLabelText('Public Base URL')).toHaveValue('https://ecm.example.com'));
+      for (const load of [api.getSettings, api.getProbeHistory, api.getProbeProgress, api.getM3UAccounts]) {
+        expect(load).toHaveBeenCalledTimes(mount);
+      }
+      await saveSettingsPage();
+      await waitFor(() => expect(api.saveSettings).toHaveBeenCalledTimes(mount));
+      const payload = vi.mocked(api.saveSettings).mock.calls[mount - 1][0];
+      expect(payload).toMatchObject({
+        public_base_url: 'https://ecm.example.com',
+        stream_probe_timeout: 30,
+        max_concurrent_probes: 8,
+        stream_fetch_page_limit: 200,
+      });
+      expect(payload).not.toHaveProperty('total_stream_count');
+      if (firstPayload) expect(payload).toEqual(firstPayload);
+      firstPayload = payload;
+      view.unmount();
+      expect(api.getStreams).not.toHaveBeenCalled();
+    }
   });
 
   it('shows Not set when the install is still on header-derived links', async () => {

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -815,7 +815,6 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
   const [lowBitrateThreshold, setLowBitrateThreshold] = useState(1.0);
   const [streamFetchPageLimit, setStreamFetchPageLimit] = useState(200);
   const [probingAll, setProbingAll] = useState(false);
-  const [, setTotalStreamCount] = useState(100); // Default to 100, will be updated on load
   const [probeProgress, setProbeProgress] = useState<{
     in_progress: boolean;
     total: number;
@@ -1032,7 +1031,6 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
       // Revert callers surface failures inline; initial load retains the
       // existing page-level error behavior.
     });
-    loadStreamCount();
     loadProbeHistory();
     checkForOngoingProbe();
     loadM3UAccountsMaxStreams();
@@ -1163,19 +1161,6 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
     // since the polling shuts down on progress completion regardless.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- polling lifecycle is owned by `probingAll`; parent callback identity doesn't need to restart polling
   }, [probingAll, notifications]);
-
-  const loadStreamCount = async () => {
-    try {
-      // Fetch just the count (page_size=1 to minimize data transfer)
-      const result = await api.getStreams({ pageSize: 1 });
-      if (result.count) {
-        setTotalStreamCount(Math.max(1, result.count));
-      }
-    } catch (err) {
-      logger.warn('Failed to load stream count for batch size max', err);
-      // Keep default of 100
-    }
-  };
 
   const loadProbeHistory = async () => {
     try {

--- a/frontend/src/hooks/dedupMergeStaging.test.ts
+++ b/frontend/src/hooks/dedupMergeStaging.test.ts
@@ -42,9 +42,9 @@ afterEach(() => {
 
 describe('useDedupOnDrop merge', () => {
   async function openModal(stageAddStream?: StageAddStream) {
-    vi.spyOn(api, 'getDedupCandidates').mockResolvedValue({
+    vi.spyOn(api, 'getChannelMergeCandidates').mockResolvedValue({
       candidates: [CANDIDATE],
-    } as unknown as Awaited<ReturnType<typeof api.getDedupCandidates>>);
+    } as unknown as Awaited<ReturnType<typeof api.getChannelMergeCandidates>>);
     const reloadChannels = vi.fn();
     const view = renderHook(() =>
       useDedupOnDrop({ reloadChannels, stageAddStream }),

--- a/frontend/src/hooks/useDedupOnDrop.test.ts
+++ b/frontend/src/hooks/useDedupOnDrop.test.ts
@@ -22,7 +22,7 @@ import { useDedupOnDrop, DEDUP_RETURNING_HIGHLIGHT_MS } from './useDedupOnDrop';
 // Mock the API surface used by the hook. We don't care about the rest of
 // services/api for this hook — only the two endpoints it calls.
 vi.mock('../services/api', () => ({
-  getDedupCandidates: vi.fn(),
+  getChannelMergeCandidates: vi.fn(),
   addStreamToChannel: vi.fn(),
 }));
 
@@ -60,7 +60,7 @@ describe('useDedupOnDrop', () => {
 
   describe('no-candidate branch', () => {
     it('runs the fallback create path and does not open the modal', async () => {
-      vi.mocked(api.getDedupCandidates).mockResolvedValue({
+      vi.mocked(api.getChannelMergeCandidates).mockResolvedValue({
         stream_name: 'CNN HD',
         candidates: [],
         total: 0,
@@ -82,14 +82,14 @@ describe('useDedupOnDrop', () => {
         );
       });
 
-      expect(api.getDedupCandidates).toHaveBeenCalledWith('CNN HD', 7);
+      expect(api.getChannelMergeCandidates).toHaveBeenCalledExactlyOnceWith('CNN HD', 7);
       expect(fallback).toHaveBeenCalledTimes(1);
       expect(result.current.modalState).toBeNull();
       expect(result.current.returningStreamIds.size).toBe(0);
     });
 
     it('falls through when the candidates lookup itself errors', async () => {
-      vi.mocked(api.getDedupCandidates).mockRejectedValue(new Error('network'));
+      vi.mocked(api.getChannelMergeCandidates).mockRejectedValue(new Error('network'));
 
       const fallback = vi.fn();
       const { result } = renderHook(() =>
@@ -121,7 +121,7 @@ describe('useDedupOnDrop', () => {
    */
   describe('reported outcome', () => {
     it('reports no_candidate when the lookup returns an empty list', async () => {
-      vi.mocked(api.getDedupCandidates).mockResolvedValue({
+      vi.mocked(api.getChannelMergeCandidates).mockResolvedValue({
         stream_name: 'CNN HD',
         candidates: [],
         total: 0,
@@ -145,7 +145,7 @@ describe('useDedupOnDrop', () => {
     });
 
     it('reports lookup_failed when the candidates endpoint errors', async () => {
-      vi.mocked(api.getDedupCandidates).mockRejectedValue(new Error('network'));
+      vi.mocked(api.getChannelMergeCandidates).mockRejectedValue(new Error('network'));
       const { result } = renderHook(() =>
         useDedupOnDrop({ reloadChannels: vi.fn() }),
       );
@@ -162,7 +162,7 @@ describe('useDedupOnDrop', () => {
     });
 
     it('reports candidate when the modal opens', async () => {
-      vi.mocked(api.getDedupCandidates).mockResolvedValue({
+      vi.mocked(api.getChannelMergeCandidates).mockResolvedValue({
         stream_name: 'CNN HD',
         candidates: [
           { channel_id: '101', channel_name: 'CNN', confidence: 1.0 },
@@ -196,7 +196,7 @@ describe('useDedupOnDrop', () => {
     };
 
     beforeEach(() => {
-      vi.mocked(api.getDedupCandidates).mockResolvedValue({
+      vi.mocked(api.getChannelMergeCandidates).mockResolvedValue({
         stream_name: 'CNN HD',
         candidates: [candidate],
         total: 1,

--- a/frontend/src/hooks/useDedupOnDrop.ts
+++ b/frontend/src/hooks/useDedupOnDrop.ts
@@ -21,7 +21,7 @@
  */
 import { useCallback, useRef, useState } from 'react';
 import * as api from '../services/api';
-import type { DedupCandidate } from '../services/api';
+import type { ChannelMergeCandidate } from '../services/api';
 import { logger } from '../utils/logger';
 
 /** Duration of the `.is-dedup-returning` outline pulse in ms. */
@@ -38,7 +38,7 @@ export interface DedupModalState {
   streamId: number;
   streamName: string;
   targetGroupId: number | null;
-  candidate: DedupCandidate;
+  candidate: ChannelMergeCandidate;
   /** The original drag-drop create path, retained so onCreateNew can run it. */
   fallback: () => void;
 }
@@ -166,7 +166,7 @@ export function useDedupOnDrop({
     async (request: DedupDropRequest, fallback: () => void): Promise<DedupDropOutcome> => {
       let response;
       try {
-        response = await api.getDedupCandidates(
+        response = await api.getChannelMergeCandidates(
           request.streamName,
           request.targetGroupId,
         );

--- a/frontend/src/services/api.candidates.test.ts
+++ b/frontend/src/services/api.candidates.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getChannelMergeCandidates, type ChannelMergeCandidatesResponse } from './api';
+import { fetchJson, HttpError } from './httpClient';
+
+vi.mock('./httpClient', async (importOriginal) => ({
+  ...await importOriginal<typeof import('./httpClient')>(),
+  fetchJson: vi.fn(),
+}));
+
+const response: ChannelMergeCandidatesResponse = {
+  stream_name: 'CNN HD',
+  candidates: [{ channel_id: '00123', channel_name: 'CNN', confidence: 0.87 }],
+  total: 1, page: 1, page_size: 1, total_pages: 1,
+};
+
+describe('getChannelMergeCandidates wire contract', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it.each([
+    ['CNN HD', undefined, '?stream_name=CNN+HD'],
+    ['CNN HD', null, '?stream_name=CNN+HD'],
+    ['CNN HD', 0, '?stream_name=CNN+HD&group_id=0'],
+    ['CNN HD', 7, '?stream_name=CNN+HD&group_id=7'],
+    ['A&B +/#?=\u00e9', 0, '?stream_name=A%26B+%2B%2F%23%3F%3D%C3%A9&group_id=0'],
+    ['', undefined, ''],
+    ['', 0, '?group_id=0'],
+    ['  ', null, '?stream_name=++'],
+  ] as const)('preserves the URL and response for %j / %s', async (name, group, query) => {
+    vi.mocked(fetchJson).mockResolvedValue(response);
+    expect(await getChannelMergeCandidates(name, group)).toBe(response);
+    expect(fetchJson).toHaveBeenCalledExactlyOnceWith(`/api/channel-merges/candidates${query}`);
+  });
+
+  it.each([
+    new HttpError('rejected', 422, [{ loc: ['query', 'stream_name'], msg: 'required' }]),
+    new TypeError('network unavailable'),
+    new SyntaxError('invalid JSON'),
+  ])('preserves rejection identity: %s', async (error) => {
+    vi.mocked(fetchJson).mockRejectedValue(error);
+    await expect(getChannelMergeCandidates('CNN HD', 0)).rejects.toBe(error);
+    expect(fetchJson).toHaveBeenCalledExactlyOnceWith('/api/channel-merges/candidates?stream_name=CNN+HD&group_id=0');
+  });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -572,45 +572,6 @@ export async function bulkCommit(
   return pollBulkCommitJob(accepted.job_id);
 }
 
-// Stream-to-channel deduplication (ADR-008 / bd-1v4ht epic) ----------------
-// Re-exports the DedupCandidate shape from the modal so consumers don't pull
-// it from a component module. The modal owns the operator-facing fields;
-// this layer owns the wire contract.
-
-/** Single candidate returned by GET /api/channel-merges/candidates (BD-D). */
-export interface DedupCandidate {
-  channel_id: string;
-  channel_name: string;
-  /** Normalized confidence 0.0–1.0. Backend already enforces the ADR-008 §D2 floor. */
-  confidence: number;
-}
-
-/** Envelope for GET /api/channel-merges/candidates (BD-D). */
-export interface DedupCandidatesResponse {
-  stream_name: string;
-  candidates: DedupCandidate[];
-  total: number;
-  page: number;
-  page_size: number;
-  total_pages: number;
-}
-
-/**
- * Look up dedup candidates for an incoming stream name (BD-D).
- *
- * Synchronous top-1 candidate lookup. The backend returns an empty
- * `candidates` array when nothing clears the §D2 confidence floor — that is
- * the signal to proceed with normal channel creation. When a candidate is
- * present, callers should surface the StreamDedupModal for operator decision.
- */
-export async function getDedupCandidates(
-  streamName: string,
-  groupId?: number | null,
-): Promise<DedupCandidatesResponse> {
-  const query = buildQuery({ stream_name: streamName, group_id: groupId ?? undefined });
-  return fetchJson(`${API_BASE}/channel-merges/candidates${query}`);
-}
-
 // Channel Groups
 export async function getChannelGroups(): Promise<ChannelGroup[]> {
   return fetchJson(`${API_BASE}/channel-groups`);


### PR DESCRIPTION
## Summary
- Remove unused Settings stream-count loading and consolidate duplicate candidate lookup API/type declarations without changing hook behavior.
- Delete an unreachable normalization regex branch and reuse the existing evaluator normalization helper after adding real-dispatch coverage.
- Retire dead channel-side profile membership restoration while preserving defensive field stripping and the live profile-row mechanism; migrate fictional reporting fixtures onto supported inputs.
- Advance all three version touchpoints to 0.18.2-0026.

Epic enhancedchannelmanager-hym4q; items enhancedchannelmanager-hym4q.2, enhancedchannelmanager-hym4q.3, enhancedchannelmanager-hym4q.4, enhancedchannelmanager-hym4q.5, enhancedchannelmanager-v4h9e, enhancedchannelmanager-pi9k2.

## Verification
- Parent full backend: 13,446 passed, 4 skipped, 2 deselected; 82.88% coverage. Completion receipt matched the finished canonical run.
- Frontend: 3,726 tests, lint, typecheck and production build passed.
- Isolated helper/browser lane: 59 passed; strict documentation build passed.
- Independent code, QA and DBA reviews found no blocking defects.
- Negative controls and parity checks cover zero-group URLs, fallback behavior, active suffix matching and preserved profile/reporting outcomes.

## Scope
Production source: 176 fewer physical lines; tests add 220 net lines; entire commit adds 46 net lines including metadata. No new runtime abstraction. Four backend skips include three existing exclusions and native Windows, which the PO excludes from required scope. No live customer-archive or Dispatcharr validation claimed; no deployment performed.

User explicitly authorized merge. Reviewed implementation commit: ad2a44b40041fef620add519568e003662ba0fbb.