### PR TITLE
v0.18.2-0032: fix stream User-Agent selection and preview startup (#995)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **Resolved User-Agent headers reach provider requests (bead `enhancedchannelmanager-yz6rv`, GitHub #995, build 0.18.2-0032).** Direct previews and metadata, bitrate, resdet, and black screen probes send the selected identity on validated provider HTTP requests, including redirects and later HLS resources. Probe substeps and transient ffprobe retries reuse the same resolved header.
+
+- **Provider preview redirects and startup failures are handled explicitly (bead `enhancedchannelmanager-yz6rv`, GitHub #995, build 0.18.2-0032).** Direct provider previews support HTTPS-to-HTTP redirects with per-hop SSRF checks; authenticated Dispatcharr channel previews retain downgrade refusal. Stream DNS validation runs off the event loop and retries only transient failures, at most twice. Previews open upstream before sending browser headers and return safe 403/502/504 errors for policy, connection/configuration/upstream, and timeout failures. Cancellation and disconnect cleanup close responses and relays and terminate/reap FFmpeg.
+
 - **Restore dialogs correlate progress and reports with the requested run (bead `enhancedchannelmanager-zt801`; build 0.18.2-0030).** Uploaded and saved DBAS restore triggers issue a server run identity carried into progress and terminal history. Reopening a dialog or rerunning the same task cannot present an older preview as the current result or enable Apply from it. Slow-upload timing, history retries, warning reports, and apply-only data refresh are preserved. Unknown identity fails closed.
 
 ### Security
+
+- **Stream diagnostics protect provider tokens (bead `enhancedchannelmanager-yz6rv`, GitHub #995, build 0.18.2-0032).** Preview startup, streaming, decoder, and black screen failures use safe diagnostics instead of raw client exceptions or provider URLs. HTTPX request URL logs stay suppressed at DEBUG level, protecting reusable path/query credentials while retaining failure categories and decoder exit codes.
 
 - **Settings URL validation uses safe public errors (bead `enhancedchannelmanager-m8dvz`; build 0.18.2-0028).** Malformed ports and outbound-policy denials return fixed messages instead of parser text or resolved-address details, including the shared Dispatcharr and media settings save paths. Host-policy diagnostics remain in redacted server logs. Media client error categories, credential escaping, human-admin/first-run gates, and outbound allow/deny decisions are preserved.
 
@@ -27,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Mapped channels moved to Settings > Channel Normalization (bead `enhancedchannelmanager-81sy8`, GitHub #775, build 0.18.2-0024).** The existing manager is now a headed, section-linked Settings section instead of an Operations sidebar destination. Old `#mapped-channels` bookmarks redirect to the new section. Mapping saves, API permissions, and the stream-selection **Add mapping** shortcut are unchanged.
 
 ### Added
+
+- **Persisted Stream User-Agent selector (bead `enhancedchannelmanager-rmf8n`, GitHub #995, build 0.18.2-0032).** Settings → Appearance → Stream Preview offers **Use Dispatcharr User-Agent (Default)** plus Chrome, Firefox, Safari, VLC, and TiviMate compatibility presets. Save Settings applies the choice to new direct previews and ECM probes. The default resolves the M3U account UA, then Dispatcharr's global default, then `Dispatcharr/{version}` or `Dispatcharr/unknown` when metadata is unavailable.
 
 - **Behavioral test guards (beads `enhancedchannelmanager-ocr52.2`, `ocr52.3`, `hh5ug`, and `sogbx`; build 0.18.2-0031).** MCP clear-flag tests pin awaited scoped endpoint calls and backend count fields. The responsive M3U filter component test checks viewport containment, unobstructed cell centers, and the Edit form transition. Runtime-derived contract/security inventories reject empty cases, and restore enum/TypeScript union mirrors are compared in both directions alongside existing model-field parity.
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -30,6 +30,7 @@ from credential_sentinel import (
 )
 from pathlib import Path
 from smart_sort_evaluator import CODEC_RANK, PointRule
+from stream_user_agent import StreamUserAgent
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -784,6 +785,7 @@ class DispatcharrSettings(BaseModel):
     # "transcode" - FFmpeg transcodes unsupported audio to AAC (CPU intensive)
     # "video_only" - Strip audio for quick preview (fast, no audio)
     stream_preview_mode: str = "passthrough"
+    stream_user_agent: StreamUserAgent = "dispatcharr"
     # Auto-creation pipeline exclusion settings
     auto_creation_excluded_terms: list[str] = []  # Terms that exclude streams by name (case-insensitive substring)
     auto_creation_excluded_groups: list[str] = []  # M3U group names to exclude (case-insensitive exact match)
@@ -2297,7 +2299,7 @@ def set_log_level(level: str) -> None:
     # Set level for all existing loggers, but keep noisy third-party
     # loggers (e.g. sqlalchemy.engine) at WARNING to avoid flooding
     # the console and ring buffer with SQL dumps.
-    _NOISY_LOGGERS = {"sqlalchemy", "httpcore"}
+    _NOISY_LOGGERS = {"sqlalchemy", "httpcore", "httpx"}
     for logger_name in logging.root.manager.loggerDict:
         if any(logger_name.startswith(prefix) for prefix in _NOISY_LOGGERS):
             continue

--- a/backend/dispatcharr_client.py
+++ b/backend/dispatcharr_client.py
@@ -2241,14 +2241,14 @@ class DispatcharrClient:
         response = await self._request("DELETE", f"{_RECORDINGS_PATH}{recording_id}/")
         response.raise_for_status()
 
-    async def get_core_settings(self) -> dict:
-        """Get Dispatcharr's core/global settings as a key->value mapping.
+    async def get_core_settings(self) -> list:
+        """Get Dispatcharr's core/global settings as a bare list of rows.
 
         WARNING (DBAS restore, enhancedchannelmanager-0i2vt.13): the response can
         carry credential/instance-identity material (API keys, auth config). The
         caller (settings_agents importer) MUST sanitize before logging/reporting.
-        Returns the raw mapping; callers normalize a list-of-{key,value} response
-        into a dict themselves.
+        Returns the raw list of {id, key, name, value} records; callers that need
+        a key/value mapping normalize it themselves (recorded against 0.28.2).
         """
         response = await self._request("GET", _CORE_SETTINGS_PATH)
         response.raise_for_status()

--- a/backend/main.py
+++ b/backend/main.py
@@ -56,6 +56,8 @@ logging.basicConfig(
 # Keep noisy third-party loggers quiet regardless of app log level
 logging.getLogger("sqlalchemy").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
+# HTTPX INFO request logs include reusable provider path/query credentials.
+logging.getLogger("httpx").setLevel(logging.WARNING)
 # Sanitize all log arguments to prevent log injection (CWE-117)
 from log_utils import (  # noqa: E402
     install_persistent_json_logging,
@@ -158,7 +160,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0031",
+    version="0.18.2-0032",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -132,7 +132,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0031"
+APP_VERSION = "0.18.2-0032"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -63,6 +63,7 @@ from cache import get_cache
 from database import get_session
 from log_utils import get_persistent_log_policy
 from stream_prober import StreamProber, get_prober, set_prober
+from stream_user_agent import StreamUserAgent
 from bandwidth_tracker import BandwidthTracker, get_tracker, set_tracker
 from services.notification_service import create_notification_internal, update_notification_internal, delete_notifications_by_source_internal
 
@@ -509,6 +510,7 @@ class SettingsRequest(BaseModel):
     telegram_chat_id: str = ""
     # Stream preview mode: "passthrough", "transcode", or "video_only"
     stream_preview_mode: str = "passthrough"
+    stream_user_agent: StreamUserAgent = "dispatcharr"
     # Auto-creation pipeline exclusion settings
     auto_creation_excluded_terms: list[str] = []
     auto_creation_excluded_groups: list[str] = []
@@ -663,6 +665,7 @@ class SettingsResponse(BaseModel):
     telegram_chat_id: str
     # Stream preview mode
     stream_preview_mode: str
+    stream_user_agent: StreamUserAgent = "dispatcharr"
     # Auto-creation pipeline exclusion settings
     auto_creation_excluded_terms: list[str]
     auto_creation_excluded_groups: list[str]
@@ -934,6 +937,7 @@ async def get_current_settings(
         telegram_bot_token="" if redact else settings.telegram_bot_token,
         telegram_chat_id="" if redact else settings.telegram_chat_id,
         stream_preview_mode=settings.stream_preview_mode,
+        stream_user_agent=settings.stream_user_agent,
         auto_creation_excluded_terms=settings.auto_creation_excluded_terms,
         auto_creation_excluded_groups=settings.auto_creation_excluded_groups,
         auto_creation_exclude_auto_sync_groups=settings.auto_creation_exclude_auto_sync_groups,
@@ -1265,6 +1269,7 @@ async def update_settings(
         telegram_bot_token=telegram_bot_token,
         telegram_chat_id=telegram_chat_id,
         stream_preview_mode=request.stream_preview_mode,
+        stream_user_agent=(request.stream_user_agent if "stream_user_agent" in request.model_fields_set else current_settings.stream_user_agent),
         auto_creation_excluded_terms=request.auto_creation_excluded_terms,
         auto_creation_excluded_groups=request.auto_creation_excluded_groups,
         auto_creation_exclude_auto_sync_groups=request.auto_creation_exclude_auto_sync_groups,
@@ -2051,15 +2056,13 @@ def _host_denied_by_outbound_policy(url: str, credential: str = "") -> Optional[
         ``None`` when the host is permitted, else a fixed public explanation.
         Detailed diagnostics stay in redacted server logs (m8dvz route tests).
     """
-    from security.ssrf import SSRFError, get_ssrf_mode, validate_outbound_url
+    from security.ssrf import DNSResolutionError, SSRFError, get_ssrf_mode, validate_outbound_url
 
     try:
         validate_outbound_url(url, get_ssrf_mode())
     except SSRFError as exc:
         message = str(exc)
-        lowered = message.lower()
-        if ("could not resolve host" in lowered
-                or "resolved to no usable address" in lowered):
+        if isinstance(exc, DNSResolutionError):
             logger.info(
                 "[SETTINGS] Outbound host did not resolve; not treating as a "
                 "policy denial (runtime re-validates before connect): %s",

--- a/backend/routers/stream_preview.py
+++ b/backend/routers/stream_preview.py
@@ -1,462 +1,229 @@
-"""
-Stream preview router — stream and channel preview proxy endpoints.
+"""Stream and channel preview proxies with validated upstream startup."""
 
-Extracted from main.py (Phase 3 of v0.13.0 backend refactor).
-"""
 import asyncio
 import logging
 import subprocess
-import time
 
+import anyio
+import httpx
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 
 from config import get_settings
 from dispatcharr_client import get_client
-from security.ssrf import SSRFError
+from security.ssrf import DNSResolutionError, SSRFError, SchemeDowngrade
 from security.stream_outbound import (
-    prepare_stream_http_url,
     stream_request,
     validated_subprocess_input,
 )
+from stream_user_agent import StreamUserAgentError, StreamUserAgentResolver
 
 logger = logging.getLogger(__name__)
 
-# Restrict ffmpeg to safe network protocols only — blocks file://, data://, concat:, etc.
-# tls and crypto are required internal protocols: HTTPS chains to tls for the TLS
-# handshake, HLS AES-128 encrypted segments chain to crypto. Without tls ffmpeg
-# fails on every HTTPS URL with "Protocol 'tls' not on whitelist" (GH-106).
 FFMPEG_PROTOCOL_WHITELIST = "http,https,tls,crypto,tcp,udp,rtp,rtmp,pipe"
 RELAY_PROTOCOL_WHITELIST = "http,tcp,crypto"
-
+PREVIEW_SCHEME_DOWNGRADE = SchemeDowngrade.ALLOW_STREAM_PREVIEW
+# Bound provider startup/stalls without limiting total viewing time.
+PREVIEW_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+_RESPONSE_HEADERS = {
+    "Cache-Control": "no-cache, no-store, must-revalidate",
+    "Pragma": "no-cache",
+    "Expires": "0",
+}
 router = APIRouter(tags=["Stream Preview"])
 
 
-async def stream_generator(
-    process: subprocess.Popen,
-    chunk_size: int = 65536,
-    *,
-    input_context=None,
-):
-    """Generator that yields chunks from FFmpeg process stdout."""
+def _startup_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, DNSResolutionError):
+        status, detail = 502, "Stream DNS resolution failed from ECM"
+    elif isinstance(exc, SSRFError):
+        status, detail = 403, "Stream destination is not permitted"
+    elif isinstance(exc, StreamUserAgentError):
+        status, detail = 502, str(exc)
+    elif isinstance(exc, httpx.HTTPStatusError):
+        status, detail = 502, f"Upstream stream returned HTTP {exc.response.status_code}"
+    elif isinstance(exc, httpx.TimeoutException):
+        status, detail = 504, "Upstream stream timed out from ECM"
+    else:
+        status, detail = 502, "Could not connect to upstream stream from ECM"
+    # No raw exception text: HTTPX errors can include provider URLs and credentials.
+    logger.warning("[PREVIEW] Startup failed: %s", detail)
+    return HTTPException(status_code=status, detail=detail)
+
+
+class _PreviewResources:
+    def __init__(self, context):
+        self.context = context
+        self.process = None
+        self.closed = False
+
+    async def close(self):
+        if self.closed:
+            return
+        self.closed = True
+        # Starlette cancels streaming on disconnect. Cleanup must outlive that
+        # cancellation, including a disconnect before the iterator's first read.
+        with anyio.CancelScope(shield=True):
+            try:
+                if self.process is not None:
+                    await _stop_process(self.process)
+            finally:
+                await self.context.__aexit__(None, None, None)
+
+
+class _PreviewResponse(StreamingResponse):
+    def __init__(self, iterator, resources):
+        super().__init__(iterator, media_type="video/mp2t", headers=_RESPONSE_HEADERS)
+        self.resources = resources
+
+    async def __call__(self, scope, receive, send):
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            await self.resources.close()
+
+
+async def _stop_process(process):
     try:
-        while True:
-            chunk = await asyncio.get_event_loop().run_in_executor(
-                None, process.stdout.read, chunk_size
-            )
-            if not chunk:
-                break
-            yield chunk
-    finally:
         process.terminate()
         try:
-            process.wait(timeout=5)
+            await asyncio.to_thread(process.wait, timeout=5)
         except subprocess.TimeoutExpired:
             process.kill()
-        if input_context is not None:
-            await input_context.__aexit__(None, None, None)
+            await asyncio.to_thread(process.wait)
+    except ProcessLookupError:
+        await asyncio.to_thread(process.wait)
+    finally:
+        for pipe in (process.stdout, process.stderr):
+            if pipe is not None:
+                pipe.close()
+
+
+async def stream_generator(process, chunk_size=65536, *, input_context=None):
+    """Yield FFmpeg stdout and release subprocess/input on generator closure."""
+    try:
+        while chunk := await asyncio.to_thread(process.stdout.read, chunk_size):
+            yield chunk
+    finally:
+        with anyio.CancelScope(shield=True):
+            try:
+                await _stop_process(process)
+            finally:
+                if input_context is not None:
+                    await input_context.__aexit__(None, None, None)
+
+
+async def _preview_response(url, mode, headers, *, provider_media=False):
+    policy = PREVIEW_SCHEME_DOWNGRADE if provider_media else SchemeDowngrade.REFUSE
+    if mode == "passthrough":
+        context = stream_request(url, headers=headers, timeout=PREVIEW_TIMEOUT, scheme_downgrade=policy)
+    else:
+        kwargs = {"headers": headers, "timeout": PREVIEW_TIMEOUT}
+        if provider_media:
+            kwargs.update(scheme_downgrade=policy)
+        context = validated_subprocess_input(url, **kwargs)
+    resources = _PreviewResources(context)
+    try:
+        upstream = await context.__aenter__()
+        if mode == "passthrough":
+            upstream.raise_for_status()
+
+            async def chunks():
+                try:
+                    async for chunk in upstream.aiter_bytes(chunk_size=65536):
+                        yield chunk
+                except httpx.HTTPError as exc:
+                    logger.warning("[PREVIEW] Upstream streaming failed (%s)", type(exc).__name__)
+                    # Headers are sent: abort the body without exposing the
+                    # provider URL through the server's exception handler.
+                    raise RuntimeError("Upstream preview stream failed") from None
+                finally:
+                    await resources.close()
+        else:
+            command = [
+                "ffmpeg", "-hide_banner", "-loglevel", "error",
+                "-protocol_whitelist", RELAY_PROTOCOL_WHITELIST if upstream.is_http_relay else FFMPEG_PROTOCOL_WHITELIST,
+                "-fflags", "+genpts+discardcorrupt", "-analyzeduration", "2000000",
+                "-probesize", "2000000", "-i", upstream.argument, "-c:v", "copy",
+            ]
+            command += ["-c:a", "aac", "-b:a", "192k", "-ac", "2"] if mode == "transcode" else ["-an"]
+            command += ["-max_muxing_queue_size", "1024", "-f", "mpegts", "-"]
+            resources.process = subprocess.Popen(
+                command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, bufsize=65536
+            )
+
+            async def chunks():
+                try:
+                    while chunk := await asyncio.to_thread(resources.process.stdout.read, 65536):
+                        yield chunk
+                    returncode = await asyncio.to_thread(resources.process.wait, timeout=5)
+                    if returncode != 0:
+                        logger.warning("[PREVIEW] Decoder exited abnormally (returncode=%s)", returncode)
+                        raise RuntimeError("Preview decoder failed")
+                except (OSError, subprocess.SubprocessError) as exc:
+                    logger.warning("[PREVIEW] Decoder streaming failed (%s)", type(exc).__name__)
+                    raise RuntimeError("Preview decoder failed") from None
+                finally:
+                    await resources.close()
+
+        return _PreviewResponse(chunks(), resources)
+    except (SSRFError, httpx.HTTPError) as exc:
+        await resources.close()
+        raise _startup_error(exc) from None
+    except FileNotFoundError:
+        await resources.close()
+        logger.warning("[PREVIEW] FFmpeg is unavailable")
+        raise HTTPException(500, "FFmpeg not found. Please install FFmpeg for preview.") from None
+    except BaseException:
+        await resources.close()
+        raise
 
 
 @router.get("/api/stream-preview/{stream_id}")
 async def stream_preview(stream_id: int):
-    """
-    Proxy endpoint for stream preview with optional transcoding.
-
-    Based on stream_preview_mode setting:
-    - passthrough: Direct proxy (may fail on AC-3/E-AC-3/DTS audio)
-    - transcode: Transcode audio to AAC for browser compatibility
-    - video_only: Strip audio for quick preview
-
-    Returns MPEG-TS stream suitable for mpegts.js playback.
-    """
-    logger.debug("[PREVIEW] GET /api/stream-preview/%s", stream_id)
+    """Preview provider media directly using ECM's shared User-Agent selection."""
     settings = get_settings()
     mode = settings.stream_preview_mode
-
-    # Get stream URL from Dispatcharr
+    if mode not in {"passthrough", "transcode", "video_only"}:
+        raise HTTPException(400, "Invalid preview mode")
     client = get_client()
     if not client:
-        raise HTTPException(status_code=503, detail="Not connected to Dispatcharr")
-
+        raise HTTPException(503, "Not connected to Dispatcharr")
     try:
-        start = time.time()
         stream = await client.get_stream(stream_id)
-        elapsed_ms = (time.time() - start) * 1000
-        logger.debug("[PREVIEW] get_stream %s completed in %.1fms", stream_id, elapsed_ms)
-        if not stream or not stream.get("url"):
-            raise HTTPException(status_code=404, detail="Stream not found or has no URL")
-        stream_url = stream["url"]
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.exception("[PREVIEW] Failed to get stream %s", stream_id)
-        raise HTTPException(status_code=500, detail=f"Failed to get stream: {str(e)}")
-
-    logger.info("[PREVIEW] Stream preview requested for stream %s, mode: %s", stream_id, mode)
-
-    if mode == "passthrough":
-        # Direct proxy - just fetch and forward
-        try:
-            initial_target = prepare_stream_http_url(stream_url)
-        except SSRFError as exc:
-            raise HTTPException(
-                status_code=403, detail="Stream destination is not permitted"
-            ) from exc
-
-        async def passthrough_generator():
-            async with stream_request(
-                stream_url, timeout=None, initial_target=initial_target
-            ) as response:
-                response.raise_for_status()
-                async for chunk in response.aiter_bytes(chunk_size=65536):
-                    yield chunk
-
-        return StreamingResponse(
-            passthrough_generator(),
-            media_type="video/mp2t",
-            headers={
-                "Cache-Control": "no-cache, no-store, must-revalidate",
-                "Pragma": "no-cache",
-                "Expires": "0",
-            }
-        )
-
-    elif mode == "transcode":
-        # Transcode audio to AAC for browser compatibility
-        # FFmpeg: copy video, transcode audio to AAC
-        input_context = validated_subprocess_input(stream_url)
-        try:
-            subprocess_input = await input_context.__aenter__()
-        except SSRFError as exc:
-            raise HTTPException(
-                status_code=403, detail="Stream destination is not permitted"
-            ) from exc
-        ffmpeg_cmd = [
-            "ffmpeg",
-            "-hide_banner",
-            "-loglevel", "error",
-            "-protocol_whitelist", (
-                RELAY_PROTOCOL_WHITELIST
-                if subprocess_input.is_http_relay
-                else FFMPEG_PROTOCOL_WHITELIST
-            ),
-            "-fflags", "+genpts+discardcorrupt",  # Generate pts, handle corruption
-            "-analyzeduration", "2000000",        # 2 seconds to analyze stream
-            "-probesize", "2000000",              # 2MB probe size
-            "-i", subprocess_input.argument,
-            "-c:v", "copy",           # Copy video as-is
-            "-c:a", "aac",            # Transcode audio to AAC
-            "-b:a", "192k",           # 192kbps audio bitrate
-            "-ac", "2",               # Stereo output
-            "-max_muxing_queue_size", "1024",     # Larger muxing buffer
-            "-f", "mpegts",           # Output format
-            "-"                       # Output to stdout
-        ]
-
-        try:
-            process = subprocess.Popen(
-                ffmpeg_cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                bufsize=65536
-            )
-
-            return StreamingResponse(
-                stream_generator(
-                    process,
-                    input_context=input_context,
-                ),
-                media_type="video/mp2t",
-                headers={
-                    "Cache-Control": "no-cache, no-store, must-revalidate",
-                    "Pragma": "no-cache",
-                    "Expires": "0",
-                }
-            )
-        except FileNotFoundError:
-            await input_context.__aexit__(None, None, None)
-            raise HTTPException(
-                status_code=500,
-                detail="FFmpeg not found. Please install FFmpeg for transcoding support."
-            )
-        except Exception as e:
-            await input_context.__aexit__(type(e), e, e.__traceback__)
-            logger.exception("[PREVIEW] FFmpeg transcode error for stream %s", stream_id)
-            raise HTTPException(status_code=500, detail=f"Transcoding failed: {str(e)}")
-
-    elif mode == "video_only":
-        # Strip audio entirely for quick preview
-        input_context = validated_subprocess_input(stream_url)
-        try:
-            subprocess_input = await input_context.__aenter__()
-        except SSRFError as exc:
-            raise HTTPException(
-                status_code=403, detail="Stream destination is not permitted"
-            ) from exc
-        ffmpeg_cmd = [
-            "ffmpeg",
-            "-hide_banner",
-            "-loglevel", "error",
-            "-protocol_whitelist", (
-                RELAY_PROTOCOL_WHITELIST
-                if subprocess_input.is_http_relay
-                else FFMPEG_PROTOCOL_WHITELIST
-            ),
-            "-fflags", "+genpts+discardcorrupt",  # Generate pts, handle corruption
-            "-analyzeduration", "2000000",        # 2 seconds to analyze stream
-            "-probesize", "2000000",              # 2MB probe size
-            "-i", subprocess_input.argument,
-            "-c:v", "copy",           # Copy video as-is
-            "-an",                    # No audio
-            "-max_muxing_queue_size", "1024",     # Larger muxing buffer
-            "-f", "mpegts",           # Output format
-            "-"                       # Output to stdout
-        ]
-
-        try:
-            process = subprocess.Popen(
-                ffmpeg_cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                bufsize=65536
-            )
-
-            return StreamingResponse(
-                stream_generator(
-                    process,
-                    input_context=input_context,
-                ),
-                media_type="video/mp2t",
-                headers={
-                    "Cache-Control": "no-cache, no-store, must-revalidate",
-                    "Pragma": "no-cache",
-                    "Expires": "0",
-                }
-            )
-        except FileNotFoundError:
-            await input_context.__aexit__(None, None, None)
-            raise HTTPException(
-                status_code=500,
-                detail="FFmpeg not found. Please install FFmpeg for video-only preview."
-            )
-        except Exception as e:
-            await input_context.__aexit__(type(e), e, e.__traceback__)
-            logger.exception("[PREVIEW] FFmpeg video-only error for stream %s", stream_id)
-            raise HTTPException(status_code=500, detail=f"Video extraction failed: {str(e)}")
-
-    else:
-        raise HTTPException(status_code=400, detail=f"Invalid preview mode: {mode}")
+    except Exception:
+        logger.warning("[PREVIEW] Could not load stream %s from Dispatcharr", stream_id)
+        raise HTTPException(502, "Could not load stream from Dispatcharr") from None
+    if not stream or not stream.get("url"):
+        raise HTTPException(404, "Stream not found or has no URL")
+    try:
+        user_agent = await StreamUserAgentResolver(client, settings.stream_user_agent).resolve(stream)
+    except StreamUserAgentError as exc:
+        raise _startup_error(exc) from None
+    return await _preview_response(stream["url"], mode, {"User-Agent": user_agent}, provider_media=True)
 
 
 @router.get("/api/channel-preview/{channel_id}")
 async def channel_preview(channel_id: int):
-    """
-    Proxy endpoint for channel preview with optional transcoding.
-
-    Previews the channel output from Dispatcharr's TS proxy. This tests the
-    actual channel stream as it would be served to clients.
-
-    Based on stream_preview_mode setting:
-    - passthrough: Direct proxy (may fail on AC-3/E-AC-3/DTS audio)
-    - transcode: Transcode audio to AAC for browser compatibility
-    - video_only: Strip audio for quick preview
-
-    Returns MPEG-TS stream suitable for mpegts.js playback.
-    """
-    logger.debug("[PREVIEW] GET /api/channel-preview/%s", channel_id)
+    """Preview Dispatcharr's authenticated TS proxy; Dispatcharr owns its provider UA."""
     settings = get_settings()
     mode = settings.stream_preview_mode
-
-    # Get channel from Dispatcharr to get its UUID
+    if mode not in {"passthrough", "transcode", "video_only"}:
+        raise HTTPException(400, "Invalid preview mode")
     client = get_client()
     if not client:
-        raise HTTPException(status_code=503, detail="Not connected to Dispatcharr")
-
+        raise HTTPException(503, "Not connected to Dispatcharr")
     try:
-        start = time.time()
         channel = await client.get_channel(channel_id)
-        elapsed_ms = (time.time() - start) * 1000
-        logger.debug("[PREVIEW] get_channel %s completed in %.1fms", channel_id, elapsed_ms)
         if not channel:
-            raise HTTPException(status_code=404, detail="Channel not found")
-
-        channel_uuid = channel.get("uuid")
-        if not channel_uuid:
-            raise HTTPException(status_code=404, detail="Channel has no UUID")
-
-        # Construct Dispatcharr TS proxy URL using UUID
-        dispatcharr_url = settings.url.rstrip("/")
-        channel_url = f"{dispatcharr_url}/proxy/ts/stream/{channel_uuid}"
-
-        # Get auth token for authenticated requests to Dispatcharr proxy
+            raise HTTPException(404, "Channel not found")
+        if not channel.get("uuid"):
+            raise HTTPException(404, "Channel has no UUID")
+        url = f"{settings.url.rstrip('/')}/proxy/ts/stream/{channel['uuid']}"
         await client._ensure_authenticated()
-        auth_headers = {"Authorization": f"Bearer {client.access_token}"}
-
-        logger.info("[PREVIEW] Channel preview: proxying Dispatcharr stream for channel %s (uuid=%s)", channel_id, channel_uuid)
-
     except HTTPException:
         raise
-    except Exception as e:
-        logger.exception("[PREVIEW] Failed to get channel %s", channel_id)
-        raise HTTPException(status_code=500, detail=f"Failed to get channel: {str(e)}")
-
-    logger.info("[PREVIEW] Channel preview requested for channel %s, mode: %s", channel_id, mode)
-
-    if mode == "passthrough":
-        # Direct proxy with JWT auth - just fetch and forward
-        try:
-            initial_target = prepare_stream_http_url(channel_url)
-        except SSRFError as exc:
-            raise HTTPException(
-                status_code=403, detail="Stream destination is not permitted"
-            ) from exc
-
-        async def passthrough_generator():
-            async with stream_request(
-                channel_url,
-                timeout=None,
-                headers=auth_headers,
-                initial_target=initial_target,
-            ) as response:
-                if response.status_code != 200:
-                    logger.error("[PREVIEW] Dispatcharr proxy returned %s", response.status_code)
-                    return
-                async for chunk in response.aiter_bytes(chunk_size=65536):
-                    yield chunk
-
-        return StreamingResponse(
-            passthrough_generator(),
-            media_type="video/mp2t",
-            headers={
-                "Cache-Control": "no-cache, no-store, must-revalidate",
-                "Pragma": "no-cache",
-                "Expires": "0",
-            }
-        )
-
-    elif mode == "transcode":
-        # Transcode audio to AAC for browser compatibility
-        # FFmpeg -headers option passes JWT auth to Dispatcharr proxy
-        input_context = validated_subprocess_input(channel_url, headers=auth_headers)
-        try:
-            subprocess_input = await input_context.__aenter__()
-        except SSRFError as exc:
-            raise HTTPException(
-                status_code=403, detail="Stream destination is not permitted"
-            ) from exc
-        ffmpeg_cmd = [
-            "ffmpeg",
-            "-hide_banner",
-            "-loglevel", "error",
-            "-protocol_whitelist", (
-                RELAY_PROTOCOL_WHITELIST
-                if subprocess_input.is_http_relay
-                else FFMPEG_PROTOCOL_WHITELIST
-            ),
-            "-fflags", "+genpts+discardcorrupt",
-            "-analyzeduration", "2000000",
-            "-probesize", "2000000",
-            "-i", subprocess_input.argument,
-            "-c:v", "copy",
-            "-c:a", "aac",
-            "-b:a", "192k",
-            "-ac", "2",
-            "-max_muxing_queue_size", "1024",
-            "-f", "mpegts",
-            "-"
-        ]
-
-        try:
-            process = subprocess.Popen(
-                ffmpeg_cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                bufsize=65536
-            )
-
-            return StreamingResponse(
-                stream_generator(
-                    process,
-                    input_context=input_context,
-                ),
-                media_type="video/mp2t",
-                headers={
-                    "Cache-Control": "no-cache, no-store, must-revalidate",
-                    "Pragma": "no-cache",
-                    "Expires": "0",
-                }
-            )
-        except FileNotFoundError:
-            await input_context.__aexit__(None, None, None)
-            raise HTTPException(
-                status_code=500,
-                detail="FFmpeg not found. Please install FFmpeg for transcoding support."
-            )
-        except Exception as e:
-            await input_context.__aexit__(type(e), e, e.__traceback__)
-            logger.exception("[PREVIEW] FFmpeg transcode error for channel %s", channel_id)
-            raise HTTPException(status_code=500, detail=f"Transcoding failed: {str(e)}")
-
-    elif mode == "video_only":
-        # Strip audio entirely for quick preview
-        # FFmpeg -headers option passes JWT auth to Dispatcharr proxy
-        input_context = validated_subprocess_input(channel_url, headers=auth_headers)
-        try:
-            subprocess_input = await input_context.__aenter__()
-        except SSRFError as exc:
-            raise HTTPException(
-                status_code=403, detail="Stream destination is not permitted"
-            ) from exc
-        ffmpeg_cmd = [
-            "ffmpeg",
-            "-hide_banner",
-            "-loglevel", "error",
-            "-protocol_whitelist", (
-                RELAY_PROTOCOL_WHITELIST
-                if subprocess_input.is_http_relay
-                else FFMPEG_PROTOCOL_WHITELIST
-            ),
-            "-fflags", "+genpts+discardcorrupt",
-            "-analyzeduration", "2000000",
-            "-probesize", "2000000",
-            "-i", subprocess_input.argument,
-            "-c:v", "copy",
-            "-an",
-            "-max_muxing_queue_size", "1024",
-            "-f", "mpegts",
-            "-"
-        ]
-
-        try:
-            process = subprocess.Popen(
-                ffmpeg_cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                bufsize=65536
-            )
-
-            return StreamingResponse(
-                stream_generator(
-                    process,
-                    input_context=input_context,
-                ),
-                media_type="video/mp2t",
-                headers={
-                    "Cache-Control": "no-cache, no-store, must-revalidate",
-                    "Pragma": "no-cache",
-                    "Expires": "0",
-                }
-            )
-        except FileNotFoundError:
-            await input_context.__aexit__(None, None, None)
-            raise HTTPException(
-                status_code=500,
-                detail="FFmpeg not found. Please install FFmpeg for video-only preview."
-            )
-        except Exception as e:
-            await input_context.__aexit__(type(e), e, e.__traceback__)
-            logger.exception("[PREVIEW] FFmpeg video-only error for channel %s", channel_id)
-            raise HTTPException(status_code=500, detail=f"Video extraction failed: {str(e)}")
-
-    else:
-        raise HTTPException(status_code=400, detail=f"Invalid preview mode: {mode}")
+    except Exception:
+        logger.warning("[PREVIEW] Could not load channel %s from Dispatcharr", channel_id)
+        raise HTTPException(502, "Could not load channel from Dispatcharr") from None
+    return await _preview_response(url, mode, {"Authorization": f"Bearer {client.access_token}"})

--- a/backend/security/ssrf.py
+++ b/backend/security/ssrf.py
@@ -63,29 +63,30 @@ Design (per §9.4)
   on a redirect target, rejects ``https → http`` downgrades, and
   :func:`check_redirect_depth` caps the chain at :data:`MAX_REDIRECTS`.
 
-Scheme-downgrade scope (bead ``enhancedchannelmanager-iyvl9``)
+Scheme-downgrade scope (beads ``iyvl9`` and ``yz6rv``)
 -------------------------------------------------------------
 The ``https → http`` refusal is the DEFAULT for every outbound path and stays
-that way. Exactly one caller may opt out: the stream-probe path, via the
+that way. Provider-media probes and direct stream previews may opt out via the
 explicit :class:`SchemeDowngrade` parameter on :func:`validate_redirect`
-(``SchemeDowngrade.ALLOW_STREAM_PROBE``). It is a per-call argument on purpose —
+(``ALLOW_STREAM_PROBE`` / ``ALLOW_STREAM_PREVIEW``). It is a per-call argument:
 not a global flag, not a settings key, not an environment variable — so that
 reading :func:`validate_redirect` tells you who is allowed to downgrade, and so
 that ``grep -rn ALLOW_STREAM_PROBE`` enumerates every site that does.
 
-Why the probe path and nothing else: XC providers routinely 302 an
+Why provider media: XC providers routinely 302 an
 ``https://<portal>/live/<user>/<pass>/<id>.ts`` request onto a plain-HTTP edge
 node, and they serve the video over HTTP at that edge regardless. Playback is
-already unencrypted in transit, and the redirect target's path is an opaque
-token carrying no credentials, so refusing the hop buys no confidentiality — it
-only costs the operator the ability to learn whether a stream works. Every other
+unencrypted on that hop. The scoped policy permits this provider behavior; it
+does not promise that arbitrary redirect paths contain no credentials. Every other
 outbound destination (cloud backup targets, EPG sources, a second Dispatcharr
 instance) is a credentialed API where a downgrade IS a real loss, so those keep
 the refusal.
 
 The relaxation is narrow in a second sense: it waives ONLY the scheme-downgrade
 clause. The denylist, resolve-then-connect-by-IP, redirect depth capping and
-origin pinning all still apply to the probe path unchanged.
+origin pinning still apply. The authenticated Dispatcharr channel proxy retains
+REFUSE. Tests: ``tests/security/test_preview_provider_policy.py`` and
+``tests/security/test_probe_scheme_downgrade.py``.
 
 Seam for bead .8
 ----------------
@@ -157,13 +158,13 @@ class SchemeDowngrade(str, Enum):
     """
 
     #: Refuse the downgrade. The default, and the policy for EVERY outbound
-    #: path other than the stream probe.
+    #: path other than explicitly opted-in provider media.
     REFUSE = "refuse"
     #: Follow the downgrade. Reserved for the stream-probe path (ffprobe /
-    #: bitrate measurement / black-screen detection), where the provider serves
-    #: the media over plain HTTP anyway and the redirect target carries no
-    #: credentials. See the module docstring for the full rationale.
+    #: bitrate measurement / black-screen detection). See the module docstring.
     ALLOW_STREAM_PROBE = "allow_stream_probe"
+    #: Provider-media preview only; never the authenticated Dispatcharr channel proxy.
+    ALLOW_STREAM_PREVIEW = "allow_stream_preview"
 
 
 class SSRFError(Exception):
@@ -345,6 +346,14 @@ def _ip_allowed(ip: _IPAddress, mode: SSRFMode) -> bool:
     return True
 
 
+class DNSResolutionError(SSRFError):
+    """A failed lookup, distinct from a destination-policy refusal."""
+
+    def __init__(self, *, transient: bool = False):
+        super().__init__("Stream DNS resolution failed (no connection made)")
+        self.transient = transient
+
+
 def _resolve(host: str, port: Optional[int]) -> list[_IPAddress]:
     """Resolve ``host`` to a list of IP addresses (ONE lookup).
 
@@ -400,10 +409,12 @@ def _validate_parsed(scheme: str, hostname: str, port: int, url: str,
     except (socket.gaierror, socket.herror, UnicodeError, OSError) as exc:
         # FAIL CLOSED (unlike the media-server validator). An unresolvable or
         # ambiguous host is rejected for the cloud-upload path.
-        raise SSRFError(f"Could not resolve host '{hostname}' — rejected (fail-closed)") from exc
+        raise DNSResolutionError(
+            transient=isinstance(exc, socket.gaierror) and exc.errno == socket.EAI_AGAIN
+        ) from exc
 
     if not records:
-        raise SSRFError(f"Host '{hostname}' resolved to no usable address — rejected (fail-closed)")
+        raise DNSResolutionError()
 
     # Validate EVERY record; ANY denied → reject the whole request (do not
     # cherry-pick the allowed one — that is the DNS-rebinding bypass).
@@ -478,18 +489,17 @@ def validate_redirect(
 
     * Re-runs the full denylist + resolve-by-IP on ``to_url``.
     * Rejects an ``https → http`` scheme downgrade UNLESS the caller explicitly
-      passes ``scheme_downgrade=SchemeDowngrade.ALLOW_STREAM_PROBE``.
+      passes an explicit provider-media downgrade policy.
 
     The caller is responsible for capping the chain length via
     :func:`check_redirect_depth`.
 
     Who may downgrade
     -----------------
-    Only the stream-probe path
-    (:mod:`stream_prober` → :mod:`security.stream_outbound`). ``scheme_downgrade``
+    Provider probes and direct stream previews. ``scheme_downgrade``
     is keyword-only and defaults to :data:`SchemeDowngrade.REFUSE`, so every
     other caller — cloud backup targets, EPG source fetches, the
-    cross-instance sync client, the browser stream preview — keeps the refusal
+    cross-instance sync client, the authenticated channel preview, keeps refusal
     without doing anything, and a new caller cannot inherit the relaxation by
     accident. Waiving the downgrade waives ONLY the downgrade: the denylist,
     resolve-then-connect-by-IP, depth cap and origin pinning are unaffected.
@@ -500,8 +510,7 @@ def validate_redirect(
         to_url: the ``Location:`` target.
         mode: active SSRF mode.
         scheme_downgrade: downgrade policy for THIS hop. Defaults to
-            :data:`SchemeDowngrade.REFUSE`; only the stream-probe path passes
-            :data:`SchemeDowngrade.ALLOW_STREAM_PROBE`.
+            :data:`SchemeDowngrade.REFUSE`; provider probes/previews opt in.
 
     Returns:
         A validated :class:`ResolvedTarget` for ``to_url``.
@@ -513,14 +522,16 @@ def validate_redirect(
     from_scheme, _, _ = _split(from_url)
     to_scheme = (urlsplit(to_url).scheme or "").lower()
     if from_scheme == "https" and to_scheme == "http":
-        if scheme_downgrade is not SchemeDowngrade.ALLOW_STREAM_PROBE:
+        if scheme_downgrade not in (
+            SchemeDowngrade.ALLOW_STREAM_PROBE, SchemeDowngrade.ALLOW_STREAM_PREVIEW
+        ):
             raise SSRFError("Refusing redirect that downgrades https → http")
         # Deliberate, scoped waiver — record it so the downgrade is never
         # silent. No URL or credential in the message (bead
         # ``enhancedchannelmanager-3dn59``): the probe path surfaces guard
         # messages to the operator, so they must stay credential-free.
         logger.warning(
-            "[SSRF] Following an https → http redirect on the stream-probe "
+            "[SSRF] Following an https → http redirect on the provider-media "
             "path (policy=%s); this hop is not confidential",
             scheme_downgrade.value,
         )

--- a/backend/security/stream_outbound.py
+++ b/backend/security/stream_outbound.py
@@ -8,17 +8,18 @@ inputs use ``validate_stream_subprocess_url`` as documented in
 
 Scheme-downgrade policy (bead ``enhancedchannelmanager-iyvl9``)
 --------------------------------------------------------------
-This module serves TWO consumers: the stream **prober** and the browser stream
-**preview** router. They do not share a redirect policy. Every entrypoint here
+This module serves provider probes, direct previews and channel-proxy previews.
+Every entrypoint here
 takes an explicit ``scheme_downgrade`` argument that defaults to
 :data:`~security.ssrf.SchemeDowngrade.REFUSE` and is forwarded verbatim to
-:func:`~security.ssrf.validate_redirect`; only :mod:`stream_prober` passes
-:data:`~security.ssrf.SchemeDowngrade.ALLOW_STREAM_PROBE`. Preview, and any
-future caller, keeps the refusal by doing nothing.
+:func:`~security.ssrf.validate_redirect`. Provider probes and direct previews
+explicitly opt in; the authenticated Dispatcharr channel proxy keeps REFUSE.
+The scoped policies are enforced by tests/security/test_preview_provider_policy.py.
 """
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 import re
@@ -27,10 +28,12 @@ from typing import AsyncIterator, Callable, Mapping
 from urllib.parse import urljoin
 from urllib.parse import urlsplit
 
+import anyio
 import httpx
 from aiohttp import web
 
 from security.ssrf import (
+    DNSResolutionError,
     SchemeDowngrade,
     SSRFError,
     SSRFMode,
@@ -40,6 +43,20 @@ from security.ssrf import (
     validate_outbound_url,
     validate_redirect,
 )
+
+# Two short retries only for EAI_AGAIN: 100ms then 200ms. Validation runs in a
+# worker thread; every successful answer still passes the complete SSRF policy.
+DNS_RETRY_DELAYS = (0.1, 0.2)
+
+
+async def _validate_with_dns_retry(validator, *args, **kwargs):
+    for attempt in range(len(DNS_RETRY_DELAYS) + 1):
+        try:
+            return await asyncio.to_thread(validator, *args, **kwargs)
+        except DNSResolutionError as exc:
+            if not exc.transient or attempt == len(DNS_RETRY_DELAYS):
+                raise
+            await asyncio.sleep(DNS_RETRY_DELAYS[attempt])
 
 
 class SSRFPinnedTransport(httpx.AsyncBaseTransport):
@@ -62,8 +79,7 @@ class SSRFPinnedTransport(httpx.AsyncBaseTransport):
         self._inner = inner or self._inner_factory()
         self._mode = mode
         # Redirect scheme-downgrade policy for every hop this transport follows.
-        # Defaults to REFUSE; only the stream-probe path overrides it (bead
-        # enhancedchannelmanager-iyvl9).
+        # Defaults to REFUSE; provider-media callers explicitly override it.
         self._scheme_downgrade = scheme_downgrade
         self._origin: tuple[str, str, int] | None = None
 
@@ -75,14 +91,15 @@ class SSRFPinnedTransport(httpx.AsyncBaseTransport):
         if prepared_target is not None:
             target = prepared_target
         elif from_url:
-            target = validate_redirect(
+            target = await _validate_with_dns_retry(
+                validate_redirect,
                 str(from_url),
                 original_url,
                 mode,
                 scheme_downgrade=self._scheme_downgrade,
             )
         else:
-            target = validate_outbound_url(original_url, mode)
+            target = await _validate_with_dns_retry(validate_outbound_url, original_url, mode)
 
         target_origin = (target.scheme, target.hostname.lower(), target.port)
         if self._origin is not None and target_origin != self._origin:
@@ -126,9 +143,8 @@ async def stream_request(
     """Open a pinned streaming GET, revalidating and capping redirects.
 
     ``scheme_downgrade`` is forwarded to the transport and from there to
-    :func:`~security.ssrf.validate_redirect`. It defaults to REFUSE; only the
-    stream-probe path passes ``ALLOW_STREAM_PROBE`` (bead
-    ``enhancedchannelmanager-iyvl9``).
+    :func:`~security.ssrf.validate_redirect`. It defaults to REFUSE; provider
+    probes and direct stream previews opt in at their call sites.
     """
 
     if transport is not None and scheme_downgrade is not SchemeDowngrade.REFUSE:
@@ -272,11 +288,14 @@ class _LocalStreamRelay:
         return f"http://127.0.0.1:{port}/resource/{self._initial_token}"
 
     async def close(self) -> None:
-        if self._runner is not None:
-            await self._runner.cleanup()
-        if self._initial_context is not None:
-            await self._initial_context.__aexit__(None, None, None)
-            self._initial_context = None
+        runner, self._runner = self._runner, None
+        context, self._initial_context = self._initial_context, None
+        try:
+            if runner is not None:
+                await runner.cleanup()
+        finally:
+            if context is not None:
+                await context.__aexit__(None, None, None)
 
     def _headers_for(self, url: str) -> dict[str, str]:
         if _origin(url) == _origin(self._initial_url):
@@ -361,13 +380,12 @@ async def validated_subprocess_input(
     lifetime of every resource; FFmpeg receives only opaque loopback URLs.
 
     ``scheme_downgrade`` defaults to REFUSE and is forwarded to the relay's
-    redirect validation; only the stream-probe path passes
-    ``ALLOW_STREAM_PROBE`` (bead ``enhancedchannelmanager-iyvl9``).
+    redirect validation. Provider probes and direct stream previews opt in.
     """
 
     scheme = urlsplit(url).scheme.lower()
     if scheme not in {"http", "https"}:
-        validate_stream_subprocess_url(url)
+        await _validate_with_dns_retry(validate_stream_subprocess_url, url)
         yield ValidatedSubprocessInput(argument=url)
         return
 
@@ -378,7 +396,10 @@ async def validated_subprocess_input(
             argument=relay_url, is_http_relay=True
         )
     finally:
-        await relay.close()
+        # Startup can be cancelled after acquiring upstream but before yield.
+        # The caller cannot resume this exhausted context manager's cleanup.
+        with anyio.CancelScope(shield=True):
+            await relay.close()
 
 
 

--- a/backend/stream_prober.py
+++ b/backend/stream_prober.py
@@ -21,7 +21,7 @@ import journal
 import safe_regex
 
 import httpx
-from security.ssrf import SchemeDowngrade, SSRFError
+from security.ssrf import DNSResolutionError, SchemeDowngrade, SSRFError
 from security.stream_outbound import (
     stream_request,
     validated_subprocess_input,
@@ -30,6 +30,7 @@ from security.stream_outbound import (
 from database import get_session
 from models import StreamStats
 from resdet_lock import RESDET_PIPELINE_LOCK_PATH, ResdetLockError, ResdetPipelineLock
+from stream_user_agent import StreamUserAgentError, StreamUserAgentResolver
 from smart_sort_evaluator import (
     PointRule,
     StreamFacts,
@@ -62,20 +63,9 @@ class ResolutionDetectionError(RuntimeError):
     """A resdet failure with a fixed operator-safe message."""
 
 
-# Bead enhancedchannelmanager-iyvl9. XC providers 302 an
-# https://<portal>/live/<user>/<pass>/<id>.ts request onto a plain-HTTP edge
-# node and serve the video over HTTP there regardless, so the media is already
-# unencrypted in transit and the redirect target's opaque-token path carries no
-# credentials. Refusing the hop cost the operator every probe against such a
-# provider and bought no confidentiality, so the PROBE PATH -- and only the
-# probe path -- waives the scheme-downgrade clause. Everything else in the SSRF
-# guard (denylist, resolve-then-connect-by-IP, redirect depth cap, origin
-# pinning) still applies here unchanged.
-#
-# This constant is the single place the prober names the waiver; the three probe
-# call sites below reference it, and no other module in the backend may pass
-# SchemeDowngrade.ALLOW_STREAM_PROBE (enforced by
-# tests/security/test_probe_scheme_downgrade.py).
+# Provider portals can redirect onto HTTP media edges. Four probe paths use this
+# explicit waiver; direct previews have their own policy (GH995). Other SSRF
+# checks remain enforced by tests/security/test_probe_scheme_downgrade.py.
 PROBE_SCHEME_DOWNGRADE = SchemeDowngrade.ALLOW_STREAM_PROBE
 
 
@@ -94,6 +84,8 @@ OPERATOR_SAFE_EXCEPTION_TYPES: tuple = (
     SSRFError,               # ECM's own SSRF chokepoint -- fixed guard messages
     ProbeNetworkRouteError,  # raised here, with a fixed message
     ResolutionDetectionError,
+    DNSResolutionError,
+    StreamUserAgentError,
 )
 
 
@@ -104,7 +96,7 @@ def operator_safe_detail(exc: BaseException) -> Optional[str]:
     caller must log the exception CLASS only.
     """
     if type(exc) in OPERATOR_SAFE_EXCEPTION_TYPES:
-        return str(exc).strip() or None
+        return "".join(char if char.isprintable() else " " for char in str(exc)).strip() or None
     return None
 
 
@@ -1119,7 +1111,8 @@ class StreamProber:
         }
 
     async def probe_stream(
-        self, stream_id: int, url: Optional[str], name: Optional[str] = None
+        self, stream_id: int, url: Optional[str], name: Optional[str] = None,
+        *, stream: Optional[dict] = None,
     ) -> dict:
         """
         Probe a single stream using ffprobe.
@@ -1134,12 +1127,13 @@ class StreamProber:
             )
 
         try:
+            user_agent = await StreamUserAgentResolver(self.client).resolve(stream, stream_id=stream_id)
             logger.debug("[STREAM-PROBE] Running ffprobe for stream %s", stream_id)
-            result = await self._run_ffprobe(url)
+            result = await self._run_ffprobe(url, user_agent=user_agent)
             logger.info("[STREAM-PROBE] Stream %s ffprobe succeeded", stream_id)
 
             if self.use_resdet_for_resolution:
-                width, height = await self._run_resdet(url)
+                width, height = await self._run_resdet(url, user_agent=user_agent)
                 for stream in result.get("streams", []):
                     if stream.get("codec_type") == "video":
                         stream["width"] = width
@@ -1148,7 +1142,7 @@ class StreamProber:
 
             # Measure actual bitrate by downloading stream data
             logger.debug("[STREAM-PROBE] Measuring bitrate for stream %s", stream_id)
-            measured_bitrate = await self._measure_stream_bitrate(url)
+            measured_bitrate = await self._measure_stream_bitrate(url, user_agent=user_agent)
 
             # Black screen detection (opt-in). `is_black` stays None when
             # detection is disabled OR when it returned indeterminate (timeout
@@ -1157,7 +1151,7 @@ class StreamProber:
             is_black: Optional[bool] = None
             if self.black_screen_detection_enabled:
                 logger.debug("[STREAM-PROBE] Running black screen detection for stream %s", stream_id)
-                is_black = await self._detect_black_screen(url)
+                is_black = await self._detect_black_screen(url, user_agent=user_agent)
 
             # Save probe result with both ffprobe metadata and measured bitrate
             saved = self._save_probe_result(
@@ -1209,9 +1203,11 @@ class StreamProber:
                 public_error = "Probe failed"
             return self._save_probe_result(stream_id, name, None, "failed", public_error)
 
-    async def _run_ffprobe(self, url: str, _retry_attempt: int = 0) -> dict:
+    async def _run_ffprobe(self, url: str, _retry_attempt: int = 0, *, user_agent: str | None = None) -> dict:
         """Run ffprobe and parse JSON output."""
-        headers = {"User-Agent": "VLC/3.0.20 LibVLC/3.0.20"}
+        if user_agent is None:
+            user_agent = await StreamUserAgentResolver(self.client).resolve()
+        headers = {"User-Agent": user_agent}
         async with validated_subprocess_input(
             url, headers=headers, scheme_downgrade=PROBE_SCHEME_DOWNGRADE
         ) as subprocess_input:
@@ -1271,7 +1267,7 @@ class StreamProber:
             if any(p in error_text for p in transient_patterns) and "404" not in error_text and _retry_attempt < self.probe_retry_count:
                 logger.info("[STREAM-PROBE] Transient provider error — retry %s/%s in %ss", _retry_attempt + 1, self.probe_retry_count, self.probe_retry_delay)
                 await asyncio.sleep(self.probe_retry_delay)
-                return await self._run_ffprobe(url, _retry_attempt=_retry_attempt + 1)
+                return await self._run_ffprobe(url, _retry_attempt=_retry_attempt + 1, user_agent=user_agent)
 
             if any(marker in error_text.lower() for marker in NETWORK_FAILURE_MARKERS):
                 raise ProbeNetworkRouteError("Provider connection failed")
@@ -1283,15 +1279,15 @@ class StreamProber:
 
         return json.loads(output)
 
-    async def _run_resdet(self, url: str) -> tuple[int, int]:
+    async def _run_resdet(self, url: str, *, user_agent: str | None = None) -> tuple[int, int]:
         """Serialize the complete native frame-extract and analysis pipeline."""
         try:
             async with ResdetPipelineLock(self._resdet_lock_path) as pipeline_lock:
-                return await self._run_resdet_pipeline(url, pipeline_lock.fileno())
+                return await self._run_resdet_pipeline(url, pipeline_lock.fileno(), user_agent=user_agent)
         except ResdetLockError:
             raise ResolutionDetectionError("resdet pipeline lock is unavailable") from None
 
-    async def _run_resdet_pipeline(self, url: str, lock_fd: int) -> tuple[int, int]:
+    async def _run_resdet_pipeline(self, url: str, lock_fd: int, *, user_agent: str | None = None) -> tuple[int, int]:
         """Decode one bounded Y4M frame, then analyze that local file with resdet."""
 
         async def kill_and_reap(process) -> None:
@@ -1324,7 +1320,9 @@ class StreamProber:
                 await kill_and_reap(process)
                 raise
 
-        headers = {"User-Agent": "VLC/3.0.20 LibVLC/3.0.20"}
+        if user_agent is None:
+            user_agent = await StreamUserAgentResolver(self.client).resolve()
+        headers = {"User-Agent": user_agent}
         with tempfile.TemporaryDirectory(prefix="ecm-resdet-") as directory:
             frame_path = Path(directory) / "frame.y4m"
             async with validated_subprocess_input(
@@ -1481,7 +1479,7 @@ class StreamProber:
         if required_size > RESDET_FRAME_MAX_BYTES or len(frame_data) != required_size:
             raise ResolutionDetectionError("resdet returned an invalid frame")
 
-    async def _measure_stream_bitrate(self, url: str) -> Optional[int]:
+    async def _measure_stream_bitrate(self, url: str, *, user_agent: str | None = None) -> Optional[int]:
         """
         Measure actual stream bitrate by downloading data for a few seconds.
         This is how Dispatcharr gets real bitrate - by measuring throughput.
@@ -1502,7 +1500,9 @@ class StreamProber:
                 pool=10.0
             )
 
-            headers = {"User-Agent": "VLC/3.0.20 LibVLC/3.0.20"}
+            if user_agent is None:
+                user_agent = await StreamUserAgentResolver(self.client).resolve()
+            headers = {"User-Agent": user_agent}
             async with stream_request(
                 url,
                 timeout=timeout,
@@ -1561,7 +1561,7 @@ class StreamProber:
     # Threshold of 20 catches: pure black, dark slates, off-air screens with small logos.
     BLACK_SCREEN_YAVG_THRESHOLD = 20
 
-    async def _detect_black_screen(self, url: str) -> Optional[bool]:
+    async def _detect_black_screen(self, url: str, *, user_agent: str | None = None, stream_id: int | None = None) -> Optional[bool]:
         """Detect dark/black screens by measuring average brightness (YAVG) via signalstats.
 
         Uses ffmpeg signalstats to compute per-frame average luma (YAVG).
@@ -1584,7 +1584,9 @@ class StreamProber:
         wait_for a generous grace window so cold-start false-timeouts don't
         flip streams to "clean".
         """
-        headers = {"User-Agent": "VLC/3.0.20 LibVLC/3.0.20"}
+        if user_agent is None:
+            user_agent = await StreamUserAgentResolver(self.client).resolve(stream_id=stream_id)
+        headers = {"User-Agent": user_agent}
         # Grace window: sample duration + ample headroom for cold-start
         # buffering, connection setup, and ffmpeg startup. The previous 15-s
         # grace was too tight for cold scans and caused every timeout to be
@@ -3025,7 +3027,7 @@ class StreamProber:
                             else:
                                 logger.debug("[STREAM-PROBE] Acquired semaphore: active=%s/%s, stream=%s", current_count, self.max_concurrent_probes, stream_id)
                         try:
-                            result = await self.probe_stream(stream_id, stream_url, stream_name)
+                            result = await self.probe_stream(stream_id, stream_url, stream_name, stream=stream)
                             probe_status = result.get("probe_status", "failed")
                             error_message = result.get("error_message", "")
                             stream_info = {"id": stream_id, "name": stream_name, "url": stream_url}
@@ -3407,7 +3409,7 @@ class StreamProber:
                             logger.debug("[STREAM-PROBE] Account %s: waiting %.1fs", m3u_account_id, hold_remaining)
                             await asyncio.sleep(hold_remaining)
 
-                    result = await self.probe_stream(stream_id, stream_url, stream_name)
+                    result = await self.probe_stream(stream_id, stream_url, stream_name, stream=stream)
 
                     # Track success/failure
                     probe_status = result.get("probe_status", "failed")
@@ -3600,7 +3602,7 @@ class StreamProber:
                     if self._probe_cancelled:
                         return
                     self._probe_progress_current_stream = stream_name
-                    result = await self.probe_stream(stream_id, stream_url, stream_name)
+                    result = await self.probe_stream(stream_id, stream_url, stream_name, stream=stream)
                     probe_status = result.get("probe_status", "failed")
                     error_message = result.get("error_message", "")
                     stream_info = {"id": stream_id, "name": stream_name, "url": stream_url}

--- a/backend/stream_user_agent.py
+++ b/backend/stream_user_agent.py
@@ -1,0 +1,141 @@
+"""Provider-facing User-Agent selection for direct previews and ECM probes.
+
+Upstream contract and fixture provenance: docs/dispatcharr_api.md, Stream User-Agent.
+"""
+
+import asyncio
+import logging
+import re
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+StreamUserAgent = Literal["dispatcharr", "chrome", "firefox", "safari", "vlc", "tivimate"]
+
+# Version-labelled compatibility presets, not a promise of browser currency.
+USER_AGENT_PRESETS = {
+    "chrome": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36",
+    "firefox": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0",
+    "safari": "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15",
+    "vlc": "VLC/3.0.20 LibVLC/3.0.20",
+    "tivimate": "TiviMate/5.1.6 (Android 12)",
+}
+UNKNOWN_VERSION_USER_AGENT = "Dispatcharr/unknown"
+_VERSION_RE = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+._a-zA-Z0-9]*)")
+
+
+class StreamUserAgentError(RuntimeError):
+    """Configuration could not be resolved; messages contain only fixed safe text."""
+
+
+def validate_user_agent(value: str) -> str:
+    """Accept a bounded printable ASCII header, rejecting injection and bad config.
+
+    Raises:
+        StreamUserAgentError: Empty, oversized, non-ASCII or control-containing value.
+    """
+    if (
+        not isinstance(value, str) or not value.strip() or len(value) > 512
+        or any(ord(char) < 32 or ord(char) > 126 for char in value)
+    ):
+        raise StreamUserAgentError("Dispatcharr User-Agent configuration is malformed")
+    return value.strip()
+
+
+class StreamUserAgentResolver:
+    """Lazy configuration snapshot, owned by one operation or explicit batch.
+
+    Args:
+        client: Connected Dispatcharr client.
+        selection: Persisted preset key. None reads the current ECM setting.
+    """
+
+    def __init__(self, client, selection: StreamUserAgent | None = None):
+        if selection is None:
+            from config import get_settings
+            selection = get_settings().stream_user_agent
+        self.client = client
+        self.selection = selection
+        self._cache = {}
+        self._lock = asyncio.Lock()
+
+    async def _read(self, key, method, *args):
+        async with self._lock:
+            if key not in self._cache:
+                try:
+                    # Existing client methods can otherwise pass timeout=None.
+                    self._cache[key] = await asyncio.wait_for(method(*args), timeout=10)
+                except Exception:
+                    logger.warning("[STREAM-UA] Dispatcharr configuration fetch failed (%s)", key[0])
+                    raise StreamUserAgentError("Could not load Dispatcharr User-Agent configuration") from None
+            return self._cache[key]
+
+    async def _agent(self, agent_id):
+        if agent_id in (None, ""):
+            return None
+        if isinstance(agent_id, str) and agent_id.isascii() and agent_id.isdecimal() and len(agent_id) <= 20:
+            agent_id = int(agent_id)
+        if type(agent_id) is not int:
+            raise StreamUserAgentError("Dispatcharr User-Agent reference is malformed")
+        rows = await self._read(("user-agents",), self.client.get_user_agents)
+        if not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows):
+            raise StreamUserAgentError("Dispatcharr User-Agent response is malformed")
+        for row in rows:
+            if row.get("id") == agent_id:
+                value = row.get("user_agent")
+                # Upstream falls through on an empty UA; is_active is not consulted.
+                return validate_user_agent(value) if value not in (None, "") else None
+        return None
+
+    async def resolve(self, stream: dict | None = None, *, stream_id: int | None = None) -> str:
+        """Resolve override, account, global default, then Dispatcharr/version.
+
+        Raises:
+            StreamUserAgentError: Required configuration failed or is malformed.
+        """
+        if self.selection in USER_AGENT_PRESETS:
+            return USER_AGENT_PRESETS[self.selection]
+        if self.selection != "dispatcharr":
+            raise StreamUserAgentError("ECM stream User-Agent selection is invalid")
+        if stream is None and stream_id is not None:
+            stream = await self._read(("stream", stream_id), self.client.get_stream, stream_id)
+            if stream is None:
+                raise StreamUserAgentError("Dispatcharr stream is unavailable for User-Agent resolution")
+        if stream is not None and not isinstance(stream, dict):
+            raise StreamUserAgentError("Dispatcharr stream response is malformed")
+        account_id = (stream or {}).get("m3u_account")
+        if account_id is not None:
+            if type(account_id) is not int:
+                raise StreamUserAgentError("Dispatcharr M3U account reference is malformed")
+            account = await self._read(("account", account_id), self.client.get_m3u_account, account_id)
+            if not isinstance(account, dict):
+                raise StreamUserAgentError("Dispatcharr M3U account response is malformed")
+            value = await self._agent(account.get("user_agent"))
+            if value is not None:
+                return value
+
+        rows = await self._read(("core-settings",), self.client.get_core_settings)
+        if not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows):
+            raise StreamUserAgentError("Dispatcharr core settings response is malformed")
+        for row in rows:
+            if row.get("key") == "stream_settings":
+                settings = row.get("value")
+                if not isinstance(settings, dict):
+                    raise StreamUserAgentError("Dispatcharr stream settings are malformed")
+                value = await self._agent(settings.get("default_user_agent"))
+                if value is not None:
+                    return value
+                break
+
+        if "fallback" not in self._cache:
+            try:
+                metadata = await self.client.get_version(timeout=5, retry_on_401=False)
+                version = metadata.get("version") if isinstance(metadata, dict) else None
+            except Exception:
+                version = None
+            if isinstance(version, str) and len(version) <= 64 and _VERSION_RE.fullmatch(version):
+                self._cache["fallback"] = f"Dispatcharr/{version}"
+            else:
+                logger.warning("[STREAM-UA] Dispatcharr version unavailable; using Dispatcharr/unknown")
+                self._cache["fallback"] = UNKNOWN_VERSION_USER_AGENT
+        return self._cache["fallback"]

--- a/backend/tasks/black_screen_scan.py
+++ b/backend/tasks/black_screen_scan.py
@@ -199,7 +199,7 @@ class BlackScreenScanTask(TaskScheduler):
                 if self._cancel_requested:
                     return
                 try:
-                    is_black = await self._prober._detect_black_screen(url)
+                    is_black = await self._prober._detect_black_screen(url, stream_id=stream_id)
 
                     # None = indeterminate (ffmpeg timed out or returned no
                     # YAVG samples). Count as an error and leave the existing
@@ -229,9 +229,11 @@ class BlackScreenScanTask(TaskScheduler):
                         else:
                             clear_count += 1
                 except Exception as e:
+                    from stream_prober import operator_safe_detail
+                    detail = operator_safe_detail(e) or "Black screen detection failed"
                     error_count += 1
-                    error_streams.append({"id": stream_id, "name": name, "error": str(e)})
-                    logger.warning("[%s] Black screen check failed for stream %s: %s", self.task_id, stream_id, e)
+                    error_streams.append({"id": stream_id, "name": name, "error": detail})
+                    logger.warning("[%s] Black screen check failed for stream %s: %s", self.task_id, stream_id, detail)
                 finally:
                     completed += 1
                     self._set_progress(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -158,6 +158,13 @@ def test_engine():
     engine.dispose()
 
 
+@pytest.fixture
+def vlc_stream_user_agent(monkeypatch):
+    """Legacy probe tests select VLC explicitly; UA resolution has its own coverage."""
+    from config import get_settings
+    monkeypatch.setattr(get_settings(), "stream_user_agent", "vlc")
+
+
 @pytest.fixture(scope="function")
 def test_session(test_engine):
     """Create a test database session."""

--- a/backend/tests/integration/test_api_stream_preview.py
+++ b/backend/tests/integration/test_api_stream_preview.py
@@ -9,8 +9,13 @@ from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
+import httpx
 
 import config
+from routers.stream_preview import PREVIEW_TIMEOUT
+from security.ssrf import SchemeDowngrade
+from security import stream_outbound
+from stream_user_agent import USER_AGENT_PRESETS
 
 
 @asynccontextmanager
@@ -65,7 +70,7 @@ class TestStreamPreview:
 
         with patch("routers.stream_preview.get_client", return_value=mock_client):
             with patch("routers.stream_preview.get_settings") as mock_settings:
-                mock_settings.return_value = MagicMock(stream_preview_mode="passthrough")
+                mock_settings.return_value = MagicMock(stream_preview_mode="passthrough", stream_user_agent="vlc")
                 response = await async_client.get("/api/stream-preview/9999")
                 assert response.status_code == 404
                 assert "Stream not found" in response.json()["detail"]
@@ -78,7 +83,7 @@ class TestStreamPreview:
 
         with patch("routers.stream_preview.get_client", return_value=mock_client):
             with patch("routers.stream_preview.get_settings") as mock_settings:
-                mock_settings.return_value = MagicMock(stream_preview_mode="passthrough")
+                mock_settings.return_value = MagicMock(stream_preview_mode="passthrough", stream_user_agent="vlc")
                 response = await async_client.get("/api/stream-preview/1")
                 assert response.status_code == 404
                 assert "no URL" in response.json()["detail"]
@@ -113,7 +118,7 @@ class TestStreamPreview:
 
         with patch("routers.stream_preview.get_client", return_value=mock_client):
             with patch("routers.stream_preview.get_settings") as mock_settings:
-                mock_settings.return_value = MagicMock(stream_preview_mode="passthrough")
+                mock_settings.return_value = MagicMock(stream_preview_mode="passthrough", stream_user_agent="vlc")
 
                 calls = []
 
@@ -123,19 +128,15 @@ class TestStreamPreview:
                     mock_response.raise_for_status = MagicMock()
                     yield mock_response
 
-                prepared = MagicMock()
-                with patch(
-                    "routers.stream_preview.prepare_stream_http_url",
-                    return_value=prepared,
-                ), \
-                     patch("routers.stream_preview.stream_request", mock_stream_request):
+                with patch("routers.stream_preview.stream_request", mock_stream_request):
                     response = await async_client.get("/api/stream-preview/1")
                     # The endpoint returns a StreamingResponse with video/mp2t content type
                     assert response.status_code == 200
                     assert response.headers.get("content-type") == "video/mp2t"
                     assert calls == [((provider_url,), {
-                        "timeout": None,
-                        "initial_target": prepared,
+                        "timeout": PREVIEW_TIMEOUT,
+                        "headers": {"User-Agent": "VLC/3.0.20 LibVLC/3.0.20"},
+                        "scheme_downgrade": SchemeDowngrade.ALLOW_STREAM_PREVIEW,
                     })]
 
     @pytest.mark.asyncio
@@ -146,7 +147,7 @@ class TestStreamPreview:
 
         with patch("routers.stream_preview.get_client", return_value=mock_client):
             with patch("routers.stream_preview.get_settings") as mock_settings:
-                mock_settings.return_value = MagicMock(stream_preview_mode="transcode")
+                mock_settings.return_value = MagicMock(stream_preview_mode="transcode", stream_user_agent="vlc")
 
                 with patch("routers.stream_preview.validated_subprocess_input", _allowed_direct_input), \
                      patch("subprocess.Popen", side_effect=FileNotFoundError("ffmpeg not found")):
@@ -240,12 +241,7 @@ class TestChannelPreview:
                     calls.append((args, kwargs))
                     yield mock_response
 
-                prepared = MagicMock()
-                with patch(
-                    "routers.stream_preview.prepare_stream_http_url",
-                    return_value=prepared,
-                ), \
-                     patch("routers.stream_preview.stream_request", mock_stream_request):
+                with patch("routers.stream_preview.stream_request", mock_stream_request):
                     response = await async_client.get("/api/channel-preview/1")
                     # The endpoint returns a StreamingResponse with video/mp2t content type
                     assert response.status_code == 200
@@ -253,9 +249,9 @@ class TestChannelPreview:
                     assert calls == [(
                         ("http://localhost:5656/proxy/ts/stream/test-uuid-123",),
                         {
-                            "timeout": None,
+                            "timeout": PREVIEW_TIMEOUT,
                             "headers": {"Authorization": "Bearer test-jwt-token"},
-                            "initial_target": prepared,
+                            "scheme_downgrade": SchemeDowngrade.REFUSE,
                         },
                     )]
 
@@ -304,6 +300,44 @@ class TestChannelPreview:
 
 class TestStreamPreviewModeSettings:
     """Tests for stream_preview_mode in settings."""
+
+    @pytest.mark.asyncio
+    async def test_shared_user_agent_persists_and_rejects_custom_values(self, async_client, isolated_settings_file):
+        client = AsyncMock()
+        client.get_stream.return_value = {"id": 42, "url": "http://93.184.216.34/live.ts", "m3u_account": None}
+        client.get_core_settings.return_value = []
+        client.get_version.return_value = {"version": "0.30.0"}
+        provider_headers = []
+
+        async def provider(request):
+            provider_headers.append(request.headers["User-Agent"])
+            return httpx.Response(200, content=b"provider-media", request=request)
+
+        transport_class = stream_outbound.SSRFPinnedTransport
+        for selection in ("dispatcharr", "chrome", "firefox", "safari", "vlc", "tivimate"):
+            response = await async_client.post("/api/settings", json={
+                "url": "http://dispatcharr.example:5656", "auth_method": "password",
+                "username": "admin", "password": "test-password", "stream_user_agent": selection,
+            })
+            assert response.status_code == 200
+            config.clear_settings_cache()
+            assert (await async_client.get("/api/settings")).json()["stream_user_agent"] == selection
+            # Real settings POST/file reload -> real preview/relay transport ->
+            # provider-facing request. Only the remote provider is a test double.
+            with patch("routers.stream_preview.get_client", return_value=client), patch.object(
+                stream_outbound, "SSRFPinnedTransport", side_effect=lambda **kwargs: transport_class(
+                    inner_factory=lambda: httpx.MockTransport(provider), **kwargs
+                )
+            ):
+                preview = await async_client.get("/api/stream-preview/42")
+            assert preview.status_code == 200
+            assert preview.content == b"provider-media"
+            assert provider_headers[-1] == USER_AGENT_PRESETS.get(selection, "Dispatcharr/0.30.0")
+        assert len(provider_headers) == 6
+        client.get_core_settings.assert_awaited_once()
+        response = await async_client.post("/api/settings", json={"stream_user_agent": "custom\r\nInjected"})
+        assert response.status_code == 422
+        assert (await async_client.get("/api/settings")).json()["stream_user_agent"] == "tivimate"
 
     @pytest.mark.asyncio
     async def test_get_settings_includes_stream_preview_mode(self, async_client):

--- a/backend/tests/routers/test_gi4zn_standard_artifact_full_redaction.py
+++ b/backend/tests/routers/test_gi4zn_standard_artifact_full_redaction.py
@@ -1551,6 +1551,9 @@ def test_no_credential_shaped_settings_field_is_left_unredacted():
         "auth_method",
         "user_timezone",
         "user_username_cache_ttl",
+        # Fixed preset key enforced by config's StreamUserAgent Literal,
+        # not a raw User-Agent header or credential.
+        "stream_user_agent",
         # Addresses, not credentials — the operator needs them to reconnect, and
         # any credential embedded in one is removed by the URL scrub.
         "url",

--- a/backend/tests/routers/test_media_connection_safe_errors.py
+++ b/backend/tests/routers/test_media_connection_safe_errors.py
@@ -147,13 +147,13 @@ async def test_url_rejection_is_safe_before_client_construction(
 async def test_host_diagnostics_are_server_only_and_redacted(
     async_client, caplog, name, client_type, unresolved, value,
 ):
-    from security.ssrf import SSRFError
+    from security.ssrf import DNSResolutionError, SSRFError
 
     caplog.set_level(logging.INFO)
     detail = ("Could not resolve host " if unresolved else "Denied host ") + value + " " + DETAIL
     client = AsyncMock()
     with (
-        patch("security.ssrf.validate_outbound_url", side_effect=SSRFError(detail)),
+        patch("security.ssrf.validate_outbound_url", side_effect=DNSResolutionError() if unresolved else SSRFError(detail)),
         patch(f"routers.settings.{client_type.__name__}", return_value=client) as constructor,
     ):
         response = await async_client.post(
@@ -167,7 +167,7 @@ async def test_host_diagnostics_are_server_only_and_redacted(
     else:
         constructor.assert_not_called()
     assert "synthetic diagnostic" not in response.text
-    assert "synthetic diagnostic" in caplog.text
+    assert ("DNS resolution failed" if unresolved else "synthetic diagnostic") in caplog.text
     for sensitive in (value, SECRET, "url-user", "url-pass", "path-user", "path-pass"):
         assert sensitive not in caplog.text
     records = [record for record in caplog.records if record.name == "routers.settings"]

--- a/backend/tests/routers/test_preview_startup.py
+++ b/backend/tests/routers/test_preview_startup.py
@@ -1,0 +1,310 @@
+"""GH995: provider headers, startup failures and single-connection ownership."""
+
+import asyncio
+from contextlib import asynccontextmanager
+import os
+import signal
+import subprocess
+import sys
+import traceback
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import anyio
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from routers import stream_preview as preview
+from security import stream_outbound
+from security.ssrf import DNSResolutionError, SSRFError
+
+
+@pytest.mark.asyncio
+async def test_passthrough_opens_once_before_return_and_closes_on_disconnect():
+    opened = []
+    closed = []
+
+    @asynccontextmanager
+    async def upstream(url, **kwargs):
+        opened.append(kwargs)
+        try:
+            yield httpx.Response(200, content=b"media", request=httpx.Request("GET", url))
+        finally:
+            closed.append(True)
+
+    client = AsyncMock()
+    client.get_stream.return_value = {"id": 1, "url": "https://provider.example/live.ts"}
+    with patch.object(preview, "get_client", return_value=client), patch.object(
+        preview, "get_settings", return_value=SimpleNamespace(
+            stream_preview_mode="passthrough", stream_user_agent="tivimate"
+        )
+    ), patch.object(preview, "stream_request", upstream):
+        response = await preview.stream_preview(1)
+        assert len(opened) == 1, "Upstream must open before downstream headers"
+        assert opened[0]["headers"]["User-Agent"] == "TiviMate/5.1.6 (Android 12)"
+        assert not closed
+        assert await anext(response.body_iterator) == b"media"
+        await response.body_iterator.aclose()
+    assert closed == [True]
+    client.get_core_settings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure,status", [
+    (SSRFError("secret-url\r\n"), 403),
+    (DNSResolutionError(), 502),
+    (httpx.ConnectError("https://user:password@provider.example/private"), 502),
+    (httpx.ReadTimeout("https://user:password@provider.example/private"), 504),
+])
+async def test_passthrough_startup_failure_is_json_not_broken_200(failure, status):
+    @asynccontextmanager
+    async def upstream(*args, **kwargs):
+        raise failure
+        yield
+
+    client = AsyncMock()
+    client.get_stream.return_value = {"id": 1, "url": "http://93.184.216.34/live.ts"}
+    app = FastAPI()
+    app.include_router(preview.router)
+    with patch.object(preview, "get_client", return_value=client), patch.object(
+        preview, "get_settings", return_value=SimpleNamespace(
+            stream_preview_mode="passthrough", stream_user_agent="vlc"
+        )
+    ), patch.object(preview, "stream_request", upstream):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app), base_url="http://test") as api:
+            response = await api.get("/api/stream-preview/1")
+    assert response.status_code == status
+    assert "password" not in response.text
+    assert "secret-url" not in response.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["transcode", "video_only"])
+async def test_cancellation_during_relay_acquisition_closes_upstream(mode):
+    closed = []
+    relays = []
+    setup_ready = asyncio.Event()
+    cancelled = []
+    returned = []
+    real_setup = stream_outbound.web.AppRunner.setup
+    real_start = stream_outbound._LocalStreamRelay.start
+
+    @asynccontextmanager
+    async def upstream(*args, **kwargs):
+        try:
+            yield httpx.Response(200, request=httpx.Request("GET", "https://provider.example/live.ts"))
+        finally:
+            # A cancellation checkpoint proves that the unwind itself is shielded.
+            await anyio.sleep(0)
+            closed.append(True)
+
+    async def setup(runner):
+        await real_setup(runner)
+        setup_ready.set()
+        await asyncio.Event().wait()
+
+    async def start(relay):
+        relays.append(relay)
+        return await real_start(relay)
+
+    async def acquire():
+        try:
+            returned.append(await preview._preview_response(
+                "https://provider.example/live.ts", mode, {}, provider_media=True
+            ))
+        except asyncio.CancelledError:
+            cancelled.append(True)
+            raise
+
+    with patch.object(stream_outbound, "stream_request", upstream), patch.object(
+        stream_outbound.web.AppRunner, "setup", setup
+    ), patch.object(stream_outbound._LocalStreamRelay, "start", start), patch.object(
+        preview.subprocess, "Popen"
+    ) as spawn:
+        try:
+            with anyio.fail_after(5):
+                async with anyio.create_task_group() as group:
+                    group.start_soon(acquire)
+                    await setup_ready.wait()
+                    group.cancel_scope.cancel()
+            assert cancelled == [True]
+            assert not returned
+            spawn.assert_not_called()
+            assert closed == [True]
+            await relays[0].close()
+            assert closed == [True], "Cleanup is idempotent"
+        finally:
+            # Repair the old implementation's leak when proving this test red.
+            for relay in relays:
+                await relay.close()
+
+
+@pytest.mark.asyncio
+async def test_relay_runner_cleanup_failure_still_closes_upstream_once():
+    closed = []
+
+    @asynccontextmanager
+    async def upstream(*args, **kwargs):
+        try:
+            yield httpx.Response(200, request=httpx.Request("GET", "https://provider.example/live.ts"))
+        finally:
+            await anyio.sleep(0)
+            closed.append(True)
+
+    relay = stream_outbound._LocalStreamRelay("https://provider.example/live.ts", {}, 5)
+    with patch.object(stream_outbound, "stream_request", upstream):
+        await relay.start()
+        real_cleanup = relay._runner.cleanup
+
+        async def failed_cleanup():
+            await real_cleanup()
+            raise RuntimeError("runner cleanup failed")
+
+        try:
+            with patch.object(stream_outbound.web.AppRunner, "cleanup", side_effect=failed_cleanup) as cleanup:
+                with pytest.raises(RuntimeError, match="runner cleanup failed"):
+                    await relay.close()
+                assert closed == [True]
+                await relay.close()
+                cleanup.assert_awaited_once()
+                assert closed == [True]
+        finally:
+            await relay.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", [httpx.ReadError, httpx.ReadTimeout])
+async def test_late_passthrough_failure_aborts_with_safe_diagnostic(error_type, caplog):
+    closed = []
+    secret = "late-private-token-995"
+
+    class BrokenBody(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b"x" * 65536
+            raise error_type(f"https://user:password@provider.example/{secret}?auth=secret")
+
+        async def aclose(self):
+            closed.append(True)
+
+    @asynccontextmanager
+    async def upstream(*args, **kwargs):
+        response = httpx.Response(200, stream=BrokenBody(), request=httpx.Request("GET", "https://provider.example/live.ts"))
+        try:
+            yield response
+        finally:
+            await response.aclose()
+
+    messages = []
+
+    async def send(message):
+        messages.append(message)
+
+    with patch.object(preview, "stream_request", upstream):
+        response = await preview._preview_response("https://provider.example/live.ts", "passthrough", {})
+        with pytest.raises(RuntimeError, match="Upstream preview stream failed") as error:
+            await response({"type": "http", "asgi": {"spec_version": "2.4"}}, None, send)
+    assert messages[0]["status"] == 200
+    assert messages[1]["body"] == b"x" * 65536
+    assert not any(message.get("more_body") is False for message in messages)
+    assert closed == [True]
+    assert f"[PREVIEW] Upstream streaming failed ({error_type.__name__})" in caplog.text
+    rendered_error = "".join(traceback.format_exception(error.value))
+    assert secret not in caplog.text + rendered_error
+    assert "password" not in caplog.text + rendered_error
+
+
+@pytest.fixture
+def real_preview_child():
+    """A real pipe/process lifecycle with no FFmpeg or external provider needed."""
+    children = []
+    closed = []
+    real_popen = subprocess.Popen
+
+    @asynccontextmanager
+    async def upstream(*args, **kwargs):
+        try:
+            yield stream_outbound.ValidatedSubprocessInput("udp://127.0.0.1:1")
+        finally:
+            closed.append(True)
+
+    def launch(script):
+        def spawn(command, **kwargs):
+            child = real_popen([sys.executable, "-u", "-c", script], **kwargs)
+            children.append(child)
+            return child
+
+        return spawn
+
+    with patch.object(preview, "validated_subprocess_input", upstream):
+        yield launch, children, closed
+    for child in children:
+        if child.poll() is None:
+            child.kill()
+        child.wait(timeout=5)
+
+
+def assert_reaped(child):
+    assert child.returncode is not None
+    assert child.stdout.closed
+    with pytest.raises(ChildProcessError):
+        os.waitpid(child.pid, os.WNOHANG)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["transcode", "video_only"])
+@pytest.mark.parametrize("returncode", [0, 7])
+async def test_decoder_completion_is_awaited_and_failure_is_diagnosed(
+    mode, returncode, real_preview_child, caplog
+):
+    launch, children, closed = real_preview_child
+    messages = []
+
+    async def send(message):
+        messages.append(message)
+
+    script = f'import sys; sys.stderr.write("private-decoder-token-995\\n"); sys.exit({returncode})'
+    with patch.object(preview.subprocess, "Popen", launch(script)):
+        response = await preview._preview_response("udp://127.0.0.1:1", mode, {})
+        call = response({"type": "http", "asgi": {"spec_version": "2.4"}}, None, send)
+        if returncode:
+            with pytest.raises(RuntimeError, match="Preview decoder failed"):
+                await asyncio.wait_for(call, 10)
+            assert "[PREVIEW] Decoder exited abnormally (returncode=7)" in caplog.text
+            assert not any(message.get("more_body") is False for message in messages)
+        else:
+            await asyncio.wait_for(call, 10)
+            assert not any(record.name == preview.__name__ for record in caplog.records)
+    assert messages[0]["status"] == 200
+    assert children[0].returncode == returncode
+    assert_reaped(children[0])
+    assert closed == [True]
+    assert "private-decoder-token-995" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stubborn", [False, True])
+async def test_decoder_disconnect_reaps_without_failure_warning(stubborn, real_preview_child, caplog):
+    launch, children, closed = real_preview_child
+    first_chunk = asyncio.Event()
+    script = 'import os,signal,time; '
+    if stubborn:
+        script += 'signal.signal(signal.SIGTERM, signal.SIG_IGN); '
+    script += 'os.write(1,b"x"*65536); time.sleep(60)'
+
+    async def send(message):
+        if message.get("body"):
+            first_chunk.set()
+
+    async def receive():
+        await first_chunk.wait()
+        return {"type": "http.disconnect"}
+
+    with patch.object(preview.subprocess, "Popen", launch(script)):
+        response = await preview._preview_response("udp://127.0.0.1:1", "transcode", {})
+        await asyncio.wait_for(response({"type": "http", "asgi": {"spec_version": "2.0"}}, receive, send), 12)
+    assert first_chunk.is_set()
+    assert children[0].returncode == -(signal.SIGKILL if stubborn else signal.SIGTERM)
+    assert_reaped(children[0])
+    assert closed == [True]
+    assert not any(record.name == preview.__name__ for record in caplog.records)

--- a/backend/tests/routers/test_settings.py
+++ b/backend/tests/routers/test_settings.py
@@ -105,6 +105,7 @@ def _mock_settings(**overrides):
         "telegram_bot_token": "",
         "telegram_chat_id": "",
         "stream_preview_mode": "passthrough",
+        "stream_user_agent": "dispatcharr",
         "auto_creation_excluded_terms": [],
         "auto_creation_excluded_groups": [],
         "auto_creation_exclude_auto_sync_groups": False,
@@ -150,6 +151,40 @@ def _mock_settings(**overrides):
     mock.is_discord_configured.return_value = False
     mock.is_telegram_configured.return_value = False
     return mock
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("selection", [None, "dispatcharr"])
+async def test_stream_user_agent_partial_post_preserves_or_explicitly_resets(selection, monkeypatch, tmp_path):
+    """GH995: exercise real settings persistence and reload, not a save mock."""
+    from fastapi import FastAPI
+    from routers import settings
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "settings.json")
+    monkeypatch.setattr(config, "MCP_SECRETS_DIR", tmp_path / "mcp")
+    monkeypatch.setattr(config, "MCP_KEY_FILE", tmp_path / "mcp" / "api-key")
+    (tmp_path / "mcp").mkdir(mode=0o700)
+    config.clear_settings_cache()
+    try:
+        config.save_settings(config.DispatcharrSettings(stream_user_agent="tivimate"))
+        config.clear_settings_cache()
+        assert config.get_settings().stream_user_agent == "tivimate"
+        app = FastAPI()
+        app.include_router(settings.router)
+        app.dependency_overrides[settings._resolve_settings_admin] = lambda: True
+        payload = {"url": "", "theme": "light"}
+        if selection is not None:
+            payload["stream_user_agent"] = selection
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app), base_url="http://test") as client:
+            response = await client.post("/api/settings", json=payload)
+        assert response.status_code == 200, response.text
+        config.clear_settings_cache()
+        reloaded = config.get_settings()
+        assert reloaded.theme == "light"
+        assert reloaded.stream_user_agent == (selection or "tivimate")
+    finally:
+        config.clear_settings_cache()
 
 
 class TestGetSettings:

--- a/backend/tests/routers/test_stream_preview.py
+++ b/backend/tests/routers/test_stream_preview.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from security.ssrf import SSRFError
-from routers.stream_preview import stream_generator
+from routers.stream_preview import PREVIEW_TIMEOUT, stream_generator
 
 
 class _DeniedInputContext:
@@ -74,7 +74,7 @@ class TestStreamPreview:
     @pytest.mark.asyncio
     async def test_returns_404_when_stream_not_found(self, async_client):
         """Returns 404 when stream doesn't exist."""
-        mock_settings = MagicMock()
+        mock_settings = MagicMock(stream_user_agent="vlc")
         mock_settings.stream_preview_mode = "passthrough"
 
         mock_client = AsyncMock()
@@ -89,7 +89,7 @@ class TestStreamPreview:
     @pytest.mark.asyncio
     async def test_returns_404_when_no_url(self, async_client):
         """Returns 404 when stream has no URL."""
-        mock_settings = MagicMock()
+        mock_settings = MagicMock(stream_user_agent="vlc")
         mock_settings.stream_preview_mode = "passthrough"
 
         mock_client = AsyncMock()
@@ -104,7 +104,7 @@ class TestStreamPreview:
     @pytest.mark.asyncio
     async def test_returns_503_when_no_client(self, async_client):
         """Returns 503 when not connected to Dispatcharr."""
-        mock_settings = MagicMock()
+        mock_settings = MagicMock(stream_user_agent="vlc")
         mock_settings.stream_preview_mode = "passthrough"
 
         with patch("routers.stream_preview.get_settings", return_value=mock_settings), \
@@ -116,7 +116,7 @@ class TestStreamPreview:
     @pytest.mark.asyncio
     async def test_rejects_invalid_mode(self, async_client):
         """Returns 400 for invalid preview mode."""
-        mock_settings = MagicMock()
+        mock_settings = MagicMock(stream_user_agent="vlc")
         mock_settings.stream_preview_mode = "invalid"
 
         mock_client = AsyncMock()
@@ -131,7 +131,7 @@ class TestStreamPreview:
     @pytest.mark.asyncio
     async def test_passthrough_returns_streaming(self, async_client):
         """Passthrough mode returns StreamingResponse."""
-        mock_settings = MagicMock()
+        mock_settings = MagicMock(stream_user_agent="vlc")
         mock_settings.stream_preview_mode = "passthrough"
 
         mock_client = AsyncMock()
@@ -139,19 +139,18 @@ class TestStreamPreview:
 
         with patch("routers.stream_preview.get_settings", return_value=mock_settings), \
              patch("routers.stream_preview.get_client", return_value=mock_client), \
-             patch("routers.stream_preview.prepare_stream_http_url"), \
              patch("routers.stream_preview.stream_request", _mock_stream_response):
             response = await async_client.get("/api/stream-preview/1")
 
-        # StreamingResponse returns 200 (the generator will fail on actual stream but headers are set)
         assert response.status_code == 200
+        assert response.content == b"mock stream data"
         assert response.headers.get("content-type") == "video/mp2t"
 
     @pytest.mark.asyncio
     async def test_passthrough_denied_destination_returns_403_before_streaming(
         self, async_client
     ):
-        mock_settings = MagicMock(stream_preview_mode="passthrough")
+        mock_settings = MagicMock(stream_preview_mode="passthrough", stream_user_agent="vlc")
         mock_client = AsyncMock()
         mock_client.get_stream.return_value = {
             "id": 1,
@@ -159,11 +158,7 @@ class TestStreamPreview:
         }
 
         with patch("routers.stream_preview.get_settings", return_value=mock_settings), \
-             patch("routers.stream_preview.get_client", return_value=mock_client), \
-             patch(
-                 "routers.stream_preview.prepare_stream_http_url",
-                 side_effect=SSRFError("denied"),
-             ):
+             patch("routers.stream_preview.get_client", return_value=mock_client):
             response = await async_client.get("/api/stream-preview/1")
 
         assert response.status_code == 403
@@ -172,7 +167,7 @@ class TestStreamPreview:
     @pytest.mark.asyncio
     async def test_transcode_ffmpeg_not_found(self, async_client):
         """Returns 500 when FFmpeg is not installed (transcode mode)."""
-        mock_settings = MagicMock()
+        mock_settings = MagicMock(stream_user_agent="vlc")
         mock_settings.stream_preview_mode = "transcode"
 
         mock_client = AsyncMock()
@@ -190,7 +185,7 @@ class TestStreamPreview:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("mode", ["transcode", "video_only"])
     async def test_ffmpeg_modes_deny_before_spawn(self, async_client, mode):
-        mock_settings = MagicMock(stream_preview_mode=mode)
+        mock_settings = MagicMock(stream_preview_mode=mode, stream_user_agent="vlc")
         mock_client = AsyncMock()
         mock_client.get_stream.return_value = {
             "id": 1,
@@ -317,6 +312,7 @@ class TestChannelPreview:
         validate.assert_called_once_with(
             "http://dispatcharr:8000/proxy/ts/stream/abc-123",
             headers={"Authorization": "Bearer synthetic-test-token"},
+            timeout=PREVIEW_TIMEOUT,
         )
         spawn.assert_not_called()
 

--- a/backend/tests/security/test_preview_console_logging.py
+++ b/backend/tests/security/test_preview_console_logging.py
@@ -1,0 +1,93 @@
+"""SEC-995-1: actual process logging setup must not emit provider URL tokens."""
+
+import asyncio
+from contextlib import redirect_stderr
+import io
+import ipaddress
+import json
+import logging
+import os
+from pathlib import Path
+import subprocess
+import sys
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+
+@pytest.mark.parametrize("log_level", ["startup", "INFO", "DEBUG"])
+@pytest.mark.parametrize("upstream_status", [200, 403])
+def test_allowed_preview_redirect_hides_url_from_actual_console(log_level, upstream_status, tmp_path):
+    (tmp_path / "mcp").mkdir(mode=0o700)
+    env = {
+        **os.environ,
+        "CONFIG_DIR": str(tmp_path),
+        "MCP_SECRETS_DIR": str(tmp_path / "mcp"),
+        "DATABASE_URL": "sqlite:///:memory:",
+        "LOG_LEVEL": "INFO",
+    }
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), log_level, str(upstream_status)],
+        env=env, capture_output=True, text=True, timeout=45,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    proof = json.loads(result.stdout)
+    assert proof == {"status": upstream_status, "hops": 2, "console_token_leaks": 0}
+
+
+async def console_proof(log_level, upstream_status):
+    # Import main once in a fresh process; no reloading or per-request logger changes.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    output = io.StringIO()
+    with redirect_stderr(output):
+        import main
+        from fastapi import HTTPException
+        from routers import stream_preview as preview
+        from security import stream_outbound
+
+        if log_level != "startup":
+            main.set_log_level(log_level)
+            main.install_observability(level=getattr(logging, log_level))
+
+        sentinels = ["private-portal-995", "private-edge-995", "private-query-995"]
+        edge_url = f"http://edge.example/{sentinels[1]}/serve?token={sentinels[2]}"
+        requests = []
+
+        async def provider(request):
+            requests.append(request)
+            if request.url.scheme == "https":
+                return httpx.Response(302, headers={"Location": edge_url}, request=request)
+            return httpx.Response(upstream_status, content=b"media", request=request)
+
+        transport_class = stream_outbound.SSRFPinnedTransport
+        with patch.object(stream_outbound, "SSRFPinnedTransport", side_effect=lambda **kwargs: transport_class(
+            inner_factory=lambda: httpx.MockTransport(provider), **kwargs
+        )), patch("security.ssrf._resolve", return_value=[ipaddress.ip_address("93.184.216.34")]):
+            try:
+                response = await preview._preview_response(
+                    f"https://portal.example/{sentinels[0]}/live.ts", "passthrough",
+                    {"User-Agent": "Provider/9"}, provider_media=True,
+                )
+            except HTTPException as exc:
+                assert upstream_status == 403
+                assert exc.status_code == 502
+                assert exc.detail == "Upstream stream returned HTTP 403"
+            else:
+                assert upstream_status == 200
+                assert b"".join([chunk async for chunk in response.body_iterator]) == b"media"
+
+        assert len(requests) == 2
+        assert requests[1].url.scheme == "http"
+        assert requests[1].url.path == f"/{sentinels[1]}/serve"
+        assert requests[1].url.params["token"] == sentinels[2]
+        console = output.getvalue()
+        assert not any(secret in console for secret in sentinels), console
+        if upstream_status == 403:
+            assert "[PREVIEW] Startup failed: Upstream stream returned HTTP 403" in console
+        assert any(getattr(handler, "_ecm_json_handler", False) for handler in logging.getLogger().handlers)
+    print(json.dumps({"status": upstream_status, "hops": len(requests), "console_token_leaks": 0}))
+
+
+if __name__ == "__main__":
+    asyncio.run(console_proof(sys.argv[1], int(sys.argv[2])))

--- a/backend/tests/security/test_preview_provider_policy.py
+++ b/backend/tests/security/test_preview_provider_policy.py
@@ -1,0 +1,140 @@
+"""GH995 provider-media policy across preview modes and later HLS resources."""
+
+import ipaddress
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException
+from starlette.requests import ClientDisconnect
+
+from routers import stream_preview as preview
+from security import stream_outbound
+from security.ssrf import DNSResolutionError, SchemeDowngrade
+
+
+@pytest.fixture
+def provider_transport():
+    requests = []
+    responses = []
+
+    async def handler(request):
+        requests.append(request)
+        if request.url.scheme == "https":
+            response = httpx.Response(302, headers={"Location": "http://edge.example/live.ts"}, request=request)
+        else:
+            response = httpx.Response(200, content=b"media", request=request)
+        responses.append(response)
+        return response
+
+    transport_class = stream_outbound.SSRFPinnedTransport
+    with patch.object(stream_outbound, "SSRFPinnedTransport", side_effect=lambda **kwargs: transport_class(
+        inner_factory=lambda: httpx.MockTransport(handler), **kwargs
+    )), patch("security.ssrf._resolve", return_value=[ipaddress.ip_address("93.184.216.34")]):
+        yield requests, responses
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["passthrough", "transcode", "video_only"])
+async def test_preview_mode_uses_provider_ua_through_downgrade(mode, provider_transport):
+    requests, responses = provider_transport
+    client = AsyncMock()
+    client.get_stream.return_value = {"url": "https://provider.example/live.ts"}
+    process = MagicMock()
+    process.stdout.read.return_value = b""
+    with patch.object(preview, "get_client", return_value=client), patch.object(preview, "get_settings", return_value=SimpleNamespace(
+        stream_preview_mode=mode, stream_user_agent="tivimate"
+    )), patch.object(preview.subprocess, "Popen", return_value=process):
+        response = await preview.stream_preview(42)
+        assert len(requests) == 2  # upstream ready before response is returned
+        assert {request.headers["User-Agent"] for request in requests} == {"TiviMate/5.1.6 (Android 12)"}
+        await response.resources.close()
+    assert all(response.is_closed for response in responses)
+    if mode != "passthrough":
+        process.terminate.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["passthrough", "transcode", "video_only"])
+async def test_disconnect_before_first_body_read_closes_opened_resources(mode, provider_transport):
+    requests, responses = provider_transport
+    client = AsyncMock()
+    client.get_stream.return_value = {"url": "https://provider.example/live.ts"}
+    process = MagicMock()
+    with patch.object(preview, "get_client", return_value=client), patch.object(preview, "get_settings", return_value=SimpleNamespace(
+        stream_preview_mode=mode, stream_user_agent="vlc"
+    )), patch.object(preview.subprocess, "Popen", return_value=process):
+        response = await preview.stream_preview(42)
+        with pytest.raises(ClientDisconnect):
+            await response({"type": "http", "asgi": {"spec_version": "2.4"}}, AsyncMock(), AsyncMock(side_effect=OSError("disconnected")))
+    assert len(requests) == 2
+    assert all(response.is_closed for response in responses)
+    process.stdout.read.assert_not_called()
+    if mode != "passthrough":
+        process.terminate.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["passthrough", "transcode", "video_only"])
+async def test_channel_proxy_refuses_downgrade_before_bearer_can_escape(mode, provider_transport):
+    requests, responses = provider_transport
+    client = AsyncMock(access_token="test-bearer")
+    client.get_channel.return_value = {"uuid": "channel"}
+    with patch.object(preview, "get_client", return_value=client), patch.object(preview, "get_settings", return_value=SimpleNamespace(
+        stream_preview_mode=mode, stream_user_agent="tivimate", url="https://dispatcharr.example"
+    )):
+        with pytest.raises(HTTPException) as error:
+            await preview.channel_preview(42)
+    assert error.value.status_code == 403
+    assert len(requests) == 1
+    assert requests[0].headers["Authorization"] == "Bearer test-bearer"
+    assert all(response.is_closed for response in responses)
+    client.get_user_agents.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["passthrough", "transcode", "video_only"])
+async def test_dns_failure_returns_502_in_every_mode(mode):
+    client = AsyncMock()
+    client.get_stream.return_value = {"url": "https://provider.example/live.ts"}
+    with patch.object(preview, "get_client", return_value=client), patch.object(preview, "get_settings", return_value=SimpleNamespace(
+        stream_preview_mode=mode, stream_user_agent="vlc"
+    )), patch("security.stream_outbound.validate_outbound_url", side_effect=DNSResolutionError()):
+        with pytest.raises(HTTPException) as error:
+            await preview.stream_preview(1)
+    assert error.value.status_code == 502
+    assert error.value.detail == "Stream DNS resolution failed from ECM"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("policy,status", [(SchemeDowngrade.ALLOW_STREAM_PREVIEW, 200), (SchemeDowngrade.REFUSE, 502)])
+async def test_later_hls_resource_keeps_ua_policy_and_strips_cross_origin_auth(policy, status):
+    requests = []
+
+    async def handler(request):
+        requests.append(request)
+        if request.url.path == "/root.m3u8":
+            return httpx.Response(200, content=b"#EXTM3U\nhttps://cdn.example/segment.ts\n", request=request)
+        if request.url.scheme == "https":
+            return httpx.Response(302, headers={"Location": "http://edge.example/segment.ts"}, request=request)
+        return httpx.Response(200, content=b"segment", request=request)
+
+    transport_class = stream_outbound.SSRFPinnedTransport
+    with patch.object(stream_outbound, "SSRFPinnedTransport", side_effect=lambda **kwargs: transport_class(
+        inner_factory=lambda: httpx.MockTransport(handler), **kwargs
+    )), patch("security.ssrf._resolve", return_value=[ipaddress.ip_address("93.184.216.34")]):
+        async with stream_outbound.validated_subprocess_input(
+            "https://provider.example/root.m3u8", headers={"User-Agent": "Provider/9", "Authorization": "Bearer local"},
+            scheme_downgrade=policy,
+        ) as source:
+            async with httpx.AsyncClient() as downstream:
+                manifest = await downstream.get(source.argument)
+                segment_url = manifest.text.splitlines()[1]
+                segment = await downstream.get(segment_url)
+                assert segment.status_code == status
+                if status == 200:
+                    assert segment.content == b"segment"
+    assert requests[0].headers["Authorization"] == "Bearer local"
+    assert all(request.headers["User-Agent"] == "Provider/9" for request in requests)
+    assert all("Authorization" not in request.headers for request in requests[1:])

--- a/backend/tests/security/test_probe_failure_diagnostics.py
+++ b/backend/tests/security/test_probe_failure_diagnostics.py
@@ -40,10 +40,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.usefixtures("vlc_stream_user_agent")
+
 from security import ssrf
 from security.ssrf import (
     MAX_REDIRECTS,
     SSRFError,
+    DNSResolutionError,
     SSRFMode,
     SchemeDowngrade,
     check_redirect_depth,
@@ -51,6 +54,7 @@ from security.ssrf import (
     validate_redirect,
 )
 from security.stream_outbound import _LocalStreamRelay, validate_stream_subprocess_url
+from stream_user_agent import StreamUserAgentError
 from stream_prober import (
     OPERATOR_SAFE_EXCEPTION_TYPES,
     PROBE_NETWORK_ROUTE_GUIDANCE,
@@ -126,6 +130,8 @@ class TestExceptionOriginClassification:
             SSRFError,
             ProbeNetworkRouteError,
             ResolutionDetectionError,
+            DNSResolutionError,
+            StreamUserAgentError,
         }
 
     def test_empty_message_reports_no_detail(self):

--- a/backend/tests/security/test_probe_scheme_downgrade.py
+++ b/backend/tests/security/test_probe_scheme_downgrade.py
@@ -1,4 +1,4 @@
-"""The scheme-downgrade waiver is scoped to the stream-probe path, and nowhere else.
+"""Provider-media downgrades are explicit; default outbound policy remains REFUSE.
 
 Bead ``enhancedchannelmanager-iyvl9``. A production incident: every probe against
 the operator's XC provider failed, because the provider 302s
@@ -10,7 +10,8 @@ confidentiality and cost the operator their entire probe capability.
 The acceptance criterion is an INVARIANT, not the reproduction above:
 
     The stream-probe path MAY follow an ``https -> http`` redirect.
-    EVERY other outbound path MUST still refuse one.
+    Direct provider previews may opt in with their own policy (GH995).
+    Other outbound paths, including the channel proxy, MUST still refuse one.
 
 Both halves are proven here on purpose. A test that only showed probes working
 again would pass just as happily if the downgrade guard had been deleted
@@ -177,7 +178,7 @@ class TestEveryOtherPathStillRefuses:
 
     @pytest.mark.asyncio
     async def test_stream_request_refuses_the_downgrade_by_default(self):
-        """A non-probe consumer (e.g. the browser preview router) still fails closed."""
+        """A caller without an explicit media policy still fails closed."""
 
         async def handler(request: httpx.Request):
             return httpx.Response(302, headers={"Location": EDGE_URL}, request=request)
@@ -244,10 +245,10 @@ class TestRefuseIsTheDefaultEverywhere:
         parameter = inspect.signature(validate_redirect).parameters["scheme_downgrade"]
         assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
 
-    def test_only_the_probe_member_waives_the_guard(self):
-        """Any policy value other than ALLOW_STREAM_PROBE must still refuse."""
+    def test_only_explicit_media_members_waive_the_guard(self):
+        """Provider preview was explicitly authorized in GH995; defaults still refuse."""
         for member in SchemeDowngrade:
-            if member is SchemeDowngrade.ALLOW_STREAM_PROBE:
+            if member in (SchemeDowngrade.ALLOW_STREAM_PROBE, SchemeDowngrade.ALLOW_STREAM_PREVIEW):
                 continue
             with _patch_dns(EDGE_IP):
                 with pytest.raises(SSRFError, match="downgrades"):
@@ -314,6 +315,15 @@ def test_only_sanctioned_modules_name_the_downgrade_waiver():
         "path genuinely needs the waiver, that is a product decision, not a "
         "refactor -- justify it and add the module here explicitly."
     )
+
+
+def test_only_preview_router_and_validator_name_preview_waiver():
+    found = {
+        str(relative) for relative, path in _production_modules()
+        if any(isinstance(node, ast.Attribute) and node.attr == "ALLOW_STREAM_PREVIEW"
+               for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")) ))
+    }
+    assert found == {"security/ssrf.py", "routers/stream_preview.py"}
 
 
 def test_prober_names_the_waiver_once_and_reuses_it():

--- a/backend/tests/security/test_stream_dns_retry.py
+++ b/backend/tests/security/test_stream_dns_retry.py
@@ -1,0 +1,65 @@
+"""Transient resolver recovery must retain reject-if-any-address-denied."""
+
+import ipaddress
+import socket
+import threading
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from security.ssrf import DNSResolutionError, SSRFError, SSRFMode
+from security.stream_outbound import SSRFPinnedTransport
+
+
+@pytest.mark.asyncio
+async def test_transient_dns_retries_off_loop_then_pins_the_validated_address():
+    thread_ids = []
+    answers = iter([socket.gaierror(socket.EAI_AGAIN, "temporary"), [ipaddress.ip_address("93.184.216.34")]])
+
+    def resolve(*args):
+        thread_ids.append(threading.get_ident())
+        result = next(answers)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    inner = AsyncMock()
+    inner.handle_async_request.return_value = httpx.Response(200)
+    transport = SSRFPinnedTransport(inner=inner, mode=SSRFMode.PUBLIC_ONLY)
+    with patch("security.ssrf._resolve", side_effect=resolve):
+        response = await transport.handle_async_request(httpx.Request("GET", "https://provider.example/live.ts"))
+    assert response.status_code == 200
+    assert len(thread_ids) == 2
+    assert threading.get_ident() not in thread_ids
+    assert inner.handle_async_request.await_args.args[0].url.host == "93.184.216.34"
+
+
+@pytest.mark.asyncio
+async def test_retry_does_not_cherry_pick_a_public_address():
+    inner = AsyncMock()
+    transport = SSRFPinnedTransport(inner=inner, mode=SSRFMode.PUBLIC_ONLY)
+    with patch("security.ssrf._resolve", side_effect=[
+        socket.gaierror(socket.EAI_AGAIN, "temporary"),
+        [ipaddress.ip_address("93.184.216.34"), ipaddress.ip_address("169.254.169.254")],
+    ]) as resolve:
+        with pytest.raises(SSRFError):
+            await transport.handle_async_request(httpx.Request("GET", "https://provider.example/live.ts"))
+    assert resolve.call_count == 2
+    inner.handle_async_request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error,count", [
+    (socket.gaierror(socket.EAI_AGAIN, "transient"), 3),
+    (socket.gaierror(socket.EAI_NONAME, "permanent"), 1),
+    (OSError("arbitrary failure"), 1),
+])
+async def test_dns_failure_is_bounded_and_typed(error, count):
+    inner = AsyncMock()
+    transport = SSRFPinnedTransport(inner=inner, mode=SSRFMode.PUBLIC_ONLY)
+    with patch("security.ssrf._resolve", side_effect=error) as resolve:
+        with pytest.raises(DNSResolutionError):
+            await transport.handle_async_request(httpx.Request("GET", "https://provider.example/live.ts"))
+    assert resolve.call_count == count
+    inner.handle_async_request.assert_not_awaited()

--- a/backend/tests/unit/test_black_screen_detection.py
+++ b/backend/tests/unit/test_black_screen_detection.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
+pytestmark = pytest.mark.usefixtures("vlc_stream_user_agent")
+
 from models import StreamStats
 from stream_prober import StreamProber, smart_sort_streams
 

--- a/backend/tests/unit/test_low_bitrate.py
+++ b/backend/tests/unit/test_low_bitrate.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+pytestmark = pytest.mark.usefixtures("vlc_stream_user_agent")
 from pydantic import ValidationError
 from sqlalchemy.orm import sessionmaker
 

--- a/backend/tests/unit/test_prober_user_agent.py
+++ b/backend/tests/unit/test_prober_user_agent.py
@@ -1,0 +1,94 @@
+"""Shared selection reaches provider HTTP requests in every probe path."""
+
+import asyncio
+import ipaddress
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from config import get_settings
+from security import stream_outbound
+from stream_prober import StreamProber
+
+
+@pytest.mark.asyncio
+async def test_full_probe_and_retry_send_account_ua_at_provider_boundary(tmp_path, monkeypatch):
+    monkeypatch.setattr(get_settings(), "stream_user_agent", "dispatcharr")
+    client = AsyncMock()
+    client.get_stream.return_value = {"m3u_account": 8, "stream_profile_id": 999}
+    client.get_m3u_account.return_value = {"user_agent": 2}
+    client.get_user_agents.return_value = [{"id": 2, "user_agent": "Account/7", "is_active": False}]
+    prober = StreamProber(client, use_resdet_for_resolution=True, black_screen_detection_enabled=True,
+                          _resdet_lock_path=tmp_path / "resdet.lock")
+    prober.probe_retry_delay = 0
+    prober._save_probe_result = MagicMock(return_value={"probe_status": "success"})
+    prober._push_stats_to_dispatcharr = AsyncMock()
+    seen = []
+    responses = []
+
+    async def handler(request):
+        seen.append(request)
+        response = httpx.Response(200, content=b"media", request=request)
+        responses.append(response)
+        return response
+
+    attempts = 0
+
+    async def spawn(*cmd, **kwargs):
+        nonlocal attempts
+        process = MagicMock(returncode=0)
+        process.wait = AsyncMock(return_value=0)
+        if cmd[0] == "ffprobe":
+            attempts += 1
+            if attempts == 1:
+                process.returncode = 1
+                output, error = b"", b"Connection reset"
+            else:
+                output, error = json.dumps({"streams": [{"codec_type": "video"}]}).encode(), b""
+        elif "-frames:v" in cmd:
+            output, error = b"YUV4MPEG2 W2 H2 F25:1 Ip A1:1 C420jpeg\nFRAME\n" + b"\x10" * 6, b""
+        elif "/usr/local/bin/resdet" in cmd:
+            output, error = b"2 2", b""
+        else:
+            output, error = b"", b"lavfi.signalstats.YAVG=16"
+        process.communicate = AsyncMock(return_value=(output, error))
+        process.stdout = asyncio.StreamReader()
+        process.stdout.feed_data(output)
+        process.stdout.feed_eof()
+        return process
+
+    transport_class = stream_outbound.SSRFPinnedTransport
+    with patch.object(stream_outbound, "SSRFPinnedTransport", side_effect=lambda **kwargs: transport_class(
+        inner_factory=lambda: httpx.MockTransport(handler), **kwargs
+    )), patch("security.ssrf._resolve", return_value=[ipaddress.ip_address("93.184.216.34")]), patch(
+        "stream_prober.asyncio.create_subprocess_exec", side_effect=spawn
+    ):
+        result = await prober.probe_stream(42, "https://provider.example/live.ts")
+
+    assert result == {"probe_status": "success"}
+    assert len(seen) == 5  # ffprobe twice, resdet frame, bitrate, blackscreen
+    assert {request.headers["User-Agent"] for request in seen} == {"Account/7"}
+    assert {request.url.host for request in seen} == {"93.184.216.34"}
+    assert all(response.is_closed for response in responses)
+    client.get_stream.assert_awaited_once_with(42)
+    client.get_m3u_account.assert_awaited_once_with(8)
+    client.get_user_agents.assert_awaited_once()
+    client.get_core_settings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_standalone_blackscreen_resolves_the_stream_account(monkeypatch):
+    monkeypatch.setattr(get_settings(), "stream_user_agent", "dispatcharr")
+    client = AsyncMock()
+    client.get_stream.return_value = {"m3u_account": 11}
+    client.get_m3u_account.return_value = {"user_agent": 4}
+    client.get_user_agents.return_value = [{"id": 4, "user_agent": "Standalone/4"}]
+    prober = StreamProber(client)
+    # Stop at the outbound boundary, after resolving the standalone stream.
+    with patch("stream_prober.validated_subprocess_input", side_effect=RuntimeError("boundary")) as outbound:
+        with pytest.raises(RuntimeError, match="boundary"):
+            await prober._detect_black_screen("https://provider.example/live.ts", stream_id=52)
+    assert outbound.call_args.kwargs["headers"] == {"User-Agent": "Standalone/4"}
+    client.get_stream.assert_awaited_once_with(52)

--- a/backend/tests/unit/test_stream_probe_reorder_option.py
+++ b/backend/tests/unit/test_stream_probe_reorder_option.py
@@ -104,6 +104,7 @@ async def test_scheduled_probe_reorder_choice_is_invocation_local_and_group_scop
     ids=["default-follows-global", "disabled", "does-not-force-global"],
 )
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("vlc_stream_user_agent")
 async def test_probe_all_reorder_gate_preserves_metadata_and_channel_order(
     test_engine,
     monkeypatch,

--- a/backend/tests/unit/test_stream_prober_bulk.py
+++ b/backend/tests/unit/test_stream_prober_bulk.py
@@ -12,6 +12,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+pytestmark = pytest.mark.usefixtures("vlc_stream_user_agent")
 import stream_prober as stream_prober_module
 
 from stream_prober import StreamProber
@@ -239,7 +241,7 @@ async def test_bulk_run_populates_results_envelope():
         12: {"stream_id": 12, "probe_status": "timeout", "error_message": "timed out"},
     }
 
-    async def fake_probe_stream(sid, url, name):
+    async def fake_probe_stream(sid, url, name, **_kwargs):
         return outcomes[sid]
 
     with patch.object(prober, "_fetch_all_streams", AsyncMock(return_value=streams)), \
@@ -302,7 +304,7 @@ async def test_bulk_run_honors_auto_reorder_setting():
 
     streams = [{"id": 10, "url": "http://example.com/10", "name": "Stream 10"}]
 
-    async def fake_probe_stream(sid, url, name):
+    async def fake_probe_stream(sid, url, name, **_kwargs):
         return {"stream_id": sid, "probe_status": "success"}
 
     reorder_mock = AsyncMock(return_value=[{"channel_id": 1, "channel_name": "Ch", "stream_count": 2}])
@@ -323,7 +325,7 @@ async def test_bulk_run_skips_reorder_when_setting_off():
 
     streams = [{"id": 10, "url": "http://example.com/10", "name": "Stream 10"}]
 
-    async def fake_probe_stream(sid, url, name):
+    async def fake_probe_stream(sid, url, name, **_kwargs):
         return {"stream_id": sid, "probe_status": "success"}
 
     reorder_mock = AsyncMock()
@@ -554,7 +556,7 @@ async def test_bulk_run_counts_missing_streams_as_failed():
 
     streams = [{"id": 10, "url": "http://example.com/10", "name": "Stream 10"}]
 
-    async def fake_probe_stream(sid, url, name):
+    async def fake_probe_stream(sid, url, name, **_kwargs):
         return {"stream_id": sid, "probe_status": "success"}
 
     with patch.object(prober, "_fetch_all_streams", AsyncMock(return_value=streams)), \

--- a/backend/tests/unit/test_stream_prober_network_route.py
+++ b/backend/tests/unit/test_stream_prober_network_route.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.usefixtures("vlc_stream_user_agent")
+
 from stream_prober import (
     PROBE_NETWORK_ROUTE_GUIDANCE,
     ProbeNetworkRouteError,

--- a/backend/tests/unit/test_stream_prober_protocol_whitelist.py
+++ b/backend/tests/unit/test_stream_prober_protocol_whitelist.py
@@ -21,6 +21,8 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
+pytestmark = pytest.mark.usefixtures("vlc_stream_user_agent")
+
 from stream_prober import FFPROBE_PROTOCOL_WHITELIST, StreamProber
 
 

--- a/backend/tests/unit/test_stream_prober_resdet.py
+++ b/backend/tests/unit/test_stream_prober_resdet.py
@@ -10,6 +10,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import stream_prober as stream_prober_module
 
+pytestmark = pytest.mark.usefixtures("vlc_stream_user_agent")
+
 from config import DispatcharrSettings
 from stream_prober import (
     RELAY_PROTOCOL_WHITELIST,
@@ -83,7 +85,7 @@ async def test_enabled_probe_replaces_only_ffprobe_video_dimensions():
 
     await prober.probe_stream(7, "https://provider.example/live.ts", "Test")
 
-    prober._run_resdet.assert_awaited_once_with("https://provider.example/live.ts")
+    prober._run_resdet.assert_awaited_once_with("https://provider.example/live.ts", user_agent="VLC/3.0.20 LibVLC/3.0.20")
     saved_ffprobe_data = prober._save_probe_result.call_args.args[2]
     video = saved_ffprobe_data["streams"][0]
     assert (video["width"], video["height"]) == (1280, 720)
@@ -395,7 +397,7 @@ async def test_resdet_pipelines_are_serialized_across_stream_probers(tmp_path):
     active = 0
     maximum = 0
 
-    async def pipeline(_url, _lock_fd):
+    async def pipeline(_url, _lock_fd, **_kwargs):
         nonlocal active, maximum
         active += 1
         maximum = max(maximum, active)
@@ -424,7 +426,7 @@ async def test_cancelling_a_resdet_lock_waiter_does_not_disturb_the_owner(tmp_pa
     release_owner = asyncio.Event()
     calls = 0
 
-    async def pipeline(_url, _lock_fd):
+    async def pipeline(_url, _lock_fd, **_kwargs):
         nonlocal calls
         calls += 1
         owner_entered.set()
@@ -455,7 +457,7 @@ async def test_cancelling_a_stale_resdet_owner_releases_the_replacement(tmp_path
     owner_entered = asyncio.Event()
     calls = 0
 
-    async def pipeline(_url, _lock_fd):
+    async def pipeline(_url, _lock_fd, **_kwargs):
         nonlocal calls
         calls += 1
         if calls == 1:

--- a/backend/tests/unit/test_stream_prober_ssrf.py
+++ b/backend/tests/unit/test_stream_prober_ssrf.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+pytestmark = pytest.mark.usefixtures("vlc_stream_user_agent")
+
 from security.ssrf import SSRFError, SSRFMode, ResolvedTarget
 from security.stream_outbound import SSRFPinnedTransport, validate_stream_subprocess_url
 from security.stream_outbound import validated_subprocess_input as real_subprocess_input

--- a/backend/tests/unit/test_stream_user_agent.py
+++ b/backend/tests/unit/test_stream_user_agent.py
@@ -1,0 +1,167 @@
+"""Dispatcharr's recorded API envelopes plus source-derived UA resolution cases.
+
+Nested settings values below are synthetic test inputs, NOT recorded live data.
+The old recorded settings fixture explicitly redacts value; it cannot prove the
+default_user_agent contract. Sources are pinned in docs/dispatcharr_api.md.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from stream_user_agent import (
+    USER_AGENT_PRESETS, StreamUserAgentError, StreamUserAgentResolver, validate_user_agent,
+)
+
+FIXTURES = Path(__file__).parents[1] / "fixtures"
+
+
+def recorded(name):
+    return json.loads((FIXTURES / name).read_text())
+
+
+def client():
+    result = AsyncMock()
+    result.get_core_settings.return_value = []
+    result.get_user_agents.return_value = []
+    result.get_version.return_value = {"version": "0.30.0", "timestamp": None}
+    return result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("selection", list(USER_AGENT_PRESETS))
+async def test_override_needs_no_dispatcharr_configuration_reads(selection):
+    upstream = client()
+    result = await StreamUserAgentResolver(upstream, selection).resolve(stream_id=42)
+    assert result == USER_AGENT_PRESETS[selection]
+    assert not upstream.mock_calls
+
+
+@pytest.mark.asyncio
+async def test_recorded_stream_integer_account_reference_and_null_account_ua():
+    upstream = client()
+    stream = recorded("dispatcharr_stream_provider_channel_number.json")
+    account = recorded("bd_g8tyd/dispatcharr_v0282_m3u_account_server_group.json")
+    # Independent recorded captures; exercise their shapes, not cross-instance IDs.
+    upstream.get_m3u_account.return_value = account
+    result = await StreamUserAgentResolver(upstream, "dispatcharr").resolve(stream)
+    assert result == "Dispatcharr/0.30.0"
+    upstream.get_m3u_account.assert_awaited_once_with(stream["m3u_account"])
+    upstream.get_user_agents.assert_not_awaited()
+    upstream.get_stream_profiles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_account_ua_short_circuits_global_and_ignores_is_active_and_stream_profile():
+    upstream = client()
+    upstream.get_m3u_account.return_value = {"user_agent": 9}
+    upstream.get_user_agents.return_value = [{"id": 9, "user_agent": "Provider/1.0", "is_active": False}]
+    resolver = StreamUserAgentResolver(upstream, "dispatcharr")
+    assert await resolver.resolve({"m3u_account": 1, "stream_profile_id": 42}) == "Provider/1.0"
+    assert await resolver.resolve({"m3u_account": 1}) == "Provider/1.0"
+    upstream.get_m3u_account.assert_awaited_once_with(1)
+    upstream.get_core_settings.assert_not_awaited()
+    upstream.get_version.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("account_value", [None, "", "Account/1.0"])
+async def test_global_default_in_recorded_list_envelope_with_source_derived_values(account_value):
+    upstream = client()
+    rows = recorded("dispatcharr_core_settings_recorded.json")["core_settings_list"]
+    # Only this value is replaced with a SOURCE-DERIVED synthetic case.
+    next(row for row in rows if row["key"] == "stream_settings")["value"] = {"default_user_agent": 8}
+    upstream.get_core_settings.return_value = rows
+    upstream.get_m3u_account.return_value = {"user_agent": 9}
+    upstream.get_user_agents.return_value = [
+        {"id": 8, "user_agent": "Global/2.0"}, {"id": 9, "user_agent": account_value},
+    ]
+    assert await StreamUserAgentResolver(upstream, "dispatcharr").resolve({"m3u_account": 1}) == (account_value or "Global/2.0")
+    upstream.get_version.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fresh_operation_observes_configuration_changes():
+    upstream = client()
+    upstream.get_core_settings.return_value = [{"key": "stream_settings", "value": {"default_user_agent": 1}}]
+    upstream.get_user_agents.side_effect = [[{"id": 1, "user_agent": "Old/1"}], [{"id": 1, "user_agent": "New/2"}]]
+    assert await StreamUserAgentResolver(upstream, "dispatcharr").resolve() == "Old/1"
+    assert await StreamUserAgentResolver(upstream, "dispatcharr").resolve() == "New/2"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("version", [None, {}, {"version": "v-secret\r\nInjected"}, {"version": "x" * 5000}])
+async def test_unknown_version_fallback_is_explicit_and_log_safe(version, caplog):
+    upstream = client()
+    upstream.get_version.return_value = version
+    assert await StreamUserAgentResolver(upstream, "dispatcharr").resolve() == "Dispatcharr/unknown"
+    assert "version unavailable" in caplog.text
+    assert "Injected" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_version_endpoint_failure_uses_documented_fallback(caplog):
+    upstream = client()
+    upstream.get_version.side_effect = RuntimeError("private credentials")
+    assert await StreamUserAgentResolver(upstream, "dispatcharr").resolve() == "Dispatcharr/unknown"
+    assert "private credentials" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_missing_stream_metadata_does_not_silently_choose_a_global_identity():
+    upstream = client()
+    upstream.get_stream.return_value = None
+    with pytest.raises(StreamUserAgentError, match="stream is unavailable"):
+        await StreamUserAgentResolver(upstream, "dispatcharr").resolve(stream_id=42)
+    upstream.get_core_settings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reference", [None, "", 99, "99"])
+async def test_absent_or_deleted_global_agent_uses_version_fallback(reference):
+    upstream = client()
+    upstream.get_core_settings.return_value = [{"key": "stream_settings", "value": {"default_user_agent": reference}}]
+    assert await StreamUserAgentResolver(upstream, "dispatcharr").resolve() == "Dispatcharr/0.30.0"
+
+
+@pytest.mark.asyncio
+async def test_malformed_account_header_is_rejected_instead_of_global_fallback():
+    upstream = client()
+    upstream.get_m3u_account.return_value = {"user_agent": 4}
+    upstream.get_user_agents.return_value = [{"id": 4, "user_agent": "UA\r\nAuthorization: stolen"}]
+    with pytest.raises(StreamUserAgentError, match="configuration is malformed"):
+        await StreamUserAgentResolver(upstream, "dispatcharr").resolve({"m3u_account": 1})
+    upstream.get_core_settings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method,stream", [
+    ("get_core_settings", {}), ("get_m3u_account", {"m3u_account": 1}),
+    ("get_user_agents", {"m3u_account": 1}), ("get_stream", None),
+])
+async def test_configuration_fetch_failure_is_not_optional_absence(method, stream, caplog):
+    upstream = client()
+    upstream.get_m3u_account.return_value = {"user_agent": 1}
+    getattr(upstream, method).side_effect = RuntimeError("https://secret:password@host\r\nInjected")
+    with pytest.raises(StreamUserAgentError, match="Could not load"):
+        await StreamUserAgentResolver(upstream, "dispatcharr").resolve(stream, stream_id=42)
+    upstream.get_version.assert_not_awaited()
+    assert "password" not in caplog.text
+    assert "Injected" not in caplog.text
+
+
+@pytest.mark.parametrize("value", ["UA\r\nAuthorization: stolen", "UA\x00", "UA\t", "UA\x7f", "é", "", " " * 2, "a" * 513, 123])
+def test_unsafe_header_values_are_rejected_without_echo(value):
+    with pytest.raises(StreamUserAgentError) as error:
+        validate_user_agent(value)
+    assert str(error.value) == "Dispatcharr User-Agent configuration is malformed"
+
+
+@pytest.mark.asyncio
+async def test_redacted_recording_is_not_mistaken_for_absent_configuration():
+    upstream = client()
+    upstream.get_core_settings.return_value = recorded("dispatcharr_core_settings_recorded.json")["core_settings_list"]
+    with pytest.raises(StreamUserAgentError, match="stream settings are malformed"):
+        await StreamUserAgentResolver(upstream, "dispatcharr").resolve()

--- a/docs/dispatcharr_api.md
+++ b/docs/dispatcharr_api.md
@@ -213,3 +213,40 @@ full refresh ~200 requests/2h). Do not wrap these in retry/polling loops.
 
 After adding a lineup, Dispatcharr fetches station metadata so channels can be
 matched before the next full schedule pull.
+## Stream User-Agent
+
+ECM's `stream_user_agent=dispatcharr` resolution follows the normal live proxy:
+stream `m3u_account` integer/null → account `user_agent` integer/null → nonempty
+core UserAgent `user_agent` string. If the account has none, select the core
+settings row with `key=stream_settings`, then `value.default_user_agent`, and
+resolve that ID against the bare UserAgent array. `is_active` is not a filter.
+Core StreamProfile UA is not consulted on normal live playback; M3U connection
+profiles and core StreamProfiles are different resources.
+
+Verified source at Dispatcharr v0.30.0 commit
+`cd3f6c509d74ad7618d870e5673476928d528de9`:
+
+- [Live URL resolution, lines 61-143](https://github.com/Dispatcharr/Dispatcharr/blob/cd3f6c509d74ad7618d870e5673476928d528de9/apps/proxy/live_proxy/url_utils.py#L61-L143)
+- [Account UA, lines 117-139](https://github.com/Dispatcharr/Dispatcharr/blob/cd3f6c509d74ad7618d870e5673476928d528de9/apps/m3u/models.py#L117-L139)
+- [Global default, lines 424-470](https://github.com/Dispatcharr/Dispatcharr/blob/cd3f6c509d74ad7618d870e5673476928d528de9/core/models.py#L424-L470)
+- [Version fallback, lines 25-28](https://github.com/Dispatcharr/Dispatcharr/blob/cd3f6c509d74ad7618d870e5673476928d528de9/core/utils.py#L25-L28)
+- [Corrected TiviMate seed](https://github.com/Dispatcharr/Dispatcharr/blob/cd3f6c509d74ad7618d870e5673476928d528de9/core/migrations/0011_fix_stream_profiles_and_user_agents.py)
+
+Fixture-backed tests use `dispatcharr_stream_provider_channel_number.json` and
+`bd_g8tyd/dispatcharr_v0282_m3u_account_server_group.json` for recorded stream and
+account shapes. `dispatcharr_core_settings_recorded.json` proves the bare array
+of `{id,key,name,value}` rows only: its values were replaced during sanitization.
+Tests explicitly label nested `default_user_agent` and UserAgent records as
+source-derived synthetic cases, not new live captures.
+
+Absent/empty/unresolved optional UA records fall through. Required configuration
+fetch errors or malformed response/header values stop the operation with a safe
+diagnostic. Configuration reads are bounded and cached only within one resolver
+operation, never globally. Overrides perform no UA configuration reads. Probe
+substeps and transient ffprobe retries reuse the same resolved string.
+
+Without a configured UA, ECM uses `Dispatcharr/{version}` from the existing
+`GET /api/core/version/` metadata endpoint. If metadata is unavailable or invalid,
+it explicitly logs and sends `Dispatcharr/unknown`. This is ECM's compatibility
+fallback, not a claim of exact equivalence with an unknown Dispatcharr release
+(older releases such as 0.28.2 could fail when the global default was missing).

--- a/docs/security/stream_outbound_ssrf.md
+++ b/docs/security/stream_outbound_ssrf.md
@@ -15,20 +15,39 @@ Dispatcharr installations continue to work.
 
 ## Redirect scheme downgrades
 
-Redirect re-validation refuses an `https` → `http` downgrade on every outbound
-path except stream probing, where it is allowed. Providers commonly answer
+Redirect re-validation refuses an `https` → `http` downgrade by default.
+Provider-media probes and direct stream previews explicitly permit it. Providers commonly answer
 `https://<portal>/live/<user>/<pass>/<id>.ts` with a 302 onto a plain-HTTP edge
-node and serve the media over HTTP there in any case, so the hop is already
-unencrypted and the redirect target's opaque-token path carries no credentials.
-Refusing it therefore protected nothing and instead failed every probe against
-such a provider.
+node. That hop is unencrypted. This compatibility policy does not guarantee
+that a provider's redirect URL contains no credentials.
 
-The waiver is scoped to the probe path (ffprobe metadata, bitrate measurement,
-black-screen detection) and covers the scheme downgrade only. The denylist,
+The waivers are scoped to probing (ffprobe metadata, resdet, bitrate measurement,
+black-screen detection) and direct stream previews, and cover only the scheme downgrade. The denylist,
 resolve-once connection pinning, per-hop re-validation, redirect chain cap, and
-cross-origin credential stripping all still apply to probes. Stream preview,
-EPG fetches, cloud backup targets, and sync targets keep the refusal. Each
+cross-origin credential stripping still apply. Authenticated Dispatcharr channel
+previews, EPG fetches, cloud backup targets, and sync targets keep refusal. Each
 downgrade that is followed is logged.
+
+These boundaries are exercised by `test_probe_scheme_downgrade.py` and
+`test_preview_provider_policy.py` under `backend/tests/security/`, including
+later HLS resources and the channel proxy's bearer header.
+
+## DNS and preview startup
+
+The stream adapter runs DNS validation in worker threads, with at most two retries
+on transient `EAI_AGAIN` only (100 ms then 200 ms). Permanent errors, empty answers,
+and denied addresses fail closed. The shared synchronous validator still performs
+one lookup per invocation. A successful lookup validates every answer and pins the
+connection without a second provider DNS lookup. `test_stream_dns_retry.py` covers
+the retry bounds, off-event-loop resolution, and mixed-answer refusal.
+
+Previews open the same upstream response they will consume before sending browser
+headers. Policy refusal is HTTP 403, DNS/connect/UA configuration failure is 502,
+upstream HTTP rejection is 502 with its status code, and upstream timeout is 504.
+Messages omit provider URLs, headers and raw client exceptions. Preview startup
+uses a 10-second connect timeout and 30-second I/O timeout (not a viewing limit).
+Disconnect cleanup closes responses/relays and terminates/reaps FFmpeg, including
+disconnects before the first body read. See `test_preview_startup.py`.
 
 ## FFmpeg and ffprobe boundary
 

--- a/docs/user_guide/settings/appearance.md
+++ b/docs/user_guide/settings/appearance.md
@@ -79,6 +79,39 @@ setup for Windows, a shell script that creates a `.desktop` file for
 on macOS. Download the one matching your OS and run it once; after that,
 `vlc://` links open VLC directly.
 
+### Set the User-Agent for direct previews and probes
+
+Under **Settings → Appearance → Stream Preview**, choose **Stream User-Agent**
+and click **Save Settings**. One selection applies to new direct stream previews
+and ECM probes: metadata, bitrate, resdet resolution, and black screen scans.
+An in-progress probe keeps its selected identity through its substeps and retries.
+
+- **Use Dispatcharr User-Agent (Default)**: use the stream's M3U account UA,
+  then Dispatcharr's global default. Core StreamProfile UA is not part of normal
+  live playback resolution.
+- **Chrome**, **Firefox**, **Safari**, **VLC**, **TiviMate**: send a fixed
+  compatibility identity instead. These presets represent Chrome 132,
+  Firefox 135, Safari 17.6, VLC/LibVLC 3.0.20, and TiviMate 5.1.6 on Android 12;
+  they are not claims to be the latest browser/player releases.
+
+Without either Dispatcharr UA setting, ECM uses `Dispatcharr/{version}` when
+version metadata is available, otherwise logs and sends `Dispatcharr/unknown`.
+Failed configuration reads and malformed UA headers produce a safe error rather
+than silently switching identities. This fallback is an ECM compatibility choice
+for missing metadata, not exact equivalence to every Dispatcharr release.
+
+**Channel previews** use Dispatcharr's TS proxy. Dispatcharr controls that proxy's
+provider UA; this ECM selector cannot override it. Non-HTTP transports have no
+HTTP User-Agent header. Changing this setting also does not give ECM Dispatcharr's
+VPN/network route. If preview returns a DNS or connection error, check connectivity
+from the ECM host/container.
+
+If playback stops after it starts, check ECM's `[PREVIEW]` warnings for an
+upstream streaming failure or an abnormal decoder exit code. These failures
+abort playback; they cannot replace already-sent HTTP headers with a JSON error.
+Normal viewer disconnects do not produce decoder-failure warnings. HTTPX request
+URL logs stay suppressed even at DEBUG level to protect provider path/query tokens.
+
 ### Clear old toast notifications
 
 1. Go to **Settings → Appearance**.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0031",
+  "version": "0.18.2-0032",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/tabs/SettingsTab.streamUserAgent.test.tsx
+++ b/frontend/src/components/tabs/SettingsTab.streamUserAgent.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { expect, it, vi } from 'vitest';
+import { SettingsTab } from './SettingsTab';
+import * as api from '../../services/api';
+
+vi.mock('../../hooks/useAuth', () => ({ useAuth: () => ({ user: { is_admin: true } }) }));
+vi.mock('../../contexts/NotificationContext', () => ({ useNotifications: () => ({
+  success: vi.fn(), error: vi.fn(), notify: vi.fn(), dismiss: vi.fn(),
+}) }));
+vi.mock('../../services/api', async (importOriginal) => ({
+  ...await importOriginal<typeof api>(),
+  getSettings: vi.fn(async () => ({
+    url: 'http://dispatcharr.example', username: 'admin',
+    stream_user_agent: 'dispatcharr', stream_sort_priority: [], stream_sort_enabled: {},
+    show_stream_urls: true, hide_auto_sync_groups: false, hide_ungrouped_streams: false,
+    auto_rename_channel_number: false, include_channel_number_in_name: false,
+    remove_country_prefix: false, include_country_in_name: false,
+    channel_number_separator: ' - ', country_separator: ' | ', timezone_preference: 'UTC',
+  })),
+  getProbeHistory: vi.fn(async () => []),
+  getProbeProgress: vi.fn(async () => ({ in_progress: false })),
+  getM3UAccounts: vi.fn(async () => []),
+  getChannelProfiles: vi.fn(async () => []),
+  listAlertMethods: vi.fn(async () => []),
+  saveSettings: vi.fn(async () => ({ status: 'ok' })),
+}));
+
+it('loads the shared default and saves an override through the existing Settings action', async () => {
+  render(<SettingsTab onSaved={vi.fn()} initialSettingsPage="appearance" />);
+  const selector = await screen.findByRole('button', { name: 'Stream User-Agent' });
+  expect(selector).toHaveTextContent('Use Dispatcharr User-Agent (Default)');
+  fireEvent.click(selector);
+  expect(screen.getAllByRole('option').map(option => option.textContent?.replace('check', '').trim())).toEqual([
+    'Use Dispatcharr User-Agent (Default)', 'Chrome', 'Firefox', 'Safari', 'VLC', 'TiviMate',
+  ]);
+  fireEvent.click(screen.getByRole('option', { name: 'TiviMate' }));
+  fireEvent.click(screen.getByRole('button', { name: /Save Settings/i }));
+  await waitFor(() => expect(api.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ stream_user_agent: 'tivimate' })));
+  expect(selector).toHaveTextContent('TiviMate');
+});

--- a/frontend/src/components/tabs/SettingsTab.tsx
+++ b/frontend/src/components/tabs/SettingsTab.tsx
@@ -3,6 +3,7 @@ import * as api from '../../services/api';
 import * as channelPipelineApi from '../../services/channelPipelineApi';
 import { useNotifications } from '../../contexts/NotificationContext';
 import type { Theme, ProbeHistoryEntry, SortCriterion, SortEnabledMap, FailedStreamCategory, GracenoteConflictMode, StreamPreviewMode, StreamSortStrategy, StreamSortPointCriterion, StreamSortPointOperator, StreamSortPointRule } from '../../services/api';
+import type { StreamUserAgent } from '../../services/api';
 import { NormalizationEngineSection } from '../settings/NormalizationEngineSection';
 import { MappedChannels } from '../MappedChannels';
 import { TagEngineSection } from '../settings/TagEngineSection';
@@ -692,6 +693,7 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
   const [dateFormat, setDateFormat] = useState<DateFormatPref>('auto');
   const [vlcOpenBehavior, setVlcOpenBehavior] = useState<'protocol_only' | 'm3u_fallback' | 'm3u_only'>('m3u_fallback');
   const [streamPreviewMode, setStreamPreviewMode] = useState<StreamPreviewMode>('passthrough');
+  const [streamUserAgent, setStreamUserAgent] = useState<StreamUserAgent>('dispatcharr');
 
   // Stats settings
   const [statsPollInterval, setStatsPollInterval] = useState(10);
@@ -930,7 +932,7 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
     dedupM3uToastSuppressed, embyEnabled, embyBaseUrl, embyApiKey, plexEnabled,
     plexBaseUrl, plexToken, jellyfinEnabled, jellyfinBaseUrl, jellyfinApiKey,
     trustedMediaNetworks, statsPollInterval, userTimezone, backendLogLevel,
-    frontendLogLevel, vlcOpenBehavior, streamPreviewMode, channelPipelineExcludedTerms,
+    frontendLogLevel, vlcOpenBehavior, streamPreviewMode, streamUserAgent, channelPipelineExcludedTerms,
     channelPipelineExcludedGroups, channelPipelineExcludeAutoSyncGroups,
     maxAutoCreatedChannelsPerRun, maxChannelPipelineLogEntries, linkedM3UAccounts,
     streamProbeTimeout, useResdetForResolution, bitrateSampleDuration, parallelProbingEnabled,
@@ -1206,6 +1208,7 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
       const vlcBehavior = settings.vlc_open_behavior as 'protocol_only' | 'm3u_fallback' | 'm3u_only';
       setVlcOpenBehavior(vlcBehavior || 'm3u_fallback');
       setStreamPreviewMode(settings.stream_preview_mode || 'passthrough');
+      setStreamUserAgent(settings.stream_user_agent || 'dispatcharr');
       setChannelPipelineExcludedTerms(settings.auto_creation_excluded_terms ?? []);
       setChannelPipelineExcludedGroups(settings.auto_creation_excluded_groups ?? []);
       setChannelPipelineExcludeAutoSyncGroups(settings.auto_creation_exclude_auto_sync_groups ?? false);
@@ -1728,6 +1731,7 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
         frontend_log_level: frontendLogLevel,
         vlc_open_behavior: vlcOpenBehavior,
         stream_preview_mode: streamPreviewMode,
+        stream_user_agent: streamUserAgent,
         auto_creation_excluded_terms: channelPipelineExcludedTerms,
         auto_creation_excluded_groups: channelPipelineExcludedGroups,
         auto_creation_exclude_auto_sync_groups: channelPipelineExcludeAutoSyncGroups,
@@ -2908,6 +2912,30 @@ export function SettingsTab({ onSaved, onThemeChange, channelProfiles = [], onPr
             AC-3 or E-AC-3 audio codecs which aren't supported by Chrome. Use "Transcode"
             for best compatibility, or "Video Only" for quick visual previews without audio.
             Transcoding requires FFmpeg on the backend and uses more CPU.
+          </p>
+        </div>
+        <div className="form-group">
+          <label htmlFor="streamUserAgent">Stream User-Agent</label>
+          <CustomSelect
+            id="streamUserAgent"
+            ariaLabel="Stream User-Agent"
+            value={streamUserAgent}
+            onChange={(value) => setStreamUserAgent(value as StreamUserAgent)}
+            options={[
+              { value: 'dispatcharr', label: 'Use Dispatcharr User-Agent (Default)' },
+              { value: 'chrome', label: 'Chrome' },
+              { value: 'firefox', label: 'Firefox' },
+              { value: 'safari', label: 'Safari' },
+              { value: 'vlc', label: 'VLC' },
+              { value: 'tivimate', label: 'TiviMate' },
+            ]}
+          />
+          <p className="form-hint">
+            Shared by direct stream previews and all ECM probes, including bitrate,
+            resolution and black screen scans. Default uses the Dispatcharr M3U account
+            User-Agent, then its global default. Presets use fixed browser/player versions
+            for compatibility. Channel previews use Dispatcharr's proxy, which controls its own
+            provider User-Agent. Save Settings to apply to new previews and probes.
           </p>
         </div>
       </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1219,6 +1219,7 @@ export interface SettingsResponse {
   telegram_chat_id: string;
   // Stream preview mode: "passthrough", "transcode", or "video_only"
   stream_preview_mode: StreamPreviewMode;
+  stream_user_agent?: StreamUserAgent;
   // Auto-creation pipeline exclusion settings
   auto_creation_excluded_terms: string[];
   auto_creation_excluded_groups: string[];
@@ -1289,6 +1290,7 @@ export async function saveSecurityMode(
 
 // Stream preview mode for browser playback
 export type StreamPreviewMode = 'passthrough' | 'transcode' | 'video_only';
+export type StreamUserAgent = 'dispatcharr' | 'chrome' | 'firefox' | 'safari' | 'vlc' | 'tivimate';
 
 export interface TestConnectionResult {
   success: boolean;
@@ -1390,6 +1392,7 @@ export async function saveSettings(settings: {
   telegram_bot_token?: string;  // Optional - Telegram bot token
   telegram_chat_id?: string;  // Optional - Telegram chat ID
   stream_preview_mode?: StreamPreviewMode;  // Optional - Stream preview mode, defaults to "passthrough"
+  stream_user_agent?: StreamUserAgent;
   // Auto-creation pipeline exclusion settings
   auto_creation_excluded_terms?: string[];
   auto_creation_excluded_groups?: string[];


### PR DESCRIPTION
## Summary
- Add a persisted Stream User-Agent selector: Dispatcharr default, Chrome, Firefox, Safari, VLC, and TiviMate.
- Resolve the Dispatcharr account/global User-Agent and propagate the selection through direct previews and all probe phases, including retries and standalone black-screen scans.
- Permit provider-only preview HTTPS-to-HTTP redirects while preserving destination validation, IP pinning, redirect limits, and credential scoping.
- Retry transient DNS failures, establish upstream before preview headers, preserve overrides on partial settings saves, and clean up interrupted streams/subprocesses.
- Provide safe startup/playback diagnostics and suppress HTTPX request URL logs, including at DEBUG level.

Addresses #995. Beads: enhancedchannelmanager-yz6rv and enhancedchannelmanager-rmf8n.

## Verification
- Full local backend gate: 13,952 passed, 4 skipped, 2 deselected; 83.02% coverage.
- Full frontend suite: 3,755 passed; typecheck, lint, and build passed.
- Browser selector, settings save/reload, explicit reset, and settings-to-provider-header tests passed.
- Code and security review findings were repaired and independently rechecked, including startup cancellation, late failures, and actual console-token suppression.
- After the version bump to 0.18.2-0032: 24 version-consistency tests and frontend rebuild passed.

## Verification boundaries
Provider/DNS boundaries were simulated; real surrogate processes exercised subprocess lifecycle. Live reporter-provider playback and real FFmpeg media decoding remain unverified on this host. Issue #995 remains open for reporter confirmation after delivery.