### PR TITLE
v0.18.2-0033: allow anonymous dummy EPG XMLTV feeds (#1000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **Generated dummy EPG feeds are retrievable without a session when authentication is enabled (bead `enhancedchannelmanager-mtvfv`, GitHub #1000, build 0.18.2-0033).** Anonymous GET requests can fetch combined and per-profile XMLTV output, with ASCII-numeric profile matching and a single trailing slash redirecting to the canonical URL. Management and write paths remain protected; encoded near-match paths do not receive the feed exemption.
+
 - **Resolved User-Agent headers reach provider requests (bead `enhancedchannelmanager-yz6rv`, GitHub #995, build 0.18.2-0032).** Direct previews and metadata, bitrate, resdet, and black screen probes send the selected identity on validated provider HTTP requests, including redirects and later HLS resources. Probe substeps and transient ffprobe retries reuse the same resolved header.
 
 - **Provider preview redirects and startup failures are handled explicitly (bead `enhancedchannelmanager-yz6rv`, GitHub #995, build 0.18.2-0032).** Direct provider previews support HTTPS-to-HTTP redirects with per-hop SSRF checks; authenticated Dispatcharr channel previews retain downgrade refusal. Stream DNS validation runs off the event loop and retries only transient failures, at most twice. Previews open upstream before sending browser headers and return safe 403/502/504 errors for policy, connection/configuration/upstream, and timeout failures. Cancellation and disconnect cleanup close responses and relays and terminate/reap FFmpeg.

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 import os
 import logging
+import re
 import time
 from collections import defaultdict
 from datetime import datetime
@@ -160,7 +161,7 @@ handle authentication automatically when accessed through the web UI.
 Login endpoints are rate-limited to 5 requests per minute per IP address.
     """,
 
-    version="0.18.2-0032",
+    version="0.18.2-0033",
     openapi_tags=tags_metadata,
     docs_url="/api/docs",
     redoc_url="/api/redoc",
@@ -573,6 +574,18 @@ AUTH_EXEMPT_PATHS = {
     "/api/openapi.json",
 }
 
+# Dispatcharr fetches generated XMLTV without a human ECM session (GH #1000).
+# Only GET is registered by these handlers. Match numeric profile IDs and at
+# most one trailing slash for FastAPI's redirect, never the whole router.
+_AUTH_EXEMPT_XMLTV_RE = re.compile(r"/api/dummy-epg/xmltv(?:/[0-9]+)?/?")
+
+
+def _is_auth_exempt_request(method: str, path: str) -> bool:
+    return path in AUTH_EXEMPT_PATHS or (
+        method == "GET" and _AUTH_EXEMPT_XMLTV_RE.fullmatch(path) is not None
+    )
+
+
 from auth.settings import get_auth_settings
 from auth.dependencies import (
     get_token_from_request,
@@ -592,7 +605,9 @@ from models import User
 # bead enhancedchannelmanager-17v07.
 async def auth_middleware(request: Request, call_next):
     """Reject unauthenticated requests to /api/* unless path is exempt."""
-    path = request.url.path
+    # URL reparsing can strip decoded control characters or treat an encoded
+    # '?' as a query delimiter. Authorize the actual ASGI path used by routing.
+    path = request.scope["path"]
 
     # Only gate /api/ paths — static files, SPA routes pass through
     if path.startswith("/api/"):
@@ -619,8 +634,8 @@ async def auth_middleware(request: Request, call_next):
 
         # Skip auth when it's not required or setup isn't complete
         if auth_settings.require_auth and auth_settings.setup_complete:
-            # Check if path is exempt
-            if path not in AUTH_EXEMPT_PATHS:
+            # Classify the same decoded path the router receives.
+            if not _is_auth_exempt_request(request.method, path):
                 token = presented_token
                 # Allow MCP API key as alternative to JWT. Constant-time compare
                 # to avoid a timing oracle on the static key (bd-1wq7z.24 (a));

--- a/backend/routers/backup.py
+++ b/backend/routers/backup.py
@@ -132,7 +132,7 @@ LEGACY_RESTORE_DIRS = ["uploads/logos", "tls", "m3u_uploads"]
 # scripts/check_version_consistency.py that used to fail the PR on divergence
 # were removed. Do NOT rename it, change its shape, or repurpose it. It is an INFORMATIONAL human-readable string ("which
 # ECM build produced this artifact") — it is NOT a compatibility gate.
-APP_VERSION = "0.18.2-0032"
+APP_VERSION = "0.18.2-0033"
 
 # DBAS backup-artifact schema version (ADR-008 D1 / ADR-012 D1). This is a
 # DEDICATED, MONOTONIC INTEGER that is DISTINCT from the human-readable

--- a/backend/tests/integration/test_dummy_epg_feed_auth.py
+++ b/backend/tests/integration/test_dummy_epg_feed_auth.py
@@ -1,0 +1,229 @@
+"""Auth-enabled XMLTV fetch contract for Dispatcharr (GitHub #1000)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from auth import settings as auth_settings
+from auth.tokens import create_access_token
+from cache import Cache
+from main import app
+from models import DummyEPGProfile, User
+from routers import dummy_epg, epg
+
+
+@pytest.fixture
+def feed_client(async_client, monkeypatch, tmp_path):
+    """Use the real app and auth loader with private, auth-enabled settings."""
+    monkeypatch.setattr(auth_settings, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(auth_settings, "AUTH_CONFIG_FILE", tmp_path / "auth_settings.json")
+    monkeypatch.setattr(auth_settings, "_cached_auth_settings", None)
+    monkeypatch.setattr(auth_settings, "_cached_auth_settings_signature", None)
+    settings = auth_settings.AuthSettings(require_auth=True, setup_complete=True)
+    settings.jwt.secret_key = "synthetic-issue1000-signing-key-" * 2
+    assert auth_settings.save_auth_settings(settings)
+    assert auth_settings.get_auth_settings().require_auth is True
+    assert auth_settings.get_auth_settings().setup_complete is True
+    monkeypatch.setattr(dummy_epg, "cache", Cache())
+    return async_client
+
+
+@pytest.fixture
+def feed_profile(test_session, monkeypatch):
+    profile = DummyEPGProfile(
+        name="Issue 1000 profile",
+        enabled=True,
+        name_source="channel",
+        title_pattern=r"(?P<title>.+)",
+        title_template="{title}",
+        description_template="Showing {title}",
+        event_timezone="UTC",
+        tvg_id_template="ecm-{channel_number}",
+    )
+    profile.set_channel_group_ids([5])
+    test_session.add(profile)
+    test_session.commit()
+    test_session.refresh(profile)
+    # Only the external Dispatcharr boundary is mocked; assignment resolution,
+    # template rendering, XML generation and the cache are real.
+    dispatcharr = AsyncMock()
+    dispatcharr.get_channels.return_value = {
+        "results": [
+            {
+                "id": 101,
+                "name": "Sports & News",
+                "channel_number": 100,
+                "channel_group_id": 5,
+                "streams": [],
+            },
+            {
+                "id": 102,
+                "name": "Unassigned channel",
+                "channel_number": 200,
+                "channel_group_id": 6,
+                "streams": [],
+            },
+        ],
+        "next": None,
+    }
+    monkeypatch.setattr(dummy_epg, "get_client", lambda: dispatcharr)
+    return profile
+
+
+@pytest.fixture
+def human_headers(feed_client, test_session):
+    user = User(username="feed-operator", is_admin=True, is_active=True)
+    test_session.add(user)
+    test_session.commit()
+    test_session.refresh(user)
+    token = create_access_token(user.id, user.username, auth_epoch=user.auth_epoch)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _feed_path(profile, per_profile):
+    # These are the routes emitted by services/api.ts's getDummyEPG*XmltvUrl
+    # helpers and registered as source_type=xmltv by DummyEPGManagerSection.
+    if per_profile:
+        return str(app.url_path_for("get_xmltv_profile", profile_id=profile.id))
+    return str(app.url_path_for("get_xmltv_all"))
+
+
+def _assert_xmltv(response):
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"] == "application/xml"
+    root = ET.fromstring(response.content)
+    assert root.tag == "tv"
+    assert [channel.attrib["id"] for channel in root.findall("channel")] == ["ecm-100"]
+    assert root.findtext("channel/display-name") == "Sports & News"
+    programme, = root.findall("programme")
+    assert programme.attrib["channel"] == "ecm-100"
+    assert programme.findtext("title") == "Sports & News"
+    assert programme.findtext("desc") == "Showing Sports & News"
+    assert programme.attrib["start"] < programme.attrib["stop"]
+
+
+@pytest.mark.parametrize("per_profile", [False, True], ids=["combined", "profile"])
+@pytest.mark.parametrize("suffix", ["", "/", "?refresh=1"])
+async def test_anonymous_get_returns_generated_xmltv_with_auth_enabled(
+    feed_client, feed_profile, per_profile, suffix
+):
+    path = _feed_path(feed_profile, per_profile)
+    response = await feed_client.get(path + suffix, follow_redirects=True)
+    _assert_xmltv(response)
+    assert [item.status_code for item in response.history] == ([307] if suffix == "/" else [])
+    assert response.url.path == path
+    # Exercise the real cached-response branch as well as cold generation.
+    _assert_xmltv(await feed_client.get(path))
+
+
+@pytest.mark.parametrize("per_profile", [False, True], ids=["combined", "profile"])
+async def test_registered_source_url_can_be_fetched_without_operator_credentials(
+    feed_client, feed_profile, human_headers, monkeypatch, per_profile
+):
+    url = str(feed_client.base_url).rstrip("/") + _feed_path(feed_profile, per_profile)
+    source = {"name": feed_profile.name, "source_type": "xmltv", "url": url, "is_active": True}
+    dispatcharr = AsyncMock()
+    dispatcharr.create_epg_source.side_effect = lambda data: {"id": 7, **data}
+    monkeypatch.setattr(epg, "get_client", lambda: dispatcharr)
+
+    registered = await feed_client.post("/api/epg/sources", json=source, headers=human_headers)
+    assert registered.status_code == 200, registered.text
+    dispatcharr.create_epg_source.assert_awaited_once_with(source)
+    assert registered.json()["url"] == url
+    # Dispatcharr receives only a URL, not the human's cookie or JWT.
+    assert not feed_client.cookies
+    _assert_xmltv(await feed_client.get(registered.json()["url"]))
+
+
+@pytest.mark.parametrize("path", ["/api/dummy-epg/%78mltv", "/api/dummy-epg/xmltv/%31"])
+async def test_percent_encoded_feed_path_uses_the_same_decoded_route(feed_client, feed_profile, path):
+    assert feed_profile.id == 1
+    _assert_xmltv(await feed_client.get(path))
+
+
+@pytest.mark.parametrize("method", ["HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE", "TRACE"])
+@pytest.mark.parametrize("path", ["/api/dummy-epg/xmltv", "/api/dummy-epg/xmltv/1"])
+@pytest.mark.parametrize("suffix", ["", "/"])
+async def test_feed_exemption_is_get_only(feed_client, method, path, suffix):
+    response = await feed_client.request(method, path + suffix)
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+@pytest.mark.parametrize("method,path", [
+    ("GET", "/api/dummy-epg/profiles"),
+    ("GET", "/api/dummy-epg/profiles/1"),
+    ("GET", "/api/dummy-epg/profiles/export/yaml"),
+    ("POST", "/api/dummy-epg/profiles"),
+    ("PATCH", "/api/dummy-epg/profiles/1"),
+    ("DELETE", "/api/dummy-epg/profiles/1"),
+    ("POST", "/api/dummy-epg/preview"),
+    ("POST", "/api/dummy-epg/preview/batch"),
+    ("POST", "/api/dummy-epg/generate"),
+    ("GET", "/api/epg/sources"),
+    ("POST", "/api/epg/sources"),
+    ("GET", "/api/epg/grid"),
+    ("GET", "/api/settings"),
+    ("POST", "/api/settings/mcp-api-key"),
+    ("GET", "/api/dummy-epg/xmltv.xml"),
+    ("GET", "/api/dummy-epg/xmltv.gz"),
+    ("GET", "/api/dummy-epg/xmltv/1.xml"),
+    ("GET", "/api/dummy-epg/xmltv/1.gz"),
+    ("GET", "/api/dummy-epg/xmltv/1/config"),
+    ("GET", "/api/dummy-epg/xmltv/profiles"),
+    ("GET", "/api/dummy-epg/xmltv/1extra"),
+    ("GET", "/api/dummy-epg/xmltv//"),
+    ("GET", "/api/dummy-epg/xmltv/1//"),
+    ("GET", "/api/dummy-epg/xmltv//1"),
+    ("GET", "/api/dummy-epg/XMLTV/1"),
+    ("GET", "/api/dummy-epg/xmltv/-1"),
+    ("GET", "/api/dummy-epg/xmltv/1%2fconfig"),
+    ("GET", "/api/dummy-epg/xmltv/%2e%2e/profiles"),
+    ("GET", "/api/dummy-epg/xmltv/%2531"),
+    ("GET", "/api/dummy-epg/xmltv/1%0a"),
+    ("GET", "/api/dummy-epg/xmltv/1%0d"),
+    ("GET", "/api/dummy-epg/xmltv/1%09"),
+    ("GET", "/api/dummy-epg/xmltv/1%3fconfig"),
+    ("GET", "/api/dummy-epg/xmltv/1%23config"),
+    ("GET", "/api/dummy-epg/xmltv/%EF%BC%91"),
+])
+async def test_neighboring_and_near_match_routes_require_auth(feed_client, method, path):
+    response = await feed_client.request(method, path)
+    assert response.status_code == 401, response.text
+    assert response.json() == {"detail": "Not authenticated"}
+
+
+async def test_unknown_profile_returns_handler_404(feed_client):
+    response = await feed_client.get("/api/dummy-epg/xmltv/99999")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Profile not found"}
+
+
+async def test_authenticated_profile_management_still_works(feed_client, feed_profile, human_headers):
+    response = await feed_client.get("/api/dummy-epg/profiles", headers=human_headers)
+    assert response.status_code == 200, response.text
+    assert [profile["id"] for profile in response.json()] == [feed_profile.id]
+    response = await feed_client.patch(
+        f"/api/dummy-epg/profiles/{feed_profile.id}",
+        json={"name": "Renamed by operator"},
+        headers=human_headers,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["name"] == "Renamed by operator"
+    response = await feed_client.get(
+        f"/api/dummy-epg/profiles/{feed_profile.id}", headers=human_headers
+    )
+    assert response.status_code == 200
+    assert response.json()["name"] == "Renamed by operator"
+
+
+async def test_feed_exemption_preserves_sidecar_client_key_refusal(feed_client, monkeypatch):
+    key = "<synthetic-sidecar-client-key>"
+    monkeypatch.setattr("main.get_settings", lambda: SimpleNamespace(mcp_api_key=key))
+    response = await feed_client.get(
+        "/api/dummy-epg/xmltv", headers={"Authorization": f"Bearer {key}"}
+    )
+    assert response.status_code == 403
+    assert "valid only at the sidecar" in response.json()["detail"]

--- a/backend/tests/test_auth_exempt_paths_snapshot.py
+++ b/backend/tests/test_auth_exempt_paths_snapshot.py
@@ -3,13 +3,13 @@
 WHY THIS FILE EXISTS
 --------------------
 
-``main.AUTH_EXEMPT_PATHS`` is the entire authentication gate for ``/api/*``.
-``main.auth_middleware`` enforces on every ``/api/`` path EXCEPT the members of
-this set, and it is a membership test on the literal
-``request.url.path`` — there is no prefix logic, no router opt-in, and no
-second layer behind it for the routers that carry no route dependency of their
-own. Adding one line to that set makes one route anonymous to the whole
-internet-facing surface of the app.
+``main.AUTH_EXEMPT_PATHS`` pins the method-independent public paths.
+``main._is_auth_exempt_request`` also permits GET of the two generated XMLTV
+feed shapes (GH #1000). The registered-route inventory below pins that extra
+grant; ``integration/test_dummy_epg_feed_auth.py`` exercises real middleware,
+handlers, methods, redirects and near-matches with authentication enabled.
+There is no second auth layer for routers without their own dependency.
+Adding a path here exposes it to anyone who can reach ECM.
 
 Before this file, the gate was proved by exactly one test
 (``tests/routers/test_client_errors.py::test_missing_jwt_returns_401_when_auth_enabled``),
@@ -105,9 +105,9 @@ EXPECTED_AUTH_EXEMPT_PATHS = frozenset(
 # usually the person who just added the line, mid-change, not someone who came
 # here to read a doc.
 _REVIEW_CHECKLIST = """
-AUTH_EXEMPT_PATHS CHANGED. This set is the ENTIRE authentication gate for
-/api/*: main.auth_middleware enforces on every /api/ path except an exact
-string match against this set. A path added here is reachable by any
+AUTH_EXEMPT_PATHS CHANGED. This set exempts exact paths for ANY method.
+main._is_auth_exempt_request separately permits GET-only generated XMLTV feeds.
+A path added here is reachable by any
 unauthenticated caller that can open a socket to ECM — there is no second
 layer behind it unless that specific route carries its own dependency.
 
@@ -154,6 +154,29 @@ def test_auth_exempt_paths_matches_the_reviewed_snapshot():
     )
 
 
+def test_method_specific_exemptions_cover_only_registered_xmltv_reads():
+    """Pin the additional public route inventory without matching source text."""
+    from fastapi.routing import APIRoute
+
+    from main import _is_auth_exempt_request, app
+
+    exposed = set()
+    for route in app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        path = route.path_format.format(**{name: "1" for name in route.param_convertors})
+        if path in AUTH_EXEMPT_PATHS:
+            continue
+        for method in {"GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE", "TRACE"}:
+            if _is_auth_exempt_request(method, path):
+                exposed.add((method, route.path))
+
+    assert exposed == {
+        ("GET", "/api/dummy-epg/xmltv"),
+        ("GET", "/api/dummy-epg/xmltv/{profile_id}"),
+    }
+
+
 def test_every_exempt_path_is_an_api_path():
     """A non-``/api/`` entry would be dead weight that reads as a grant.
 
@@ -170,7 +193,7 @@ def test_every_exempt_path_is_an_api_path():
 
 
 def test_no_exempt_path_carries_a_trailing_slash_or_query():
-    """Membership is an exact match on ``request.url.path``.
+    """Path-only membership is an exact match on the decoded ASGI scope path.
 
     A trailing slash, a query string or a case variant silently exempts
     nothing, for the same reason as above. Pinned rather than assumed because

--- a/docs/auth_middleware.md
+++ b/docs/auth_middleware.md
@@ -1,6 +1,6 @@
 # Global Auth Middleware
 
-All /api/* endpoints are secure-by-default via middleware; new endpoints must be added to AUTH_EXEMPT_PATHS to be public.
+All /api/* endpoints are secure-by-default via middleware. Public access is classified by `main._is_auth_exempt_request`.
 
 ECM uses a global auth middleware in `main.py` that blocks unauthenticated requests to all `/api/*` paths unless explicitly exempted.
 
@@ -8,14 +8,14 @@ ECM uses a global auth middleware in `main.py` that blocks unauthenticated reque
 
 **How to apply:**
 - New endpoints are automatically protected: no auth dependency needed
-- To make an endpoint public, add its path to `AUTH_EXEMPT_PATHS` in `main.py`
+- Method-independent public paths live in `AUTH_EXEMPT_PATHS` in `main.py`. The classifier also permits GET-only generated XMLTV feeds, described below.
 - The middleware respects `RequireAuthIfEnabled` semantics: skips enforcement when `auth.require_auth=False` or `auth.setup_complete=False`
 - Token validation uses `decode_token_safe()` from `auth/dependencies.py` (non-raising, returns payload or None)
 - Per-endpoint `RequireAuthIfEnabled` / `RequireAdminIfEnabled` DI dependencies still exist for role-based checks (e.g., admin-only routes in `backup.py`)
 
-**The exempt set is pinned by a test.** `AUTH_EXEMPT_PATHS` is the entire
-authentication gate for `/api/*`: an exact string match, no prefix logic, no
-second layer behind it for routers that carry no dependency of their own. Its
+**The exempt set is pinned by a test.** `AUTH_EXEMPT_PATHS` uses an exact
+string match, with no prefix logic and no second layer behind it for routers
+that carry no dependency of their own. Its
 contents are snapshotted in
 `backend/tests/test_auth_exempt_paths_snapshot.py`, so adding a path requires
 editing that file in the same commit. The failure message is the review
@@ -29,6 +29,31 @@ Note that middleware exemption is not the same as anonymity: `GET` and `PUT
 /api/auth/admin/settings` are exempt from the middleware but carry
 `auth.routes.require_admin`, which chains `get_current_user` and validates a
 token in every mode. That is pinned too.
+
+## Generated XMLTV feeds
+
+Dispatcharr and other XMLTV consumers can fetch these read-only feeds without
+an ECM session even when `require_auth` and `setup_complete` are both true:
+
+- `GET /api/dummy-epg/xmltv`: combined output for enabled profiles.
+- `GET /api/dummy-epg/xmltv/{profile_id}`: output for one profile, with an ASCII
+  numeric ID.
+
+A single trailing slash is permitted so FastAPI can redirect to the canonical
+URL. Matching uses the decoded ASGI scope path, as routing does; query strings
+do not change the grant. There are no filename or gzip feed routes. HEAD and other
+methods do not receive this exemption. Profile listing/configuration, preview,
+generation commands and `/api/epg/*` retain their existing authentication rules.
+The MCP client-key refusal still runs before public-request classification.
+
+These URLs expose generated channel names and programme listings to anyone
+who can reach ECM. They carry no session credential or feed token. The UI's
+copy-URL and Add to Dispatcharr actions use these paths directly.
+
+The method-specific route inventory is pinned in
+`backend/tests/test_auth_exempt_paths_snapshot.py`; auth-enabled middleware and
+handler behavior is covered by
+`backend/tests/integration/test_dummy_epg_feed_auth.py`.
 
 ## What `require_auth: false` permits
 

--- a/docs/user_guide/epg/dummy-epg-overview.md
+++ b/docs/user_guide/epg/dummy-epg-overview.md
@@ -31,6 +31,13 @@ Dispatcharr as EPG source** to wire it in automatically. Profiles offer a
 live preview, rich per-state templates (see [Author dummy EPG
 templates](dummy-epg-templates.md)), and Event Sync integration.
 
+The profile URL (`/api/dummy-epg/xmltv/{profile_id}`) and **Copy combined XMLTV
+URL** (`/api/dummy-epg/xmltv`) allow anonymous GET requests even when ECM login
+is required. Dispatcharr does not need your ECM session or an API key to fetch
+them. Anyone who can reach those URLs can read the generated channel names and
+programme listings; profile management and preview still require ECM login
+when authentication is enabled.
+
 > **Legacy note.** ECM previously also exposed Dispatcharr's native
 > `source_type=dummy` EPG sources through a separate "Dummy EPG Sources"
 > section. That path is **deprecated**: it now appears only if such sources

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "enhanced-channel-manager",
   "private": true,
 
-  "version": "0.18.2-0032",
+  "version": "0.18.2-0033",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Allow anonymous GET requests to the generated combined and numeric-profile XMLTV feeds so Dispatcharr can refresh them when ECM authentication is enabled.
- Support the existing single trailing-slash redirect to each canonical feed URL.
- Classify the actual decoded ASGI path with a full match; management APIs, write requests, and encoded near-matches remain protected.
- Preserve the MCP client-key refusal and document the feed access contract.

Addresses #1000. Bead: enhancedchannelmanager-mtvfv.

## Verification
- Full local backend gate: 14,029 passed, 4 skipped, 2 deselected; 83.05% coverage.
- Independent focused auth/router/MCP run: 376 passed.
- Real loopback HTTP proof through auth-enabled main.app, actual frontend URL helpers, authenticated profile/source registration, then anonymous XMLTV fetching: passed.
- Independent code review approved; security review passed 202 raw HTTP checks across Uvicorn httptools and h11, with no findings.
- After version bump: 24 version-consistency tests and frontend rebuild passed.

## Verification boundary
The upstream Dispatcharr client was mocked; no live Dispatcharr instance was used. Keep #1000 open for reporter confirmation after the fix is published.