### PR TITLE
v0.18.2-0028: return safe settings URL errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Security
+
+- **Settings URL validation uses safe public errors (bead `enhancedchannelmanager-m8dvz`; build 0.18.2-0028).** Malformed ports and outbound-policy denials return fixed messages instead of parser text or resolved-address details, including the shared Dispatcharr and media settings save paths. Host-policy diagnostics remain in redacted server logs. Media client error categories, credential escaping, human-admin/first-run gates, and outbound allow/deny decisions are preserved.
+
 ### Changed
 
 - **Media connection tests use safe error messages (bead `enhancedchannelmanager-m8dvz`; build 0.18.2-0027).** Emby, Plex, and Jellyfin report stable authentication, timeout, TLS, unreachable-host, malformed-response, and upstream-status categories instead of raw network diagnostics. Unexpected failures use a constant fallback; detailed exceptions are sanitized in server logs. Existing response fields, human-admin/first-run gates, and outbound policy are unchanged.

--- a/backend/main.py
+++ b/backend/main.py
@@ -158,7 +158,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0027",
+    version="0.18.2-0028",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -132,7 +132,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0027"
+APP_VERSION = "0.18.2-0028"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -2013,7 +2013,7 @@ async def test_telegram_bot(
         return {"success": False, "message": "Unexpected error during Telegram test"}
 
 
-def _host_denied_by_outbound_policy(url: str) -> Optional[str]:
+def _host_denied_by_outbound_policy(url: str, credential: str = "") -> Optional[str]:
     """Mode-aware host policy for an operator-supplied base URL.
 
     GH #754 / bead ``0yh70``. This replaces the hardcoded, non-mode-aware
@@ -2048,8 +2048,8 @@ def _host_denied_by_outbound_policy(url: str) -> Optional[str]:
         url: an already scheme-checked base URL (scheme + netloc).
 
     Returns:
-        ``None`` when the host is permitted, else an admin-safe explanation of
-        why the active mode denied it (carries no secret).
+        ``None`` when the host is permitted, else a fixed public explanation.
+        Detailed diagnostics stay in redacted server logs (m8dvz route tests).
     """
     from security.ssrf import SSRFError, get_ssrf_mode, validate_outbound_url
 
@@ -2062,14 +2062,19 @@ def _host_denied_by_outbound_policy(url: str) -> Optional[str]:
                 or "resolved to no usable address" in lowered):
             logger.info(
                 "[SETTINGS] Outbound host did not resolve; not treating as a "
-                "policy denial (runtime re-validates before connect): %s", exc
+                "policy denial (runtime re-validates before connect): %s",
+                redact_media_diagnostic(message, credential),
             )
             return None
-        return message
+        logger.info(
+            "[SETTINGS] Outbound host denied: %s",
+            redact_media_diagnostic(message, credential),
+        )
+        return "destination is not permitted by the outbound policy"
     return None
 
 
