### PR TITLE
v0.18.2-0030: pin cache lifecycle and correlate restore runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Restore dialogs correlate progress and reports with the requested run (bead `enhancedchannelmanager-zt801`; build 0.18.2-0030).** Uploaded and saved DBAS restore triggers issue a server run identity carried into progress and terminal history. Reopening a dialog or rerunning the same task cannot present an older preview as the current result or enable Apply from it. Slow-upload timing, history retries, warning reports, and apply-only data refresh are preserved. Unknown identity fails closed.
+
 ### Security
 
 - **Settings URL validation uses safe public errors (bead `enhancedchannelmanager-m8dvz`; build 0.18.2-0028).** Malformed ports and outbound-policy denials return fixed messages instead of parser text or resolved-address details, including the shared Dispatcharr and media settings save paths. Host-policy diagnostics remain in redacted server logs. Media client error categories, credential escaping, human-admin/first-run gates, and outbound allow/deny decisions are preserved.
@@ -23,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Mapped channels moved to Settings > Channel Normalization (bead `enhancedchannelmanager-81sy8`, GitHub #775, build 0.18.2-0024).** The existing manager is now a headed, section-linked Settings section instead of an Operations sidebar destination. Old `#mapped-channels` bookmarks redirect to the new section. Mapping saves, API permissions, and the stream-selection **Add mapping** shortcut are unchanged.
 
 ### Added
+
+- **Shared regression coverage for unchanged media caches (bead `enhancedchannelmanager-eal0l.2`; build 0.18.2-0030).** Isolated Emby/Plex/Jellyfin lifecycle tests pin monotonic TTL boundaries, concurrent refresh coalescing, stale fallback, cancellation, cleanup, and provider isolation; Jellyfin enrichment remains provider-specific.
 
 - **Stream probes now classify resolution-relative low bitrate (bead `enhancedchannelmanager-8gmk8.4`, GitHub #980, build 0.18.2-0020).** Fresh bitrate in bits/second is low only when strictly below `width * height * low_bitrate_threshold`, independent of FPS. The configurable positive finite threshold defaults to 1.0 bit/pixel/second. Inputs prefer fresh measured throughput, then video metadata, then overall format metadata, using current effective dimensions including opt-in resdet results. Missing or invalid inputs and failed probes clear the flag rather than reusing stale values. Classification remains visible independently of sorting; Priority deprioritization defaults off and follows the existing global health gate. Points mode uses explicit `low_bitrate` rules only, with no hidden bucket, injected rule, or automatic penalty. Existing numeric bitrate ranking and direct sorts are unchanged.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -158,7 +158,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0029",
+    version="0.18.2-0030",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -132,7 +132,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0029"
+APP_VERSION = "0.18.2-0030"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable
@@ -4997,6 +4997,9 @@ async def restore_dbas_artifact(
     even if this flag were bypassed). Validation (.17 version + integrity) runs
     inside the task BEFORE any decode or importer.
     """
+    from uuid import uuid4
+
+    run_id = str(uuid4())
     reattach_mode = ChannelReattachMode.coerce(channel_reattach_mode)
     logger.info(
         "[BACKUP] DBAS restore requested (filename=%s, confirm_apply=%s, "
@@ -5032,7 +5035,7 @@ async def restore_dbas_artifact(
         # frontend polls /api/tasks/{id} for live progress. The task's own
         # finally-block cleans up the temp artifact on success AND failure.
         asyncio.create_task(
-            engine.run_task(DBAS_RESTORE_TASK_ID, parameters=parameters)
+            engine.run_task(DBAS_RESTORE_TASK_ID, parameters=parameters, run_id=run_id)
         )
     except Exception as exc:
         logger.exception("[BACKUP] Failed to schedule DBAS restore task: %s", exc)
@@ -5047,6 +5050,7 @@ async def restore_dbas_artifact(
     return {
         "status": "started",
         "task_id": DBAS_RESTORE_TASK_ID,
+        "run_id": run_id,
         "is_dry_run": not confirm_apply,
         "channel_reattach_mode": reattach_mode.value,
     }
@@ -7230,6 +7234,9 @@ async def restore_dbas_saved(
         )
         raise HTTPException(status_code=403, detail=_DBAS_APPLY_MCP_DENIAL)
 
+    from uuid import uuid4
+
+    run_id = str(uuid4())
     filename = req.filename
     reattach_mode = ChannelReattachMode.coerce(req.channel_reattach_mode)
     logger.info(
@@ -7285,7 +7292,7 @@ async def restore_dbas_saved(
         # Fire-and-forget: schedule as a background asyncio task and return the
         # task id immediately. The caller polls /api/tasks/{id} for progress.
         asyncio.create_task(
-            engine.run_task(DBAS_RESTORE_TASK_ID, parameters=parameters)
+            engine.run_task(DBAS_RESTORE_TASK_ID, parameters=parameters, run_id=run_id)
         )
     except Exception as exc:
         logger.exception("[BACKUP] Failed to schedule DBAS restore-from-saved task: %s", exc)
@@ -7294,6 +7301,7 @@ async def restore_dbas_saved(
     return {
         "status": "started",
         "task_id": DBAS_RESTORE_TASK_ID,
+        "run_id": run_id,
         "is_dry_run": not req.confirm_apply,
         "channel_reattach_mode": reattach_mode.value,
     }

--- a/backend/task_engine.py
+++ b/backend/task_engine.py
@@ -11,6 +11,7 @@ Background service that manages and executes scheduled tasks:
 import asyncio
 import copy
 import contextlib
+import json
 import logging
 from datetime import datetime
 from typing import Optional
@@ -1003,6 +1004,7 @@ class TaskEngine:
         triggered_by: str = "manual",
         parameters: Optional[dict] = None,
         schedule_id: Optional[int] = None,
+        run_id: Optional[str] = None,
     ) -> Optional[TaskResult]:
         """
         Execute a task and record the result.
@@ -1158,7 +1160,13 @@ class TaskEngine:
             )
 
             instance.set_run_trigger(triggered_by)
-            result = validation_result or await instance.run()
+            result = validation_result or (
+                await instance.run(run_id=run_id) if run_id is not None else await instance.run()
+            )
+            if run_id is not None:
+                # Transport-issued identity, not task parameters or a clock.
+                # Existing JSON details persist it without changing the schema.
+                result.details = {**result.details, "run_id": run_id}
 
             # Update execution record
             if execution_id:
@@ -1183,7 +1191,6 @@ class TaskEngine:
                         execution.failed_count = result.failed_count
                         execution.skipped_count = result.skipped_count
                         if result.details:
-                            import json
                             execution.details = json.dumps(result.details)
                         session.commit()
                     session.close()
@@ -1448,6 +1455,8 @@ class TaskEngine:
                         execution.status = "failed"
                         execution.success = False
                         execution.error = failure_error
+                        if run_id is not None:
+                            execution.details = json.dumps({"run_id": run_id})
                         session.commit()
                     session.close()
                 except Exception as db_err:
@@ -1474,7 +1483,7 @@ class TaskEngine:
                 async with self._lock:
                     self._active_tasks.discard(task_id)
 
-    async def run_task(self, task_id: str, schedule_id: Optional[int] = None, parameters: Optional[dict] = None) -> Optional[TaskResult]:
+    async def run_task(self, task_id: str, schedule_id: Optional[int] = None, parameters: Optional[dict] = None, *, run_id: Optional[str] = None) -> Optional[TaskResult]:
         """
         Manually run a task (API entry point).
 
@@ -1489,6 +1498,8 @@ class TaskEngine:
         if parameters:
             logger.info("[%s] Manual run with ad-hoc parameters: %s", task_id,
                         _param_keys(parameters))
+            if run_id is not None:
+                return await self._execute_task(task_id, triggered_by="manual", parameters=parameters, run_id=run_id)
             return await self._execute_task(task_id, triggered_by="manual", parameters=parameters)
 
         if schedule_id:
@@ -1518,6 +1529,8 @@ class TaskEngine:
                 logger.exception("[%s] Failed to load schedule parameters: %s", task_id, e)
                 return None
 
+        if run_id is not None:
+            return await self._execute_task(task_id, triggered_by="manual", parameters=parameters, schedule_id=schedule_id, run_id=run_id)
         return await self._execute_task(task_id, triggered_by="manual", parameters=parameters, schedule_id=schedule_id)
 
     async def cancel_task(self, task_id: str) -> dict:

--- a/backend/task_scheduler.py
+++ b/backend/task_scheduler.py
@@ -49,6 +49,7 @@ class TaskProgress:
     failed_count: int = 0
     skipped_count: int = 0
     started_at: Optional[datetime] = None
+    run_id: Optional[str] = None
 
     @property
     def percentage(self) -> float:
@@ -69,6 +70,7 @@ class TaskProgress:
             "failed_count": self.failed_count,
             "skipped_count": self.skipped_count,
             "started_at": self.started_at.isoformat() + "Z" if self.started_at else None,
+            **({"run_id": self.run_id} if self.run_id is not None else {}),
         }
 
 
@@ -697,7 +699,7 @@ class TaskScheduler(ABC):
     # Task Execution
     # -------------------------------------------------------------------------
 
-    async def run(self) -> TaskResult:
+    async def run(self, *, run_id: Optional[str] = None) -> TaskResult:
         """
         Run the task immediately.
 
@@ -730,6 +732,7 @@ class TaskScheduler(ABC):
 
         # Initialize for this run
         self._reset_progress()
+        self._progress.run_id = run_id
         self._status = TaskStatus.RUNNING
         self._progress.started_at = datetime.utcnow()
         self._progress.status = "starting"

--- a/backend/tests/integration/test_restore_run_correlation.py
+++ b/backend/tests/integration/test_restore_run_correlation.py
@@ -1,0 +1,109 @@
+"""Real HTTP trigger -> engine/scheduler -> SQLite history, synthetic task body."""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+from uuid import UUID
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.orm import sessionmaker
+
+import task_engine
+from routers import backup
+from task_scheduler import TaskResult
+from tasks.dbas_restore import DbasRestoreTask
+
+
+@pytest.fixture
+def runtime(test_engine, tmp_path, monkeypatch):
+    factory = sessionmaker(bind=test_engine, expire_on_commit=False)
+    engine = task_engine.TaskEngine()
+    monkeypatch.setattr(engine, '_notify_task_result', AsyncMock())
+    task = DbasRestoreTask()
+    registry = Mock()
+    registry.get_task_instance.return_value = task
+    monkeypatch.setattr(task_engine, 'get_registry', lambda: registry)
+    monkeypatch.setattr(task_engine, 'get_session', factory)
+    monkeypatch.setattr(task_engine, 'get_engine', lambda: engine)
+    monkeypatch.setattr(task_engine, 'log_entry', Mock())
+    monkeypatch.setattr(backup, '_DBAS_RESTORE_TMP_DIR', tmp_path)
+    monkeypatch.setattr(backup, 'BACKUPS_DIR', tmp_path)
+    name = 'ecm-backup-2026-01-01_000000.zip'
+    (tmp_path / name).write_bytes(b'PK synthetic')
+    app = FastAPI()
+    app.include_router(backup.router)
+    # Existing auth tiers remain exercised by dedicated HTTP authorization suites.
+    for dependency in [backup.RequireHumanAdminIfEnabled, backup.RequireAdminIfEnabled,
+                       backup.ResolveIsMcpServicePrincipalIfEnabled]:
+        app.dependency_overrides[dependency.dependency] = lambda: False
+    return SimpleNamespace(engine=engine, task=task, app=app, name=name)
+
+
+@pytest.mark.parametrize('flow', ['uploaded', 'saved'])
+@pytest.mark.parametrize('outcome', ['completed', 'failed', 'cancelled', 'completed_with_warnings'])
+async def test_trigger_identity_matches_progress_and_persisted_terminal_history(runtime, monkeypatch, flow, outcome):
+    entered, release, finished = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    task, engine = runtime.task, runtime.engine
+
+    async def execute():
+        entered.set()
+        await release.wait()
+        if outcome == 'cancelled':
+            task.cancel()
+        return TaskResult(success=outcome == 'completed',
+                          completed_degraded=outcome == 'completed_with_warnings',
+                          error='synthetic failure' if outcome == 'failed' else None,
+                          details={'restore_report': {'is_dry_run': True}})
+    monkeypatch.setattr(task, '_execute_run', execute)
+    original_run = engine.run_task
+    results = []
+    async def tracked_run(*args, **kwargs):
+        try:
+            result = await original_run(*args, **kwargs)
+            results.append(result)
+            return result
+        finally:
+            if 'dbas_restore' not in engine._active_tasks:
+                finished.set()
+    monkeypatch.setattr(engine, 'run_task', tracked_run)
+
+    async with AsyncClient(transport=ASGITransport(app=runtime.app), base_url='http://test') as client:
+        async def trigger():
+            if flow == 'uploaded':
+                return await client.post('/api/backup/restore-dbas?run_id=caller-chosen', files={'file': ('backup.zip', b'PK synthetic')})
+            return await client.post('/api/backup/restore-dbas-saved', json={'filename': runtime.name, 'run_id': 'caller-chosen'})
+        try:
+            first = await trigger()
+            assert first.status_code == 200
+            run_id = first.json()['run_id']
+            assert str(UUID(run_id)) == run_id
+            await asyncio.wait_for(entered.wait(), 2)
+            assert task._progress.to_dict()['run_id'] == run_id
+            # A second accepted transport request is rejected by the existing
+            # engine lock. Its token must never relabel the running singleton.
+            overlap = await trigger()
+            assert overlap.json()['run_id'] != run_id
+            await asyncio.sleep(0)
+            assert task._progress.to_dict()['run_id'] == run_id
+            assert any(result.error == 'ALREADY_RUNNING' for result in results)
+            release.set()
+            await asyncio.wait_for(finished.wait(), 3)
+            assert task._progress.to_dict()['status'] == outcome
+            history = engine.get_task_history('dbas_restore')
+            assert len(history) == 1
+            assert history[0]['status'] == outcome
+            assert history[0]['details']['run_id'] == run_id
+            assert history[0]['details']['restore_report'] == {'is_dry_run': True}
+            assert not engine._active_tasks
+            # Fixed task-ID rerun gets a fresh transport identity and row.
+            finished.clear()
+            rerun = await trigger()
+            await asyncio.wait_for(finished.wait(), 3)
+            assert rerun.json()['run_id'] not in {run_id, overlap.json()['run_id']}
+            assert task._progress.to_dict()['run_id'] == rerun.json()['run_id']
+            assert engine.get_task_history('dbas_restore')[0]['details']['run_id'] == rerun.json()['run_id']
+        finally:
+            release.set()
+            if engine._active_tasks:
+                await asyncio.wait_for(finished.wait(), 3)

--- a/backend/tests/services/test_media_cache_lifecycle.py
+++ b/backend/tests/services/test_media_cache_lifecycle.py
@@ -1,0 +1,228 @@
+"""Shared lifecycle contract for unchanged provider caches (eal0l.2).
+
+Patch module-local references, restoring prior singleton identities on teardown;
+no network, global clock patch, shared metrics registry, or persistent settings.
+"""
+import asyncio
+from contextlib import nullcontext
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+
+@pytest.fixture
+def providers(monkeypatch):
+    cases = []
+    for name, client_name in [('emby', 'Emby'), ('plex', 'Plex'), ('jellyfin', 'Jellyfin')]:
+        module = import_module(f'services.{name}_cache')
+        settings = SimpleNamespace(**{
+            f'{name}_enabled': True, f'{name}_base_url': f'http://{name}.invalid',
+            f'{name}_api_key': 'synthetic', f'{name}_token': 'synthetic',
+        })
+        clock = SimpleNamespace(now=100.0)
+        sessions = [SimpleNamespace(now_playing_item_name=name, now_playing_queue_item_id=None)]
+        client = SimpleNamespace(get_sessions=AsyncMock(return_value=sessions), close=AsyncMock())
+        constructor = Mock(return_value=client)
+        monkeypatch.setattr(module, '_cached_entry', None)
+        monkeypatch.setattr(module, '_fetch_lock', None)
+        monkeypatch.setattr(module, 'get_settings', lambda s=settings: s)
+        monkeypatch.setattr(module, 'time', SimpleNamespace(monotonic=lambda c=clock: c.now))
+        monkeypatch.setattr(module, 'observability', Mock())
+        # Metric timers need a context manager; all metrics stay case-local.
+        module.observability.get_metric.return_value.labels.return_value.time.side_effect = nullcontext
+        monkeypatch.setattr(module, f'{client_name}Client', constructor)
+        cases.append(SimpleNamespace(
+            name=name, module=module, settings=settings, clock=clock, sessions=sessions,
+            client=client, constructor=constructor,
+            error=getattr(module, f'{client_name}ClientError'),
+            get=getattr(module, f'get_cached_{name}_sessions'),
+        ))
+    return cases
+
+
+@pytest.fixture(params=range(3), ids=['emby', 'plex', 'jellyfin'])
+def cache(request, providers):
+    return providers[request.param]
+
+
+async def test_monotonic_exact_ttl_and_store_after_close(cache):
+    async def close():
+        assert cache.module._cached_entry is None
+        cache.clock.now = 102.0
+    cache.client.close.side_effect = close
+    first = await cache.get()
+    assert first == cache.sessions
+    assert cache.module._cached_entry.cached_at == 102.0
+    cache.client.close.side_effect = None
+    cache.clock.now = 106.999
+    assert await cache.get() is first
+    assert cache.client.get_sessions.await_count == 1
+    cache.clock.now = 107.0
+    await cache.get()
+    assert cache.client.get_sessions.await_count == 2
+    assert cache.client.close.await_count == 2
+
+
+@pytest.mark.parametrize('setting,value', [('enabled', False), ('base_url', ''), ('base_url', None)])
+async def test_disabled_or_unconfigured_does_not_touch_state(cache, setting, value):
+    cache.module._store_entry(cache.sessions)
+    entry = cache.module._cached_entry
+    setattr(cache.settings, f'{cache.name}_{setting}', value)
+    assert await cache.get() == []
+    assert cache.module._cached_entry is entry
+    assert cache.module._fetch_lock is None
+    cache.constructor.assert_not_called()
+
+
+async def test_concurrent_misses_recheck_under_lock(cache):
+    entered, release = asyncio.Event(), asyncio.Event()
+    async def fetch():
+        entered.set()
+        await release.wait()
+        return cache.sessions
+    cache.client.get_sessions.side_effect = fetch
+    tasks = [asyncio.create_task(cache.get()) for _ in range(20)]
+    try:
+        await asyncio.wait_for(entered.wait(), 1)
+        await asyncio.sleep(0)
+        release.set()
+        results = await asyncio.wait_for(asyncio.gather(*tasks), 2)
+        assert all(result == cache.sessions for result in results)
+        assert cache.constructor.call_count == 1
+        assert cache.client.get_sessions.await_count == 1
+        assert cache.client.close.await_count == 1
+        assert not cache.module._get_lock().locked()
+    finally:
+        release.set()
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.parametrize('stale', [False, True])
+@pytest.mark.parametrize('failure', ['provider', 'unexpected', 'cancel'])
+async def test_fetch_failures_preserve_timestamp_and_retry(cache, stale, failure):
+    if stale:
+        await cache.get()
+    entry = cache.module._cached_entry
+    cache.clock.now += 5.0
+    error = {'provider': cache.error('synthetic'), 'unexpected': RuntimeError('synthetic'),
+             'cancel': asyncio.CancelledError()}[failure]
+    cache.client.get_sessions.side_effect = error
+    for _ in range(2):
+        before = cache.client.get_sessions.await_count
+        if failure == 'provider':
+            assert await cache.get() == (cache.sessions if stale else [])
+        else:
+            with pytest.raises(type(error)):
+                await cache.get()
+        assert cache.client.get_sessions.await_count == before + 1
+        assert cache.client.close.await_count == cache.client.get_sessions.await_count
+        assert cache.module._cached_entry is entry
+        if entry:
+            assert entry.cached_at == 100.0
+        assert not cache.module._get_lock().locked()
+    cache.client.get_sessions.side_effect = None
+    assert await cache.get() == cache.sessions
+
+
+async def test_queued_cancellation_does_not_construct_or_close_client(cache):
+    lock = cache.module._get_lock()
+    await lock.acquire()
+    task = asyncio.create_task(cache.get())
+    try:
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        cache.constructor.assert_not_called()
+        cache.client.close.assert_not_awaited()
+        assert lock.locked()
+    finally:
+        lock.release()
+    assert await cache.get() == cache.sessions
+
+
+@pytest.mark.parametrize('stale', [False, True])
+@pytest.mark.parametrize('failure', ['provider', 'unexpected', 'cancel'])
+async def test_close_failure_policy_does_not_store_success(cache, stale, failure):
+    if stale:
+        await cache.get()
+    entry = cache.module._cached_entry
+    cache.clock.now += 5.0
+    error = {'provider': cache.error('close'), 'unexpected': RuntimeError('close'),
+             'cancel': asyncio.CancelledError()}[failure]
+    cache.client.close.side_effect = error
+    if failure == 'provider':
+        assert await cache.get() == (cache.sessions if stale else [])
+    else:
+        with pytest.raises(type(error)):
+            await cache.get()
+    assert cache.module._cached_entry is entry
+    assert cache.client.close.await_count == cache.client.get_sessions.await_count
+    assert not cache.module._get_lock().locked()
+    cache.client.close.side_effect = None
+    assert await cache.get() == cache.sessions
+
+
+async def test_providers_have_distinct_cache_lock_and_client_resources(providers):
+    for cache in providers:
+        assert await cache.get() == cache.sessions
+    assert len({id(c.module._cached_entry) for c in providers}) == 3
+    assert len({id(c.module._get_lock()) for c in providers}) == 3
+    for cache in providers:
+        assert await cache.get() == cache.sessions
+        cache.constructor.assert_called_once()
+        assert cache.module._cached_entry.sessions == cache.sessions
+
+
+async def test_cancelling_fetch_holder_releases_lock_for_next_caller(cache):
+    entered = asyncio.Event()
+    async def fetch():
+        entered.set()
+        await asyncio.Event().wait()
+    cache.client.get_sessions.side_effect = fetch
+    holder = asyncio.create_task(cache.get())
+    try:
+        await asyncio.wait_for(entered.wait(), 1)
+        holder.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await holder
+        cache.client.close.assert_awaited_once()
+        assert cache.module._cached_entry is None
+        assert not cache.module._get_lock().locked()
+        cache.client.get_sessions.side_effect = None
+        assert await asyncio.wait_for(cache.get(), 1) == cache.sessions
+    finally:
+        holder.cancel()
+        await asyncio.gather(holder, return_exceptions=True)
+
+
+async def test_jellyfin_enrichment_precedes_close_and_store_without_mutating_input(providers):
+    from jellyfin_client import JellyfinSession
+
+    cache = providers[2]
+    sessions = [JellyfinSession(
+        session_id=str(i), user_id='user', user_name='synthetic', remote_endpoint='127.0.0.1',
+        now_playing_item_name=None, now_playing_channel_name=None,
+        last_activity_date='2026-01-01T00:00:00Z', now_playing_queue_item_id=str(i),
+    ) for i in range(2)]
+    cache.client.get_sessions.return_value = sessions
+    # get_user_item owns per-item transport failure -> None. One failed lookup
+    # must not prevent the following session from being enriched.
+    cache.client.get_user_item = AsyncMock(side_effect=[None, {'Name': 'Channel', 'ChannelNumber': '7'}])
+    async def close():
+        assert cache.client.get_user_item.await_count == 2
+        assert cache.module._cached_entry is None
+        assert all(s.now_playing_item_name is None for s in sessions)
+    cache.client.close.side_effect = close
+    result = await cache.get()
+    assert result is not sessions
+    assert result[0] is sessions[0]
+    assert result[1] is not sessions[1]
+    assert result[1].now_playing_item_name == 'Channel'
+    assert result[1].channel_number == '7'
+    assert cache.module._cached_entry.sessions is result
+    assert sessions[1].now_playing_item_name is None

--- a/docs/user_guide/backup-restore/restore-a-backup.md
+++ b/docs/user_guide/backup-restore/restore-a-backup.md
@@ -44,6 +44,15 @@ The restore modal runs a **dry-run by default**. It does not apply anything unle
 
 Review the report before applying. A large unexpected "would create" count on an existing instance is a signal to investigate before proceeding.
 
+Uploaded and saved-backup dialogs wait for progress and a report belonging to the
+run you requested, including after closing and reopening the dialog. An older
+preview does not enable **Apply these changes**. If ECM says **The restore did
+not start**, check **Settings → Scheduled Tasks → DBAS Restore → History** before
+retrying: another restore may already be running. The start-wait budget begins
+after the upload request succeeds, so uploading a large archive does not consume
+that budget. These cases are covered by the isolated restore-correlation browser
+and hook/modal regression tests.
+
 ### Step 3: Apply
 
 If the preview looks correct:

--- a/e2e/restore-run-correlation.spec.ts
+++ b/e2e/restore-run-correlation.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test'
+import assert from 'node:assert/strict'
+
+// Full built app + actual modals/hook/API client; only HTTP data is synthetic.
+for (const flow of ['uploaded', 'saved']) {
+  test(`${flow}: remount ignores old progress and history before enabling Apply`, async ({ page, context, baseURL }, info) => {
+    assert.equal(info.project.metadata.rdniaIsolated, true, 'requires private verification config')
+    assert.ok(baseURL && new URL(baseURL).hostname === '127.0.0.1')
+    const filename = 'ecm-backup-2026-01-01_000000.zip'
+    const state = { requested: 0, progress: 0, history: 0, progressReads: 0, historyReads: 0 }
+    const blocked: string[] = []
+    const traffic: object[] = []
+    page.on('pageerror', error => console.error('browser error:', error.message))
+    await context.routeWebSocket('**/*', socket => socket.close())
+    await context.route('**/*', async route => {
+      const request = route.request()
+      const url = new URL(request.url())
+      const path = url.pathname
+      if (url.origin !== new URL(baseURL!).origin) {
+        blocked.push(request.url())
+        return route.abort('blockedbyclient')
+      }
+      if (!path.startsWith('/api/')) return route.continue()
+      if (path === '/api/backup/restore-dbas' || path === '/api/backup/restore-dbas-saved') {
+        assert.equal(request.method(), 'POST')
+        state.requested++
+        traffic.push({ trigger: path, run_id: `run-${state.requested}` })
+        return route.fulfill({ json: { status: 'started', task_id: 'dbas_restore',
+          run_id: `run-${state.requested}`, is_dry_run: true, channel_reattach_mode: 'preserve' } })
+      }
+      if (path === '/api/tasks/dbas_restore') {
+        state.progressReads++
+        traffic.push({ progress: state.progress })
+        return route.fulfill({ json: { task_id: 'dbas_restore', progress: {
+          run_id: `run-${state.progress}`, started_at: '2026-01-01T00:00:00Z',
+          status: 'completed', total: 13, current: 13, percentage: 100, current_item: 'finalize',
+          success_count: 1, failed_count: 0, skipped_count: 0,
+        } } })
+      }
+      if (path === '/api/tasks/dbas_restore/history') {
+        state.historyReads++
+        traffic.push({ history: state.history })
+        return route.fulfill({ json: { history: [{ status: 'completed', details: {
+          run_id: `run-${state.history}`, restore_report: {
+            contract_version: 1, is_dry_run: true, categories: [], logo_misses: 0, notes: [],
+            epg_link_reattach: { mode: 'overwrite', created_channels: 0, existing_channels: 1,
+              preserved_channels: 0, existing_channels_named: [`REPORT-${state.history}`], preserved_channels_named: [] },
+          },
+        } }] } })
+      }
+      if (path === '/api/auth/refresh') return route.fulfill({ status: 401, json: {} })
+      if (request.method() !== 'GET' && path !== '/api/session-start') {
+        blocked.push(`${request.method()} ${path}`)
+        return route.abort('blockedbyclient')
+      }
+      const data: Record<string, unknown> = {
+        '/api/auth/status': { require_auth: false, setup_complete: true, dispatcharr_enabled: false },
+        '/api/auth/setup-required': { required: false },
+        '/api/auth/me': null,
+        '/api/settings': { configured: true, url: '', theme: 'dark', ssrf_outbound_mode: 'lan', ssrf_outbound_mode_acknowledged: true },
+        '/api/backup/saved': [{ filename, size_bytes: 12, type: 'zip', created_at: '2026-01-01T00:00:00Z' }],
+        '/api/backup/export-sections': [],
+        '/api/tasks': { tasks: [] },
+        '/api/notifications': { notifications: [], unread_count: 0 },
+        '/api/profile-conflict-reviews': { reviews: [] },
+        '/api/event-sync-reviews': { reviews: [], total: 0 },
+      }
+      return route.fulfill({ status: path === '/api/auth/me' ? 401 : 200, json: data[path] ?? [] })
+    })
+    try {
+      await page.goto('/')
+      await page.locator('[data-tab="settings"]').click()
+      await page.locator('.settings-nav-item').filter({ hasText: 'Backup & Restore' }).click()
+      async function open() {
+        if (flow === 'saved') await page.getByRole('button', { name: 'Restore as DBAS backup', exact: true }).click()
+        else {
+          await page.getByRole('button', { name: 'Restore from artifact...', exact: false }).click()
+          const chooser = page.waitForEvent('filechooser')
+          await page.getByText(/drag & drop a backup artifact/i).click()
+          await (await chooser).setFiles({ name: filename, mimeType: 'application/zip', buffer: Buffer.from('PK synthetic') })
+        }
+        await page.getByRole('button', { name: 'Run preview', exact: true }).click()
+      }
+      // Establish a genuine prior terminal report, close, and remount the modal.
+      state.progress = state.history = 1
+      await open()
+      await expect(page.getByTestId('existing-channel-reattach-notice')).toContainText('REPORT-1')
+      await page.getByRole('button', { name: 'Done', exact: true }).click()
+      const oldHistoryReads = state.historyReads
+      const oldProgressReads = state.progressReads
+      await open()
+      await expect.poll(() => state.progressReads).toBeGreaterThan(oldProgressReads + 1)
+      expect(state.historyReads).toBe(oldHistoryReads)
+      await expect(page.getByRole('button', { name: /apply these changes/i })).toHaveCount(0)
+      await page.screenshot({ path: info.outputPath(`${flow}-old-progress-rejected.png`) })
+      state.progress = 2
+      await expect.poll(() => state.historyReads).toBeGreaterThan(oldHistoryReads)
+      await expect(page.getByRole('button', { name: /apply these changes/i })).toHaveCount(0)
+      state.history = 2
+      await expect(page.getByTestId('existing-channel-reattach-notice')).toContainText('REPORT-2')
+      await expect(page.getByTestId('existing-channel-reattach-notice')).not.toContainText('REPORT-1')
+      const apply = page.getByRole('button', { name: /apply these changes/i })
+      await expect(apply).toBeEnabled()
+      await expect(apply).toBeInViewport()
+      await apply.click({ trial: true })
+      await page.screenshot({ path: info.outputPath(`${flow}-current-report.png`) })
+      await info.attach('trigger-progress-history.json', { body: JSON.stringify(traffic, null, 2), contentType: 'application/json' })
+    } finally {
+      console.log('browser evidence:', info.outputDir)
+      await info.attach('final-dom.txt', { body: await page.locator('body').innerText(), contentType: 'text/plain' })
+      await page.screenshot({ path: info.outputPath('final.png') })
+      await page.close()
+      await context.unrouteAll({ behavior: 'wait' })
+      expect(blocked).toEqual([])
+    }
+  })
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0029",
+  "version": "0.18.2-0030",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/DbasRestoreCorrelation.test.tsx
+++ b/frontend/src/components/DbasRestoreCorrelation.test.tsx
@@ -1,0 +1,199 @@
+/** Actual hook/modal seam: a remount must not trust another run's terminal payload. */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import * as api from '../services/api';
+import { DbasRestoreModal } from './DbasRestoreModal';
+import { DbasRestoreSavedModal } from './DbasRestoreSavedModal';
+import { invalidateServerData } from '../hooks/useServerDataInvalidation';
+
+vi.mock('../services/api', () => ({
+  getSettings: vi.fn(), startDbasRestore: vi.fn(), restoreDbasBackupSaved: vi.fn(),
+  getTask: vi.fn(), getTaskHistory: vi.fn(),
+}));
+vi.mock('../hooks/useNavigateAwayGuard', () => ({ useNavigateAwayGuard: () => {} }));
+vi.mock('../hooks/useServerDataInvalidation', () => ({ invalidateServerData: vi.fn() }));
+
+function task(runId: string, status = 'completed') {
+  return { task_id: 'dbas_restore', progress: {
+    run_id: runId, started_at: '2026-01-01T00:00:00Z', status,
+    total: 13, current: 13, percentage: 100, current_item: 'finalize',
+    success_count: 0, failed_count: 0, skipped_count: 0,
+  } };
+}
+function history(runId: string) {
+  return { history: [{ status: 'completed', details: { run_id: runId, restore_report: {
+    contract_version: 1, is_dry_run: true, categories: [], logo_misses: 0,
+    notes: [], epg_link_reattach: {
+      mode: 'overwrite', created_channels: 0, existing_channels: 1, preserved_channels: 0,
+      existing_channels_named: [runId === 'current' ? 'CURRENT REPORT' : 'OLD REPORT'],
+      preserved_channels_named: [],
+    },
+  } } }] };
+}
+async function tick(ms = 1000) {
+  await act(async () => { await vi.advanceTimersByTimeAsync(ms); });
+}
+
+describe.each(['uploaded', 'saved'] as const)('%s initiated restore correlation', (flow) => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    vi.mocked(api.getSettings).mockResolvedValue({ url: '' } as never);
+    for (const trigger of [api.startDbasRestore, api.restoreDbasBackupSaved]) {
+      vi.mocked(trigger).mockResolvedValue({ status: 'started', task_id: 'dbas_restore',
+        is_dry_run: true, run_id: 'current' } as never);
+    }
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  async function mount() {
+    const view = render(flow === 'saved'
+      ? <DbasRestoreSavedModal filename="backup.zip" onClose={vi.fn()} />
+      : <DbasRestoreModal onClose={vi.fn()} />);
+    if (flow === 'uploaded') {
+      fireEvent.drop(screen.getByText(/drag & drop/i).closest('div')!, {
+        dataTransfer: { files: [new File(['PK'], 'backup.zip')] },
+      });
+    }
+    await tick(0);
+    fireEvent.click(screen.getByRole('button', { name: /run preview/i }));
+    await tick(0);
+    return view;
+  }
+
+  it('ignores old terminal progress after remount, then waits for matching history', async () => {
+    vi.mocked(api.getTask).mockResolvedValue(task('old') as never);
+    vi.mocked(api.getTaskHistory).mockResolvedValue(history('old') as never);
+    await mount();
+    expect(api.getTask).toHaveBeenCalledTimes(1);
+    expect(api.getTaskHistory).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /apply these changes/i })).not.toBeInTheDocument();
+    vi.mocked(api.getTask).mockResolvedValue(task('current') as never);
+    await tick();
+    expect(api.getTaskHistory).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('OLD REPORT')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /apply these changes/i })).not.toBeInTheDocument();
+    vi.mocked(api.getTaskHistory).mockResolvedValue(history('current') as never);
+    await tick(500);
+    expect(screen.getByTestId('existing-channel-reattach-notice')).toHaveTextContent('CURRENT REPORT');
+    expect(screen.getByRole('button', { name: /apply these changes/i })).toBeEnabled();
+  });
+
+  it('unknown progress identity exhausts start budget with zero history reads', async () => {
+    vi.mocked(api.getTask).mockResolvedValue(task('') as never);
+    await mount();
+    for (let i = 0; i < 20; i++) await tick();
+    expect(screen.getByText(/restore did not start/i)).toBeInTheDocument();
+    expect(api.getTaskHistory).not.toHaveBeenCalled();
+  });
+
+  it('suppresses a late history response after unmount', async () => {
+    vi.mocked(api.getTask).mockResolvedValue(task('current') as never);
+    let resolve!: (value: never) => void;
+    vi.mocked(api.getTaskHistory).mockImplementation(() => new Promise((r) => { resolve = r; }));
+    const view = await mount();
+    view.unmount();
+    const applied = history('current');
+    applied.history[0].details.restore_report.is_dry_run = false;
+    await act(async () => { resolve(applied as never); });
+    expect(screen.queryByText('CURRENT REPORT')).not.toBeInTheDocument();
+    expect(invalidateServerData).not.toHaveBeenCalled();
+  });
+
+  it.each(['failed', 'cancelled'])('reads genuine %s history without saying no-start', async (status) => {
+    vi.mocked(api.getTask).mockResolvedValue(task('current', status) as never);
+    vi.mocked(api.getTaskHistory).mockResolvedValue({ history: [{ status,
+      details: { run_id: 'current' }, error: 'CURRENT FAILURE' }] } as never);
+    await mount();
+    for (let i = 0; i < 6; i++) await tick(500);
+    expect(screen.getByText('CURRENT FAILURE')).toBeInTheDocument();
+    expect(screen.queryByText(/did not start/i)).not.toBeInTheDocument();
+    expect(api.getTaskHistory).toHaveBeenCalledTimes(status === 'failed' ? 1 : 6);
+    expect(invalidateServerData).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])('keeps warning reports and invalidates only apply=%s', async (apply) => {
+    const response = history('current');
+    response.history[0].status = 'completed_with_warnings';
+    response.history[0].details.restore_report.is_dry_run = !apply;
+    vi.mocked(api.getTask).mockResolvedValue(task('current', 'completed_with_warnings') as never);
+    vi.mocked(api.getTaskHistory).mockResolvedValue(response as never);
+    await mount();
+    expect(screen.getByTestId('existing-channel-reattach-notice')).toHaveTextContent('CURRENT REPORT');
+    expect(screen.queryByText(/restore failed/i)).not.toBeInTheDocument();
+    expect(vi.mocked(invalidateServerData).mock.calls).toEqual(apply ? [['channel-groups'], ['channels']] : []);
+  });
+
+  it('history identity missing or different never yields a report, keeping six retries', async () => {
+    vi.mocked(api.getTask).mockResolvedValue(task('current') as never);
+    vi.mocked(api.getTaskHistory).mockResolvedValue(history('old') as never);
+    await mount();
+    for (let i = 0; i < 6; i++) await tick(500);
+    expect(api.getTaskHistory).toHaveBeenCalledTimes(6);
+    expect(screen.getByText('Restore failed')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /apply these changes/i })).not.toBeInTheDocument();
+    expect(invalidateServerData).not.toHaveBeenCalled();
+  });
+
+  it('a rejected trigger never polls or reads another operation', async () => {
+    vi.mocked(api.startDbasRestore).mockRejectedValue(new Error('Rejected overlap'));
+    vi.mocked(api.restoreDbasBackupSaved).mockRejectedValue(new Error('Rejected overlap'));
+    await mount();
+    expect(screen.getByText('Rejected overlap')).toBeInTheDocument();
+    expect(api.getTask).not.toHaveBeenCalled();
+    expect(api.getTaskHistory).not.toHaveBeenCalled();
+  });
+
+  it('a trigger without authoritative identity fails closed even with fresh terminal progress', async () => {
+    for (const trigger of [api.startDbasRestore, api.restoreDbasBackupSaved]) {
+      vi.mocked(trigger).mockResolvedValue({ task_id: 'dbas_restore', status: 'started' } as never);
+    }
+    vi.mocked(api.getTask).mockResolvedValue(task('current') as never);
+    await mount();
+    for (let i = 0; i < 20; i++) await tick();
+    expect(screen.getByText(/restore did not start/i)).toBeInTheDocument();
+    expect(api.getTaskHistory).not.toHaveBeenCalled();
+  });
+
+  it('keeps transient history retry behavior', async () => {
+    vi.mocked(api.getTask).mockResolvedValue(task('current') as never);
+    vi.mocked(api.getTaskHistory).mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValue(history('current') as never);
+    await mount();
+    expect(screen.queryByRole('button', { name: /apply these changes/i })).not.toBeInTheDocument();
+    await tick(500);
+    expect(screen.getByRole('button', { name: /apply these changes/i })).toBeEnabled();
+    expect(api.getTaskHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it('starts its full polling budget only after a slow successful trigger', async () => {
+    let resolve!: (value: never) => void;
+    const trigger = flow === 'uploaded' ? api.startDbasRestore : api.restoreDbasBackupSaved;
+    vi.mocked(trigger).mockImplementation(() => new Promise((r) => { resolve = r; }));
+    vi.mocked(api.getTask).mockResolvedValue(task('old') as never);
+    vi.mocked(api.getTaskHistory).mockResolvedValue(history('current') as never);
+    await mount();
+    for (let i = 0; i < 30; i++) await tick();
+    expect(api.getTask).not.toHaveBeenCalled();
+    expect(api.getTaskHistory).not.toHaveBeenCalled();
+    await act(async () => { resolve({ status: 'started', task_id: 'dbas_restore', run_id: 'current' } as never); });
+    for (let i = 0; i < 18; i++) await tick();
+    expect(api.getTask).toHaveBeenCalledTimes(19);
+    expect(screen.queryByText(/did not start/i)).not.toBeInTheDocument();
+    vi.mocked(api.getTask).mockResolvedValue(task('current') as never);
+    await tick();
+    expect(screen.getByRole('button', { name: /apply these changes/i })).toBeEnabled();
+  });
+
+  it('late progress from an unmounted consumer cannot finalize a new mount', async () => {
+    let resolve!: (value: never) => void;
+    vi.mocked(api.getTask).mockImplementationOnce(() => new Promise((r) => { resolve = r; }));
+    const first = await mount();
+    first.unmount();
+    vi.mocked(api.getTask).mockResolvedValue(task('old') as never);
+    await mount();
+    await act(async () => { resolve(task('current') as never); });
+    expect(api.getTaskHistory).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /apply these changes/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/DbasRestoreModal.test.tsx
+++ b/frontend/src/components/DbasRestoreModal.test.tsx
@@ -148,10 +148,10 @@ describe('DbasRestoreModal', () => {
 
   it('Run preview triggers a dry-run and renders the report', async () => {
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed', details: { restore_report: dryRunReport } }],
+      history: [{ status: 'completed', details: { run_id: 'test-run', restore_report: dryRunReport } }],
     });
     // The poll hook reports terminal-complete as soon as the run starts.
     mockView = view({ isComplete: true, status: 'completed' });
@@ -172,10 +172,10 @@ describe('DbasRestoreModal', () => {
 
   it('applying from a completed dry-run requires typing the exact file name in the confirm dialog', async () => {
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed', details: { restore_report: dryRunReport } }],
+      history: [{ status: 'completed', details: { run_id: 'test-run', restore_report: dryRunReport } }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
 
@@ -213,7 +213,7 @@ describe('DbasRestoreModal', () => {
 
   it('selecting Apply at the configure step also gates the mutation behind the confirm dialog', async () => {
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: false,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: false,
     });
 
     render(<DbasRestoreModal onClose={vi.fn()} />);
@@ -242,7 +242,7 @@ describe('DbasRestoreModal', () => {
 
   it('Preview (dry run) remains one click even with the confirm gate in place', async () => {
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
 
     render(<DbasRestoreModal onClose={vi.fn()} />);
@@ -259,10 +259,10 @@ describe('DbasRestoreModal', () => {
 
   it('passes the passphrase through for an encrypted artifact', async () => {
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed', details: { restore_report: dryRunReport } }],
+      history: [{ status: 'completed', details: { run_id: 'test-run', restore_report: dryRunReport } }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
 
@@ -279,11 +279,11 @@ describe('DbasRestoreModal', () => {
 
   it('surfaces a sanitized failure (wrong passphrase) and returns to configure', async () => {
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
       history: [{
-        status: 'failed', details: null,
+        status: 'failed', details: { run_id: 'test-run' },
         error: 'Could not decrypt backup: wrong passphrase or corrupted artifact',
       }],
     });
@@ -306,10 +306,10 @@ describe('DbasRestoreModal', () => {
     // until the retries ran out and land back on configure with
     // "Restore failed" — for a restore that completed and rolled nothing back.
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed_with_warnings', details: { restore_report: dryRunReport } }],
+      history: [{ status: 'completed_with_warnings', details: { run_id: 'test-run', restore_report: dryRunReport } }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
 
@@ -338,10 +338,10 @@ describe('DbasRestoreModal', () => {
 
   it('sends overwrite only when the operator explicitly picks it', async () => {
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed', details: { restore_report: dryRunReport } }],
+      history: [{ status: 'completed', details: { run_id: 'test-run', restore_report: dryRunReport } }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
 
@@ -378,10 +378,10 @@ describe('DbasRestoreModal', () => {
 
   it('offers a way back to the options from a dry-run result', async () => {
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed', details: { restore_report: touchedDryRunReport } }],
+      history: [{ status: 'completed', details: { run_id: 'test-run', restore_report: touchedDryRunReport } }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
 
@@ -409,12 +409,12 @@ describe('DbasRestoreModal', () => {
 
   it('offers no way back from an APPLIED result, and says so', async () => {
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: false,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: false,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
       history: [{
         status: 'completed',
-        details: { restore_report: { ...touchedDryRunReport, is_dry_run: false, outcome: 'success' } },
+        details: { run_id: 'test-run', restore_report: { ...touchedDryRunReport, is_dry_run: false, outcome: 'success' } },
       }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
@@ -449,12 +449,12 @@ describe('DbasRestoreModal', () => {
     const unsubscribe = subscribeForTest('channel-groups', reload);
 
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: false,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: false,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
       history: [{
         status: 'completed',
-        details: { restore_report: { ...dryRunReport, is_dry_run: false, outcome: 'success' } },
+        details: { run_id: 'test-run', restore_report: { ...dryRunReport, is_dry_run: false, outcome: 'success' } },
       }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
@@ -473,10 +473,10 @@ describe('DbasRestoreModal', () => {
     const unsubscribe = subscribeForTest('channel-groups', reload);
 
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed', details: { restore_report: dryRunReport } }],
+      history: [{ status: 'completed', details: { run_id: 'test-run', restore_report: dryRunReport } }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
 
@@ -504,12 +504,12 @@ describe('DbasRestoreModal', () => {
     const unsubscribe = subscribeForTest('channels', reload);
 
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: false,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: false,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
       history: [{
         status: 'completed',
-        details: { restore_report: { ...dryRunReport, is_dry_run: false, outcome: 'success' } },
+        details: { run_id: 'test-run', restore_report: { ...dryRunReport, is_dry_run: false, outcome: 'success' } },
       }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
@@ -528,10 +528,10 @@ describe('DbasRestoreModal', () => {
     const unsubscribe = subscribeForTest('channels', reload);
 
     (api.startDbasRestore as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed', details: { restore_report: dryRunReport } }],
+      history: [{ status: 'completed', details: { run_id: 'test-run', restore_report: dryRunReport } }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
 

--- a/frontend/src/components/DbasRestoreModal.tsx
+++ b/frontend/src/components/DbasRestoreModal.tsx
@@ -65,6 +65,7 @@ export function DbasRestoreModal({ onClose }: { onClose: () => void }) {
   const [reattachMode, setReattachMode] = useState<ChannelReattachMode>('preserve');
   const [runningApply, setRunningApply] = useState(false);
   const [restoreTaskId, setRestoreTaskId] = useState<string | null>(null);
+  const [restoreRunId, setRestoreRunId] = useState<string | null>(null);
   const [restoreReport, setRestoreReport] = useState<RestoreReport | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -87,7 +88,7 @@ export function DbasRestoreModal({ onClose }: { onClose: () => void }) {
     return () => { active = false; };
   }, []);
 
-  const progress = useRestoreProgress({ taskId: restoreTaskId, runKey });
+  const progress = useRestoreProgress({ taskId: restoreTaskId, runId: restoreRunId, runKey });
   // True when the progress hook synthesised a terminal ERROR because no new run
   // ever appeared, as opposed to the backend genuinely reporting one. Only the
   // synthesised view has a null payload.
@@ -161,6 +162,7 @@ export function DbasRestoreModal({ onClose }: { onClose: () => void }) {
       // in this same batch.
       setRunKey((n) => n + 1);
       setRestoreTaskId(res.task_id);
+      setRestoreRunId(res.run_id || null);
       setStep('restoring');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Restore failed');
@@ -178,9 +180,8 @@ export function DbasRestoreModal({ onClose }: { onClose: () => void }) {
     if (finalizedRef.current) return;
     finalizedRef.current = true;
 
-    // The hook gave up waiting for the run to start (it never saw a new
-    // `started_at`). There is NO result for this run, and task history is
-    // unversioned — `?limit=1` still holds the PREVIOUS run's row, so reading it
+    // The hook gave up waiting for the initiated run's identity. There is NO
+    // result for this run; `?limit=1` can still hold the PREVIOUS run's row, so reading it
     // here would render that run's report as this one's, which is the whole
     // defect this machinery exists to prevent. `progress.progress === null` is
     // what tells the two apart: a real backend terminal state always arrives
@@ -206,7 +207,7 @@ export function DbasRestoreModal({ onClose }: { onClose: () => void }) {
           // Any terminal status, not just completed/failed: a degraded run
           // reports `completed_with_warnings` (bead fexq1) and its report is
           // just as readable as a clean one's.
-          if (exec && isTerminalExecutionStatus(exec.status)) {
+          if (restoreRunId && exec?.details?.run_id === restoreRunId && isTerminalExecutionStatus(exec.status)) {
             const rep = exec.details?.restore_report as RestoreReport | undefined;
             if (rep) { report = rep; break; }
             failMsg = exec.error || exec.message || 'Restore failed';
@@ -244,7 +245,7 @@ export function DbasRestoreModal({ onClose }: { onClose: () => void }) {
       }
     })();
     return () => { cancelled = true; };
-  }, [step, restoreTaskId, progress.isComplete, progress.isError, runDidNotStart, progress.error]);
+  }, [step, restoreTaskId, restoreRunId, progress.isComplete, progress.isError, runDidNotStart, progress.error]);
 
   const canClose = step !== 'restoring';
   const canStart = !!file && (!isEncrypted || passphrase.length > 0) && !busy;

--- a/frontend/src/components/DbasRestoreRerun.test.tsx
+++ b/frontend/src/components/DbasRestoreRerun.test.tsx
@@ -43,7 +43,7 @@ function completedTask(startedAt: string) {
     progress: {
       total: 13, current: 13, percentage: 100, status: 'completed',
       current_item: 'finalize', success_count: 1, failed_count: 0,
-      skipped_count: 0, started_at: startedAt,
+      skipped_count: 0, started_at: startedAt, run_id: startedAt,
     },
   };
 }
@@ -125,7 +125,7 @@ function wireTwoRuns(trigger: ReturnType<typeof vi.fn>) {
   const server = { requested: 0, executed: 0 };
   trigger.mockImplementation(async () => {
     server.requested += 1;
-    return { status: 'started', task_id: 'dbas_restore', is_dry_run: true };
+    return { status: 'started', task_id: 'dbas_restore', is_dry_run: true, run_id: STARTED_AT[server.requested] };
   });
   (api.getTask as ReturnType<typeof vi.fn>).mockImplementation(async () => {
     server.executed = server.requested;
@@ -136,6 +136,7 @@ function wireTwoRuns(trigger: ReturnType<typeof vi.fn>) {
       {
         status: 'completed',
         details: {
+          run_id: STARTED_AT[server.executed],
           restore_report: reportFor(server.executed === 1 ? 'preserve' : 'overwrite'),
         },
       },
@@ -244,7 +245,7 @@ describe('Re-running a preview in one modal session', () => {
     let pollsInRun2 = 0;
     trigger.mockImplementation(async () => {
       server.requested += 1;
-      return { status: 'started', task_id: 'dbas_restore', is_dry_run: true };
+      return { status: 'started', task_id: 'dbas_restore', is_dry_run: true, run_id: STARTED_AT[server.requested] };
     });
     (api.getTask as ReturnType<typeof vi.fn>).mockImplementation(async () => {
       if (server.requested === 1) {
@@ -263,6 +264,7 @@ describe('Re-running a preview in one modal session', () => {
         {
           status: 'completed',
           details: {
+            run_id: STARTED_AT[server.executed],
             restore_report: reportFor(server.executed === 1 ? 'preserve' : 'overwrite'),
           },
         },
@@ -314,7 +316,7 @@ describe('Re-running a preview in one modal session', () => {
     const server = { requested: 0, executed: 0 };
     trigger.mockImplementation(async () => {
       server.requested += 1;
-      return { status: 'started', task_id: 'dbas_restore', is_dry_run: true };
+      return { status: 'started', task_id: 'dbas_restore', is_dry_run: true, run_id: STARTED_AT[server.requested] };
     });
     (api.getTask as ReturnType<typeof vi.fn>).mockImplementation(async () => {
       // Only the FIRST run ever executes. Run 2 is rejected upstream, so the
@@ -324,7 +326,7 @@ describe('Re-running a preview in one modal session', () => {
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockImplementation(async () => ({
       history: [
-        { status: 'completed', details: { restore_report: reportFor('preserve') } },
+        { status: 'completed', details: { run_id: STARTED_AT[1], restore_report: reportFor('preserve') } },
       ],
     }));
     return server;
@@ -425,7 +427,7 @@ describe('Re-running a preview in one modal session', () => {
         await new Promise<void>((resolve) => { releaseSecondTrigger = resolve; });
         triggerInFlight = false;
       }
-      return { status: 'started', task_id: 'dbas_restore', is_dry_run: true };
+      return { status: 'started', task_id: 'dbas_restore', is_dry_run: true, run_id: STARTED_AT[server.requested] };
     });
     (api.getTask as ReturnType<typeof vi.fn>).mockImplementation(async () => {
       if (triggerInFlight) pollsDuringTrigger += 1;
@@ -437,6 +439,7 @@ describe('Re-running a preview in one modal session', () => {
         {
           status: 'completed',
           details: {
+            run_id: STARTED_AT[server.executed],
             restore_report: reportFor(server.executed === 1 ? 'preserve' : 'overwrite'),
           },
         },

--- a/frontend/src/components/DbasRestoreSavedModal.test.tsx
+++ b/frontend/src/components/DbasRestoreSavedModal.test.tsx
@@ -135,10 +135,10 @@ describe('DbasRestoreSavedModal', () => {
 
   it('Run preview triggers a dry-run and renders the report', async () => {
     (api.restoreDbasBackupSaved as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed', details: { restore_report: dryRunReport } }],
+      history: [{ status: 'completed', details: { run_id: 'test-run', restore_report: dryRunReport } }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
 
@@ -158,10 +158,10 @@ describe('DbasRestoreSavedModal', () => {
     // modal polls the same history row, so it needs the same fix or a degraded
     // restore never renders its report here either.
     (api.restoreDbasBackupSaved as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed_with_warnings', details: { restore_report: dryRunReport } }],
+      history: [{ status: 'completed_with_warnings', details: { run_id: 'test-run', restore_report: dryRunReport } }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
 
@@ -175,10 +175,10 @@ describe('DbasRestoreSavedModal', () => {
 
   it('applying requires typing the exact filename in the confirm dialog', async () => {
     (api.restoreDbasBackupSaved as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed', details: { restore_report: dryRunReport } }],
+      history: [{ status: 'completed', details: { run_id: 'test-run', restore_report: dryRunReport } }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
 
@@ -208,10 +208,10 @@ describe('DbasRestoreSavedModal', () => {
 
   it('passes the passphrase through for an encrypted artifact', async () => {
     (api.restoreDbasBackupSaved as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed', details: { restore_report: dryRunReport } }],
+      history: [{ status: 'completed', details: { run_id: 'test-run', restore_report: dryRunReport } }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
 
@@ -227,11 +227,11 @@ describe('DbasRestoreSavedModal', () => {
 
   it('surfaces a sanitized failure and returns to configure', async () => {
     (api.restoreDbasBackupSaved as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
       history: [{
-        status: 'failed', details: null,
+        status: 'failed', details: { run_id: 'test-run' },
         error: 'Could not decrypt backup: wrong passphrase or corrupted artifact',
       }],
     });
@@ -264,10 +264,10 @@ describe('DbasRestoreSavedModal', () => {
 
   it('sends overwrite only when the operator explicitly picks it', async () => {
     (api.restoreDbasBackupSaved as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed', details: { restore_report: dryRunReport } }],
+      history: [{ status: 'completed', details: { run_id: 'test-run', restore_report: dryRunReport } }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
 
@@ -300,10 +300,10 @@ describe('DbasRestoreSavedModal', () => {
 
   it('offers a way back to the options from a dry-run result', async () => {
     (api.restoreDbasBackupSaved as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: true,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: true,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
-      history: [{ status: 'completed', details: { restore_report: touchedDryRunReport } }],
+      history: [{ status: 'completed', details: { run_id: 'test-run', restore_report: touchedDryRunReport } }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
 
@@ -330,12 +330,12 @@ describe('DbasRestoreSavedModal', () => {
 
   it('offers no way back from an APPLIED result, and says so', async () => {
     (api.restoreDbasBackupSaved as ReturnType<typeof vi.fn>).mockResolvedValue({
-      status: 'started', task_id: 'dbas_restore', is_dry_run: false,
+      status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: false,
     });
     (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
       history: [{
         status: 'completed',
-        details: { restore_report: { ...touchedDryRunReport, is_dry_run: false, outcome: 'success' } },
+        details: { run_id: 'test-run', restore_report: { ...touchedDryRunReport, is_dry_run: false, outcome: 'success' } },
       }],
     });
     mockView = view({ isComplete: true, status: 'completed' });
@@ -370,12 +370,12 @@ describe('DbasRestoreSavedModal', () => {
 
       (api.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue({});
       (api.restoreDbasBackupSaved as ReturnType<typeof vi.fn>).mockResolvedValue({
-        status: 'started', task_id: 'dbas_restore', is_dry_run: false,
+        status: 'started', task_id: 'dbas_restore', run_id: 'test-run', is_dry_run: false,
       });
       (api.getTaskHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
         history: [{
           status: 'completed',
-          details: { restore_report: { ...dryRunReport, is_dry_run: false, outcome: 'success' } },
+          details: { run_id: 'test-run', restore_report: { ...dryRunReport, is_dry_run: false, outcome: 'success' } },
         }],
       });
       mockView = view({ isComplete: true, status: 'completed' });

--- a/frontend/src/components/DbasRestoreSavedModal.tsx
+++ b/frontend/src/components/DbasRestoreSavedModal.tsx
@@ -47,6 +47,7 @@ export function DbasRestoreSavedModal({
   const [reattachMode, setReattachMode] = useState<ChannelReattachMode>('preserve');
   const [runningApply, setRunningApply] = useState(false);
   const [restoreTaskId, setRestoreTaskId] = useState<string | null>(null);
+  const [restoreRunId, setRestoreRunId] = useState<string | null>(null);
   const [restoreReport, setRestoreReport] = useState<RestoreReport | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -66,7 +67,7 @@ export function DbasRestoreSavedModal({
     return () => { active = false; };
   }, []);
 
-  const progress = useRestoreProgress({ taskId: restoreTaskId, runKey });
+  const progress = useRestoreProgress({ taskId: restoreTaskId, runId: restoreRunId, runKey });
   // True when the progress hook synthesised a terminal ERROR because no new run
   // ever appeared, as opposed to the backend genuinely reporting one. Only the
   // synthesised view has a null payload.
@@ -105,6 +106,7 @@ export function DbasRestoreSavedModal({
       // in this same batch.
       setRunKey((n) => n + 1);
       setRestoreTaskId(res.task_id);
+      setRestoreRunId(res.run_id || null);
       setStep('restoring');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Restore failed');
@@ -122,9 +124,8 @@ export function DbasRestoreSavedModal({
     if (finalizedRef.current) return;
     finalizedRef.current = true;
 
-    // The hook gave up waiting for the run to start (it never saw a new
-    // `started_at`). There is NO result for this run, and task history is
-    // unversioned — `?limit=1` still holds the PREVIOUS run's row, so reading it
+    // The hook gave up waiting for the initiated run's identity. There is NO
+    // result for this run; `?limit=1` can still hold the PREVIOUS run's row, so reading it
     // here would render that run's report as this one's, which is the whole
     // defect this machinery exists to prevent. `progress.progress === null` is
     // what tells the two apart: a real backend terminal state always arrives
@@ -150,7 +151,7 @@ export function DbasRestoreSavedModal({
           // Any terminal status, not just completed/failed: a degraded run
           // reports `completed_with_warnings` (bead fexq1) and its report is
           // just as readable as a clean one's.
-          if (exec && isTerminalExecutionStatus(exec.status)) {
+          if (restoreRunId && exec?.details?.run_id === restoreRunId && isTerminalExecutionStatus(exec.status)) {
             const rep = exec.details?.restore_report as RestoreReport | undefined;
             if (rep) { report = rep; break; }
             failMsg = exec.error || exec.message || 'Restore failed';
@@ -186,7 +187,7 @@ export function DbasRestoreSavedModal({
       }
     })();
     return () => { cancelled = true; };
-  }, [step, restoreTaskId, progress.isComplete, progress.isError, runDidNotStart, progress.error]);
+  }, [step, restoreTaskId, restoreRunId, progress.isComplete, progress.isError, runDidNotStart, progress.error]);
 
   const canClose = step !== 'restoring';
   const canStart = (!isEncrypted || passphrase.length > 0) && !busy;

--- a/frontend/src/hooks/useRestoreProgress.test.ts
+++ b/frontend/src/hooks/useRestoreProgress.test.ts
@@ -21,6 +21,7 @@ const mockedGetTask = vi.mocked(api.getTask);
 /** Build a TaskStatus whose progress carries the fields the hook reads. */
 function makeTaskStatus(progress: Partial<TaskProgress>): TaskStatus {
   const fullProgress: TaskProgress = {
+    run_id: '1',
     total: 0,
     current: 0,
     percentage: 0,
@@ -75,7 +76,7 @@ describe('useRestoreProgress', () => {
     );
 
     const { result } = renderHook(() =>
-      useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 5 })
+      useRestoreProgress({ taskId: 'dbas_restore', runId: '1', pollIntervalMs: 5 })
     );
 
     await waitFor(() => expect(result.current.progress).not.toBeNull());
@@ -96,7 +97,7 @@ describe('useRestoreProgress', () => {
       .mockResolvedValue(makeTaskStatus({ status: 'completed', current_item: 'finalize', percentage: 100 }));
 
     const { result } = renderHook(() =>
-      useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 5 })
+      useRestoreProgress({ taskId: 'dbas_restore', runId: '1', pollIntervalMs: 5 })
     );
 
     await waitFor(() => expect(result.current.isComplete).toBe(true));
@@ -121,7 +122,7 @@ describe('useRestoreProgress', () => {
     );
 
     const { result } = renderHook(() =>
-      useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 5 })
+      useRestoreProgress({ taskId: 'dbas_restore', runId: '1', pollIntervalMs: 5 })
     );
 
     await waitFor(() => expect(result.current.isComplete).toBe(true));
@@ -142,7 +143,7 @@ describe('useRestoreProgress', () => {
     );
 
     const { result } = renderHook(() =>
-      useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 5 })
+      useRestoreProgress({ taskId: 'dbas_restore', runId: '1', pollIntervalMs: 5 })
     );
 
     await waitFor(() => expect(result.current.isError).toBe(true));
@@ -157,7 +158,7 @@ describe('useRestoreProgress', () => {
     );
 
     const { unmount } = renderHook(() =>
-      useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 5 })
+      useRestoreProgress({ taskId: 'dbas_restore', runId: '1', pollIntervalMs: 5 })
     );
 
     await waitFor(() => expect(mockedGetTask).toHaveBeenCalled());
@@ -176,7 +177,7 @@ describe('useRestoreProgress', () => {
     );
 
     const { result } = renderHook(() =>
-      useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 5 })
+      useRestoreProgress({ taskId: 'dbas_restore', runId: '1', pollIntervalMs: 5 })
     );
 
     await waitFor(() => expect(mockedGetTask).toHaveBeenCalled());
@@ -199,7 +200,7 @@ describe('useRestoreProgress', () => {
   // which makes the hook accept the first poll immediately — so none of those
   // tests can reach this code at all.
 
-  it('does not publish a terminal state that still carries the previous run started_at', async () => {
+  it('does not publish a terminal state that still carries the previous run identity', async () => {
     const RUN_1 = '2026-08-05T10:00:00Z';
     mockedGetTask.mockResolvedValue(
       makeTaskStatus({ status: 'completed', started_at: RUN_1 })
@@ -207,7 +208,7 @@ describe('useRestoreProgress', () => {
 
     // Run 1 publishes normally and establishes the baseline.
     const { result, rerender } = renderHook(
-      ({ runKey }) => useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 2, runKey }),
+      ({ runKey }) => useRestoreProgress({ taskId: 'dbas_restore', runId: String(runKey), pollIntervalMs: 2, runKey }),
       { initialProps: { runKey: 1 } }
     );
     await waitFor(() => expect(result.current.isComplete).toBe(true));
@@ -231,7 +232,7 @@ describe('useRestoreProgress', () => {
     );
 
     const { result, rerender } = renderHook(
-      ({ runKey }) => useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 1, runKey }),
+      ({ runKey }) => useRestoreProgress({ taskId: 'dbas_restore', runId: String(runKey), pollIntervalMs: 1, runKey }),
       { initialProps: { runKey: 1 } }
     );
     await waitFor(() => expect(result.current.isComplete).toBe(true));
@@ -257,7 +258,7 @@ describe('useRestoreProgress', () => {
     );
 
     const { result } = renderHook(() =>
-      useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 2, runKey: 1 })
+      useRestoreProgress({ taskId: 'dbas_restore', runId: '1', pollIntervalMs: 2, runKey: 1 })
     );
 
     await waitFor(() => expect(result.current.isError).toBe(true));
@@ -265,7 +266,7 @@ describe('useRestoreProgress', () => {
     expect(result.current.progress?.status).toBe('failed');
   });
 
-  it('a new run publishes as soon as its own started_at appears', async () => {
+  it('a new run publishes as soon as its own server identity appears', async () => {
     const RUN_1 = '2026-08-05T10:00:00Z';
     const RUN_2 = '2026-08-05T11:00:00Z';
     mockedGetTask.mockResolvedValue(
@@ -273,18 +274,43 @@ describe('useRestoreProgress', () => {
     );
 
     const { result, rerender } = renderHook(
-      ({ runKey }) => useRestoreProgress({ taskId: 'dbas_restore', pollIntervalMs: 2, runKey }),
+      ({ runKey }) => useRestoreProgress({ taskId: 'dbas_restore', runId: String(runKey), pollIntervalMs: 2, runKey }),
       { initialProps: { runKey: 1 } }
     );
     await waitFor(() => expect(result.current.isComplete).toBe(true));
 
     rerender({ runKey: 2 });
     mockedGetTask.mockResolvedValue(
-      makeTaskStatus({ status: 'completed', started_at: RUN_2 })
+      makeTaskStatus({ status: 'completed', started_at: RUN_2, run_id: '2' })
     );
 
     await waitFor(() => expect(result.current.isComplete).toBe(true));
     expect(result.current.isError).toBe(false);
     expect(result.current.progress?.started_at).toBe(RUN_2);
+  });
+
+  it('checks identity on every poll after a matching running payload', async () => {
+    mockedGetTask.mockResolvedValueOnce(makeTaskStatus({ status: 'running' }))
+      .mockResolvedValue(makeTaskStatus({ status: 'completed', run_id: 'another' }));
+    const { result } = renderHook(() =>
+      useRestoreProgress({ taskId: 'dbas_restore', runId: '1', pollIntervalMs: 1 }),
+    );
+    await waitFor(() => expect(mockedGetTask.mock.calls.length).toBeGreaterThan(20));
+    expect(result.current.isComplete).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.progress?.run_id).toBe('1');
+    mockedGetTask.mockResolvedValue(makeTaskStatus({ status: 'completed' }));
+    await waitFor(() => expect(result.current.isComplete).toBe(true));
+  });
+
+  it('retries transient progress errors without synthesizing no-start', async () => {
+    mockedGetTask.mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValue(makeTaskStatus({ status: 'completed' }));
+    const { result } = renderHook(() =>
+      useRestoreProgress({ taskId: 'dbas_restore', runId: '1', pollIntervalMs: 1 }),
+    );
+    await waitFor(() => expect(result.current.isComplete).toBe(true));
+    expect(result.current.isError).toBe(false);
+    expect(mockedGetTask).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/hooks/useRestoreProgress.ts
+++ b/frontend/src/hooks/useRestoreProgress.ts
@@ -9,14 +9,9 @@
  * dnd/observer-leak discipline in this repo — the same applies to polling
  * timers).
  *
- * SEAM: the restore-trigger endpoint / restore TaskScheduler is a LATER bead.
- * The backend orchestrator (`backend/dbas/restore_orchestrator.py`, bead .18)
- * exists but does not yet emit `_set_progress`, and no restore task is wired to
- * `task_scheduler`. This hook therefore takes the `taskId` as a prop/seam and
- * polls the EXISTING generic task status endpoint (`getTask` →
- * `/api/tasks/{id}`), reading the REAL `TaskProgress` shape
- * (`backend/task_scheduler.py` — `TaskProgress.to_dict()`). When the restore
- * task lands and emits its stage via `current_item`, this hook needs no change.
+ * Both restore triggers return a server-issued run_id. Every progress response
+ * must carry that identity; a timestamp or a fresh mount cannot establish it.
+ * DbasRestoreCorrelation.test.tsx exercises the actual consumer seam.
  */
 import { useState, useCallback, useEffect, useRef } from 'react';
 import * as api from '../services/api';
@@ -48,10 +43,11 @@ const MAX_RUN_START_POLLS = 20;
 
 export interface UseRestoreProgressOptions {
   /**
-   * Task id to poll. `null` disables polling (no task running yet) — the seam
-   * for the not-yet-wired restore-trigger endpoint.
+   * Task id to poll. `null` disables polling (no task running yet).
    */
   taskId: string | null;
+  /** Server-issued identity returned by the successful restore trigger. */
+  runId?: string | null;
   /** Poll cadence in ms (default 1000). */
   pollIntervalMs?: number;
   /**
@@ -153,12 +149,13 @@ export interface UseRestoreProgressResult extends RestoreProgressView {
 export function useRestoreProgress(
   options: UseRestoreProgressOptions
 ): UseRestoreProgressResult {
-  const { taskId, pollIntervalMs = DEFAULT_POLL_INTERVAL_MS, runKey = 0 } = options;
+  const { taskId, runId, pollIntervalMs = DEFAULT_POLL_INTERVAL_MS, runKey = 0 } = options;
 
   // The view is stored WITH the run it belongs to, so a view can never outlive
   // its run.
-  const [tracked, setTracked] = useState<{ runKey: number; view: RestoreProgressView }>({
+  const [tracked, setTracked] = useState<{ runKey: number; runId?: string | null; view: RestoreProgressView }>({
     runKey,
+    runId,
     view: EMPTY_VIEW,
   });
 
@@ -167,14 +164,10 @@ export function useRestoreProgress(
   // same pass would still see the previous run's `true` and act on it — which
   // is exactly the bug this exists to close. Deriving it makes the new run's
   // empty view visible in the very render where `runKey` changed.
-  const view = tracked.runKey === runKey ? tracked.view : EMPTY_VIEW;
+  const view = tracked.runKey === runKey && tracked.runId === runId ? tracked.view : EMPTY_VIEW;
 
   // Holds the live abort controller so stopPolling() can tear down the loop.
   const abortRef = useRef<AbortController | null>(null);
-  // `started_at` of the last progress payload this hook PUBLISHED. It is the
-  // discriminator between "this run" and "the run before it": the scheduler
-  // stamps a fresh one in its synchronous prologue, before the task body runs.
-  const publishedStartedAtRef = useRef<string | null>(null);
 
   const stopPolling = useCallback(() => {
     abortRef.current?.abort();
@@ -183,7 +176,7 @@ export function useRestoreProgress(
 
   useEffect(() => {
     if (!taskId) {
-      setTracked({ runKey, view: EMPTY_VIEW });
+      setTracked({ runKey, runId, view: EMPTY_VIEW });
       return;
     }
 
@@ -192,13 +185,10 @@ export function useRestoreProgress(
     const { signal } = controller;
     const startedAt = Date.now();
 
-    // The run this loop is watching must be a DIFFERENT run from the last one
-    // published. Until that is established, every payload belongs to the
-    // previous run and must not be shown. With nothing published yet there is
-    // no previous run to confuse this one with.
-    const previousRunStartedAt = publishedStartedAtRef.current;
-    let confirmedNewRun = previousRunStartedAt === null;
+    // Check EVERY response, including after a matching running payload. A later
+    // trigger can replace the singleton while this consumer is still polling.
     let pollsAwaitingRun = 0;
+    let hasSeenRun = false;
 
     // Async setState fires inside this poll loop (not synchronously in the
     // effect body), so the set-state-in-effect lint rule does not apply.
@@ -209,13 +199,13 @@ export function useRestoreProgress(
           if (signal.aborted) return;
           const progress = taskStatus.progress;
 
-          if (!confirmedNewRun) {
-            if (progress.started_at && progress.started_at !== previousRunStartedAt) {
-              confirmedNewRun = true;
-            } else if (++pollsAwaitingRun >= MAX_RUN_START_POLLS) {
+          const matchesRun = !!runId && progress.run_id === runId;
+          if (!matchesRun) {
+            if (!hasSeenRun && ++pollsAwaitingRun >= MAX_RUN_START_POLLS) {
               // Say nothing started rather than replay the last run's result.
               setTracked({
                 runKey,
+                runId,
                 view: {
                   ...EMPTY_VIEW,
                   status: 'failed',
@@ -227,10 +217,10 @@ export function useRestoreProgress(
             }
           }
 
-          if (confirmedNewRun) {
-            publishedStartedAtRef.current = progress.started_at;
+          if (matchesRun) {
+            hasSeenRun = true;
             const nextView = viewFromProgress(progress);
-            setTracked({ runKey, view: nextView });
+            setTracked({ runKey, runId, view: nextView });
             if (!nextView.isRunning) {
               // Terminal — stop polling, leave the final view in place.
               return;
@@ -243,8 +233,8 @@ export function useRestoreProgress(
           const message =
             err instanceof Error ? err.message : 'Failed to fetch restore progress';
           setTracked((prev) =>
-            prev.runKey === runKey
-              ? { runKey, view: { ...prev.view, error: message } }
+            prev.runKey === runKey && prev.runId === runId
+              ? { runKey, runId, view: { ...prev.view, error: message } }
               : prev
           );
         }
@@ -273,7 +263,7 @@ export function useRestoreProgress(
         abortRef.current = null;
       }
     };
-  }, [taskId, pollIntervalMs, runKey]);
+  }, [taskId, runId, pollIntervalMs, runKey]);
 
   return { ...view, stopPolling };
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2944,6 +2944,7 @@ export interface TaskParameterSchemaResponse {
 }
 
 export interface TaskProgress {
+  run_id?: string | null;
   total: number;
   current: number;
   percentage: number;
@@ -4922,6 +4923,7 @@ export async function restoreBackupYaml(file: File, sections: string[]): Promise
 
 /** Response of the async DBAS restore-trigger endpoint (bead o8tbv). */
 export interface DbasRestoreStartResult {
+  run_id: string;
   status: string;
   /** Poll `/api/tasks/{task_id}` for per-stage progress + the terminal report. */
   task_id: string;

--- a/playwright.verification.config.ts
+++ b/playwright.verification.config.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path'
 const output = mkdtempSync(join(tmpdir(), 'rdnia-e2e-'))
 export default defineConfig({
   testDir: './e2e',
-  testMatch: ['verification-helpers.spec.ts', 'task-notification-lifecycle.spec.ts', 'verification-browser.spec.ts', 'task-notifications.spec.ts'],
+  testMatch: ['verification-helpers.spec.ts', 'task-notification-lifecycle.spec.ts', 'verification-browser.spec.ts', 'task-notifications.spec.ts', 'restore-run-correlation.spec.ts'],
   timeout: 90000,
   retries: 0,
   workers: 1,


### PR DESCRIPTION
## Summary
Delivers enhancedchannelmanager-eal0l.2 and enhancedchannelmanager-zt801 under epic eal0l. Adds shared lifecycle regressions for unchanged Emby/Plex/Jellyfin caches. Both restore triggers issue server-generated correlation IDs, propagated through progress/history and required by both restore modals before accepting results. Preserves authorization, slow-upload timing, constant task-ID reruns, remounts, late responses, history retry policy, warnings/failure/cancellation, no-start and apply-only invalidation. No cache runtime consolidation or broad finalization extraction.

## Verification
Parent independently ran full canonical backend: 13,867 passed, 4 skipped, 2 deselected; 82.94% coverage; 74 pins match. Frontend lint/typecheck/3,754 tests/build passed. Parent isolated Chromium browser seam: uploaded and saved prior-preview/remount/old-progress/old-history/current-report sequences both passed. Engineer strict MkDocs passed. Cache and restore negative controls failed as intended.

Independent code, QA, security and DBA reviews approved the unchanged patch. These local reviews are not GitHub approval objects. All3canonical versions0.18.2-0030.

## Limits
Synthetic HTTP/browser fixtures and private SQLite; no live restore or Windows claim. Run identity is correlation, not authorization. Existing history-write failure can leave applied data without a usable report; UI fails closed on missing/mismatched history. No schema, transaction, compensation, TLS/SSRF, publication or auth policy changes. Rollback is matching code/tests, not applied data. Exact-head CI and exact-merge dual-architecture publication remain required.