-def _sanitize_base_url(raw_url: str) -> tuple[Optional[str], Optional[str]]:
+def _sanitize_base_url(raw_url: str, credential: str = "") -> tuple[Optional[str], Optional[str]]:
     """Sanitize + policy-check an operator-supplied outbound base URL.
 
     SSRF mitigation (security finding SEC-2 — bd-r5f0c.4 backfill, host policy
@@ -2114,13 +2119,19 @@ def _sanitize_base_url(raw_url: str) -> tuple[Optional[str], Optional[str]]:
         return None, "Invalid URL scheme — must be http or https"
     if not parsed.hostname:
         return None, "Invalid base URL — no hostname provided"
+    try:
+        # Access validates numeric/range constraints without returning parser
+        # exception text, which can contain caller-supplied port contents.
+        parsed.port
+    except ValueError:
+        return None, "Invalid base URL — invalid port"
     # Reconstruct from (scheme, netloc, path='', params='', query='',
     # fragment=''). netloc carries hostname + optional port + optional
     # userinfo — the operator's port stays attached, but everything past
     # the authority is dropped. The policy check runs on the RECONSTRUCTED
     # URL so it never sees an attacker-embedded path.
     sanitized = urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
-    denial = _host_denied_by_outbound_policy(sanitized)
+    denial = _host_denied_by_outbound_policy(sanitized, credential)
     if denial is not None:
         return None, f"Invalid host — {denial}"
     return sanitized, None
@@ -2161,7 +2172,7 @@ async def test_emby_connection(
         "[SETTINGS-TEST] POST /api/settings/emby/test-connection - base_url=%s",
         redact_media_diagnostic(request.base_url, request.api_key),
     )
-    base_url, err = _sanitize_base_url(request.base_url)
+    base_url, err = _sanitize_base_url(request.base_url, request.api_key)
     if err is not None:
         logger.info("[SETTINGS-TEST] Emby test rejected by SSRF guard: %s", err)
         return {"ok": False, "error": err}
@@ -2206,7 +2217,7 @@ async def test_plex_connection(
         "[SETTINGS-TEST] POST /api/settings/plex/test-connection - base_url=%s",
         redact_media_diagnostic(request.base_url, request.token),
     )
-    base_url, err = _sanitize_base_url(request.base_url)
+    base_url, err = _sanitize_base_url(request.base_url, request.token)
     if err is not None:
         logger.info("[SETTINGS-TEST] Plex test rejected by SSRF guard: %s", err)
         return {"ok": False, "error": err}
@@ -2247,7 +2258,7 @@ async def test_jellyfin_connection(
         "[SETTINGS-TEST] POST /api/settings/jellyfin/test-connection - base_url=%s",
         redact_media_diagnostic(request.base_url, request.api_key),
     )
-    base_url, err = _sanitize_base_url(request.base_url)
+    base_url, err = _sanitize_base_url(request.base_url, request.api_key)
     if err is not None:
         logger.info("[SETTINGS-TEST] Jellyfin test rejected by SSRF guard: %s", err)
         return {"ok": False, "error": err}

--- a/backend/tests/routers/test_media_connection_safe_errors.py
+++ b/backend/tests/routers/test_media_connection_safe_errors.py
@@ -1,7 +1,9 @@
 """m8dvz: real media wrappers and routes, with synthetic upstream failures."""
 
+import ipaddress
 import logging
 import re
+import socket
 import ssl
 from urllib.parse import quote
 from unittest.mock import AsyncMock, patch
@@ -25,6 +27,7 @@ DETAIL = (
     f'Authorization: MediaBrowser Token="{SECRET}"'
 )
 CLIENTS = [("emby", EmbyClient), ("plex", PlexClient), ("jellyfin", JellyfinClient)]
+HOST_ERROR = "Invalid host — destination is not permitted by the outbound policy"
 CASES = [
     (401, "Authentication failed. Check the media server credentials."),
     (403, "Authentication failed. Check the media server credentials."),
@@ -100,6 +103,96 @@ def upstream(case, request):
         "unknown": RuntimeError,
     }[case]
     raise error(DETAIL)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name,client_type", CLIENTS)
+@pytest.mark.parametrize("admin", [False, True], ids=["first-run", "human-admin"])
+@pytest.mark.parametrize("url,message", [
+    ("https://media.invalid:synthetic-port-detail", "Invalid base URL — invalid port"),
+    ("https://media.invalid:65536", "Invalid base URL — invalid port"),
+    ("https://[broken", "Invalid base URL — could not parse"),
+    ("ftp://media.invalid", "Invalid URL scheme — must be http or https"),
+    ("https:///path", "Invalid base URL — no hostname provided"),
+    ("https://media.invalid", HOST_ERROR),
+    ("https://169.254.169.254", HOST_ERROR),
+])
+async def test_url_rejection_is_safe_before_client_construction(
+    async_client, name, client_type, admin, url, message,
+):
+    with (
+        patch(f"routers.settings.{client_type.__name__}") as constructor,
+        patch_ssrf_dns("169.254.169.254"),
+        patch("auth.dependencies.get_auth_settings") as auth,
+        patch("auth.dependencies.get_current_user", new=AsyncMock(return_value=User(
+            id=7151, username="synthetic-admin", is_admin=True,
+            is_active=True, auth_provider="local",
+        ) if admin else None)),
+    ):
+        auth.return_value.require_auth = admin
+        auth.return_value.setup_complete = admin
+        response = await async_client.post(
+            f"/api/settings/{name}/test-connection",
+            json={"base_url": url, "token" if name == "plex" else "api_key": SECRET},
+        )
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "error": message}
+    constructor.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name,client_type", CLIENTS)
+@pytest.mark.parametrize("unresolved", [False, True])
+@pytest.mark.parametrize("value", [SECRET, quote(quote(SECRET, safe=""), safe="")])
+async def test_host_diagnostics_are_server_only_and_redacted(
+    async_client, caplog, name, client_type, unresolved, value,
+):
+    from security.ssrf import SSRFError
+
+    caplog.set_level(logging.INFO)
+    detail = ("Could not resolve host " if unresolved else "Denied host ") + value + " " + DETAIL
+    client = AsyncMock()
+    with (
+        patch("security.ssrf.validate_outbound_url", side_effect=SSRFError(detail)),
+        patch(f"routers.settings.{client_type.__name__}", return_value=client) as constructor,
+    ):
+        response = await async_client.post(
+            f"/api/settings/{name}/test-connection",
+            json={"base_url": "https://media.invalid", "token" if name == "plex" else "api_key": SECRET},
+        )
+    assert response.json() == ({"ok": True} if unresolved else {"ok": False, "error": HOST_ERROR})
+    if unresolved:
+        client.get_sessions.assert_awaited_once()
+        client.close.assert_awaited_once()
+    else:
+        constructor.assert_not_called()
+    assert "synthetic diagnostic" not in response.text
+    assert "synthetic diagnostic" in caplog.text
+    for sensitive in (value, SECRET, "url-user", "url-pass", "path-user", "path-pass"):
+        assert sensitive not in caplog.text
+    records = [record for record in caplog.records if record.name == "routers.settings"]
+    assert records
+    assert all(record.exc_info is None for record in records)
+
+
+@pytest.mark.parametrize("records", [None, [], [ipaddress.ip_address("8.8.8.8"), ipaddress.ip_address("169.254.169.254")]])
+def test_settings_dns_allowance_preserves_runtime_revalidation(records):
+    from routers.settings import _sanitize_base_url
+    from security.ssrf import SSRFError, SSRFMode, validate_outbound_url
+
+    url = "https://media.invalid:8920/path?ignored=true#fragment"
+    with (
+        patch("security.ssrf._resolve", **(
+            {"side_effect": socket.gaierror("synthetic DNS failure")} if records is None
+            else {"return_value": records}
+        )),
+        patch("security.ssrf.get_ssrf_mode", return_value=SSRFMode.LAN_FRIENDLY),
+    ):
+        assert _sanitize_base_url(url) == (
+            ("https://media.invalid:8920", None) if not records else (None, HOST_ERROR)
+        )
+        with pytest.raises(SSRFError):
+            validate_outbound_url(url, SSRFMode.LAN_FRIENDLY)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_settings.py
+++ b/backend/tests/routers/test_settings.py
@@ -3258,7 +3258,13 @@ class TestSettingsSsrfOnSave:
             response = await async_client.post("/api/settings", json=payload)
 
         assert response.status_code == 400, response.json()
-        assert "169.254" in response.json()["detail"] or "denied" in response.json()["detail"].lower()
+        label = {
+            "emby_base_url": "Emby base URL", "plex_base_url": "Plex base URL",
+            "jellyfin_base_url": "Jellyfin base URL", "url": "Dispatcharr URL",
+        }[field]
+        assert response.json() == {"detail": (
+            f"Invalid {label}: Invalid host — destination is not permitted by the outbound policy"
+        )}
         mock_save.assert_not_called()
 
     @pytest.mark.asyncio
@@ -3293,8 +3299,10 @@ class TestSettingsSsrfOnSave:
             response = await async_client.post("/api/settings", json=payload)
 
         assert response.status_code == 400, response.json()
-        detail = response.json()["detail"]
-        assert "169.254" in detail or "denied" in detail.lower(), detail
+        label = "Emby base URL" if field == "emby_base_url" else "Dispatcharr URL"
+        assert response.json() == {"detail": (
+            f"Invalid {label}: Invalid host — destination is not permitted by the outbound policy"
+        )}
         mock_save.assert_not_called()
 
     @pytest.mark.asyncio

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0027",
+  "version": "0.18.2-0028",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Finishes the residual enhancedchannelmanager-m8dvz implementation tracked by enhancedchannelmanager-98eah. Malformed ports and outbound host denials use fixed public errors; useful diagnostics use existing credential redaction. Preserves authorization, first-run behavior, outbound policy, client categories and explicit regex escaping.

## Verification
- Independently rerun canonical backend: 13,783 passed, 4 skipped, 2 deselected; 82.93% coverage; all 74 dependency pins matched.
- Independently rerun frontend lint, typecheck, 3,726 tests and production build: passed.
- Engineer strict MkDocs and syntax checks passed.
- Baseline and unsafe-return/logging negative controls fail as expected.
- Independent code, QA and security review agents approved the scoped diff without blockers. These are local reviews, not GitHub approval objects.

## Delivery boundary
Fresh exact-PR/dev CodeQL validation is required. Original main-bound alert verification remains on existing enhancedchannelmanager-0m06f.2; no alert dismissal or main promotion. Exact-merge AMD64/ARM64 publication verification follows merge. Version 0.18.2-0028 across all three canonical touchpoints.